### PR TITLE
fix(security): prevent TOCTOU and symlink attacks in file operations

### DIFF
--- a/collegue/core/file_security.py
+++ b/collegue/core/file_security.py
@@ -1,0 +1,135 @@
+"""
+Utilitaires de lecture de fichiers sécurisés.
+
+Ce module fournit des fonctions pour lire des fichiers en toute sécurité,
+protégées contre les attaques TOCTOU, les symlinks et les traversées de chemin.
+"""
+import os
+import fcntl
+from typing import Optional
+
+
+class FileSecurityError(Exception):
+    """Exception levée lors d'une violation de sécurité fichier."""
+    pass
+
+
+def safe_read_file(filepath: str, max_size: int, base_dir: Optional[str] = None) -> str:
+    """
+    Lit un fichier de manière sécurisée en préservant contre les attaques TOCTOU.
+    
+    Protection implémentée:
+    - Vérifie que le fichier est dans le répertoire de base autorisé (si spécifié)
+    - Bloque les symlinks (O_NOFOLLOW)
+    - Vérifie que c'est un fichier régulier (pas un device, fifo, etc.)
+    - Vérifie la taille via le file descriptor (pas de race condition)
+    - Utilise un verrou partagé pendant la lecture
+    
+    Args:
+        filepath: Chemin du fichier à lire
+        max_size: Taille maximale autorisée en octets
+        base_dir: Répertoire de base autorisé (pour éviter la traversée de chemin)
+        
+    Returns:
+        Contenu du fichier en tant que chaîne
+        
+    Raises:
+        FileSecurityError: Si une violation de sécurité est détectée
+        OSError: Si le fichier ne peut pas être ouvert ou lu
+    """
+    # Vérification du chemin canonique si un répertoire de base est spécifié
+    if base_dir is not None:
+        real_path = os.path.realpath(filepath)
+        base_path = os.path.realpath(base_dir)
+        
+        # Vérifier que le fichier est bien dans le répertoire autorisé
+        if not real_path.startswith(base_path + os.sep) and real_path != base_path:
+            raise FileSecurityError(f'Path traversal detected: {filepath} is outside {base_dir}')
+    
+    # Ouvrir le fichier avec O_NOFOLLOW pour bloquer les symlinks
+    try:
+        fd = os.open(filepath, os.O_RDONLY | os.O_NOFOLLOW)
+    except OSError as e:
+        if e.errno == 40:  # ELOOP - trop de niveaux de liens symboliques
+            raise FileSecurityError(f'Symlink detected and blocked: {filepath}')
+        raise
+    
+    try:
+        # Vérifier les stats via le file descriptor (pas de race condition)
+        stat_info = os.fstat(fd)
+        
+        # Vérifier que c'est un fichier régulier
+        if not os.path.isfile(fd):
+            raise FileSecurityError(f'Not a regular file: {filepath}')
+        
+        # Vérifier la taille via le file descriptor (TOCTOU-safe)
+        if stat_info.st_size > max_size:
+            raise FileSecurityError(f'File too large: {stat_info.st_size} bytes (max: {max_size})')
+        
+        # Vérifier que le fichier n'est pas un symlink (double vérification)
+        # os.O_NOFOLLOW devrait déjà bloquer, mais on vérifie quand même
+        try:
+            if os.path.islink(filepath):
+                raise FileSecurityError(f'Symlink detected: {filepath}')
+        except OSError:
+            pass  # Si le fichier a été supprimé entre-temps, on continuera avec le fd
+        
+        # Lire le contenu avec verrouillage partagé
+        with os.fdopen(fd, 'r', encoding='utf-8', errors='ignore') as f:
+            # Verrouiller le fichier pendant la lecture (optionnel, mais plus sûr)
+            try:
+                fcntl.flock(f.fileno(), fcntl.LOCK_SH)
+                content = f.read(max_size + 1)  # Lire un octet de plus pour vérifier
+                
+                # Vérifier si le fichier a été modifié pendant la lecture
+                current_stat = os.fstat(f.fileno())
+                if current_stat.st_size != stat_info.st_size:
+                    raise FileSecurityError(f'File size changed during read: {filepath}')
+                
+                return content[:max_size]  # Tronquer si nécessaire
+            finally:
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+    except:
+        os.close(fd)
+        raise
+
+
+def safe_getsize(filepath: str, base_dir: Optional[str] = None) -> int:
+    """
+    Obtient la taille d'un fichier de manière sécurisée.
+    
+    Args:
+        filepath: Chemin du fichier
+        base_dir: Répertoire de base autorisé
+        
+    Returns:
+        Taille du fichier en octets
+        
+    Raises:
+        FileSecurityError: Si une violation de sécurité est détectée
+    """
+    # Vérification du chemin canonique
+    if base_dir is not None:
+        real_path = os.path.realpath(filepath)
+        base_path = os.path.realpath(base_dir)
+        
+        if not real_path.startswith(base_path + os.sep) and real_path != base_path:
+            raise FileSecurityError(f'Path traversal detected: {filepath}')
+    
+    # Ouvrir et vérifier via file descriptor
+    try:
+        fd = os.open(filepath, os.O_RDONLY | os.O_NOFOLLOW)
+    except OSError as e:
+        if e.errno == 40:
+            raise FileSecurityError(f'Symlink detected and blocked: {filepath}')
+        raise
+    
+    try:
+        stat_info = os.fstat(fd)
+        
+        if not os.path.isfile(fd):
+            raise FileSecurityError(f'Not a regular file: {filepath}')
+        
+        return stat_info.st_size
+    finally:
+        os.close(fd)

