### PR TITLE
fix(docker): Ajouter réseau explicite pour la communication inter-services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       dockerfile: docker/collegue/Dockerfile
     image: collegue-app:latest
     restart: always
+    networks:
+      - collegue-network
     environment:
       PYTHONUNBUFFERED: 1
       PORT: 4121
@@ -36,6 +38,8 @@ services:
   keycloak:
     image: quay.io/keycloak/keycloak:26.3.2
     command: start-dev
+    networks:
+      - collegue-network
     environment:
       KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN}
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
@@ -70,6 +74,8 @@ services:
       context: .
       dockerfile: docker/nginx/Dockerfile
     restart: always
+    networks:
+      - collegue-network
     ports:
       - "8088:80"
     volumes:
@@ -82,6 +88,10 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+
+networks:
+  collegue-network:
+    driver: bridge
 
 volumes:
   nginx_logs:

--- a/tests/test_docker_compose_config.py
+++ b/tests/test_docker_compose_config.py
@@ -23,6 +23,13 @@ class TestDockerComposeConfig:
         assert 'services' in compose_file
         assert 'collegue-app' in compose_file['services']
     
+    def test_network_is_defined(self, compose_file):
+        """Test que le réseau collegue-network est défini."""
+        assert 'networks' in compose_file, "Networks section not found"
+        assert 'collegue-network' in compose_file['networks'], "collegue-network not defined"
+        network = compose_file['networks']['collegue-network']
+        assert network.get('driver') == 'bridge', "Network should use bridge driver"
+    
     def test_healthcheck_port_is_correct(self, compose_file):
         """Test que le healthcheck pointe sur le bon port (4122 pour health_server)."""
         collegue_app = compose_file['services']['collegue-app']
@@ -73,6 +80,18 @@ class TestDockerComposeConfig:
             condition = depends_on.get('collegue-app', {}).get('condition', '')
             assert condition == 'service_healthy', \
                 f"nginx should wait for collegue-app to be healthy, got: {condition}"
+    
+    def test_collegue_app_uses_network(self, compose_file):
+        """Test que collegue-app utilise le réseau collegue-network."""
+        collegue_app = compose_file['services']['collegue-app']
+        networks = collegue_app.get('networks', [])
+        assert 'collegue-network' in networks, "collegue-app should use collegue-network"
+    
+    def test_nginx_uses_network(self, compose_file):
+        """Test que nginx utilise le réseau collegue-network."""
+        nginx = compose_file['services'].get('nginx', {})
+        networks = nginx.get('networks', [])
+        assert 'collegue-network' in networks, "nginx should use collegue-network"
     
     def test_collegue_app_environment_variables(self, compose_file):
         """Test que les variables d'environnement essentielles sont présentes."""


### PR DESCRIPTION
## Problème
nginx retournait toujours '503 no available server' car il ne trouvait pas le backend collegue-app. Les conteneurs n'étaient pas sur le même réseau Docker.

## Solution
- Créer un réseau `collegue-network` explicite dans docker-compose.yml
- Attacher tous les services (collegue-app, nginx, keycloak) à ce réseau
- Ainsi `collegue-app` est résolvable depuis nginx via DNS Docker

## Changements
- Ajout de `networks: collegue-network` sur tous les services
- Définition du driver bridge pour le réseau
- 3 tests unitaires ajoutés pour valider la config réseau

## Note
Suite aux merges des PR précédentes (#116, #118, #119).