### PR TITLE
Fix: Echec de l'opération GitHub: Erreur API GitHub 422: {"message":"Reference already exists","documentation_url":"https://docs.github.com/rest/git/refs#create-a-reference","status":"422"} (Sentry-COLLEGUE-SENTRY-14)

### DIFF
--- a/mcp_server/github_client.py
+++ b/mcp_server/github_client.py
@@ -1,0 +1,35 @@
+import requests
+
+class GitHubClient:
+    def __init__(self, token, repo):
+        self.token = token
+        self.repo = repo
+        self.base_url = f"https://api.github.com/repos/{repo}"
+        self.headers = {
+            "Authorization": f"token {token}",
+            "Accept": "application/vnd.github.v3+json"
+        }
+
+    def create_branch(self, branch_name, source_branch="main"):
+        # 1. Récupérer le SHA du dernier commit de la branche source
+        ref_url = f"{self.base_url}/git/refs/heads/{source_branch}"
+        response = requests.get(ref_url, headers=self.headers)
+        response.raise_for_status()
+        sha = response.json()["object"]["sha"]
+
+        # 2. Tenter de créer la nouvelle branche
+        create_ref_url = f"{self.base_url}/git/refs"
+        payload = {
+            "ref": f"refs/heads/{branch_name}",
+            "sha": sha
+        }
+        
+        res = requests.post(create_ref_url, json=payload, headers=self.headers)
+        
+        if res.status_code == 422 and "Reference already exists" in res.text:
+            # La branche existe déjà, on ignore l'erreur ou on logue
+            print(f"La branche {branch_name} existe déjà.")
+            return True
+        
+        res.raise_for_status()
+        return res.json()


### PR DESCRIPTION
Fix automatique généré par Collegue Watchdog.

Issue: https://vynodepal.sentry.io/issues/89318753/

Explication:
L'erreur 422 'Reference already exists' se produit lors de la tentative de création d'une branche qui existe déjà. Le correctif consiste à vérifier l'existence de la branche avant la création ou à intercepter l'exception pour logger l'info sans faire planter le processus.