--- a/collegue/tools/secret_scan/engine.py
+++ b/collegue/tools/secret_scan/engine.py
@@ -10,6 +10,7 @@ import fnmatch
 from typing import List, Optional, Tuple
 from .models import SecretFinding
 from .config import SECRET_PATTERNS, SEVERITY_LEVELS, SECRET_RECOMMENDATIONS, DEFAULT_EXTENSIONS, DEFAULT_EXCLUDES
+from ...core.file_security import safe_read_file, FileSecurityError
 
 
 class SecretDetectionEngine:
@@ -107,15 +108,14 @@ class SecretDetectionEngine:
                  max_size: int) -> List[SecretFinding]:
         """Scanne un fichier pour trouver des secrets."""
         try:
-            if os.path.getsize(filepath) > max_size:
-                if self.logger:
-                    self.logger.debug(f"Fichier ignoré (trop grand): {filepath}")
-                return []
-            
-            with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
-                content = f.read()
-            
+            # Utiliser safe_read_file pour éviter les attaques TOCTOU et symlinks
+            content = safe_read_file(filepath, max_size)
             return self.scan_content(content, filepath, severity_threshold)
+        except FileSecurityError as e:
+            # Log les violations de sécurité au niveau warning
+            if self.logger:
+                self.logger.warning(f"Security violation for {filepath}: {e}")
+            return []
         except Exception as e:
             if self.logger:
                 self.logger.warning(f"Erreur lecture {filepath}: {e}")

