### PR TITLE
🔧 Fix: Fuites mémoire sur les sessions longues (#141)

### DIFF
--- a/collegue/core/memory_manager.py
+++ b/collegue/core/memory_manager.py
@@ -5,16 +5,12 @@ Fournit des utilitaires pour surveiller et nettoyer la mémoire,
 prévenant les fuites sur les sessions longues.
 """
 import gc
-import sys
 import weakref
 import logging
-from typing import Any, Dict, Optional, Callable, List
-from dataclasses import dataclass, field
+import time
+from typing import Any, Dict, Optional, Callable, List, Iterator, Tuple
+from dataclasses import dataclass
 from collections import deque
-
-
-# Logger pour le module
-logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -53,9 +49,17 @@ class MemoryManager:
             obj_id: Identifiant unique de l'objet
             obj: Objet à suivre
         """
+        # Capturer l'ID dans la closure
+        captured_id = obj_id
+        
         def on_delete(ref):
-            self._stats.cleaned_objects += 1
-            self._logger.debug(f"Object {obj_id} garbage collected")
+            # Supprimer l'entrée du dict quand l'objet est garbage collecté
+            try:
+                if captured_id in self._tracked_objects:
+                    del self._tracked_objects[captured_id]
+                    self._stats.tracked_objects = len(self._tracked_objects)
+            except KeyError:
+                pass  # Déjà supprimé
         
         self._tracked_objects[obj_id] = weakref.ref(obj, on_delete)
         self._stats.tracked_objects = len(self._tracked_objects)
@@ -92,6 +96,10 @@ class MemoryManager:
             except Exception as e:
                 self._logger.warning(f"Cleanup callback failed: {e}")
         
+        # Forcer le garbage collection si demandé (pour mettre à jour les weakrefs)
+        if force:
+            gc.collect()
+        
         # Nettoyer les références faibles mortes
         dead_refs = [
             obj_id for obj_id, ref in self._tracked_objects.items()
@@ -100,12 +108,7 @@ class MemoryManager:
         for obj_id in dead_refs:
             del self._tracked_objects[obj_id]
         
-        # Forcer le garbage collection si demandé
-        if force:
-            gc.collect()
-        
         cleaned = len(dead_refs)
-        self._stats.cleaned_objects += cleaned
         self._stats.tracked_objects = len(self._tracked_objects)
         
         if cleaned > 0:
@@ -185,6 +188,7 @@ class TTLCache:
     Cache avec expiration automatique (TTL).
     
     Les entrées expirent après un certain temps et sont automatiquement nettoyées.
+    Implémente l'interface Mapping pour être compatible avec les opérations dict-like.
     """
     
     def __init__(self, max_size: int = 100, ttl_seconds: float = 3600, name: str = "cache"):
@@ -197,7 +201,6 @@ class TTLCache:
     
     def _is_expired(self, key: str) -> bool:
         """Vérifie si une entrée est expirée."""
-        import time
         if key not in self._timestamps:
             return True
         return time.time() - self._timestamps[key] > self.ttl_seconds
@@ -237,8 +240,6 @@ class TTLCache:
     
     def set(self, key: str, value: Any) -> None:
         """Stocke une valeur dans le cache."""
-        import time
-        
         # Nettoyer si nécessaire avant d'ajouter
         if len(self._cache) >= self.max_size:
             self._cleanup_expired()
@@ -258,9 +259,41 @@ class TTLCache:
         self._timestamps.clear()
         self._logger.info(f"Cache {self.name} cleared")
     
+    def items(self) -> Iterator[Tuple[str, Any]]:
+        """Retourne un itérateur sur les paires (clé, valeur) non expirées."""
+        self._cleanup_expired()
+        return iter(list(self._cache.items()))
+    
+    def keys(self) -> Iterator[str]:
+        """Retourne un itérateur sur les clés non expirées."""
+        self._cleanup_expired()
+        return iter(list(self._cache.keys()))
+    
+    def values(self) -> Iterator[Any]:
+        """Retourne un itérateur sur les valeurs non expirées."""
+        self._cleanup_expired()
+        return iter(list(self._cache.values()))
+    
+    def __getitem__(self, key: str) -> Any:
+        """Permet l'accès par index : cache[key]"""
+        result = self.get(key)
+        if result is None and key not in self._cache:
+            raise KeyError(key)
+        return result
+    
+    def __contains__(self, key: str) -> bool:
+        """Permet l'opérateur 'in' : key in cache"""
+        self._cleanup_expired()
+        return key in self._cache and not self._is_expired(key)
+    
     def __len__(self) -> int:
         self._cleanup_expired()
         return len(self._cache)
+    
+    def __iter__(self) -> Iterator[str]:
+        """Permet d'itérer sur les clés : for key in cache"""
+        self._cleanup_expired()
+        return iter(list(self._cache.keys()))
 
 
 # Instance globale du gestionnaire de mémoire
@@ -284,8 +317,5 @@ def cleanup_all() -> int:
     """
     manager = get_memory_manager()
     cleaned = manager.cleanup(force=True)
-    
-    # Forcer le garbage collection Python
-    gc.collect()
     
     return cleaned

--- a/collegue/core/memory_manager.py
+++ b/collegue/core/memory_manager.py
@@ -54,6 +54,9 @@ class MemoryManager:
         Args:
             obj_id: Identifiant unique de l'objet
             obj: Objet à suivre
+
+        Raises:
+            ValueError: Si un objet avec le même ID est déjà suivi
         """
         # Capturer l'ID dans la closure
         captured_id = obj_id
@@ -62,13 +65,23 @@ class MemoryManager:
             # Supprimer l'entrée du dict quand l'objet est garbage collecté
             with self._lock:
                 try:
+                    # Vérifier que l'entrée correspond toujours à cette weakref
+                    # pour éviter de supprimer un nouvel objet tracké avec le même ID
                     if captured_id in self._tracked_objects:
-                        del self._tracked_objects[captured_id]
-                        self._stats.tracked_objects = len(self._tracked_objects)
+                        existing_ref = self._tracked_objects[captured_id]
+                        if existing_ref is ref or existing_ref() is None:
+                            del self._tracked_objects[captured_id]
+                            self._stats.tracked_objects = len(self._tracked_objects)
                 except KeyError:
                     pass  # Déjà supprimé
 
         with self._lock:
+            # Refuser les doublons pour éviter les problèmes de callback
+            if obj_id in self._tracked_objects:
+                existing_ref = self._tracked_objects[obj_id]
+                if existing_ref() is not None:
+                    raise ValueError(f"Object with ID '{obj_id}' is already tracked")
+                # L'ancienne entrée est morte, on peut la remplacer
             self._tracked_objects[obj_id] = weakref.ref(obj, on_delete)
             self._stats.tracked_objects = len(self._tracked_objects)
 
@@ -82,11 +95,13 @@ class MemoryManager:
     def register_cleanup_callback(self, callback: Callable) -> None:
         """
         Enregistre une fonction de nettoyage à appeler périodiquement.
-        
+        Thread-safe via verrou interne.
+
         Args:
             callback: Fonction à appeler lors du nettoyage
         """
-        self._cleanup_callbacks.append(callback)
+        with self._lock:
+            self._cleanup_callbacks.append(callback)
     
     def cleanup(self, force: bool = False) -> int:
         """

--- a/collegue/core/memory_manager.py
+++ b/collegue/core/memory_manager.py
@@ -1,0 +1,291 @@
+"""
+Gestionnaire de mémoire pour Collègue.
+
+Fournit des utilitaires pour surveiller et nettoyer la mémoire,
+prévenant les fuites sur les sessions longues.
+"""
+import gc
+import sys
+import weakref
+import logging
+from typing import Any, Dict, Optional, Callable, List
+from dataclasses import dataclass, field
+from collections import deque
+
+
+# Logger pour le module
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MemoryStats:
+    """Statistiques de mémoire."""
+    tracked_objects: int = 0
+    cleaned_objects: int = 0
+    peak_memory_mb: float = 0.0
+    current_memory_mb: float = 0.0
+
+
+class MemoryManager:
+    """
+    Gestionnaire centralisé de la mémoire.
+    
+    Fournit:
+    - Suivi des objets avec références faibles
+    - Nettoyage périodique automatique
+    - Limitation de la taille des collections
+    - Cache avec TTL (Time To Live)
+    """
+    
+    def __init__(self, max_history_size: int = 100, cleanup_threshold: int = 1000):
+        self.max_history_size = max_history_size
+        self.cleanup_threshold = cleanup_threshold
+        self._tracked_objects: Dict[str, weakref.ref] = {}
+        self._cleanup_callbacks: List[Callable] = []
+        self._stats = MemoryStats()
+        self._logger = logging.getLogger(__name__)
+    
+    def track_object(self, obj_id: str, obj: Any) -> None:
+        """
+        Suit un objet avec une référence faible.
+        
+        Args:
+            obj_id: Identifiant unique de l'objet
+            obj: Objet à suivre
+        """
+        def on_delete(ref):
+            self._stats.cleaned_objects += 1
+            self._logger.debug(f"Object {obj_id} garbage collected")
+        
+        self._tracked_objects[obj_id] = weakref.ref(obj, on_delete)
+        self._stats.tracked_objects = len(self._tracked_objects)
+    
+    def untrack_object(self, obj_id: str) -> None:
+        """Arrête de suivre un objet."""
+        if obj_id in self._tracked_objects:
+            del self._tracked_objects[obj_id]
+            self._stats.tracked_objects = len(self._tracked_objects)
+    
+    def register_cleanup_callback(self, callback: Callable) -> None:
+        """
+        Enregistre une fonction de nettoyage à appeler périodiquement.
+        
+        Args:
+            callback: Fonction à appeler lors du nettoyage
+        """
+        self._cleanup_callbacks.append(callback)
+    
+    def cleanup(self, force: bool = False) -> int:
+        """
+        Déclenche le nettoyage de la mémoire.
+        
+        Args:
+            force: Si True, force le garbage collection complet
+        
+        Returns:
+            Nombre d'objets nettoyés
+        """
+        # Exécuter les callbacks de nettoyage enregistrés
+        for callback in self._cleanup_callbacks:
+            try:
+                callback()
+            except Exception as e:
+                self._logger.warning(f"Cleanup callback failed: {e}")
+        
+        # Nettoyer les références faibles mortes
+        dead_refs = [
+            obj_id for obj_id, ref in self._tracked_objects.items()
+            if ref() is None
+        ]
+        for obj_id in dead_refs:
+            del self._tracked_objects[obj_id]
+        
+        # Forcer le garbage collection si demandé
+        if force:
+            gc.collect()
+        
+        cleaned = len(dead_refs)
+        self._stats.cleaned_objects += cleaned
+        self._stats.tracked_objects = len(self._tracked_objects)
+        
+        if cleaned > 0:
+            self._logger.info(f"Memory cleanup: {cleaned} objects cleaned")
+        
+        return cleaned
+    
+    def get_stats(self) -> MemoryStats:
+        """Retourne les statistiques de mémoire."""
+        return self._stats
+    
+    @staticmethod
+    def limit_collection_size(collection: deque, max_size: int) -> int:
+        """
+        Limite la taille d'une collection (deque, list, etc.).
+        
+        Args:
+            collection: Collection à limiter
+            max_size: Taille maximale
+        
+        Returns:
+            Nombre d'éléments supprimés
+        """
+        if isinstance(collection, deque):
+            removed = max(0, len(collection) - max_size)
+            while len(collection) > max_size:
+                try:
+                    collection.popleft()
+                except IndexError:
+                    break
+            return removed
+        elif isinstance(collection, list):
+            removed = max(0, len(collection) - max_size)
+            if removed > 0:
+                del collection[:removed]
+            return removed
+        return 0
+
+
+class LimitedSizeHistory:
+    """
+    Historique avec taille limitée.
+    
+    Supprime automatiquement les anciens éléments quand la limite est atteinte.
+    """
+    
+    def __init__(self, max_size: int = 100, name: str = "history"):
+        self.max_size = max_size
+        self.name = name
+        self._deque: deque = deque(maxlen=max_size)
+        self._logger = logging.getLogger(f"{__name__}.{name}")
+    
+    def append(self, item: Any) -> None:
+        """Ajoute un élément, supprime automatiquement le plus ancien si nécessaire."""
+        if len(self._deque) >= self.max_size:
+            self._logger.debug(f"History {self.name} full, removing oldest item")
+        self._deque.append(item)
+    
+    def get_all(self) -> List[Any]:
+        """Retourne tous les éléments sous forme de liste."""
+        return list(self._deque)
+    
+    def clear(self) -> None:
+        """Vide l'historique."""
+        self._deque.clear()
+        self._logger.info(f"History {self.name} cleared")
+    
+    def __len__(self) -> int:
+        return len(self._deque)
+    
+    def __iter__(self):
+        return iter(self._deque)
+
+
+class TTLCache:
+    """
+    Cache avec expiration automatique (TTL).
+    
+    Les entrées expirent après un certain temps et sont automatiquement nettoyées.
+    """
+    
+    def __init__(self, max_size: int = 100, ttl_seconds: float = 3600, name: str = "cache"):
+        self.max_size = max_size
+        self.ttl_seconds = ttl_seconds
+        self.name = name
+        self._cache: Dict[str, Any] = {}
+        self._timestamps: Dict[str, float] = {}
+        self._logger = logging.getLogger(f"{__name__}.{name}")
+    
+    def _is_expired(self, key: str) -> bool:
+        """Vérifie si une entrée est expirée."""
+        import time
+        if key not in self._timestamps:
+            return True
+        return time.time() - self._timestamps[key] > self.ttl_seconds
+    
+    def _cleanup_expired(self) -> int:
+        """Nettoie les entrées expirées."""
+        expired_keys = [
+            key for key in list(self._cache.keys())
+            if self._is_expired(key)
+        ]
+        for key in expired_keys:
+            del self._cache[key]
+            del self._timestamps[key]
+        
+        if expired_keys:
+            self._logger.debug(f"Cleaned {len(expired_keys)} expired entries from {self.name}")
+        
+        return len(expired_keys)
+    
+    def get(self, key: str, default: Any = None) -> Any:
+        """
+        Récupère une valeur du cache.
+        
+        Retourne default si la clé n'existe pas ou est expirée.
+        """
+        self._cleanup_expired()
+        
+        if key in self._cache and not self._is_expired(key):
+            return self._cache[key]
+        
+        # Nettoyer si expiré
+        if key in self._cache:
+            del self._cache[key]
+            del self._timestamps[key]
+        
+        return default
+    
+    def set(self, key: str, value: Any) -> None:
+        """Stocke une valeur dans le cache."""
+        import time
+        
+        # Nettoyer si nécessaire avant d'ajouter
+        if len(self._cache) >= self.max_size:
+            self._cleanup_expired()
+            
+            # Si toujours plein, supprimer l'entrée la plus ancienne
+            if len(self._cache) >= self.max_size and self._timestamps:
+                oldest_key = min(self._timestamps, key=self._timestamps.get)
+                del self._cache[oldest_key]
+                del self._timestamps[oldest_key]
+        
+        self._cache[key] = value
+        self._timestamps[key] = time.time()
+    
+    def clear(self) -> None:
+        """Vide le cache."""
+        self._cache.clear()
+        self._timestamps.clear()
+        self._logger.info(f"Cache {self.name} cleared")
+    
+    def __len__(self) -> int:
+        self._cleanup_expired()
+        return len(self._cache)
+
+
+# Instance globale du gestionnaire de mémoire
+_memory_manager: Optional[MemoryManager] = None
+
+
+def get_memory_manager() -> MemoryManager:
+    """Retourne l'instance globale du gestionnaire de mémoire."""
+    global _memory_manager
+    if _memory_manager is None:
+        _memory_manager = MemoryManager()
+    return _memory_manager
+
+
+def cleanup_all() -> int:
+    """
+    Nettoie toute la mémoire (fonction utilitaire globale).
+    
+    Returns:
+        Nombre total d'objets nettoyés
+    """
+    manager = get_memory_manager()
+    cleaned = manager.cleanup(force=True)
+    
+    # Forcer le garbage collection Python
+    gc.collect()
+    
+    return cleaned

--- a/collegue/core/memory_manager.py
+++ b/collegue/core/memory_manager.py
@@ -53,10 +53,11 @@ class MemoryManager:
 
         Args:
             obj_id: Identifiant unique de l'objet
-            obj: Objet à suivre
+            obj: Objet à suivre (doit être weakref-able)
 
         Raises:
             ValueError: Si un objet avec le même ID est déjà suivi
+            TypeError: Si l'objet n'est pas weakref-able (ex: int, str, tuple)
         """
         # Capturer l'ID dans la closure
         captured_id = obj_id
@@ -82,7 +83,13 @@ class MemoryManager:
                 if existing_ref() is not None:
                     raise ValueError(f"Object with ID '{obj_id}' is already tracked")
                 # L'ancienne entrée est morte, on peut la remplacer
-            self._tracked_objects[obj_id] = weakref.ref(obj, on_delete)
+            try:
+                self._tracked_objects[obj_id] = weakref.ref(obj, on_delete)
+            except TypeError as e:
+                raise TypeError(
+                    f"Object of type {type(obj).__name__} is not weakref-able. "
+                    f"Only objects that support weak references can be tracked."
+                ) from e
             self._stats.tracked_objects = len(self._tracked_objects)
 
     def untrack_object(self, obj_id: str) -> None:
@@ -214,7 +221,7 @@ class TTLCache:
     Cache avec expiration automatique (TTL).
 
     Les entrées expirent après un certain temps et sont automatiquement nettoyées.
-    Implémente l'interface Mapping pour être compatible avec les opérations dict-like.
+    Fournit des opérations de cache de base de type dict (get/set/clear/items/keys/values).
     Thread-safe via un verrou interne.
     """
 

--- a/collegue/core/memory_manager.py
+++ b/collegue/core/memory_manager.py
@@ -7,10 +7,15 @@ prévenant les fuites sur les sessions longues.
 import gc
 import weakref
 import logging
+import threading
 import time
 from typing import Any, Dict, Optional, Callable, List, Iterator, Tuple
 from dataclasses import dataclass
 from collections import deque
+
+
+# Lock pour le singleton MemoryManager
+_memory_manager_lock = threading.Lock()
 
 
 @dataclass
@@ -102,7 +107,7 @@ class MemoryManager:
         
         # Nettoyer les références faibles mortes
         dead_refs = [
-            obj_id for obj_id, ref in self._tracked_objects.items()
+            obj_id for obj_id, ref in list(self._tracked_objects.items())
             if ref() is None
         ]
         for obj_id in dead_refs:
@@ -301,10 +306,12 @@ _memory_manager: Optional[MemoryManager] = None
 
 
 def get_memory_manager() -> MemoryManager:
-    """Retourne l'instance globale du gestionnaire de mémoire."""
+    """Retourne l'instance globale du gestionnaire de mémoire (thread-safe)."""
     global _memory_manager
     if _memory_manager is None:
-        _memory_manager = MemoryManager()
+        with _memory_manager_lock:
+            if _memory_manager is None:
+                _memory_manager = MemoryManager()
     return _memory_manager
 
 

--- a/collegue/core/memory_manager.py
+++ b/collegue/core/memory_manager.py
@@ -30,14 +30,14 @@ class MemoryStats:
 class MemoryManager:
     """
     Gestionnaire centralisé de la mémoire.
-    
+
     Fournit:
     - Suivi des objets avec références faibles
     - Nettoyage périodique automatique
     - Limitation de la taille des collections
     - Cache avec TTL (Time To Live)
     """
-    
+
     def __init__(self, max_history_size: int = 100, cleanup_threshold: int = 1000):
         self.max_history_size = max_history_size
         self.cleanup_threshold = cleanup_threshold
@@ -45,35 +45,39 @@ class MemoryManager:
         self._cleanup_callbacks: List[Callable] = []
         self._stats = MemoryStats()
         self._logger = logging.getLogger(__name__)
+        self._lock = threading.RLock()
     
     def track_object(self, obj_id: str, obj: Any) -> None:
         """
         Suit un objet avec une référence faible.
-        
+
         Args:
             obj_id: Identifiant unique de l'objet
             obj: Objet à suivre
         """
         # Capturer l'ID dans la closure
         captured_id = obj_id
-        
+
         def on_delete(ref):
             # Supprimer l'entrée du dict quand l'objet est garbage collecté
-            try:
-                if captured_id in self._tracked_objects:
-                    del self._tracked_objects[captured_id]
-                    self._stats.tracked_objects = len(self._tracked_objects)
-            except KeyError:
-                pass  # Déjà supprimé
-        
-        self._tracked_objects[obj_id] = weakref.ref(obj, on_delete)
-        self._stats.tracked_objects = len(self._tracked_objects)
-    
+            with self._lock:
+                try:
+                    if captured_id in self._tracked_objects:
+                        del self._tracked_objects[captured_id]
+                        self._stats.tracked_objects = len(self._tracked_objects)
+                except KeyError:
+                    pass  # Déjà supprimé
+
+        with self._lock:
+            self._tracked_objects[obj_id] = weakref.ref(obj, on_delete)
+            self._stats.tracked_objects = len(self._tracked_objects)
+
     def untrack_object(self, obj_id: str) -> None:
         """Arrête de suivre un objet."""
-        if obj_id in self._tracked_objects:
-            del self._tracked_objects[obj_id]
-            self._stats.tracked_objects = len(self._tracked_objects)
+        with self._lock:
+            if obj_id in self._tracked_objects:
+                del self._tracked_objects[obj_id]
+                self._stats.tracked_objects = len(self._tracked_objects)
     
     def register_cleanup_callback(self, callback: Callable) -> None:
         """
@@ -87,39 +91,41 @@ class MemoryManager:
     def cleanup(self, force: bool = False) -> int:
         """
         Déclenche le nettoyage de la mémoire.
-        
+
         Args:
             force: Si True, force le garbage collection complet
-        
+
         Returns:
             Nombre d'objets nettoyés
         """
-        # Exécuter les callbacks de nettoyage enregistrés
-        for callback in self._cleanup_callbacks:
-            try:
-                callback()
-            except Exception as e:
-                self._logger.warning(f"Cleanup callback failed: {e}")
-        
-        # Forcer le garbage collection si demandé (pour mettre à jour les weakrefs)
-        if force:
-            gc.collect()
-        
-        # Nettoyer les références faibles mortes
-        dead_refs = [
-            obj_id for obj_id, ref in list(self._tracked_objects.items())
-            if ref() is None
-        ]
-        for obj_id in dead_refs:
-            del self._tracked_objects[obj_id]
-        
-        cleaned = len(dead_refs)
-        self._stats.tracked_objects = len(self._tracked_objects)
-        
-        if cleaned > 0:
-            self._logger.info(f"Memory cleanup: {cleaned} objects cleaned")
-        
-        return cleaned
+        with self._lock:
+            # Exécuter les callbacks de nettoyage enregistrés
+            for callback in self._cleanup_callbacks:
+                try:
+                    callback()
+                except Exception as e:
+                    self._logger.warning(f"Cleanup callback failed: {e}")
+
+            # Forcer le garbage collection si demandé (pour mettre à jour les weakrefs)
+            if force:
+                gc.collect()
+
+            # Nettoyer les références faibles mortes
+            dead_refs = [
+                obj_id for obj_id, ref in list(self._tracked_objects.items())
+                if ref() is None
+            ]
+            for obj_id in dead_refs:
+                del self._tracked_objects[obj_id]
+
+            cleaned = len(dead_refs)
+            self._stats.cleaned_objects += cleaned
+            self._stats.tracked_objects = len(self._tracked_objects)
+
+            if cleaned > 0:
+                self._logger.info(f"Memory cleanup: {cleaned} objects cleaned")
+
+            return cleaned
     
     def get_stats(self) -> MemoryStats:
         """Retourne les statistiques de mémoire."""
@@ -191,11 +197,12 @@ class LimitedSizeHistory:
 class TTLCache:
     """
     Cache avec expiration automatique (TTL).
-    
+
     Les entrées expirent après un certain temps et sont automatiquement nettoyées.
     Implémente l'interface Mapping pour être compatible avec les opérations dict-like.
+    Thread-safe via un verrou interne.
     """
-    
+
     def __init__(self, max_size: int = 100, ttl_seconds: float = 3600, name: str = "cache"):
         self.max_size = max_size
         self.ttl_seconds = ttl_seconds
@@ -203,102 +210,114 @@ class TTLCache:
         self._cache: Dict[str, Any] = {}
         self._timestamps: Dict[str, float] = {}
         self._logger = logging.getLogger(f"{__name__}.{name}")
+        self._lock = threading.RLock()
     
     def _is_expired(self, key: str) -> bool:
-        """Vérifie si une entrée est expirée."""
+        """Vérifie si une entrée est expirée (utilise time.monotonic pour robustesse)."""
         if key not in self._timestamps:
             return True
-        return time.time() - self._timestamps[key] > self.ttl_seconds
-    
+        return time.monotonic() - self._timestamps[key] > self.ttl_seconds
+
     def _cleanup_expired(self) -> int:
         """Nettoie les entrées expirées."""
-        expired_keys = [
-            key for key in list(self._cache.keys())
-            if self._is_expired(key)
-        ]
-        for key in expired_keys:
-            del self._cache[key]
-            del self._timestamps[key]
-        
-        if expired_keys:
-            self._logger.debug(f"Cleaned {len(expired_keys)} expired entries from {self.name}")
-        
-        return len(expired_keys)
-    
+        with self._lock:
+            expired_keys = [
+                key for key in list(self._cache.keys())
+                if self._is_expired(key)
+            ]
+            for key in expired_keys:
+                del self._cache[key]
+                del self._timestamps[key]
+
+            if expired_keys:
+                self._logger.debug(f"Cleaned {len(expired_keys)} expired entries from {self.name}")
+
+            return len(expired_keys)
+
     def get(self, key: str, default: Any = None) -> Any:
         """
         Récupère une valeur du cache.
-        
+
         Retourne default si la clé n'existe pas ou est expirée.
         """
-        self._cleanup_expired()
-        
-        if key in self._cache and not self._is_expired(key):
-            return self._cache[key]
-        
-        # Nettoyer si expiré
-        if key in self._cache:
-            del self._cache[key]
-            del self._timestamps[key]
-        
-        return default
-    
+        with self._lock:
+            self._cleanup_expired()
+
+            if key in self._cache and not self._is_expired(key):
+                return self._cache[key]
+
+            # Nettoyer si expiré
+            if key in self._cache:
+                del self._cache[key]
+                del self._timestamps[key]
+
+            return default
+
     def set(self, key: str, value: Any) -> None:
         """Stocke une valeur dans le cache."""
-        # Nettoyer si nécessaire avant d'ajouter
-        if len(self._cache) >= self.max_size:
-            self._cleanup_expired()
-            
-            # Si toujours plein, supprimer l'entrée la plus ancienne
-            if len(self._cache) >= self.max_size and self._timestamps:
-                oldest_key = min(self._timestamps, key=self._timestamps.get)
-                del self._cache[oldest_key]
-                del self._timestamps[oldest_key]
-        
-        self._cache[key] = value
-        self._timestamps[key] = time.time()
-    
+        with self._lock:
+            # Nettoyer si nécessaire avant d'ajouter
+            if len(self._cache) >= self.max_size:
+                self._cleanup_expired()
+
+                # Si toujours plein, supprimer l'entrée la plus ancienne
+                if len(self._cache) >= self.max_size and self._timestamps:
+                    oldest_key = min(self._timestamps, key=self._timestamps.get)
+                    del self._cache[oldest_key]
+                    del self._timestamps[oldest_key]
+
+            self._cache[key] = value
+            self._timestamps[key] = time.monotonic()
+
     def clear(self) -> None:
         """Vide le cache."""
-        self._cache.clear()
-        self._timestamps.clear()
-        self._logger.info(f"Cache {self.name} cleared")
+        with self._lock:
+            self._cache.clear()
+            self._timestamps.clear()
+            self._logger.info(f"Cache {self.name} cleared")
     
     def items(self) -> Iterator[Tuple[str, Any]]:
         """Retourne un itérateur sur les paires (clé, valeur) non expirées."""
-        self._cleanup_expired()
-        return iter(list(self._cache.items()))
-    
+        with self._lock:
+            self._cleanup_expired()
+            return iter(list(self._cache.items()))
+
     def keys(self) -> Iterator[str]:
         """Retourne un itérateur sur les clés non expirées."""
-        self._cleanup_expired()
-        return iter(list(self._cache.keys()))
-    
+        with self._lock:
+            self._cleanup_expired()
+            return iter(list(self._cache.keys()))
+
     def values(self) -> Iterator[Any]:
         """Retourne un itérateur sur les valeurs non expirées."""
-        self._cleanup_expired()
-        return iter(list(self._cache.values()))
-    
+        with self._lock:
+            self._cleanup_expired()
+            return iter(list(self._cache.values()))
+
     def __getitem__(self, key: str) -> Any:
         """Permet l'accès par index : cache[key]"""
-        result = self.get(key)
-        if result is None and key not in self._cache:
-            raise KeyError(key)
-        return result
-    
+        with self._lock:
+            result = self.get(key)
+            if result is None and key not in self._cache:
+                raise KeyError(key)
+            return result
+
     def __contains__(self, key: str) -> bool:
         """Permet l'opérateur 'in' : key in cache"""
-        self._cleanup_expired()
-        return key in self._cache and not self._is_expired(key)
-    
+        with self._lock:
+            self._cleanup_expired()
+            return key in self._cache and not self._is_expired(key)
+
     def __len__(self) -> int:
-        self._cleanup_expired()
-        return len(self._cache)
-    
+        with self._lock:
+            self._cleanup_expired()
+            return len(self._cache)
+
     def __iter__(self) -> Iterator[str]:
         """Permet d'itérer sur les clés : for key in cache"""
-        self._cleanup_expired()
-        return iter(list(self._cache.keys()))
+        with self._lock:
+            self._cleanup_expired()
+            return iter(list(self._cache.keys()))
 
 
 # Instance globale du gestionnaire de mémoire

--- a/collegue/core/meta_orchestrator.py
+++ b/collegue/core/meta_orchestrator.py
@@ -113,6 +113,7 @@ def register_meta_orchestrator(app: FastMCP):
                                 and obj != BaseTool
                                 and obj.__module__ == module.__name__
                             ):
+                                temp_instance = None
                                 try:
                                     # Instantiation temporaire pour métadonnées
                                     temp_instance = obj({})
@@ -145,14 +146,15 @@ def register_meta_orchestrator(app: FastMCP):
                                         "prompt_desc": f"{tool_name}: {temp_instance.get_description()}\\n  Arguments:\\n{formatted_args}",
                                         "schema": schema,
                                     })
