### PR TITLE
refactor: ajouter support PHP dans config, parser, analyzers et dependency_guard

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -27,7 +27,7 @@ class Settings(BaseSettings):
     CACHE_ENABLED: bool = True
     CACHE_TTL: int = 3600
     
-    SUPPORTED_LANGUAGES: List[str] = ["python", "javascript", "typescript"]
+    SUPPORTED_LANGUAGES: List[str] = ["python", "javascript", "typescript", "php"]
     
     OAUTH_ENABLED: bool = False
     OAUTH_JWKS_URI: Optional[str] = None

--- a/collegue/tools/analyzers/php.py
+++ b/collegue/tools/analyzers/php.py
@@ -1,0 +1,158 @@
+"""
+PHP Analyzer for Repo Consistency Check.
+
+Détecte les imports (use) et variables inutilisés dans le code PHP.
+"""
+import re
+from typing import List, Dict, Any
+from .base import BaseAnalyzer, AnalyzerError
+from ...core.shared import ConsistencyIssue
+
+class PHPAnalyzer(BaseAnalyzer):
+    def analyze_unused_imports(self, code: str, filepath: str) -> List[ConsistencyIssue]:
+        issues = []
+        
+        # Regex pour capturer les 'use' (imports)
+        # Format: use Namespace\Class; ou use Namespace\Class as Alias;
+        import_pattern = r"^use\s+([a-zA-Z0-9_\\]+)(?:\s+as\s+([a-zA-Z0-9_]+))?\s*;"
+        
+        lines = code.split('\n')
+        defined_imports = []
+        
+        for i, line in enumerate(lines):
+            line = line.strip()
+            # Ignorer les use dans les classes (Traits) ou closures
+            if not line.startswith('use '):
+                continue
+                
+            match = re.search(import_pattern, line)
+            if match:
+                full_class = match.group(1)
+                alias = match.group(2)
+                
+                # Le nom à chercher dans le code est l'alias s'il existe, sinon le dernier segment du namespace
+                name_to_check = alias if alias else full_class.split('\\')[-1]
+                
+                defined_imports.append({
+                    'name': name_to_check,
+                    'full_name': full_class,
+                    'line': i + 1,
+                    'statement': line
+                })
+        
+        # Analyser le reste du code pour trouver les usages
+        content_without_imports = '\n'.join([l for l in lines if not l.strip().startswith('use ')])
+        
+        for imp in defined_imports:
+            # Recherche simple du nom de la classe/alias
+            # Attention aux faux positifs (commentaires, chaînes), mais acceptable pour une analyse statique légère
+            # On cherche le mot entier précédé par non-alphanumérique ou début de ligne
+            # et suivi par non-alphanumérique ou fin de ligne
+            pattern = r'(?:^|[^a-zA-Z0-9_])' + re.escape(imp['name']) + r'(?:[^a-zA-Z0-9_]|$)'
+            
+            if not re.search(pattern, content_without_imports):
+                issues.append(ConsistencyIssue(
+                    kind="unused_imports",
+                    severity="low",
+                    path=filepath,
+                    line=imp['line'],
+                    message=f"Import inutilisé: {imp['name']}",
+                    confidence=90,
+                    suggested_fix=f"Supprimer la ligne: {imp['statement']}",
+                    engine="php-regex-analyzer"
+                ))
+                
+        return issues
+
+    def analyze_unused_vars(self, code: str, filepath: str) -> List[ConsistencyIssue]:
+        issues = []
+        lines = code.split('\n')
+        
+        # Analyse simple portée par fonction pour éviter trop de faux positifs
+        # On détecte les définitions de variables: $var = ...
+        # Et on vérifie si $var est utilisé ensuite
+        
+        # Pattern d'assignation: $variable = ...
+        assign_pattern = r"(\$[a-zA-Z0-9_]+)\s*="
+        
+        # Pattern d'usage: $variable (sans être suivi de =)
+        
+        variables = {} # {name: {line: int, used: bool}}
+        
+        for i, line in enumerate(lines):
+            line = line.strip()
+            if line.startswith('//') or line.startswith('#') or line.startswith('*'):
+                continue
+                
+            # Détection des usages d'abord (pour gérer $a = $a + 1)
+            for var_name in list(variables.keys()):
+                # Si la variable apparaît dans la ligne et ce n'est pas (uniquement) une assignation de cette variable
+                # Cas simple: on marque comme utilisé si on trouve la string
+                if var_name in line:
+                    # Vérifier si c'est une assignation de cette variable
+                    is_assignment = re.search(re.escape(var_name) + r"\s*=", line)
+                    
+                    # Si c'est une assignation, ça compte comme usage seulement si c'est $a .= ... ou $a = $a ...
+                    # Pour simplifier: si le nom apparaît 2 fois ou si pas d'assignation
+                    if not is_assignment or line.count(var_name) > 1:
+                        variables[var_name]['used'] = True
+            
+            # Détection des déclarations
+            match = re.search(assign_pattern, line)
+            if match:
+                var_name = match.group(1)
+                # On ne suit que les variables locales (pas $this->...)
+                if var_name != '$this' and not var_name.startswith('$_'):
+                    if var_name not in variables:
+                        variables[var_name] = {'line': i + 1, 'used': False}
+        
+        for name, data in variables.items():
+            if not data['used']:
+                issues.append(ConsistencyIssue(
+                    kind="unused_vars",
+                    severity="medium",
+                    path=filepath,
+                    line=data['line'],
+                    message=f"Variable locale inutilisée: {name}",
+                    confidence=70, # Regex moins fiable que AST
+                    suggested_fix=f"Supprimer la variable ou l'utiliser",
+                    engine="php-regex-analyzer"
+                ))
+                
+        return issues
+
+    def analyze_dead_code(self, code: str, filepath: str, all_code: str = "") -> List[ConsistencyIssue]:
+        # Analyse basique des méthodes privées non utilisées
+        issues = []
+        
+        # Pattern: private function name(...)
+        private_method_pattern = r"private\s+function\s+([a-zA-Z0-9_]+)\s*\("
+        
+        methods = []
+        for i, line in enumerate(code.split('\n')):
+            match = re.search(private_method_pattern, line)
+            if match:
+                methods.append({'name': match.group(1), 'line': i + 1})
+        
+        for method in methods:
+            # Recherche de ->name( ou ::name(
+            call_pattern = r"(?:->|::)" + re.escape(method['name']) + r"\s*\("
+            
+            # On cherche dans le fichier courant (car méthode privée)
+            # On exclut la définition elle-même (approximatif)
+            matches = re.findall(call_pattern, code)
+            
+            # Si < 1 appel (c'est-à-dire 0, car la regex ne matche pas la définition 'private function ...')
+            if len(matches) == 0:
+                 issues.append(ConsistencyIssue(
+                    kind="dead_code",
+                    severity="medium",
+                    path=filepath,
+                    line=method['line'],
+                    message=f"Méthode privée non utilisée: {method['name']}",
+                    confidence=80,
+                    suggested_fix=f"Supprimer la méthode si elle n'est pas utilisée via call_user_func",
+                    engine="php-regex-analyzer"
+                ))
+                
+        return issues

