### PR TITLE
fix(docker): Supprimer le réseau custom pour compatibilité avec Caddy/Coolify

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
       dockerfile: docker/collegue/Dockerfile
     image: collegue-app:latest
     restart: always
-    networks:
-      - collegue-network
     environment:
       PYTHONUNBUFFERED: 1
       PORT: 4121
@@ -38,8 +36,6 @@ services:
   keycloak:
     image: quay.io/keycloak/keycloak:26.3.2
     command: start-dev
-    networks:
-      - collegue-network
     environment:
       KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN}
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
@@ -74,8 +70,6 @@ services:
       context: .
       dockerfile: docker/nginx/Dockerfile
     restart: always
-    networks:
-      - collegue-network
     ports:
       - "8088:80"
     volumes:
@@ -88,10 +82,6 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-
-networks:
-  collegue-network:
-    driver: bridge
 
 volumes:
   nginx_logs:

--- a/tests/test_docker_compose_config.py
+++ b/tests/test_docker_compose_config.py
@@ -23,12 +23,21 @@ class TestDockerComposeConfig:
         assert 'services' in compose_file
         assert 'collegue-app' in compose_file['services']
     
-    def test_network_is_defined(self, compose_file):
-        """Test que le réseau collegue-network est défini."""
-        assert 'networks' in compose_file, "Networks section not found"
-        assert 'collegue-network' in compose_file['networks'], "collegue-network not defined"
-        network = compose_file['networks']['collegue-network']
-        assert network.get('driver') == 'bridge', "Network should use bridge driver"
+    def test_no_custom_network_defined(self, compose_file):
+        """Test qu'aucun réseau custom n'est défini (utilise le réseau par défaut de Coolify)."""
+        # Pas de networks section, ou si elle existe, pas de collegue-network
+        # car Coolify gère son propre réseau et Caddy utilise {{upstreams}}
+        if 'networks' in compose_file:
+            assert 'collegue-network' not in compose_file.get('networks', {}), \
+                "collegue-network should not be defined - let Coolify manage the network"
+    
+    def test_services_use_default_network(self, compose_file):
+        """Test que les services n'ont pas de réseau explicite (utilisent le réseau par défaut)."""
+        for service_name in ['collegue-app', 'nginx', 'keycloak']:
+            service = compose_file['services'].get(service_name, {})
+            # Les services ne doivent pas avoir de networks explicitement défini
+            assert 'networks' not in service, \
+                f"{service_name} should not have explicit networks - use Coolify's default network"
     
     def test_healthcheck_port_is_correct(self, compose_file):
         """Test que le healthcheck pointe sur le bon port (4122 pour health_server)."""
@@ -80,18 +89,6 @@ class TestDockerComposeConfig:
             condition = depends_on.get('collegue-app', {}).get('condition', '')
             assert condition == 'service_healthy', \
                 f"nginx should wait for collegue-app to be healthy, got: {condition}"
-    
-    def test_collegue_app_uses_network(self, compose_file):
-        """Test que collegue-app utilise le réseau collegue-network."""
-        collegue_app = compose_file['services']['collegue-app']
-        networks = collegue_app.get('networks', [])
-        assert 'collegue-network' in networks, "collegue-app should use collegue-network"
-    
-    def test_nginx_uses_network(self, compose_file):
-        """Test que nginx utilise le réseau collegue-network."""
-        nginx = compose_file['services'].get('nginx', {})
-        networks = nginx.get('networks', [])
-        assert 'collegue-network' in networks, "nginx should use collegue-network"
     
     def test_collegue_app_environment_variables(self, compose_file):
         """Test que les variables d'environnement essentielles sont présentes."""


### PR DESCRIPTION
## Problème
Caddy (reverse proxy intégré à Coolify) utilisait `{{upstreams}}` pour résoudre automatiquement les conteneurs backend. Mais nos services étaient sur un réseau custom `collegue-network`, donc Caddy ne les trouvait pas → erreur 'no available server'.

## Solution
- Supprimer la définition explicite du réseau `collegue-network`
- Laisser Coolify gérer le réseau par défaut du projet
- Ainsi Caddy peut résoudre `collegue-app` avec `{{upstreams}}`

## Changements
- Retiré `networks: collegue-network` de tous les services
- Retiré la section `networks:` du docker-compose
- Mise à jour des tests pour refléter ce changement

## Note
Les services communiquent toujours entre eux via le réseau par défaut créé automatiquement par Docker Compose.