### PR TITLE
Fix: ToolExecutionError: Erreur API Sentry 400: {"detail":"Invalid project parameter. Values must be numbers."} (Sentry-COLLEGUE-SENTRY-5)

### DIFF
--- a/collegue/tools/sentry_monitor.py
+++ b/collegue/tools/sentry_monitor.py
@@ -302,6 +302,14 @@ class SentryMonitorTool(BaseTool):
         base_url = self._get_base_url(sentry_url)
         url = f"{base_url}{endpoint}"
         headers = self._get_headers(token)
+
+        # Sentry API requires project IDs to be numbers, not strings
+        if params and "project" in params:
+            p = params["project"]
+            if isinstance(p, list):
+                params["project"] = [int(x) if str(x).isdigit() else x for x in p]
+            elif isinstance(p, str) and p.isdigit():
+                params["project"] = int(p)
         
         try:
             response = requests.get(url, headers=headers, params=params, timeout=30)


### PR DESCRIPTION
## Fix automatique généré par Collegue Watchdog

**Issue Sentry:** https://vynodepal.sentry.io/issues/89018155/

### Explication
L'API Sentry rejette la requête car certains paramètres (probablement 'project') sont envoyés sous forme de chaînes de caractères au lieu de nombres dans les query params. Le correctif s'assure que si un paramètre 'project' est présent dans le dictionnaire 'params', il est converti en entier ou en liste d'entiers avant l'envoi.

### Patchs appliqués
1 modification(s) minimale(s) sur `collegue/tools/sentry_monitor.py`

### Validation
- ✅ Syntaxe Python vérifiée
- ✅ Taille du fichier préservée

---
*Ce fix a été généré automatiquement. Veuillez le revoir avant de merger.*