--- a/collegue/tools/documentation.py
+++ b/collegue/tools/documentation.py
@@ -31,7 +31,8 @@ LANGUAGE_INSTRUCTIONS = {
     "java": "Utilise Javadoc format avec @param, @return, @throws",
     "c#": "Utilise XML documentation format avec <summary>, <param>, <returns>",
     "go": "Utilise les conventions Go avec commentaires au-dessus des déclarations",
-    "rust": "Utilise les doc comments avec /// et inclus les exemples avec ```"
+    "rust": "Utilise les doc comments avec /// et inclus les exemples avec ```",
+    "php": "Utilise le format PHPDoc (PSR-5/PSR-19) avec @param, @return, @throws et types explicites"
 }
 
 
@@ -407,6 +408,45 @@ Style de documentation: {request.doc_style or 'standard'}."""
                         "complexity": "medium"
                     })
 
+        elif language.lower() == 'php':
+            for i, line in enumerate(lines):
+                line_stripped = line.strip()
+                
+                # Functions and methods
+                if 'function ' in line_stripped:
+                    func_name = "anonymous"
+                    if 'function ' in line_stripped and '(' in line_stripped:
+                        parts = line_stripped.split('function ')[1].split('(')
+                        if parts[0].strip():
+                            func_name = parts[0].strip()
+                            
+                    elements.append({
+                        "type": "function",
+                        "name": func_name,
+                        "description": "",
+                        "signature": line_stripped,
+                        "line_number": str(i + 1),
+                        "complexity": "medium"
+                    })
+                
+                # Classes, Interfaces, Traits
+                elif line_stripped.startswith('class ') or line_stripped.startswith('abstract class ') or line_stripped.startswith('interface ') or line_stripped.startswith('trait '):
+                    parts = line_stripped.split()
+                    name_idx = 1
+                    if parts[0] == 'abstract': name_idx = 2
+                    
+                    if len(parts) > name_idx:
+                        name = parts[name_idx]
+                        
+                        elements.append({
+                            "type": "class",
+                            "name": name,
+                            "description": "",
+                            "signature": line_stripped,
+                            "line_number": str(i + 1),
+                            "complexity": "medium"
+                        })
+
         return elements
 
     def _estimate_complexity(self, element: Dict[str, Any]) -> str:
@@ -470,7 +510,8 @@ Style de documentation: {request.doc_style or 'standard'}."""
             "java": "Utilise Javadoc format avec @param, @return, @throws",
             "c#": "Utilise XML documentation format avec <summary>, <param>, <returns>",
             "go": "Utilise les conventions Go avec commentaires au-dessus des déclarations",
