### PR TITLE
feat(core): validation stricte de la clé et modèle LLM au démarrage

### DIFF
--- a/collegue/app.py
+++ b/collegue/app.py
@@ -191,6 +191,30 @@ class LazyPromptEngine:
         return getattr(self._engine, name)
 
 
+async def validate_llm_config():
+    """Valide la clé API et le modèle configuré au lancement."""
+    if not settings.LLM_API_KEY:
+        error_msg = "❌ Configuration LLM manquante : LLM_API_KEY n'est pas définie."
+        logger.error(error_msg)
+        raise ValueError(error_msg)
+        
+    logger.info(f"🔍 Validation du modèle LLM '{settings.LLM_MODEL}' en cours...")
+    try:
+        from google import genai
+        client = genai.Client(api_key=settings.LLM_API_KEY)
+        
+        def check_model():
+            return client.models.get(model=settings.LLM_MODEL)
+            
+        model = await asyncio.to_thread(check_model)
+        logger.info(f"✅ Configuration LLM validée: Le modèle '{model.name}' est disponible.")
+        return True
+    except Exception as e:
+        error_msg = f"❌ Configuration LLM invalide (Clé API ou modèle '{settings.LLM_MODEL}' incorrect) : {str(e)}"
+        logger.error(error_msg)
+        raise ValueError(error_msg)
+
+
 @lifespan
 async def core_lifespan(server):
     from collegue.core.parser import CodeParser
@@ -198,6 +222,9 @@ async def core_lifespan(server):
 
     startup_start = time.time()
     logger.info("🔄 Démarrage du core_lifespan...")
+    
+    # Validation stricte du LLM au démarrage
+    await validate_llm_config()
 
     state = {
         "parser": CodeParser(),

--- a/tests/test_mcp_init_timeout.py
+++ b/tests/test_mcp_init_timeout.py
@@ -154,8 +154,13 @@ class TestStartupPerformance:
         mock_server = Mock()
         
         start_time = time.time()
-        async with core_lifespan(mock_server) as state:
-            startup_time = time.time() - start_time
+        with patch("collegue.app.validate_llm_config", new_callable=MagicMock) as mock_val:
+            # On simule la fonction asynchrone pour qu'elle passe sans rien faire
+            mock_val.return_value = asyncio.Future()
+            mock_val.return_value.set_result(True)
+            
+            async with core_lifespan(mock_server) as state:
+                startup_time = time.time() - start_time
             # Le lifespan doit yield en moins de 1 seconde
             assert startup_time < 1.0, f"Startup took {startup_time}s, expected < 1s"
             


### PR DESCRIPTION
Ajout d'une fonction asynchrone `validate_llm_config()` appelée dans `core_lifespan` pour valider que :
- La clé API Gemini (`LLM_API_KEY`) est bien définie.
- Le modèle spécifié (`LLM_MODEL`) est valide et joignable via l'API `google-genai`.
Cela empêche le serveur de démarrer silencieusement si les identifiants sont invalides.