### PR TITLE
Fix: ToolExecutionError: Erreur API Sentry 400: {"detail":"Invalid project parameter. Values must be numbers."} (Sentry-COLLEGUE-SENTRY-W)

### DIFF
--- a/collegue/tools/sentry_monitor.py
+++ b/collegue/tools/sentry_monitor.py
@@ -303,6 +303,11 @@ class SentryMonitorTool(BaseTool):
         url = f"{base_url}{endpoint}"
         headers = self._get_headers(token)
         
+        # Sentry API often requires numeric IDs for 'project' parameter in stats/issues
+        if params and "project" in params and isinstance(params["project"], dict):
+            params = params.copy()
+            params["project"] = params["project"].get("id", params["project"])
+
         try:
             response = requests.get(url, headers=headers, params=params, timeout=30)
             


### PR DESCRIPTION
## Fix automatique généré par Collegue Watchdog

**Issue Sentry:** https://vynodepal.sentry.io/issues/89314357/

### Explication
L'API Sentry rejette la requête car le paramètre 'project' dans les stats doit être un ID numérique et non un slug (string). Le correctif s'assure que si un objet projet est passé dans les paramètres, on utilise son ID numérique avant d'appeler l'API.

### Patchs appliqués
1 modification(s) minimale(s) sur `collegue/tools/sentry_monitor.py`

### Validation
- ✅ Syntaxe Python vérifiée
- ✅ Taille du fichier préservée

---
*Ce fix a été généré automatiquement. Veuillez le revoir avant de merger.*
