### PR TITLE
fix(security): prevent SSRF in SentryClient and command injection in KubernetesClient

### DIFF
--- a/collegue/tools/clients/kubernetes.py
+++ b/collegue/tools/clients/kubernetes.py
@@ -47,6 +47,16 @@ class KubernetesClient:
     def _run_kubectl(self, command: List[str]) -> APIResponse:
         import subprocess
 
+        # Validation stricte des arguments
+        if not all(isinstance(arg, str) for arg in command):
+            raise ValueError("Command arguments must be strings")
+        
+        # Sanitization - rejeter les caractères dangereux
+        dangerous_chars = [';', '&', '|', '$', '`', '\n']
+        for arg in command:
+            if any(char in arg for char in dangerous_chars):
+                raise ValueError(f"Dangerous character detected in argument: {arg}")
+
         args = self._get_kubectl_args() + command
 
         try:

--- a/collegue/tools/clients/sentry.py
+++ b/collegue/tools/clients/sentry.py
@@ -4,6 +4,7 @@ Sentry API client for error tracking operations.
 Provides access to Sentry API for listing projects, issues, and releases.
 """
 import os
+import re
 from typing import Dict, Optional
 from .base import APIClient, APIResponse, APIError
 
@@ -22,12 +23,29 @@ class SentryClient(APIClient):
             raise APIError("Sentry token required. Provide token or set SENTRY_AUTH_TOKEN env var.")
 
         self.organization = organization or os.environ.get('SENTRY_ORG', '')
+        if self.organization:
+            self._validate_slug(self.organization, "organization")
 
         super().__init__(
             base_url=f"{base_url}/api/0",
             auth_token=auth_token,
             **kwargs
         )
+
+    def _validate_slug(self, value: str, param_name: str) -> None:
+        """
+        Validate Sentry slugs (org, project, issue_id) to prevent SSRF/Path Traversal.
+        Allow alphanumeric, dash, underscore.
+        """
+        if not value:
+            return
+            
+        # Sentry slugs are typically lowercase alphanumeric + dashes. 
+        # Issue IDs are numeric but treated as strings.
+        # We allow a bit more flexibility but forbid dangerous chars.
+        # STRICT ALLOWLIST: ^[a-zA-Z0-9_\-]+$
+        if not re.match(r'^[a-zA-Z0-9_\-]+$', value):
+            raise APIError(f"Invalid characters in {param_name}: '{value}'. Suspected path traversal attack.")
 
     def _get_auth_header(self) -> Dict[str, str]:
         return {"Authorization": f"Bearer {self.auth_token}"}
@@ -56,6 +74,7 @@ class SentryClient(APIClient):
             )
 
         if project:
+            self._validate_slug(project, "project")
             endpoint = f"projects/{self.organization}/{project}/issues/"
         else:
             endpoint = f"organizations/{self.organization}/issues/"
@@ -67,10 +86,12 @@ class SentryClient(APIClient):
         return self._get(endpoint, params=params)
 
     def get_issue(self, issue_id: str) -> APIResponse:
+        self._validate_slug(issue_id, "issue_id")
         endpoint = f"issues/{issue_id}/"
         return self._get(endpoint)
 
     def get_issue_events(self, issue_id: str, limit: int = 100) -> APIResponse:
+        self._validate_slug(issue_id, "issue_id")
         endpoint = f"issues/{issue_id}/events/"
         return self._get(endpoint, params={"limit": limit, "full": "true"})
 
@@ -86,6 +107,7 @@ class SentryClient(APIClient):
             )
 
         if project:
+            self._validate_slug(project, "project")
             endpoint = f"projects/{self.organization}/{project}/releases/"
         else:
             endpoint = f"organizations/{self.organization}/releases/"
@@ -119,6 +141,7 @@ class SentryClient(APIClient):
             )
 
     def get_issue_tags(self, issue_id: str) -> APIResponse:
+        self._validate_slug(issue_id, "issue_id")
         endpoint = f"issues/{issue_id}/tags/"
         return self._get(endpoint)
 
@@ -128,6 +151,7 @@ class SentryClient(APIClient):
                 success=False,
                 error_message="Organization slug required"
             )
+        self._validate_slug(project_slug, "project_slug")
         endpoint = f"projects/{self.organization}/{project_slug}/"
         return self._get(endpoint)
 
@@ -150,6 +174,8 @@ class SentryClient(APIClient):
                 success=False,
                 error_message="Organization slug required"
             )
+        
+        self._validate_slug(project, "project")
             
         stat_periods = {
             '1h': '1h', '24h': '1d', '7d': '1d', '14d': '1d', '30d': '1d'

--- a/tests/test_kubernetes_injection.py
+++ b/tests/test_kubernetes_injection.py
@@ -1,0 +1,25 @@
+import pytest
+from collegue.tools.clients.kubernetes import KubernetesClient
+
+def test_kubernetes_client_command_injection():
+    client = KubernetesClient()
+    
+    # Validation stricte des arguments - ne doit pas lever d'erreur pour une commande valide
+    try:
+        client._run_kubectl(["get", "pods"])
+    except FileNotFoundError:
+        # Expected if kubectl is not installed, which is fine for this test
+        pass
+    except Exception as e:
+        if "kubectl not found" not in str(e):
+            raise
+    
+    # Injection via caractère dangereux
+    with pytest.raises(ValueError, match="Dangerous character detected in argument"):
+        client._run_kubectl(["get", "pods; rm -rf /"])
+        
+    with pytest.raises(ValueError, match="Dangerous character detected in argument"):
+        client._run_kubectl(["get", "pods", "--namespace=default&echo 'PWNED'"])
+        
+    with pytest.raises(ValueError, match="Command arguments must be strings"):
+        client._run_kubectl(["get", 123])

--- a/tests/test_sentry_security.py
+++ b/tests/test_sentry_security.py
@@ -1,0 +1,42 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from collegue.tools.clients.sentry import SentryClient
+from collegue.tools.clients.base import APIError
+
+class TestSentrySecurity:
+    
+    @pytest.fixture
+    def client(self):
+        return SentryClient(token="fake", organization="org")
+
+    def test_list_issues_path_traversal(self, client):
+        """Test that list_issues rejects path traversal in project."""
+        with pytest.raises(APIError, match="Invalid characters in project"):
+            client.list_issues(project="../../etc/passwd")
+
+    def test_get_issue_path_traversal(self, client):
+        """Test that get_issue rejects path traversal in issue_id."""
+        with pytest.raises(APIError, match="Invalid characters in issue_id"):
+            client.get_issue(issue_id="../123")
+
+    def test_get_project_path_traversal(self, client):
+        """Test that get_project rejects path traversal in project_slug."""
+        with pytest.raises(APIError, match="Invalid characters in project_slug"):
+            client.get_project(project_slug="; drop table")
+
+    def test_list_releases_path_traversal(self, client):
+        """Test that list_releases rejects path traversal in project."""
+        with pytest.raises(APIError, match="Invalid characters in project"):
+            client.list_releases(project="valid/../../invalid")
+
+    def test_valid_slugs(self, client):
+        """Test that valid slugs are accepted."""
+        # We mock _get to avoid making actual requests
+        with patch.object(client, '_get') as mock_get:
+            mock_get.return_value = MagicMock(success=True)
+            
+            # These should not raise exceptions
+            client.list_issues(project="my-project")
+            client.list_issues(project="my_project_123")
+            client.get_issue(issue_id="123456")
+            client.get_project(project_slug="valid-slug")


### PR DESCRIPTION
Fixes #148

This PR addresses two critical security vulnerabilities:

## 1. SSRF in SentryClient (Issue #148)
- Added `_validate_slug()` method to validate Sentry slugs (organization, project, issue_id)
- Prevents path traversal attacks like `../../../../internal/api`
- Validates against whitelist pattern: `[a-zA-Z0-9_-]+`

## 2. Command Injection in KubernetesClient
- Added input validation in `_run_kubectl()` to detect dangerous shell characters
- Rejects commands containing `;`, `&`, `|`, `$`, `` ` ``, `
`

## Tests
- Added `tests/test_sentry_security.py` with 5 security test cases
- Added `tests/test_kubernetes_injection.py` for command injection tests
- All tests pass ✅