### PR TITLE
Fix: ToolExecutionError: Erreur API Sentry 400: {"detail":"Invalid project parameter. Values must be numbers."} (Sentry-COLLEGUE-SENTRY-W)

### DIFF
--- a/collegue/tools/sentry_monitor.py
+++ b/collegue/tools/sentry_monitor.py
@@ -303,10 +303,10 @@ class SentryMonitorTool(BaseTool):
         url = f"{base_url}{endpoint}"
         headers = self._get_headers(token)
         
-        # Sentry API often requires numeric IDs for 'project' parameter in stats/issues
-        if params and "project" in params and isinstance(params["project"], dict):
+        # Sentry API often expects project IDs as numbers in query params
+        if params and "project" in params and hasattr(params["project"], "id"):
             params = params.copy()
-            params["project"] = params["project"].get("id", params["project"])
+            params["project"] = params["project"].id
 
         try:
             response = requests.get(url, headers=headers, params=params, timeout=30)


### PR DESCRIPTION
## Fix automatique généré par Collegue Watchdog

**Issue Sentry:** https://vynodepal.sentry.io/issues/89314357/

### Explication
L'API Sentry s'attend à recevoir l'ID numérique du projet plutôt que son slug dans certains paramètres de requête (notamment pour les stats/issues). Le correctif s'assure que si un objet projet est passé dans les paramètres, on utilise son attribut 'id' (numérique) au lieu du slug.

### Patchs appliqués
1 modification(s) minimale(s) sur `collegue/tools/sentry_monitor.py`

### Sources consultées
- [Script d'alerte Amazon - Ajouter les alertes Sentry](https://docstring.fr/formations/scraping-avance-mise-en-production/ajouter-les-alertes-sentry-2073)
- [6 erreurs d'API fréquentes et comment les éviter](https://www.astera.com/fr/type/blog/api-errors/)
- [Sentry | IndieMakers](https://indiemakers.dev/fr/tools/sentry)

### Validation
- ✅ Syntaxe Python vérifiée
- ✅ Taille du fichier préservée

---
*Ce fix a été généré automatiquement. Veuillez le revoir avant de merger.*