-            "rust": "Utilise les doc comments avec /// et inclus les exemples avec ```"
+            "rust": "Utilise les doc comments avec /// et inclus les exemples avec ```",
+            "php": "Utilise le format PHPDoc (PSR-5) avec @param, @return et types scalaires/objets"
         }
         return instructions.get(language.lower(), "")
 
@@ -492,7 +533,7 @@ Style de documentation: {request.doc_style or 'standard'}."""
             formatted_lines.extend(lines)
             formatted_lines.append('"""')
             return '\n'.join(formatted_lines)
-        elif language.lower() in ["javascript", "typescript"]:
+        elif language.lower() in ["javascript", "typescript", "java", "php", "c#"]:
 
             lines = docs.split('\n')
             formatted_lines = ['/**']

--- a/collegue/tools/utils/test_generators_adapter.py
+++ b/collegue/tools/utils/test_generators_adapter.py
@@ -340,6 +340,114 @@ def generate_typescript_mocha_tests(code: str, functions: List[Dict[str, Any]],
     return "\n".join(lines)
 
 
+def generate_phpunit_tests(code: str, functions: List[Dict[str, Any]],
+                         classes: List[Dict[str, Any]], include_mocks: bool = False) -> str:
+    """Generate PHPUnit tests template."""
+    lines = [
+        "<?php",
+        "",
+        "namespace Tests\\Unit;",
+        "",
+        "use PHPUnit\\Framework\\TestCase;",
+        "use Mockery;",
+        "",
+        "class ModuleTest extends TestCase",
+        "{",
+    ]
+
+    if include_mocks:
+        lines.extend([
+            "    protected function setUp(): void",
+            "    {",
+            "        parent::setUp();",
+            "        // Set up mocks",
+            "    }",
+            "",
+            "    protected function tearDown(): void",
+            "    {",
+            "        Mockery::close();",
+            "        parent::tearDown();",
+            "    }",
+            "",
+        ])
+
+    # Add test cases for functions (wrapped in a class usually in PHPUnit)
+    for func in functions:
+        func_name = func.get("name", "unknown")
+        test_name = f"test_{func_name}".replace(" ", "_")
+        lines.extend([
+            f"    /** @test */",
+            f"    public function {test_name}()",
+            "    {",
+            "        // TODO: Implement test",
+            "        $this->assertTrue(true);",
+            "    }",
+            "",
+        ])
+
+    # Add test cases for classes
+    for cls in classes:
+        class_name = cls.get("name", "Unknown")
+        lines.extend([
+            f"    /** @test */",
+            f"    public function {class_name.lower()}_initialization()",
+            "    {",
+            "        // TODO: Implement test",
+            "        $this->assertTrue(true);",
+            "    }",
+            "",
+        ])
+
+    lines.extend([
+        "}",
+    ])
+
+    return "\n".join(lines)
+
+
+def generate_pest_tests(code: str, functions: List[Dict[str, Any]],
+                      classes: List[Dict[str, Any]], include_mocks: bool = False) -> str:
+    """Generate Pest tests template."""
+    lines = [
+        "<?php",
+        "",
+        "use function Pest\\Laravel\\get;",
+        "",
+    ]
+
+    if include_mocks:
+        lines.extend([
+            "beforeEach(function () {",
+            "    // Set up mocks",
+            "});",
+            "",
+        ])
+
+    # Add test cases for functions
+    for func in functions:
+        func_name = func.get("name", "unknown")
+        lines.extend([
+            f"it('{func_name} works correctly', function () {{",
+            "    // TODO: Implement test",
+            "    expect(true)->toBeTrue();",
+            "});",
+            "",
+        ])
+
+    # Add test cases for classes
+    for cls in classes:
+        class_name = cls.get("name", "Unknown")
+        lines.extend([
+            f"it('{class_name} initializes correctly', function () {{",
+            "    // TODO: Implement test",
+            "    expect(true)->toBeTrue();",
+            "});",
+            "",
+        ])
+
+    return "\n".join(lines)
+
+
 def generate_generic_tests(code: str, language: str, framework: str) -> str:
     """Generate generic tests for unsupported language/framework combinations."""
     return f"""# Tests générés pour {language} avec {framework}


### PR DESCRIPTION
- Ajouter "php" dans SUPPORTED_LANGUAGES dans config.py
- Ajouter "php" dans supported_languages et méthode _parse_php dans parser.py
- Ajouter détection PHP avec score dans _detect_language (<?php, $, namespace, use, ->, ::)
- Refactoriser détection langage avec dict scores et max() au lieu de if/elif
- Ajouter méthodes _extract_php_imports, _extract_php_functions, _extract_php_classes et _extract_php_variables