### PR TITLE
fix(nginx): Corriger la résolution DNS du backend MCP

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -7,32 +7,52 @@ events {
 
 http {
     # Résolution DNS dynamique pour les services Docker
-    # 127.0.0.11 est le résolveur DNS interne de Docker
-    resolver 127.0.0.11 ipv6=off valid=30s;
+    resolver 127.0.0.11 valid=10s;
+    resolver_timeout 5s;
+
+    # Configuration upstream pour le backend MCP
+    upstream mcp_backend {
+        server collegue-app:4121 max_fails=3 fail_timeout=30s;
+    }
+
+    # Configuration upstream pour le health server
+    upstream health_backend {
+        server collegue-app:4122 max_fails=3 fail_timeout=30s;
+    }
 
     server {
         listen 80;
         server_name beta.collegue.dev;
-        set $collegue_host collegue-app;
 
+        # Health check endpoint
         location /_health {
-            proxy_pass http://$collegue_host:4122/_health;
+            proxy_pass http://health_backend/_health;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            
+            proxy_connect_timeout 5s;
+            proxy_send_timeout 5s;
+            proxy_read_timeout 5s;
         }
 
+        # OAuth well-known endpoints
         location ^~ /.well-known/ {
-            proxy_pass http://$collegue_host:4122;
+            proxy_pass http://health_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            
+            proxy_connect_timeout 5s;
+            proxy_send_timeout 5s;
+            proxy_read_timeout 5s;
         }
         
+        # MCP endpoint - Streamable HTTP
         location /mcp/ {
-            proxy_pass http://$collegue_host:4121;
+            proxy_pass http://mcp_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -43,6 +63,10 @@ http {
             proxy_set_header Connection "";
             proxy_buffering off;
             proxy_cache off;
+            
+            # Timeouts longs pour les streams MCP
+            proxy_connect_timeout 30s;
+            proxy_send_timeout 86400s;
             proxy_read_timeout 86400s;
             
             proxy_set_header Accept-Encoding "";
@@ -57,10 +81,15 @@ http {
             proxy_temp_file_write_size 64k;
 
             proxy_set_header X-Original-URI $request_uri;
+            
+            # Gestion des erreurs temporaires
+            proxy_next_upstream error timeout http_502 http_503 http_504;
+            proxy_next_upstream_tries 3;
         }
         
+        # Catch-all pour le MCP server
         location / {
-            proxy_pass http://$collegue_host:4121;
+            proxy_pass http://mcp_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -80,6 +109,11 @@ http {
             client_body_buffer_size 16k;
             proxy_busy_buffers_size 24k;
             proxy_temp_file_write_size 64k;
+            
+            # Gestion des erreurs temporaires
+            proxy_connect_timeout 30s;
+            proxy_next_upstream error timeout http_502 http_503 http_504;
+            proxy_next_upstream_tries 3;
         }
 
         access_log /var/log/nginx/access.log;

--- a/tests/test_nginx_config.py
+++ b/tests/test_nginx_config.py
@@ -1,0 +1,56 @@
+"""
+Tests unitaires pour la configuration nginx
+"""
+import pytest
+import re
+import os
+
+
+class TestNginxConfig:
+    """Tests pour la configuration nginx."""
+    
+    @pytest.fixture
+    def nginx_conf(self):
+        """Charge le fichier nginx.conf."""
+        nginx_path = os.path.join(os.path.dirname(__file__), '..', 'docker', 'nginx', 'nginx.conf')
+        with open(nginx_path, 'r') as f:
+            return f.read()
+    
+    def test_nginx_config_exists(self):
+        """Test que le fichier nginx.conf existe."""
+        nginx_path = os.path.join(os.path.dirname(__file__), '..', 'docker', 'nginx', 'nginx.conf')
+        assert os.path.exists(nginx_path), "nginx.conf not found"
+    
+    def test_upstream_mcp_backend_defined(self, nginx_conf):
+        """Test que l'upstream mcp_backend est défini."""
+        assert 'upstream mcp_backend' in nginx_conf, "mcp_backend upstream not defined"
+        assert 'server collegue-app:4121' in nginx_conf, "collegue-app:4121 not in upstream"
+    
+    def test_upstream_health_backend_defined(self, nginx_conf):
+        """Test que l'upstream health_backend est défini."""
+        assert 'upstream health_backend' in nginx_conf, "health_backend upstream not defined"
+        assert 'server collegue-app:4122' in nginx_conf, "collegue-app:4122 not in upstream"
+    
+    def test_mcp_location_uses_upstream(self, nginx_conf):
+        """Test que le location /mcp/ utilise l'upstream."""
+        assert 'location /mcp/' in nginx_conf, "/mcp/ location not found"
+        assert 'proxy_pass http://mcp_backend' in nginx_conf, "mcp_backend not used in /mcp/ location"
+    
+    def test_health_location_uses_upstream(self, nginx_conf):
+        """Test que le location /_health utilise l'upstream health."""
+        assert 'location /_health' in nginx_conf, "/_health location not found"
+        assert 'proxy_pass http://health_backend/_health' in nginx_conf, "health_backend not used"
+    
+    def test_proxy_next_upstream_configured(self, nginx_conf):
+        """Test que proxy_next_upstream est configuré pour les erreurs."""
+        assert 'proxy_next_upstream' in nginx_conf, "proxy_next_upstream not configured"
+        assert 'http_503' in nginx_conf, "http_503 not in proxy_next_upstream"
+    
+    def test_resolver_configured(self, nginx_conf):
+        """Test que le resolver DNS est configuré."""
+        assert 'resolver' in nginx_conf, "resolver not configured"
+        assert '127.0.0.11' in nginx_conf, "Docker DNS resolver not configured"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problème
nginx retournait '503 no available server' car il ne trouvait pas le backend collegue-app. La résolution DNS avec variables ($collegue_host) ne fonctionnait pas correctement dans Docker.

## Solution
- Remplacer les variables par des blocs `upstream`
- Utiliser directement `server collegue-app:4121`
- Ajouter `proxy_next_upstream` pour gérer les erreurs temporaires
- Augmenter les timeouts de connexion

## Changements
- Refonte complète de la config nginx
- Ajout de retry automatiques sur erreur 503/504
- 7 tests unitaires pour valider la config

## Note
Suite aux merges des PR #116 et #118.