-                                    
-                                    # Nettoyer explicitement l'instance temporaire
-                                    if hasattr(temp_instance, 'cleanup'):
-                                        temp_instance.cleanup()
-                                    del temp_instance
-                                    
+
                                 except Exception as e:
                                     await ctx.warning(f"Skip {name}: {e}")
+                                finally:
+                                    # Nettoyer explicitement l'instance temporaire (même en cas d'erreur)
+                                    if temp_instance is not None:
+                                        if hasattr(temp_instance, 'cleanup'):
+                                            temp_instance.cleanup()
+                                        del temp_instance
                     except Exception:
                         pass
             except Exception as e:

--- a/collegue/core/meta_orchestrator.py
+++ b/collegue/core/meta_orchestrator.py
@@ -93,7 +93,8 @@ def register_meta_orchestrator(app: FastMCP):
         )
 
         # 1. Découverte des tools (avec Cache TTL)
-        if _TOOLS_CACHE is None:
+        # Relancer la discovery si le cache est None ou vide (après expiration)
+        if _TOOLS_CACHE is None or len(_TOOLS_CACHE) == 0:
             # Construire le cache dans une variable locale pour éviter les race conditions
             _tools_cache_local = TTLCache(
                 max_size=_MAX_TOOLS_CACHE_SIZE,

--- a/collegue/core/meta_orchestrator.py
+++ b/collegue/core/meta_orchestrator.py
@@ -5,14 +5,21 @@ Meta Orchestrator - Tool intelligent utilisant FastMCP sampling with tools
 from typing import List, Dict, Any, Optional
 from pydantic import BaseModel, Field
 
+from .memory_manager import TTLCache, LimitedSizeHistory
+
 try:
     from fastmcp import FastMCP, Context
 except ImportError:
     FastMCP = Any
     Context = Any
 
-# Cache global pour les outils découverts
+# Cache global pour les outils découverts (avec TTL de 1 heure)
 _TOOLS_CACHE = None
+_MAX_TOOLS_CACHE_SIZE = 50
+_TOOLS_CACHE_TTL = 3600  # 1 heure
+
+# Historique des exécutions (limité à 100 entrées)
+_EXECUTION_HISTORY = LimitedSizeHistory(max_size=100, name="orchestrator_executions")
 
 
 class OrchestratorStep(BaseModel):
@@ -82,15 +89,19 @@ def register_meta_orchestrator(app: FastMCP):
         import collegue.tools
         from collegue.tools.base import BaseTool
 
-        global _TOOLS_CACHE
+        global _TOOLS_CACHE, _MAX_TOOLS_CACHE_SIZE, _TOOLS_CACHE_TTL
         start_time = time.time()
         await ctx.info(
             f"Démarrage orchestration (mode v4 robust): {request.query[:100]}..."
         )
 
-        # 1. Découverte des tools (avec Cache)
+        # 1. Découverte des tools (avec Cache TTL)
         if _TOOLS_CACHE is None:
-            _TOOLS_CACHE = {}
+            _TOOLS_CACHE = TTLCache(
+                max_size=_MAX_TOOLS_CACHE_SIZE,
+                ttl_seconds=_TOOLS_CACHE_TTL,
+                name="tools_discovery"
+            )
             try:
                 for _, name, _ in pkgutil.iter_modules(collegue.tools.__path__):
                     if name.startswith("_") or name == "base":
@@ -130,18 +141,28 @@ def register_meta_orchestrator(app: FastMCP):
 
                                     formatted_args = "\\n".join(args_desc)
 
-                                    _TOOLS_CACHE[tool_name] = {
+                                    _TOOLS_CACHE.set(tool_name, {
                                         "class": obj,
                                         "description": temp_instance.get_description(),
                                         "prompt_desc": f"{tool_name}: {temp_instance.get_description()}\\n  Arguments:\\n{formatted_args}",
                                         "schema": schema,
-                                    }
+                                    })
+                                    
+                                    # Nettoyer explicitement l'instance temporaire
+                                    if hasattr(temp_instance, 'cleanup'):
+                                        temp_instance.cleanup()
+                                    del temp_instance
+                                    
                                 except Exception as e:
                                     await ctx.warning(f"Skip {name}: {e}")
                     except Exception:
                         pass
             except Exception as e:
                 await ctx.error(f"Erreur discovery: {e}")
+        
+        # Nettoyer le cache si trop grand
+        if len(_TOOLS_CACHE) > _MAX_TOOLS_CACHE_SIZE:
+            await ctx.info("Nettoyage du cache tools...")
 
         available_tools = _TOOLS_CACHE
         tools_desc = "\\n".join(

--- a/collegue/core/meta_orchestrator.py
+++ b/collegue/core/meta_orchestrator.py
@@ -254,6 +254,7 @@ RÈGLES :
 
             await ctx.info(f"Étape {i + 1}: {tool_name} ({step.reason})")
 
+            tool_instance = None
             try:
                 tool_class = available_tools[tool_name]["class"]
                 tool_instance = tool_class({})  # Nouvelle instance propre
@@ -275,6 +276,16 @@ RÈGLES :
                 err_msg = f"Erreur exécution {tool_name}: {e}"
                 await ctx.error(err_msg)
                 execution_results.append({"step": i + 1, "error": err_msg})
+            finally:
+                # Nettoyer explicitement l'instance après usage
+                if tool_instance is not None:
+                    try:
+                        if hasattr(tool_instance, 'cleanup'):
+                            tool_instance.cleanup()
+                        del tool_instance
+                    except Exception:
+                        # Ne jamais faire échouer le nettoyage
+                        pass
 
         # 4. Étape SYNTHÈSE
         await ctx.info("Phase 3: Synthèse...")

--- a/collegue/core/meta_orchestrator.py
+++ b/collegue/core/meta_orchestrator.py
@@ -5,7 +5,7 @@ Meta Orchestrator - Tool intelligent utilisant FastMCP sampling with tools
 from typing import List, Dict, Any, Optional
 from pydantic import BaseModel, Field
 
-from .memory_manager import TTLCache, LimitedSizeHistory
+from .memory_manager import TTLCache
 
 try:
     from fastmcp import FastMCP, Context
@@ -17,9 +17,6 @@ except ImportError:
 _TOOLS_CACHE = None
 _MAX_TOOLS_CACHE_SIZE = 50
 _TOOLS_CACHE_TTL = 3600  # 1 heure
-
-# Historique des exécutions (limité à 100 entrées)
-_EXECUTION_HISTORY = LimitedSizeHistory(max_size=100, name="orchestrator_executions")
 
 
 class OrchestratorStep(BaseModel):
@@ -97,7 +94,8 @@ def register_meta_orchestrator(app: FastMCP):
 
         # 1. Découverte des tools (avec Cache TTL)
         if _TOOLS_CACHE is None:
-            _TOOLS_CACHE = TTLCache(
+            # Construire le cache dans une variable locale pour éviter les race conditions
+            _tools_cache_local = TTLCache(
                 max_size=_MAX_TOOLS_CACHE_SIZE,
                 ttl_seconds=_TOOLS_CACHE_TTL,
                 name="tools_discovery"
@@ -141,7 +139,7 @@ def register_meta_orchestrator(app: FastMCP):
 
                                     formatted_args = "\\n".join(args_desc)
 
-                                    _TOOLS_CACHE.set(tool_name, {
+                                    _tools_cache_local.set(tool_name, {
                                         "class": obj,
                                         "description": temp_instance.get_description(),
                                         "prompt_desc": f"{tool_name}: {temp_instance.get_description()}\\n  Arguments:\\n{formatted_args}",
@@ -159,10 +157,9 @@ def register_meta_orchestrator(app: FastMCP):
                         pass
             except Exception as e:
                 await ctx.error(f"Erreur discovery: {e}")
-        
-        # Nettoyer le cache si trop grand
-        if len(_TOOLS_CACHE) > _MAX_TOOLS_CACHE_SIZE:
-            await ctx.info("Nettoyage du cache tools...")
+            
+            # Assigner le cache complet une fois rempli (évite les race conditions)
+            _TOOLS_CACHE = _tools_cache_local
 
         available_tools = _TOOLS_CACHE
         tools_desc = "\\n".join(

--- a/collegue/tools/base.py
+++ b/collegue/tools/base.py
@@ -87,6 +87,13 @@ class BaseTool(ABC):
         # Gestionnaire de quotas pour cette session
         self._quota_manager: Optional[QuotaManager] = None
         self._session_id: str = "default"
+        
+        # Enregistrer pour nettoyage périodique
+        from ..core.memory_manager import get_memory_manager
+        get_memory_manager().track_object(
+            f"{self.__class__.__name__}_{id(self)}",
+            self
+        )
 
         self._validate_config()
 
@@ -154,6 +161,28 @@ class BaseTool(ABC):
         except RateLimitExceeded as e:
             self.logger.warning(f"Rate limit exceeded for {self.tool_name}: {e}")
             raise ToolRateLimitError(str(e))
+    
+    def cleanup(self) -> None:
+        """
+        Nettoie les ressources pour éviter les fuites mémoire.
+        
+        Cette méthode doit être appelée quand le tool n'est plus utilisé,
+        surtout pour les sessions longues.
+        """
+        self.logger.debug(f"Cleaning up {self.tool_name}")
+        
+        # Libérer les références circulaires potentielles
+        self.app_state = None
+        self.config = None
+        self.prompt_engine = None
+        self.context_manager = None
+        self._quota_manager = None
+        
+        # Forcer le garbage collection pour ce tool
+        import gc
+        gc.collect()
+        
+        self.logger.info(f"{self.tool_name} cleaned up")
     
     def _get_quota_manager(self, **kwargs) -> QuotaManager:
         """Récupère ou crée le gestionnaire de quotas pour cette session."""

--- a/collegue/tools/base.py
+++ b/collegue/tools/base.py
@@ -90,8 +90,9 @@ class BaseTool(ABC):
         
         # Enregistrer pour nettoyage périodique
         from ..core.memory_manager import get_memory_manager
+        self._memory_manager_id = f"{self.__class__.__name__}_{id(self)}"
         get_memory_manager().track_object(
-            f"{self.__class__.__name__}_{id(self)}",
+            self._memory_manager_id,
             self
         )
 
@@ -162,14 +163,26 @@ class BaseTool(ABC):
             self.logger.warning(f"Rate limit exceeded for {self.tool_name}: {e}")
             raise ToolRateLimitError(str(e))
     
-    def cleanup(self) -> None:
+    def cleanup(self, force_gc: bool = False) -> None:
         """
         Nettoie les ressources pour éviter les fuites mémoire.
         
         Cette méthode doit être appelée quand le tool n'est plus utilisé,
         surtout pour les sessions longues.
+        
+        Args:
+            force_gc: Si True, force le garbage collection (peut ajouter de la latence)
         """
         self.logger.debug(f"Cleaning up {self.tool_name}")
+        
+        # Dé-enregistrer l'objet du MemoryManager
+        if hasattr(self, '_memory_manager_id'):
+            try:
+                from ..core.memory_manager import get_memory_manager
+                get_memory_manager().untrack_object(self._memory_manager_id)
+            except Exception:
+                # Ne jamais faire échouer le nettoyage à cause du MemoryManager
+                pass
         
         # Libérer les références circulaires potentielles
         self.app_state = None
@@ -178,9 +191,10 @@ class BaseTool(ABC):
         self.context_manager = None
         self._quota_manager = None
         
-        # Forcer le garbage collection pour ce tool
-        import gc
-        gc.collect()
+        # Forcer le garbage collection si demandé (optionnel pour éviter les pauses)
+        if force_gc:
+            import gc
+            gc.collect()
         
         self.logger.info(f"{self.tool_name} cleaned up")
     

--- a/collegue/tools/base.py
+++ b/collegue/tools/base.py
@@ -196,7 +196,7 @@ class BaseTool(ABC):
             import gc
             gc.collect()
         
-        self.logger.info(f"{self.tool_name} cleaned up")
+        self.logger.debug(f"{self.tool_name} cleaned up")
     
     def _get_quota_manager(self, **kwargs) -> QuotaManager:
         """Récupère ou crée le gestionnaire de quotas pour cette session."""

--- a/collegue/tools/base.py
+++ b/collegue/tools/base.py
@@ -190,6 +190,11 @@ class BaseTool(ABC):
         self.prompt_engine = None
         self.context_manager = None
         self._quota_manager = None
+
+        # Nettoyer les attributs injectés dynamiquement (ex: parser)
+        for attr_name in ("parser",):
+            if hasattr(self, attr_name):
+                setattr(self, attr_name, None)
         
         # Forcer le garbage collection si demandé (optionnel pour éviter les pauses)
         if force_gc:

--- a/collegue/tools/iac_guardrails_scan/tool.py
+++ b/collegue/tools/iac_guardrails_scan/tool.py
@@ -81,17 +81,17 @@ class IacGuardrailsScanTool(BaseTool):
         self._tf_scanner = TerraformScanner(logger=self.logger)
         self._dockerfile_scanner = DockerfileScanner(logger=self.logger)
     
-    def cleanup(self) -> None:
+    def cleanup(self, force_gc: bool = False) -> None:
         """Nettoie les ressources pour éviter les fuites mémoire."""
-        super().cleanup()
-        
+        super().cleanup(force_gc=force_gc)
+
         # Libérer les références aux scanners et engine
         self._engine = None
         self._k8s_scanner = None
         self._tf_scanner = None
         self._dockerfile_scanner = None
-        
-        self.logger.info("IaC Guardrails Scan tool cleaned up")
+
+        self.logger.debug("IaC Guardrails Scan tool cleaned up")
 
     def get_usage_description(self) -> str:
         return (

--- a/collegue/tools/iac_guardrails_scan/tool.py
+++ b/collegue/tools/iac_guardrails_scan/tool.py
@@ -80,6 +80,18 @@ class IacGuardrailsScanTool(BaseTool):
         self._k8s_scanner = KubernetesScanner(logger=self.logger)
         self._tf_scanner = TerraformScanner(logger=self.logger)
         self._dockerfile_scanner = DockerfileScanner(logger=self.logger)
+    
+    def cleanup(self) -> None:
+        """Nettoie les ressources pour éviter les fuites mémoire."""
+        super().cleanup()
+        
+        # Libérer les références aux scanners et engine
+        self._engine = None
+        self._k8s_scanner = None
+        self._tf_scanner = None
+        self._dockerfile_scanner = None
+        
+        self.logger.info("IaC Guardrails Scan tool cleaned up")
 
     def get_usage_description(self) -> str:
         return (

--- a/tests/test_memory_leak_fixes.py
+++ b/tests/test_memory_leak_fixes.py
@@ -55,16 +55,16 @@ class TestMemoryManager:
         # Créer un objet et le suivre
         obj = TestTool()
         manager.track_object("temp_obj", obj)
+        assert manager._stats.tracked_objects == 1
         
         # Supprimer la référence
         del obj
+        
+        # Forcer GC pour déclencher le callback de weakref
         gc.collect()
         
-        # Nettoyer
-        cleaned = manager.cleanup()
-        
-        # La référence devrait être nettoyée
-        assert cleaned >= 0  # Au moins 0 (peut être 1 si GC a déjà nettoyé)
+        # Le callback on_delete devrait avoir nettoyé l'entrée automatiquement
+        assert manager._stats.tracked_objects == 0
     
     def test_register_cleanup_callback(self):
         """Test l'enregistrement de callbacks de nettoyage."""
@@ -142,13 +142,13 @@ class TestTTLCache:
     
     def test_cache_expires_entries(self):
         """Test que les entrées expirées sont supprimées."""
-        cache = TTLCache(max_size=10, ttl_seconds=0.01, name="test")  # 10ms TTL
+        cache = TTLCache(max_size=10, ttl_seconds=0.1, name="test")  # 100ms TTL
         
         cache.set("key1", "value1")
         
-        # Attendre l'expiration
+        # Attendre l'expiration (marge plus large pour CI)
         import time
-        time.sleep(0.02)
+        time.sleep(0.15)
         
         # L'entrée devrait être expirée
         result = cache.get("key1", default="expired")
@@ -200,11 +200,11 @@ class TestBaseToolMemory:
         assert tool._quota_manager is None
     
     def test_base_tool_cleanup_calls_gc(self):
-        """Test que cleanup appelle gc.collect()."""
+        """Test que cleanup appelle gc.collect() quand force_gc=True."""
         tool = TestTool()
         
         with patch('gc.collect') as mock_gc:
-            tool.cleanup()
+            tool.cleanup(force_gc=True)
             mock_gc.assert_called_once()
 
 

--- a/tests/test_memory_leak_fixes.py
+++ b/tests/test_memory_leak_fixes.py
@@ -2,7 +2,6 @@
 Tests pour les corrections de fuites mémoire (issue #141).
 """
 import gc
-import pytest
 from unittest.mock import Mock, patch
 from pydantic import BaseModel
 

--- a/tests/test_memory_leak_fixes.py
+++ b/tests/test_memory_leak_fixes.py
@@ -157,7 +157,6 @@ class TestTTLCache:
     
     def test_cache_expires_entries(self):
         """Test que les entrées expirées sont supprimées (avec patch du temps)."""
-        from unittest.mock import patch
         
         cache = TTLCache(max_size=10, ttl_seconds=0.1, name="test")  # 100ms TTL
         

--- a/tests/test_memory_leak_fixes.py
+++ b/tests/test_memory_leak_fixes.py
@@ -156,17 +156,21 @@ class TestTTLCache:
         assert result == "default_value"
     
     def test_cache_expires_entries(self):
-        """Test que les entrées expirées sont supprimées."""
+        """Test que les entrées expirées sont supprimées (avec patch du temps)."""
+        from unittest.mock import patch
+        
         cache = TTLCache(max_size=10, ttl_seconds=0.1, name="test")  # 100ms TTL
         
-        cache.set("key1", "value1")
-        
-        # Attendre l'expiration (marge plus large pour CI)
-        import time
-        time.sleep(0.15)
-        
-        # L'entrée devrait être expirée
-        result = cache.get("key1", default="expired")
+        # Simuler l'expiration en patchant le temps monotone
+        start_time = 1000.0
+        with patch(
+            "collegue.core.memory_manager.time.monotonic",
+            side_effect=[start_time, start_time + 0.2],  # set() puis get()
+        ):
+            cache.set("key1", "value1")
+            # L'entrée devrait être expirée lorsque nous la lisons
+            result = cache.get("key1", default="expired")
+            
         assert result == "expired"
     
     def test_cache_respects_max_size(self):

--- a/tests/test_memory_leak_fixes.py
+++ b/tests/test_memory_leak_fixes.py
@@ -1,0 +1,225 @@
+"""
+Tests pour les corrections de fuites mémoire (issue #141).
+"""
+import gc
+import pytest
+from unittest.mock import Mock, patch
+from pydantic import BaseModel
+
+from collegue.core.memory_manager import (
+    MemoryManager,
+    LimitedSizeHistory,
+    TTLCache,
+    get_memory_manager,
+    cleanup_all,
+)
+from collegue.tools.base import BaseTool
+
+
+# Modèles de test
+class TestRequest(BaseModel):
+    code: str
+
+
+class TestResponse(BaseModel):
+    result: str
+
+
+class TestTool(BaseTool):
+    """Tool de test simple."""
+    tool_name = "test_memory_tool"
+    tool_description = "A test tool"
+    request_model = TestRequest
+    response_model = TestResponse
+    
+    def _execute_core_logic(self, request: TestRequest, **kwargs) -> TestResponse:
+        return TestResponse(result=f"Processed: {request.code}")
+
+
+class TestMemoryManager:
+    """Tests pour MemoryManager."""
+    
+    def test_track_object(self):
+        """Test le suivi d'objets."""
+        manager = MemoryManager()
+        obj = TestTool()  # Utiliser un objet qui supporte weakref
+        
+        manager.track_object("test_obj", obj)
+        
+        assert manager._stats.tracked_objects == 1
+    
+    def test_cleanup_removes_dead_refs(self):
+        """Test que cleanup supprime les références mortes."""
+        manager = MemoryManager()
+        
+        # Créer un objet et le suivre
+        obj = TestTool()
+        manager.track_object("temp_obj", obj)
+        
+        # Supprimer la référence
+        del obj
+        gc.collect()
+        
+        # Nettoyer
+        cleaned = manager.cleanup()
+        
+        # La référence devrait être nettoyée
+        assert cleaned >= 0  # Au moins 0 (peut être 1 si GC a déjà nettoyé)
+    
+    def test_register_cleanup_callback(self):
+        """Test l'enregistrement de callbacks de nettoyage."""
+        manager = MemoryManager()
+        callback_called = [False]
+        
+        def my_callback():
+            callback_called[0] = True
+        
+        manager.register_cleanup_callback(my_callback)
+        manager.cleanup()
+        
+        assert callback_called[0] is True
+    
+    def test_cleanup_callback_exception_handled(self):
+        """Test que les exceptions dans les callbacks sont gérées."""
+        manager = MemoryManager()
+        
+        def failing_callback():
+            raise ValueError("Test error")
+        
+        manager.register_cleanup_callback(failing_callback)
+        
+        # Ne devrait pas lever d'exception
+        manager.cleanup()
+
+
+class TestLimitedSizeHistory:
+    """Tests pour LimitedSizeHistory."""
+    
+    def test_history_limits_size(self):
+        """Test que l'historique limite sa taille."""
+        history = LimitedSizeHistory(max_size=5, name="test")
+        
+        # Ajouter 10 éléments
+        for i in range(10):
+            history.append(f"item_{i}")
+        
+        # Ne devrait garder que les 5 derniers
+        assert len(history) == 5
+        items = history.get_all()
+        assert items[0] == "item_5"  # Premier élément = item_5
+        assert items[-1] == "item_9"  # Dernier élément = item_9
+    
+    def test_history_clear(self):
+        """Test le vidage de l'historique."""
+        history = LimitedSizeHistory(max_size=10, name="test")
+        
+        for i in range(5):
+            history.append(f"item_{i}")
+        
+        history.clear()
+        
+        assert len(history) == 0
+
+
+class TestTTLCache:
+    """Tests pour TTLCache."""
+    
+    def test_cache_stores_and_retrieves(self):
+        """Test le stockage et la récupération."""
+        cache = TTLCache(max_size=10, ttl_seconds=3600, name="test")
+        
+        cache.set("key1", "value1")
+        
+        assert cache.get("key1") == "value1"
+    
+    def test_cache_returns_default_for_missing(self):
+        """Test que get retourne default pour une clé manquante."""
+        cache = TTLCache(max_size=10, ttl_seconds=3600, name="test")
+        
+        result = cache.get("missing_key", default="default_value")
+        
+        assert result == "default_value"
+    
+    def test_cache_expires_entries(self):
+        """Test que les entrées expirées sont supprimées."""
+        cache = TTLCache(max_size=10, ttl_seconds=0.01, name="test")  # 10ms TTL
+        
+        cache.set("key1", "value1")
+        
+        # Attendre l'expiration
+        import time
+        time.sleep(0.02)
+        
+        # L'entrée devrait être expirée
+        result = cache.get("key1", default="expired")
+        assert result == "expired"
+    
+    def test_cache_respects_max_size(self):
+        """Test que le cache respecte la taille maximale."""
+        cache = TTLCache(max_size=3, ttl_seconds=3600, name="test")
+        
+        # Ajouter 5 éléments
+        for i in range(5):
+            cache.set(f"key_{i}", f"value_{i}")
+        
+        # Le cache ne devrait garder que les 3 plus récents
+        assert len(cache) == 3
+        assert cache.get("key_2") is not None
+        assert cache.get("key_3") is not None
+        assert cache.get("key_4") is not None
+
+
+class TestBaseToolMemory:
+    """Tests pour la gestion mémoire dans BaseTool."""
+    
+    def test_base_tool_tracked_by_memory_manager(self):
+        """Test que BaseTool est suivi par le memory manager."""
+        manager = get_memory_manager()
+        initial_count = manager._stats.tracked_objects
+        
+        tool = TestTool()
+        
+        # Le tool devrait être suivi
+        assert manager._stats.tracked_objects == initial_count + 1
+    
+    def test_base_tool_cleanup_releases_references(self):
+        """Test que cleanup libère les références."""
+        tool = TestTool()
+        tool.config = {"key": "value"}
+        tool.app_state = {"state": "data"}
+        tool.prompt_engine = Mock()
+        tool.context_manager = Mock()
+        tool._quota_manager = Mock()
+        
+        tool.cleanup()
+        
+        assert tool.config is None
+        assert tool.app_state is None
+        assert tool.prompt_engine is None
+        assert tool.context_manager is None
+        assert tool._quota_manager is None
+    
+    def test_base_tool_cleanup_calls_gc(self):
+        """Test que cleanup appelle gc.collect()."""
+        tool = TestTool()
+        
+        with patch('gc.collect') as mock_gc:
+            tool.cleanup()
+            mock_gc.assert_called_once()
+
+
+class TestCleanupAll:
+    """Tests pour cleanup_all."""
+    
+    def test_cleanup_all_calls_manager_cleanup(self):
+        """Test que cleanup_all appelle manager.cleanup."""
+        with patch.object(MemoryManager, 'cleanup') as mock_cleanup:
+            cleanup_all()
+            mock_cleanup.assert_called_once_with(force=True)
+    
+    def test_cleanup_all_calls_gc_collect(self):
+        """Test que cleanup_all appelle gc.collect."""
+        with patch('gc.collect') as mock_gc:
+            cleanup_all()
+            # Devrait être appelé au moins une fois
+            assert mock_gc.call_count >= 1

--- a/tests/test_memory_leak_fixes.py
+++ b/tests/test_memory_leak_fixes.py
@@ -42,18 +42,33 @@ class TestMemoryManager:
     def test_track_object(self):
         """Test le suivi d'objets."""
         manager = MemoryManager()
-        obj = TestTool()  # Utiliser un objet qui supporte weakref
         
-        manager.track_object("test_obj", obj)
+        # Utiliser un objet dummy weakref-able sans effets de bord
+        class DummyObject:
+            pass
         
-        assert manager._stats.tracked_objects == 1
+        obj = DummyObject()
+        
+        try:
+            manager.track_object("test_obj", obj)
+            
+            assert manager._stats.tracked_objects == 1
+        finally:
+            # Nettoyer explicitement pour ne pas laisser d'état global
+            del obj
+            gc.collect()
     
     def test_cleanup_removes_dead_refs(self):
         """Test que cleanup supprime les références mortes."""
         manager = MemoryManager()
         
+        # Utiliser un objet dummy weakref-able sans effets de bord
+        # pour éviter de polluer le MemoryManager global
+        class DummyObject:
+            pass
+        
         # Créer un objet et le suivre
-        obj = TestTool()
+        obj = DummyObject()
         manager.track_object("temp_obj", obj)
         assert manager._stats.tracked_objects == 1
         
@@ -179,8 +194,14 @@ class TestBaseToolMemory:
         
         tool = TestTool()
         
-        # Le tool devrait être suivi
-        assert manager._stats.tracked_objects == initial_count + 1
+        try:
+            # Le tool devrait être suivi
+            assert manager._stats.tracked_objects == initial_count + 1
+        finally:
+            # Nettoyer explicitement pour ne pas laisser d'état global
+            tool.cleanup()
+            del tool
+            gc.collect()
     
     def test_base_tool_cleanup_releases_references(self):
         """Test que cleanup libère les références."""


### PR DESCRIPTION
## Description

Cette PR corrige les fuites mémoire identifiées dans l'issue #141 qui causaient une augmentation progressive de la mémoire sur les sessions longues.

## Changements

### 🔧 Fichiers modifiés

| Fichier | Changement |
|---------|-----------|
| `collegue/core/memory_manager.py` | **Nouveau** - Gestionnaire de mémoire centralisé |
| `collegue/tools/base.py` | Ajout méthode `cleanup()` et suivi weakref |
| `collegue/core/meta_orchestrator.py` | TTLCache pour le cache des tools |
| `collegue/tools/iac_guardrails_scan/tool.py` | Ajout méthode `cleanup()` |

### 🧠 Memory Manager (nouveau)

Module `collegue/core/memory_manager.py` fournissant:

**MemoryManager:**
- Suivi des objets avec références faibles (weakref)
- Callbacks de nettoyage enregistrables
- Nettoyage automatique des références mortes

**LimitedSizeHistory:**
- Historique avec taille limitée (deque maxlen)
- Suppression automatique des anciens éléments

**TTLCache:**
- Cache avec expiration automatique
- Nettoyage périodique des entrées expirées
- Limite de taille maximale

### 🛠️ Corrections spécifiques

**1. BaseTool (base.py):**
```python
def cleanup(self):
    """Libère les références pour éviter les fuites."""
    self.app_state = None
    self.config = None
    self.prompt_engine = None
    self.context_manager = None
    self._quota_manager = None
    gc.collect()
```

**2. MetaOrchestrator (meta_orchestrator.py):**
- Cache TTL de 1 heure pour les tools découverts
- Limite de 50 entrées maximum
- Nettoyage explicite des instances temporaires

**3. IacGuardrailsScanTool (iac_guardrails_scan/tool.py):**
```python
def cleanup(self):
    super().cleanup()
    self._engine = None
    self._k8s_scanner = None
    self._tf_scanner = None
    self._dockerfile_scanner = None
```

## 🧪 Tests

15 nouveaux tests dans `tests/test_memory_leak_fixes.py`:

```bash
pytest tests/test_memory_leak_fixes.py -v
# 15 passed
```

Tests couvrant:
- MemoryManager (suivi, nettoyage, callbacks)
- LimitedSizeHistory (limitation taille)
- TTLCache (expiration, taille max)
- BaseTool.cleanup()
- cleanup_all()

## 📖 Utilisation

```python
# Nettoyer un tool après utilisation
tool = SomeTool()
try:
    result = tool.execute(request)
finally:
    tool.cleanup()

# Nettoyage global
from collegue.core.memory_manager import cleanup_all
cleanup_all()
```

## ✅ Checklist

- [x] Code propre et documenté
- [x] Tests unitaires (15 nouveaux tests)
- [x] Pas de régression
- [x] Thread-safe
- [x] Utilisation de weakref pour éviter les références circulaires

Closes #141