### PR TITLE
Make FastMCP optional in lightweight authentication mode

### DIFF
--- a/collegue/core/auth.py
+++ b/collegue/core/auth.py
@@ -1,15 +1,18 @@
 """
 Authentication - Gestion de l'authentification OAuth pour le MCP Collègue
 """
-from fastmcp import FastMCP
+from typing import Optional, Any
+import logging
+
+# Rendre FastMCP optionnel pour permettre l'exécution en mode "watchdog" léger
 try:
+    from fastmcp import FastMCP
     from fastmcp.server.auth.providers.jwt import JWTVerifier
 except ImportError:
-    # Fallback pour anciennes versions de FastMCP
+    FastMCP = Any
     JWTVerifier = None
+
 from collegue.config import settings
-from typing import Optional
-import logging
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This pull request introduces the following changes:

- Adds an option to enable/disable FastMCP, allowing a lightweight "watchdog" mode in the authentication process without using FastMCP. 

No related issues were linked to this pull request.