### PR TITLE
refactor: ajouter validation syntaxique PHP et exécution tests depuis working_dir projet

### DIFF
--- a/docker/collegue/Dockerfile
+++ b/docker/collegue/Dockerfile
@@ -26,9 +26,10 @@ WORKDIR /app
 # Création utilisateur non-root
 RUN groupadd -r collegue && useradd -r -g collegue collegue
 
-# Installation de curl pour le healthcheck
+# Installation de curl (healthcheck) et php-cli (validation syntaxique PHP)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
+    php-cli \
     && rm -rf /var/lib/apt/lists/*
 
 # Copie des dépendances depuis le builder


### PR DESCRIPTION
- Ajouter méthode _validate_php_syntax avec php -l pour valider syntaxe sans vendor/
- Modifier _validate_generated_tests pour détecter vendor/bin/<framework> PHP et exécuter depuis working_dir projet
- Ajouter fallback vers php -l quand vendor/ non disponible pour PHP
- Modifier _run_tests.py pour exécuter tests PHP depuis working_dir projet avec vendor/ et passer chemin absolu test
- Retirer variable