### PR TITLE
fix(security): forbid extra fields in Pydantic models to prevent mass assignment

### DIFF
--- a/collegue/core/meta_orchestrator.py
+++ b/collegue/core/meta_orchestrator.py
@@ -14,22 +14,26 @@ except ImportError:
 _TOOLS_CACHE = None
 
 class OrchestratorStep(BaseModel):
+    model_config = {'extra': 'forbid'}
     tool: str = Field(..., description="Nom de l'outil à exécuter")
     reason: str = Field(..., description="Raison de l'utilisation de cet outil")
     params: Dict[str, Any] = Field(..., description="Paramètres d'appel de l'outil")
 
 class OrchestratorPlan(BaseModel):
+    model_config = {'extra': 'forbid'}
     steps: List[OrchestratorStep] = Field(..., description="Liste séquentielle des étapes à exécuter")
 
 
 
 class OrchestratorRequest(BaseModel):
+    model_config = {'extra': 'forbid'}
     query: str = Field(..., description="Requête utilisateur à traiter")
     tools: Optional[List[str]] = Field(None, description="Liste des tools à utiliser (vide = auto-détection)")
     context: Optional[Dict[str, Any]] = Field(None, description="Contexte additionnel")
 
 
 class OrchestratorResponse(BaseModel):
+    model_config = {'extra': 'forbid'}
     result: str = Field(..., description="Résultat généré par le LLM")
     tools_used: List[str] = Field(default_factory=list, description="Tools utilisés")
     execution_time: float = Field(..., description="Temps d'exécution en secondes")

--- a/collegue/core/shared.py
+++ b/collegue/core/shared.py
@@ -19,6 +19,7 @@ from . import validators as _validators
 
 
 class ConsistencyIssue(BaseModel):
+	model_config = {'extra': 'forbid'}
 	"""Issue de cohérence détectée dans le code.
 
 	Modèle Pydantic partagé entre repo_consistency_check et les analyzers.
@@ -35,6 +36,7 @@ class ConsistencyIssue(BaseModel):
 
 
 class FileInput(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Un fichier avec son chemin et contenu."""
     path: str = Field(..., description="Chemin relatif du fichier")
     content: str = Field(..., description="Contenu du fichier")

--- a/collegue/prompts/engine/models.py
+++ b/collegue/prompts/engine/models.py
@@ -18,6 +18,7 @@ class PromptVariableType(str, Enum):
     OBJECT = "object"
 
 class PromptVariable(BaseModel):
+    model_config = {'extra': 'forbid'}
     name: str
     description: str
     type: PromptVariableType = PromptVariableType.STRING
@@ -27,6 +28,7 @@ class PromptVariable(BaseModel):
     example: Optional[Any] = None
 
 class PromptTemplate(BaseModel):
+    model_config = {'extra': 'forbid'}
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     name: str
     description: str
@@ -43,6 +45,7 @@ class PromptTemplate(BaseModel):
     version: str = "1.0.0"
 
 class PromptCategory(BaseModel):
+    model_config = {'extra': 'forbid'}
     id: str
     name: str
     description: str
@@ -50,6 +53,7 @@ class PromptCategory(BaseModel):
     icon: Optional[str] = None
 
 class PromptExecution(BaseModel):
+    model_config = {'extra': 'forbid'}
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     template_id: str
     variables: Dict[str, Any]
@@ -62,6 +66,7 @@ class PromptExecution(BaseModel):
     feedback: Optional[Dict[str, Any]] = None
 
 class PromptLibrary(BaseModel):
+    model_config = {'extra': 'forbid'}
     templates: Dict[str, PromptTemplate] = {}
     categories: Dict[str, PromptCategory] = {}
     history: List[PromptExecution] = []

