### PR TITLE
fix(docker): Exposer ports MCP directement - contournement Traefik

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,10 @@ services:
       dockerfile: docker/collegue/Dockerfile
     image: collegue-app:latest
     restart: always
+    # Exposer directement le port MCP pour contourner Traefik (version incompatible)
+    ports:
+      - "4121:4121"
+      - "4122:4122"
     environment:
       PYTHONUNBUFFERED: 1
       PORT: 4121

--- a/tests/test_docker_compose_config.py
+++ b/tests/test_docker_compose_config.py
@@ -90,6 +90,24 @@ class TestDockerComposeConfig:
             assert condition == 'service_healthy', \
                 f"nginx should wait for collegue-app to be healthy, got: {condition}"
     
+    def test_collegue_app_ports_exposed(self, compose_file):
+        """Test que les ports MCP sont exposés directement (contournement Traefik)."""
+        collegue_app = compose_file['services']['collegue-app']
+        ports = collegue_app.get('ports', [])
+        
+        # Vérifier que les ports sont exposés
+        port_mappings = []
+        for port in ports:
+            if isinstance(port, str):
+                port_mappings.append(port)
+            elif isinstance(port, dict):
+                port_mappings.append(f"{port.get('published')}:{port.get('target')}")
+        
+        # Port 4121 (MCP) doit être exposé
+        assert any('4121' in p for p in port_mappings), "MCP port 4121 should be exposed"
+        # Port 4122 (health) doit être exposé  
+        assert any('4122' in p for p in port_mappings), "Health port 4122 should be exposed"
+    
     def test_collegue_app_environment_variables(self, compose_file):
         """Test que les variables d'environnement essentielles sont présentes."""
         collegue_app = compose_file['services']['collegue-app']


### PR DESCRIPTION
## Problème
Traefik (reverse proxy Coolify) ne fonctionne pas à cause d'une incompatibilité de version Docker :
```
client version 1.24 is too old. Minimum supported API version is 1.44
```
Donc le routing HTTPS vers le MCP ne fonctionne pas → timeout côté client.

## Solution temporaire
Exposer directement les ports sur le host :
- Port 4121 : MCP server
- Port 4122 : Health check

## Connexion
Le client MCP peut maintenant se connecter directement à :
```
http://64.227.113.123:4121/mcp/
```

## Note
C'est une solution temporaire. Pour la production, il faudra :
- Mettre à jour Coolify/Traefik
- Ou configurer Caddy
- Ou utiliser un reverse proxy externe

## Tests
- 1 test ajouté pour vérifier l'exposition des ports