### PR TITLE
Add 'get_file' command to GitHub operations

### DIFF
--- a/collegue/tools/github_ops.py
+++ b/collegue/tools/github_ops.py
@@ -83,7 +83,7 @@ class GitHubRequest(BaseModel):
     @field_validator('command')
     @classmethod
     def validate_command(cls, v: str) -> str:
-        valid = ['list_repos', 'get_repo', 'list_prs', 'get_pr', 'create_pr',
+        valid = ['list_repos', 'get_repo', 'get_file', 'list_prs', 'get_pr', 'create_pr',
                  'list_issues', 'get_issue', 'create_issue', 'pr_files', 'pr_comments', 
                  'repo_branches', 'create_branch', 'update_file',
                  'repo_commits', 'search_code', 'list_workflows', 'workflow_runs']


### PR DESCRIPTION
This pull request introduces the following changes:

- Implements the `get_file` command in `github_ops.py` to extend the list of valid GitHub operations supported by the module.

No further modifications or refactoring are included in this change.