### PR TITLE
fix: Désactiver kc-provisioner et corriger healthcheck port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       restart_policy:
         condition: on-failure
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:4122/_health"]
+      test: ["CMD", "curl", "-f", "http://localhost:4121/_health"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -46,22 +46,24 @@ services:
     ports:
       - "4123:8080"
 
-  kc-provisioner:
-    build:
-      context: .
-      dockerfile: docker/kc-provisioner/Dockerfile
-    depends_on:
-      keycloak:
-        condition: service_started
-    environment:
-      KC_URL: http://keycloak:8080
-      KC_REALM: ${KC_REALM:-master}
-      KC_ADMIN_USERNAME: ${KEYCLOAK_ADMIN}
-      KC_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
-      PROVISION_CLIENT_ID: ${PROVISION_CLIENT_ID:-windsurf-client}
-      REQUIRED_SCOPE: ${OAUTH_REQUIRED_SCOPES:-mcp.read}
-      WAIT_FOR_CLIENT_SECONDS: ${WAIT_FOR_CLIENT_SECONDS:-600}
-    restart: "no"
+  # kc-provisioner: TEMPORAIREMENT DÉSACTIVÉ - bloquait le démarrage (client windsurf non trouvé)
+  # TODO: Réactiver après création du client OAuth dans Keycloak ou suppression si non nécessaire
+  # kc-provisioner:
+  #   build:
+  #     context: .
+  #     dockerfile: docker/kc-provisioner/Dockerfile
+  #   depends_on:
+  #     keycloak:
+  #       condition: service_started
+  #   environment:
+  #     KC_URL: http://keycloak:8080
+  #     KC_REALM: ${KC_REALM:-master}
+  #     KC_ADMIN_USERNAME: ${KEYCLOAK_ADMIN}
+  #     KC_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
+  #     PROVISION_CLIENT_ID: ${PROVISION_CLIENT_ID:-windsurf-client}
+  #     REQUIRED_SCOPE: ${OAUTH_REQUIRED_SCOPES:-mcp.read}
+  #     WAIT_FOR_CLIENT_SECONDS: ${WAIT_FOR_CLIENT_SECONDS:-600}
+  #   restart: "no"
 
   nginx:
     build:

--- a/tests/test_docker_compose_config.py
+++ b/tests/test_docker_compose_config.py
@@ -1,0 +1,114 @@
+"""
+Tests unitaires pour la configuration Docker Compose.
+Vérifie que le kc-provisioner est désactivé et que le healthcheck est correct.
+"""
+import pytest
+import yaml
+import os
+
+
+class TestDockerComposeConfig:
+    """Tests pour la configuration docker-compose.yml."""
+    
+    @pytest.fixture
+    def compose_file(self):
+        """Charge le fichier docker-compose.yml."""
+        compose_path = os.path.join(os.path.dirname(__file__), '..', 'docker-compose.yml')
+        with open(compose_path, 'r') as f:
+            return yaml.safe_load(f)
+    
+    def test_docker_compose_syntax_is_valid(self, compose_file):
+        """Test que le fichier docker-compose.yml est syntaxiquement valide."""
+        assert compose_file is not None
+        assert 'services' in compose_file
+        assert 'collegue-app' in compose_file['services']
+    
+    def test_healthcheck_port_is_correct(self, compose_file):
+        """Test que le healthcheck pointe sur le bon port (4121, pas 4122)."""
+        collegue_app = compose_file['services']['collegue-app']
+        healthcheck = collegue_app.get('healthcheck', {})
+        test_command = healthcheck.get('test', [])
+        
+        # Vérifier que la commande healthcheck existe
+        assert test_command, "Healthcheck test command not found"
+        
+        # Trouver l'URL dans la commande
+        healthcheck_url = None
+        for item in test_command:
+            if isinstance(item, str) and 'http://localhost' in item:
+                healthcheck_url = item
+                break
+        
+        assert healthcheck_url is not None, "Healthcheck URL not found in test command"
+        assert ':4121/' in healthcheck_url, f"Healthcheck should use port 4121, found: {healthcheck_url}"
+        assert ':4122/' not in healthcheck_url, f"Healthcheck should NOT use port 4122, found: {healthcheck_url}"
+    
+    def test_kc_provisioner_is_disabled(self, compose_file):
+        """Test que le service kc-provisioner est désactivé/commenté."""
+        services = compose_file.get('services', {})
+        
+        # Le service ne devrait pas être présent ou être commenté (donc pas parsé par YAML)
+        assert 'kc-provisioner' not in services, \
+            "kc-provisioner service should be disabled (commented out)"
+    
+    def test_keycloak_service_still_present(self, compose_file):
+        """Test que Keycloak est toujours présent (au cas où on veut l'utiliser plus tard)."""
+        services = compose_file.get('services', {})
+        assert 'keycloak' in services, "Keycloak service should still be present"
+        
+        keycloak = services['keycloak']
+        assert keycloak.get('image', '').startswith('quay.io/keycloak/'), \
+            "Keycloak should use the correct image"
+    
+    def test_nginx_depends_on_app(self, compose_file):
+        """Test que nginx dépend bien de collegue-app."""
+        nginx = compose_file['services'].get('nginx', {})
+        depends_on = nginx.get('depends_on', {})
+        
+        assert 'collegue-app' in depends_on, \
+            "nginx should depend on collegue-app"
+        
+        # Vérifier que la condition est bien sur le healthcheck
+        if isinstance(depends_on, dict):
+            condition = depends_on.get('collegue-app', {}).get('condition', '')
+            assert condition == 'service_healthy', \
+                f"nginx should wait for collegue-app to be healthy, got: {condition}"
+    
+    def test_collegue_app_environment_variables(self, compose_file):
+        """Test que les variables d'environnement essentielles sont présentes."""
+        collegue_app = compose_file['services']['collegue-app']
+        env = collegue_app.get('environment', {})
+        
+        required_env = ['PORT', 'MCP_TRANSPORT', 'MCP_HOST', 'PYTHONUNBUFFERED']
+        for var in required_env:
+            assert var in env, f"Required environment variable {var} not found"
+        
+        # Vérifier que le port est bien 4121 (peut être int ou string selon le parsing YAML)
+        port_value = env.get('PORT')
+        assert str(port_value) == '4121', f"PORT should be 4121, got: {port_value} (type: {type(port_value)})"
+
+
+class TestDockerComposeHealthcheckIntegration:
+    """Tests d'intégration pour le healthcheck."""
+    
+    def test_healthcheck_matches_app_port(self):
+        """Test que le port du healthcheck correspond au port exposé par l'app."""
+        compose_path = os.path.join(os.path.dirname(__file__), '..', 'docker-compose.yml')
+        
+        with open(compose_path, 'r') as f:
+            content = f.read()
+        
+        # Extraire le port du healthcheck
+        import re
+        healthcheck_match = re.search(r'http://localhost:(\d+)/_health', content)
+        assert healthcheck_match, "Could not find healthcheck URL pattern"
+        
+        healthcheck_port = int(healthcheck_match.group(1))
+        
+        # Vérifier que le port est 4121
+        assert healthcheck_port == 4121, \
+            f"Healthcheck port {healthcheck_port} should be 4121"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problèmes résolus
- kc-provisioner bloquait le démarrage Docker (attente infinie du client 'windsurf' dans Keycloak)
- Healthcheck pointait sur port 4122 au lieu de 4121

## Changements
- Commenté le service kc-provisioner dans docker-compose.yml
- Corrigé healthcheck: localhost:4121/_health
- Ajouté 7 tests unitaires pour valider la config Docker
- 13 tests pour le LazyPromptEngine (fix timeout MCP)

## Note
Keycloak reste disponible si besoin d'OAuth plus tard.

## Tests
```bash
python -m pytest tests/test_docker_compose_config.py -v
python -m pytest tests/test_mcp_init_timeout.py -v
```
✅ 20/20 tests passent