### PR TITLE
Add GitHub repository parameter to user configuration

### DIFF
--- a/collegue/autonomous/config_registry.py
+++ b/collegue/autonomous/config_registry.py
@@ -19,6 +19,7 @@ class UserConfig:
     sentry_token: Optional[str] = None
     github_token: Optional[str] = None
     github_owner: Optional[str] = None
+    github_repo: Optional[str] = None  # Nom du repo GitHub (ex: "Collegue")
     last_seen: float = field(default_factory=time.time)
     
     def update_last_seen(self):
@@ -61,7 +62,8 @@ class UserConfigRegistry:
         sentry_org: str,
         sentry_token: Optional[str] = None,
         github_token: Optional[str] = None,
-        github_owner: Optional[str] = None
+        github_owner: Optional[str] = None,
+        github_repo: Optional[str] = None
     ) -> Optional[str]:
         """
         Enregistre ou met à jour une configuration utilisateur.
@@ -80,7 +82,8 @@ class UserConfigRegistry:
             sentry_org=normalized_org,
             sentry_token=sentry_token,
             github_token=github_token,
-            github_owner=github_owner
+            github_owner=github_owner,
+            github_repo=github_repo
         )
         
         with self._config_lock:
@@ -93,6 +96,8 @@ class UserConfigRegistry:
                     existing.github_token = github_token
                 if github_owner:
                     existing.github_owner = github_owner
+                if github_repo:
+                    existing.github_repo = github_repo
                 existing.update_last_seen()
             else:
                 self._configs[config.config_id] = config

--- a/collegue/tools/github_ops.py
+++ b/collegue/tools/github_ops.py
@@ -693,7 +693,8 @@ class GitHubOpsTool(BaseTool):
                     get_config_registry().register(
                         sentry_org=sentry_org,
                         github_token=token,
-                        github_owner=request.owner
+                        github_owner=request.owner,
+                        github_repo=request.repo
                     )
             except Exception:
                 pass


### PR DESCRIPTION

### Summary
This pull request introduces a new parameter, `github_repo`, in the user configuration. This parameter is now utilized in relevant methods to allow improved customization for repository-specific operations.

### Changes
- Added `github_repo` parameter to user configuration.
- Updated related methods to reference this new parameter.

### Checklist
- [ ] Tests have been added or updated to cover the new changes.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] Code changes include appropriate comments and annotations.

### Additional Notes
Please ensure backward compatibility is maintained with existing configurations.