### PR TITLE
refactor: installer curl pour le healthcheck dans docker/collegue/Dockerfile

### DIFF
--- a/docker/collegue/Dockerfile
+++ b/docker/collegue/Dockerfile
@@ -26,6 +26,11 @@ WORKDIR /app
 # Création utilisateur non-root
 RUN groupadd -r collegue && useradd -r -g collegue collegue
 
+# Installation de curl pour le healthcheck
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copie des dépendances depuis le builder
 COPY --from=builder /root/.local /home/collegue/.local
 


### PR DESCRIPTION
- Ajouter installation de curl avec apt-get avant copie des dépendances
- Nettoyer /var/lib/apt/lists/* après installation pour réduire la taille de l'image