### PR TITLE
fix(core): centralisation et cohérence des timeouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,3 +61,10 @@ LLM_API_KEY="votre_clé_api_gemini"
 # WATCHDOG_INTERVAL=300
 # GITHUB_OWNER=your-username
 # GITHUB_REPO=your-repo
+
+# Performance et Timeouts
+# -----------------------
+# REQUEST_TIMEOUT=60
+# ENGINE_INIT_TIMEOUT=10.0
+# ENGINE_WAIT_TIMEOUT=30.0
+# MAX_TOKENS=8192

--- a/collegue/app.py
+++ b/collegue/app.py
@@ -114,18 +114,18 @@ class LazyPromptEngine:
         return self._initialization_task
     
     async def _initialize_with_timeout(self):
-        """Initialise le PromptEngine avec un timeout de 10 secondes."""
+        """Initialise le PromptEngine avec le timeout configuré."""
         try:
             # Utiliser to_thread pour ne pas bloquer l'event loop
             self._engine = await asyncio.wait_for(
                 asyncio.to_thread(self._create_engine),
-                timeout=10.0
+                timeout=settings.ENGINE_INIT_TIMEOUT
             )
             self._initialized = True
             elapsed = time.time() - self._init_start_time
             logger.info(f"✅ EnhancedPromptEngine initialisé en {elapsed:.2f}s")
         except asyncio.TimeoutError:
-            self._initialization_error = "Timeout après 10s lors de l'initialisation"
+            self._initialization_error = f"Timeout après {settings.ENGINE_INIT_TIMEOUT}s lors de l'initialisation"
             logger.error(f"⏱️ {self._initialization_error}")
         except Exception as e:
             self._initialization_error = str(e)
@@ -136,17 +136,20 @@ class LazyPromptEngine:
         from collegue.prompts.engine.enhanced_prompt_engine import EnhancedPromptEngine
         return EnhancedPromptEngine()
     
-    async def get_engine(self, timeout: float = 30.0):
+    async def get_engine(self, timeout: float = None):
         """
         Récupère l'engine, en attendant si nécessaire qu'il soit initialisé.
         Intègre un circuit breaker limitant le nombre de tentatives d'initialisation.
         
         Args:
-            timeout: Temps maximum d'attente en secondes
+            timeout: Temps maximum d'attente en secondes (par défaut settings.ENGINE_WAIT_TIMEOUT)
             
         Returns:
             L'instance EnhancedPromptEngine ou lève une exception si échec critique.
         """
+        if timeout is None:
+            timeout = settings.ENGINE_WAIT_TIMEOUT
+            
         if self._initialized and self._engine:
             return self._engine
             

--- a/collegue/config.py
+++ b/collegue/config.py
@@ -23,6 +23,8 @@ class Settings(BaseSettings):
 
     MAX_TOKENS: int = 8192
     REQUEST_TIMEOUT: int = 60
+    ENGINE_INIT_TIMEOUT: float = 10.0
+    ENGINE_WAIT_TIMEOUT: float = 30.0
     MAX_HISTORY_LENGTH: int = 20
     CACHE_ENABLED: bool = True
     CACHE_TTL: int = 3600

--- a/collegue/tools/base.py
+++ b/collegue/tools/base.py
@@ -178,7 +178,7 @@ class BaseTool(ABC):
             prompt_engine = kwargs.get('prompt_engine')
             # Support pour le LazyPromptEngine - attendre l'initialisation si nécessaire
             if hasattr(prompt_engine, 'get_engine'):
-                self.prompt_engine = await prompt_engine.get_engine(timeout=25.0)
+                self.prompt_engine = await prompt_engine.get_engine()
             else:
                 self.prompt_engine = prompt_engine
         if not getattr(self, 'parser', None) and kwargs.get('parser'):

--- a/tests/test_mcp_init_timeout.py
+++ b/tests/test_mcp_init_timeout.py
@@ -200,7 +200,7 @@ class TestBaseToolIntegration:
                 self.get_engine_called = False
                 self.timeout_value = None
                 
-            async def get_engine(self, timeout=30.0):
+            async def get_engine(self, timeout=None):
                 self.get_engine_called = True
                 self.timeout_value = timeout
                 return Mock()
@@ -215,7 +215,7 @@ class TestBaseToolIntegration:
         
         # Vérifier que get_engine a été appelé avec le bon timeout
         assert lazy_engine.get_engine_called is True
-        assert lazy_engine.timeout_value == 25.0
+        assert lazy_engine.timeout_value is None
         assert result.result == "ok"
     
     @pytest.mark.asyncio


### PR DESCRIPTION
Centralisation des timeouts d'initialisation du moteur de prompt dans la configuration globale (`config.py`).
- `ENGINE_INIT_TIMEOUT` (10s): pour le thread de chargement initial.
- `ENGINE_WAIT_TIMEOUT` (30s): temps d'attente maximum par défaut avant d'abandonner l'obtention de l'engine.
- Retrait des valeurs en dur (`10.0`, `30.0`, `25.0`) dans `app.py` et `tools/base.py`.
- Mise à jour des tests pour correspondre à cette nouvelle logique.