--- a/tests/test_file_security.py
+++ b/tests/test_file_security.py
@@ -1,0 +1,101 @@
+"""
+Tests unitaires pour les utilitaires de sécurité fichier.
+"""
+import pytest
+import os
+import tempfile
+import fcntl
+from unittest.mock import patch, MagicMock
+from collegue.core.file_security import safe_read_file, safe_getsize, FileSecurityError
+
+
+class TestFileSecurity:
+    
+    def test_safe_read_file_success(self):
+        """Test la lecture normale d'un fichier."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+            f.write("Hello, World!")
+            temp_path = f.name
+        
+        try:
+            content = safe_read_file(temp_path, max_size=1024)
+            assert content == "Hello, World!"
+        finally:
+            os.unlink(temp_path)
+    
+    def test_safe_read_file_size_limit(self):
+        """Test que les fichiers trop grands sont rejetés."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+            f.write("A" * 1000)
+            temp_path = f.name
+        
+        try:
+            with pytest.raises(FileSecurityError, match="File too large"):
+                safe_read_file(temp_path, max_size=100)
+        finally:
+            os.unlink(temp_path)
+    
+    def test_safe_read_file_symlink_blocked(self):
+        """Test que les symlinks sont bloqués."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+            f.write("secret content")
+            real_file = f.name
+        
+        # Créer un symlink vers le fichier
+        symlink_path = real_file + "_link"
+        os.symlink(real_file, symlink_path)
+        
+        try:
+            with pytest.raises(FileSecurityError, match="Symlink"):
+                safe_read_file(symlink_path, max_size=1024)
+        finally:
+            os.unlink(symlink_path)
+            os.unlink(real_file)
+    
+    def test_safe_read_file_path_traversal(self):
+        """Test que la traversée de chemin est détectée."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Créer un fichier dans le répertoire temporaire
+            safe_file = os.path.join(tmpdir, "safe.txt")
+            with open(safe_file, 'w') as f:
+                f.write("safe content")
+            
+            # Essayer de lire un fichier en dehors du répertoire
+            outside_file = "/etc/passwd"
+            if os.path.exists(outside_file):
+                with pytest.raises(FileSecurityError, match="Path traversal"):
+                    safe_read_file(outside_file, max_size=1024, base_dir=tmpdir)
+    
+    def test_safe_read_file_not_regular_file(self):
+        """Test que les non-fichiers (répertoires) sont rejetés."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pytest.raises(FileSecurityError, match="Not a regular file"):
+                safe_read_file(tmpdir, max_size=1024)
+    
+    def test_safe_getsize_success(self):
+        """Test l'obtention de la taille d'un fichier."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+            f.write("Hello")
+            temp_path = f.name
+        
+        try:
+            size = safe_getsize(temp_path)
+            assert size == 5
+        finally:
+            os.unlink(temp_path)
+    
+    def test_safe_getsize_symlink_blocked(self):
+        """Test que safe_getsize bloque les symlinks."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+            f.write("content")
+            real_file = f.name
+        
+        symlink_path = real_file + "_link"
+        os.symlink(real_file, symlink_path)
+        
+        try:
+            with pytest.raises(FileSecurityError, match="Symlink"):
+                safe_getsize(symlink_path)
+        finally:
+            os.unlink(symlink_path)
+            os.unlink(real_file)


### PR DESCRIPTION
Fixes #165

This PR fixes Time-of-Check to Time-of-Use (TOCTOU) vulnerabilities and symlink attacks in file operations.

## Problem
The `scan_file()` method in secret_scan/engine.py was vulnerable to TOCTOU attacks:
- `os.path.getsize()` was called before `open()`, creating a race condition window
- An attacker could replace the file with a symlink between the check and use
- This could allow reading arbitrary files (e.g., `/etc/passwd`)

## Solution

### 1. New file_security module (`collegue/core/file_security.py`)
- `safe_read_file()`: Reads files securely with TOCTOU protection
  - Uses `O_NOFOLLOW` to block symlinks at the OS level
  - Checks file type and size via file descriptor (atomic)
  - Adds file locking during reads
  - Validates paths against directory traversal
- `safe_getsize()`: Securely gets file size with symlink protection

### 2. Updated secret_scan/engine.py
- Replaced vulnerable `os.path.getsize()` + `open()` pattern
- Now uses `safe_read_file()` for all file reads
- Logs security violations appropriately

### 3. Security Features
- **Symlink protection**: `O_NOFOLLOW` blocks all symlink attacks
- **TOCTOU protection**: All checks done via file descriptor after open
- **Path traversal protection**: Optional `base_dir` validation
- **File locking**: Shared locks prevent race conditions during reads
- **Regular file verification**: Rejects devices, FIFOs, etc.

### 4. Tests
- Added `tests/test_file_security.py` with 7 comprehensive tests
- Tests cover: normal reads, size limits, symlinks, path traversal, non-regular files
- All tests pass ✅

## Security Impact
- Prevents symlink attacks that could read arbitrary files
- Eliminates TOCTOU race conditions
- Protects against directory traversal attacks