--- a/collegue/resources/javascript/best_practices.py
+++ b/collegue/resources/javascript/best_practices.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional, Any
 import json
 
 class JavaScriptBestPractice(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Modèle pour une bonne pratique JavaScript."""
     title: str
     description: str

--- a/collegue/resources/javascript/frameworks.py
+++ b/collegue/resources/javascript/frameworks.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional, Any
 import json
 
 class JavaScriptFrameworkReference(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Modèle pour une référence de framework JavaScript."""
     name: str
     description: str

--- a/collegue/resources/javascript/standard_library.py
+++ b/collegue/resources/javascript/standard_library.py
@@ -7,6 +7,7 @@ import json
 import os
 
 class JavaScriptAPIReference(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Modèle pour une référence d'API JavaScript."""
     name: str
     description: str

--- a/collegue/resources/llm/optimization.py
+++ b/collegue/resources/llm/optimization.py
@@ -20,6 +20,7 @@ class OptimizationStrategy(str, Enum):
     SELF_CONSISTENCY = "self_consistency"
 
 class PromptOptimization(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Modèle pour une optimisation de prompt."""
     name: str
     description: str

--- a/collegue/resources/llm/prompts.py
+++ b/collegue/resources/llm/prompts.py
@@ -12,6 +12,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class PromptTemplate(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Modèle pour un template de prompt."""
     name: str
     description: str

--- a/collegue/resources/llm/providers.py
+++ b/collegue/resources/llm/providers.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class LLMConfig(BaseModel):
+	model_config = {'extra': 'forbid'}
 	"""Configuration pour Google Gemini."""
 	model_name: str
 	api_key: Optional[str] = None
@@ -22,6 +23,7 @@ class LLMConfig(BaseModel):
 
 
 class LLMResponse(BaseModel):
+	model_config = {'extra': 'forbid'}
 	"""Réponse de Google Gemini."""
 	text: str
 	usage: Dict[str, int] = {}

--- a/collegue/resources/php/best_practices.py
+++ b/collegue/resources/php/best_practices.py
@@ -7,6 +7,7 @@ import json
 
 
 class PHPBestPractice(BaseModel):
+	model_config = {'extra': 'forbid'}
 	"""Modèle pour une bonne pratique PHP."""
 	title: str
 	description: str

--- a/collegue/resources/php/frameworks.py
+++ b/collegue/resources/php/frameworks.py
@@ -8,6 +8,7 @@ import json
 
 
 class PHPFrameworkReference(BaseModel):
+	model_config = {'extra': 'forbid'}
 	"""Modèle pour une référence de framework PHP."""
 	name: str
 	description: str

--- a/collegue/resources/php/standard_library.py
+++ b/collegue/resources/php/standard_library.py
@@ -8,6 +8,7 @@ import os
 
 
 class PHPModuleReference(BaseModel):
+	model_config = {'extra': 'forbid'}
 	"""Modèle pour une référence de module/extension PHP."""
 	name: str
 	description: str

--- a/collegue/resources/python/best_practices.py
+++ b/collegue/resources/python/best_practices.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Any
 import json
 
 class PythonBestPractice(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Modèle pour une bonne pratique Python."""
     title: str
     description: str

--- a/collegue/resources/python/frameworks.py
+++ b/collegue/resources/python/frameworks.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional, Any
 import json
 
 class PythonFrameworkReference(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Modèle pour une référence de framework Python."""
     name: str
     description: str

--- a/collegue/resources/python/standard_library.py
+++ b/collegue/resources/python/standard_library.py
@@ -7,6 +7,7 @@ import json
 import os
 
 class PythonModuleReference(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Modèle pour une référence de module Python."""
     name: str
     description: str

--- a/collegue/tools/code_documentation/models.py
+++ b/collegue/tools/code_documentation/models.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 
 
 class DocumentationRequest(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Requête pour la génération de documentation."""
     code: str = Field(..., description="Code à documenter")
     language: str = Field(..., description="Langage de programmation du code")
@@ -18,6 +19,7 @@ class DocumentationRequest(BaseModel):
 
 
 class DocumentationResponse(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Réponse de la génération de documentation."""
     documentation: str = Field(..., description="Documentation générée")
     language: str = Field(..., description="Langage du code documenté")

--- a/collegue/tools/dependency_guard/models.py
+++ b/collegue/tools/dependency_guard/models.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field, field_validator
 
 
 class DependencyIssue(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Un problème détecté sur une dépendance."""
     package: str = Field(..., description="Nom du package")
     version: Optional[str] = Field(None, description="Version concernée")
@@ -17,6 +18,7 @@ class DependencyIssue(BaseModel):
 
 
 class DependencyGuardRequest(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Requête pour la validation des dépendances."""
     content: str = Field(
         ...,
@@ -54,6 +56,7 @@ class DependencyGuardRequest(BaseModel):
 
 
 class DependencyGuardResponse(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Réponse de la validation des dépendances."""
     valid: bool = Field(..., description="True si aucune vulnérabilité critique/haute")
     summary: str = Field(..., description="Résumé de l'analyse")

--- a/collegue/tools/github_commands/branches.py
+++ b/collegue/tools/github_commands/branches.py
@@ -10,12 +10,14 @@ from ..base import ToolExecutionError
 
 
 class BranchInfo(BaseModel):
+	model_config = {'extra': 'forbid'}
 	name: str
 	commit_sha: str
 	protected: bool = False
 
 
 class CommitInfo(BaseModel):
+	model_config = {'extra': 'forbid'}
 	sha: str
 	message: str
 	author: str

--- a/collegue/tools/github_commands/issues.py
+++ b/collegue/tools/github_commands/issues.py
@@ -9,6 +9,7 @@ from ..clients import GitHubClient
 
 
 class IssueInfo(BaseModel):
+	model_config = {'extra': 'forbid'}
 	number: int
 	title: str
 	state: str

--- a/collegue/tools/github_commands/prs.py
+++ b/collegue/tools/github_commands/prs.py
@@ -9,6 +9,7 @@ from ..clients import GitHubClient
 
 
 class PRInfo(BaseModel):
+	model_config = {'extra': 'forbid'}
 	number: int
 	title: str
 	state: str
@@ -23,6 +24,7 @@ class PRInfo(BaseModel):
 
 
 class IssueInfo(BaseModel):
+	model_config = {'extra': 'forbid'}
 	number: int
 	title: str
 	state: str
@@ -38,12 +40,14 @@ class IssueInfo(BaseModel):
 
 
 class BranchInfo(BaseModel):
+	model_config = {'extra': 'forbid'}
 	name: str
 	commit: str
 	protected: bool = False
 
 
 class FileChange(BaseModel):
+	model_config = {'extra': 'forbid'}
 	filename: str
 	status: str
 	additions: int
@@ -53,6 +57,7 @@ class FileChange(BaseModel):
 
 
 class Comment(BaseModel):
+	model_config = {'extra': 'forbid'}
 	id: int
 	user: str
 	body: str

--- a/collegue/tools/github_commands/repos.py
+++ b/collegue/tools/github_commands/repos.py
@@ -9,6 +9,7 @@ from ..clients import GitHubClient
 
 
 class RepoInfo(BaseModel):
+	model_config = {'extra': 'forbid'}
 	name: str
 	full_name: str
 	description: Optional[str] = None

--- a/collegue/tools/github_commands/search.py
+++ b/collegue/tools/github_commands/search.py
@@ -9,6 +9,7 @@ from ..clients import GitHubClient
 
 
 class SearchResult(BaseModel):
+	model_config = {'extra': 'forbid'}
 	name: str
 	path: str
 	repository: str

--- a/collegue/tools/github_commands/workflows.py
+++ b/collegue/tools/github_commands/workflows.py
@@ -9,6 +9,7 @@ from ..clients import GitHubClient
 
 
 class WorkflowRun(BaseModel):
+	model_config = {'extra': 'forbid'}
 	id: int
 	name: str
 	status: str

--- a/collegue/tools/github_ops.py
+++ b/collegue/tools/github_ops.py
@@ -18,6 +18,7 @@ from ..core.shared import validate_github_command
 
 
 class GitHubRequest(BaseModel):
+    model_config = {'extra': 'forbid'}
     command: str = Field(
         ...,
         description="Commande à exécuter. IMPORTANT: list_prs/list_issues/get_repo nécessitent owner ET repo. Commandes: list_repos, get_repo, get_file, create_pr, list_prs, get_pr, create_issue, list_issues, get_issue, pr_files, pr_comments, create_branch, update_file, repo_branches, repo_commits, search_code, list_workflows"
@@ -53,6 +54,7 @@ class GitHubRequest(BaseModel):
         return validate_github_command(v)
 
 class GitHubResponse(BaseModel):
+    model_config = {'extra': 'forbid'}
     success: bool
     command: str
     message: str

--- a/collegue/tools/iac_guardrails_scan/models.py
+++ b/collegue/tools/iac_guardrails_scan/models.py
@@ -7,6 +7,7 @@ from ...core.shared import FileInput, validate_fast_deep
 
 
 class CustomPolicy(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Policy personnalisée pour le scan IaC."""
     id: str = Field(..., description="Identifiant unique de la policy")
     description: Optional[str] = Field(None, description="Description de la policy")
@@ -16,6 +17,7 @@ class CustomPolicy(BaseModel):
 
 
 class IacGuardrailsRequest(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Requête pour le scan IaC Guardrails."""
     files: List[FileInput] = Field(
         ...,
@@ -78,6 +80,7 @@ class IacGuardrailsRequest(BaseModel):
 
 
 class IacFinding(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Un finding de sécurité détecté."""
     rule_id: str = Field(..., description="Identifiant de la règle")
     severity: str = Field(..., description="Sévérité: low, medium, high, critical")
@@ -92,6 +95,7 @@ class IacFinding(BaseModel):
 
 
 class LLMSecurityInsight(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Insight généré par le LLM en mode deep analysis."""
     category: str = Field(..., description="Catégorie: vulnerability, misconfiguration, compliance, best_practice")
     insight: str = Field(..., description="L'insight détaillé")
@@ -101,6 +105,7 @@ class LLMSecurityInsight(BaseModel):
 
 
 class RemediationAction(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Action de remédiation suggérée."""
     tool_name: str = Field(..., description="Nom du tool à appeler (ex: code_refactoring)")
     action_type: str = Field(..., description="Type: fix_config, add_security, remove_exposure")
@@ -111,6 +116,7 @@ class RemediationAction(BaseModel):
 
 
 class IacGuardrailsResponse(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Réponse du scan IaC Guardrails."""
     passed: bool = Field(..., description="True si aucun problème critique/high")
     summary: Dict[str, int] = Field(

--- a/collegue/tools/impact_analysis/models.py
+++ b/collegue/tools/impact_analysis/models.py
@@ -7,6 +7,7 @@ from ...core.shared import validate_fast_deep, validate_confidence_mode
 
 
 class ImpactAnalysisRequest(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Requête pour l'analyse d'impact."""
     change_intent: str = Field(
         ...,
@@ -48,6 +49,7 @@ class ImpactAnalysisRequest(BaseModel):
 
 
 class ImpactedFile(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Fichier impacté par le changement."""
     path: str = Field(..., description="Chemin du fichier")
     reason: str = Field(..., description="Raison de l'impact")
@@ -56,6 +58,7 @@ class ImpactedFile(BaseModel):
 
 
 class RiskNote(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Note de risque identifiée."""
     category: str = Field(..., description="Catégorie: breaking_change, security, data_migration, performance, compat")
     note: str = Field(..., description="Description du risque")
@@ -64,6 +67,7 @@ class RiskNote(BaseModel):
 
 
 class SearchQuery(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Requête de recherche pour compléter l'analyse."""
     query: str = Field(..., description="Pattern de recherche")
     rationale: str = Field(..., description="Pourquoi cette recherche")
@@ -71,6 +75,7 @@ class SearchQuery(BaseModel):
 
 
 class TestRecommendation(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Recommandation de test à exécuter."""
     command: str = Field(..., description="Commande à exécuter")
     rationale: str = Field(..., description="Pourquoi ce test")
@@ -79,12 +84,14 @@ class TestRecommendation(BaseModel):
 
 
 class FollowupAction(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Action de suivi recommandée."""
     action: str = Field(..., description="Action à effectuer")
     rationale: str = Field(..., description="Pourquoi cette action")
 
 
 class LLMInsight(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Insight généré par le LLM en mode deep."""
     category: str = Field(..., description="Catégorie: semantic, architectural, business, suggestion")
     insight: str = Field(..., description="L'insight détaillé")
@@ -92,6 +99,7 @@ class LLMInsight(BaseModel):
 
 
 class ImpactAnalysisResponse(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Réponse de l'analyse d'impact."""
     change_summary: str = Field(..., description="Résumé du changement analysé")
     impacted_files: List[ImpactedFile] = Field(default_factory=list, description="Fichiers impactés")

--- a/collegue/tools/kubernetes_ops.py
+++ b/collegue/tools/kubernetes_ops.py
@@ -29,6 +29,7 @@ except ImportError:
 
 
 class KubernetesRequest(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Modèle de requête pour les opérations Kubernetes.
 
     PARAMÈTRES REQUIS PAR COMMANDE:
@@ -64,6 +65,7 @@ class KubernetesRequest(BaseModel):
         return validate_k8s_command(v)
 
 class PodInfo(BaseModel):
+    model_config = {'extra': 'forbid'}
     name: str
     namespace: str
     status: str
@@ -77,6 +79,7 @@ class PodInfo(BaseModel):
 
 
 class ContainerStatus(BaseModel):
+    model_config = {'extra': 'forbid'}
     name: str
     ready: bool
     restart_count: int
@@ -87,6 +90,7 @@ class ContainerStatus(BaseModel):
 
 
 class PodDetail(BaseModel):
+    model_config = {'extra': 'forbid'}
     name: str
     namespace: str
     status: str
@@ -101,6 +105,7 @@ class PodDetail(BaseModel):
 
 
 class DeploymentInfo(BaseModel):
+    model_config = {'extra': 'forbid'}
     name: str
     namespace: str
     replicas: str
@@ -113,6 +118,7 @@ class DeploymentInfo(BaseModel):
 
 
 class ServiceInfo(BaseModel):
+    model_config = {'extra': 'forbid'}
     name: str
     namespace: str
     type: str
@@ -124,6 +130,7 @@ class ServiceInfo(BaseModel):
 
 
 class NamespaceInfo(BaseModel):
+    model_config = {'extra': 'forbid'}
     name: str
     status: str
     age: str
@@ -131,6 +138,7 @@ class NamespaceInfo(BaseModel):
 
 
 class EventInfo(BaseModel):
+    model_config = {'extra': 'forbid'}
     name: str
     namespace: str
     type: str
@@ -144,6 +152,7 @@ class EventInfo(BaseModel):
 
 
 class NodeInfo(BaseModel):
+    model_config = {'extra': 'forbid'}
     name: str
     status: str
     roles: List[str] = []
@@ -156,6 +165,7 @@ class NodeInfo(BaseModel):
 
 
 class ConfigMapInfo(BaseModel):
+    model_config = {'extra': 'forbid'}
     name: str
     namespace: str
     data_keys: List[str] = []
@@ -163,6 +173,7 @@ class ConfigMapInfo(BaseModel):
 
 
 class SecretInfo(BaseModel):
+    model_config = {'extra': 'forbid'}
     name: str
     namespace: str
     type: str
@@ -171,6 +182,7 @@ class SecretInfo(BaseModel):
 
 
 class KubernetesResponse(BaseModel):
+    model_config = {'extra': 'forbid'}
     success: bool
     command: str
     message: str

--- a/collegue/tools/postgres_db.py
+++ b/collegue/tools/postgres_db.py
@@ -21,6 +21,7 @@ except ImportError:
 
 
 class PostgresRequest(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Modèle de requête pour les opérations PostgreSQL.
 
     PARAMÈTRES REQUIS PAR COMMANDE:
@@ -72,6 +73,7 @@ class PostgresRequest(BaseModel):
 
 
 class TableInfo(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Information sur une table."""
     name: str
     schema_name: str
@@ -81,6 +83,7 @@ class TableInfo(BaseModel):
 
 
 class ColumnInfo(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Information sur une colonne."""
     name: str
     type: str
@@ -92,6 +95,7 @@ class ColumnInfo(BaseModel):
 
 
 class IndexInfo(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Information sur un index."""
     name: str
     table: str
@@ -102,6 +106,7 @@ class IndexInfo(BaseModel):
 
 
 class ForeignKeyInfo(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Information sur une clé étrangère."""
     name: str
     table: str
@@ -111,6 +116,7 @@ class ForeignKeyInfo(BaseModel):
 
 
 class QueryResult(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Résultat d'une requête."""
     columns: List[str]
     rows: List[Dict[str, Any]]
@@ -119,6 +125,7 @@ class QueryResult(BaseModel):
 
 
 class PostgresResponse(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Modèle de réponse pour les opérations PostgreSQL."""
     success: bool
     command: str

--- a/collegue/tools/refactoring/models.py
+++ b/collegue/tools/refactoring/models.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 
 
 class RefactoringRequest(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Requête pour le refactoring de code."""
     code: str = Field(..., description="Code à refactorer")
     language: str = Field(..., description="Langage de programmation du code")
@@ -16,6 +17,7 @@ class RefactoringRequest(BaseModel):
 
 
 class RefactoringResponse(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Réponse du refactoring de code."""
     refactored_code: str = Field(..., description="Code refactoré")
     original_code: str = Field(..., description="Code original")
@@ -26,6 +28,7 @@ class RefactoringResponse(BaseModel):
 
 
 class LLMRefactoringResult(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Résultat structuré du refactoring par LLM."""
     refactored_code: str = Field(..., description="Code refactoré complet")
     changes_summary: str = Field(..., description="Résumé des changements effectués")

--- a/collegue/tools/repo_consistency_check/models.py
+++ b/collegue/tools/repo_consistency_check/models.py
@@ -7,6 +7,7 @@ from ...core.shared import validate_fast_deep
 
 
 class LLMInsight(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Insight généré par le LLM en mode deep analysis."""
     category: str = Field(..., description="Catégorie: pattern, architecture, debt, suggestion")
     insight: str = Field(..., description="L'insight détaillé")
@@ -15,6 +16,7 @@ class LLMInsight(BaseModel):
 
 
 class SuggestedAction(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Action suggérée pour corriger les problèmes."""
     tool_name: str = Field(..., description="Nom du tool à appeler (ex: code_refactoring)")
     action_type: str = Field(..., description="Type: refactor, cleanup, restructure")
@@ -25,6 +27,7 @@ class SuggestedAction(BaseModel):
 
 
 class ConsistencyCheckRequest(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Requête pour la vérification de cohérence."""
     files: List = Field(
         ...,
@@ -88,6 +91,7 @@ class ConsistencyCheckRequest(BaseModel):
 
 
 class ConsistencyCheckResponse(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Réponse de la vérification de cohérence."""
     valid: bool = Field(..., description="True si aucun problème trouvé")
     summary: Dict[str, int] = Field(

--- a/collegue/tools/secret_scan/models.py
+++ b/collegue/tools/secret_scan/models.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field, field_validator
 
 
 class SecretFinding(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Un secret détecté dans le code."""
     type: str = Field(..., description="Type de secret (api_key, password, token, etc.)")
     severity: str = Field(..., description="Sévérité: low, medium, high, critical")
@@ -18,6 +19,7 @@ class SecretFinding(BaseModel):
 
 
 class SecretScanRequest(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Requête pour le scan de secrets."""
     target: Optional[str] = Field(
         None,
@@ -82,6 +84,7 @@ class SecretScanRequest(BaseModel):
 
 
 class SecretScanResponse(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Réponse du scan de secrets."""
     clean: bool = Field(..., description="True si aucun secret trouvé")
     total_findings: int = Field(..., description="Nombre total de secrets détectés")

--- a/collegue/tools/sentry_monitor.py
+++ b/collegue/tools/sentry_monitor.py
@@ -42,6 +42,7 @@ except ImportError:
 
 
 class SentryRequest(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Modèle de requête pour les opérations Sentry.
 
     PARAMÈTRES REQUIS PAR COMMANDE:
@@ -87,6 +88,7 @@ class SentryRequest(BaseModel):
 
 
 class ConfigInfo(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Information de configuration extraite."""
     token: Optional[str] = None
     organization: Optional[str] = None
@@ -95,6 +97,7 @@ class ConfigInfo(BaseModel):
 
 
 class RepoInfo(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Information sur un repository Sentry (intégration)."""
     id: str
     name: str
@@ -104,6 +107,7 @@ class RepoInfo(BaseModel):
 
 
 class ProjectInfo(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Information sur un projet Sentry."""
     id: str
     slug: str
@@ -114,6 +118,7 @@ class ProjectInfo(BaseModel):
     organization: Optional[Dict[str, Any]] = None
 
 class IssueInfo(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Information sur une issue Sentry."""
     id: str
     short_id: str
@@ -131,6 +136,7 @@ class IssueInfo(BaseModel):
 
 
 class EventInfo(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Information sur un événement/stacktrace."""
     event_id: str
     title: str
@@ -145,6 +151,7 @@ class EventInfo(BaseModel):
 
 
 class ReleaseInfo(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Information sur une release."""
     version: str
     short_version: str
@@ -156,6 +163,7 @@ class ReleaseInfo(BaseModel):
 
 
 class ProjectStats(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Statistiques d'un projet."""
     project: str
     total_events: int = 0
@@ -166,6 +174,7 @@ class ProjectStats(BaseModel):
 
 
 class TagDistribution(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Distribution d'un tag."""
     key: str
     name: str
@@ -173,6 +182,7 @@ class TagDistribution(BaseModel):
 
 
 class SentryResponse(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Modèle de réponse pour les opérations Sentry."""
     success: bool
     command: str

--- a/collegue/tools/test_generation/models.py
+++ b/collegue/tools/test_generation/models.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field, field_validator
 
 
 class TestGenerationRequest(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Requête pour la génération de tests."""
     __test__ = False
     
@@ -32,6 +33,7 @@ class TestGenerationRequest(BaseModel):
 
 
 class TestGenerationResponse(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Réponse de la génération de tests."""
     __test__ = False
     
@@ -44,6 +46,7 @@ class TestGenerationResponse(BaseModel):
 
 
 class LLMTestGenerationResult(BaseModel):
+    model_config = {'extra': 'forbid'}
     """Résultat structuré de la génération de tests par LLM."""
     test_code: str = Field(..., description="Code de test complet et exécutable")
     test_count: int = Field(..., description="Nombre de tests générés")

--- a/patch.py
+++ b/patch.py
@@ -1,0 +1,65 @@
+import os
+import re
+
+def patch_file(filepath):
+    with open(filepath, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    # We only want to patch files that define a BaseModel subclass
+    if 'BaseModel' not in content:
+        return
+
+    lines = content.split('\n')
+    out_lines = []
+    i = 0
+    in_docstring = False
+
+    while i < len(lines):
+        line = lines[i]
+        out_lines.append(line)
+        
+        # We need to make sure we don't accidentally patch a class inside a docstring.
+        # Simple heuristic: if we are in a blockquote or docstring, skip
+        if '"""' in line or "'''" in line:
+            # Count occurrences of """ or ''' to toggle state if needed
+            # For simplicity, we just skip checking for class definition on lines with docstring quotes.
+            pass
+            
+        m = re.match(r'^(\s*)class\s+[A-Za-z0-9_]+\s*\([^)]*BaseModel[^)]*\):', line)
+        
+        # Check if the next few lines are a docstring.
+        if m:
+            indent = m.group(1)
+            # Find body indentation
+            j = i + 1
+            body_indent = None
+            while j < len(lines):
+                next_line = lines[j]
+                if next_line.strip() and not next_line.strip().startswith('#'):
+                    indent_match = re.match(r'^(\s+)', next_line)
+                    if indent_match:
+                        body_indent = indent_match.group(1)
+                    break
+                j += 1
+            
+            if body_indent is None:
+                body_indent = indent + "    "
+            
+            # Simple check to avoid patching classes inside docstrings: 
+            # Check if this class definition starts at column 0. Most of our classes do.
+            if indent == '' or indent == '\t' or indent == '    ':
+                out_lines.append(body_indent + "model_config = {'extra': 'forbid'}")
+            
+        i += 1
+
+    new_content = '\n'.join(out_lines)
+    if new_content != content:
+        with open(filepath, 'w', encoding='utf-8') as f:
+            f.write(new_content)
+        print(f"Patched {filepath}")
+
+if __name__ == "__main__":
+    for root, dirs, files in os.walk('collegue'):
+        for file in files:
+            if file.endswith('.py'):
+                patch_file(os.path.join(root, file))


### PR DESCRIPTION
Fixes #173

This PR adds `model_config = {\"extra\": \"forbid\"}` to all Pydantic models inheriting from `BaseModel` to prevent Mass Assignment vulnerabilities, as requested in issue #173.