### PR TITLE
Make FastMCP optional to support lightweight mode

### DIFF
--- a/collegue/resources/typescript/__init__.py
+++ b/collegue/resources/typescript/__init__.py
@@ -6,7 +6,12 @@ Ce module fournit des ressources pour le langage TypeScript, notamment:
 - Frameworks populaires
 - Bonnes pratiques
 """
-from fastmcp import FastMCP
+from typing import Any
+
+try:
+    from fastmcp import FastMCP
+except ImportError:
+    FastMCP = Any
 
 def register(app: FastMCP, app_state: dict):
     """

--- a/collegue/tools/__init__.py
+++ b/collegue/tools/__init__.py
@@ -5,7 +5,14 @@ import os
 import importlib
 import inspect
 from typing import Dict, List, Type, Any, Optional
-from fastmcp import FastMCP, Context
+
+# Rendre FastMCP optionnel pour permettre l'exécution en mode "watchdog" léger
+try:
+    from fastmcp import FastMCP, Context
+except ImportError:
+    FastMCP = Any
+    Context = Any
+
 from pydantic import BaseModel
 from .base import BaseTool
 


### PR DESCRIPTION
This pull request introduces the following changes:

- Adds an option to disable FastMCP functionality, enabling a lightweight "watchdog" mode. 

**Checklist:**

- [ ] Code implementation completed
- [ ] Unit tests added/updated
- [ ] Documentation updated