### PR TITLE
fix(tools): syntax error in try/except block

### DIFF
--- a/collegue/tools/base.py
+++ b/collegue/tools/base.py
@@ -104,7 +104,6 @@ class BaseTool(ABC):
 
                 self.logger.info(f"Prompt préparé avec version {version} pour {tool_name}")
                 return prompt
-
             except Exception as e:
                 self.logger.warning(f"Erreur lors de la préparation du prompt optimisé: {e}")
                 if hasattr(self, '_build_prompt'):


### PR DESCRIPTION
Fixes a syntax error caused by an empty line before the except block.