### PR TITLE
feat(prompts): per-subtype templates for all refactoring_* lookups

### DIFF
--- a/collegue/prompts/templates/tools/refactoring_clean/default.yaml
+++ b/collegue/prompts/templates/tools/refactoring_clean/default.yaml
@@ -1,0 +1,63 @@
+name: refactoring_clean_default
+version: 1.0.0
+description: Template pour le refactoring de type 'clean' — suppression de code mort et imports inutiles.
+tags:
+  - refactoring
+  - clean
+template: |
+  You are an expert software engineer specializing in cleanup refactoring for {language} code.
+
+  Original code:
+  ```{language}
+  {code}
+  ```
+
+  Clean parameters: {parameters}
+
+  Additional context: {context}
+
+  Your task: apply a CLEAN refactoring only.
+
+  Remove, in this order:
+  1. Unused imports (never referenced by the remaining code).
+  2. Unused local variables and parameters the function never reads.
+  3. Private helpers (prefixed `_`) that are no longer called by anything in the given snippet.
+  4. Commented-out code blocks that are clearly leftovers (TODOs with a real description stay).
+  5. Trailing debug artifacts: `print(...)`, `console.log(...)`, `var_dump(...)` used for debugging.
+  6. Duplicated literal strings → extract to a module-level constant IF used ≥ 3 times.
+
+  Non-goals (do NOT do these here):
+  - Do NOT rename anything (rename refactoring handles it).
+  - Do NOT restructure control flow (simplify refactoring handles it).
+  - Do NOT touch public exported names — only internals.
+  - Do NOT remove code whose effect you cannot fully verify from the snippet (preserve on doubt).
+
+  Hard constraints:
+  - Behaviour must stay identical.
+  - Whitespace consistent with the rest of the file.
+  - Output MUST be shorter (or equal if nothing to clean).
+
+  Output: the cleaned source code only, no surrounding prose, fenced with ```{language}.
+variables:
+  - name: code
+    description: "Code to refactor"
+    type: string
+    required: true
+  - name: language
+    description: "Programming language"
+    type: string
+    required: true
+  - name: parameters
+    description: "Optional scope (keep_logs=true, etc.)"
+    type: string
+    required: false
+    default: ""
+  - name: context
+    description: "Additional context"
+    type: string
+    required: false
+    default: ""
+optimization_hints:
+  - dead_code_removal
+  - import_pruning
+  - conservative_on_doubt

--- a/collegue/prompts/templates/tools/refactoring_extract/default.yaml
+++ b/collegue/prompts/templates/tools/refactoring_extract/default.yaml
@@ -1,0 +1,59 @@
+name: refactoring_extract_default
+version: 1.0.0
+description: Template pour le refactoring de type 'extract' — extract method / extract variable.
+tags:
+  - refactoring
+  - extract
+template: |
+  You are an expert software engineer specializing in extract refactoring for {language} code.
+
+  Original code:
+  ```{language}
+  {code}
+  ```
+
+  Extract parameters: {parameters}
+
+  Additional context: {context}
+
+  Your task: apply an EXTRACT refactoring only.
+
+  Rules:
+  1. Use `parameters` to decide what to extract:
+     - `{"kind": "function", "name": "compute_total", "lines": "12-28"}` — extract a range into a function.
+     - `{"kind": "variable", "name": "price_ttc", "expression": "..."}` — extract a magic expression into a named local.
+     - `{"kind": "class", "name": "ReceiptPrinter"}` — extract cohesive methods into a new class.
+     If `parameters` is empty, extract the most obvious block (largest duplicated expression, longest inner
+     procedure, or cohesive group of fields) that reduces cognitive load.
+  2. Keep the public API and side effects of the original code unchanged.
+  3. The extracted symbol must:
+     - have a clear, intent-revealing name (follows {language} conventions);
+     - take exactly the parameters it needs — no hidden globals;
+     - return what the call sites consume (tuple/object if multiple values).
+  4. Update the original code to call the extracted symbol; add imports only if strictly needed.
+  5. Do NOT reformat untouched lines, do NOT reorder other functions.
+
+  Output: the refactored source code only, no surrounding prose, fenced with ```{language}.
+variables:
+  - name: code
+    description: "Code to refactor"
+    type: string
+    required: true
+  - name: language
+    description: "Programming language"
+    type: string
+    required: true
+  - name: parameters
+    description: "Extract spec: kind/name/range/expression"
+    type: string
+    required: false
+    default: ""
+  - name: context
+    description: "Additional context"
+    type: string
+    required: false
+    default: ""
+optimization_hints:
+  - single_responsibility
+  - intent_revealing_names
+  - minimal_diff

--- a/collegue/prompts/templates/tools/refactoring_modernize/default.yaml
+++ b/collegue/prompts/templates/tools/refactoring_modernize/default.yaml
@@ -1,0 +1,68 @@
+name: refactoring_modernize_default
+version: 1.0.0
+description: Template pour le refactoring de type 'modernize' — migration vers les idiomes récents du langage.
+tags:
+  - refactoring
+  - modernize
+template: |
+  You are an expert software engineer specializing in modernization refactoring for {language} code.
+
+  Original code:
+  ```{language}
+  {code}
+  ```
+
+  Modernize parameters: {parameters}
+
+  Additional context: {context}
+
+  Your task: apply a MODERNIZE refactoring only — adopt current language idioms.
+
+  Python modernisation cheatsheet (apply only what fits):
+  - `%`/`.format()` → f-strings.
+  - `dict(a=1, b=2)` → `{"a": 1, "b": 2}`.
+  - Manual class boilerplate → `@dataclass` / `NamedTuple` when the class is a data container.
+  - `os.path` joins → `pathlib.Path`.
+  - `typing.Dict/List/Tuple` → builtin generics (`dict[str, int]`) when target is Py ≥ 3.9.
+  - `typing.Optional[X]` → `X | None` when target is Py ≥ 3.10.
+  - Loop + `append` → list/dict/set comprehension when the body is a single expression.
+  - `try/except/pass` swallow → narrow exception + logging.
+  - `open(...)` calls → `with open(...) as f:` context manager.
+
+  JavaScript / TypeScript modernisation cheatsheet:
+  - `var` → `const`/`let`.
+  - `function foo() {{}}` callbacks → arrow functions where `this` binding is not needed.
+  - Promise chains → `async/await`.
+  - Object property shorthand, spread operator, optional chaining (`?.`), nullish coalescing (`??`).
+
+  General constraints:
+  - Only modernise constructs the `parameters` or the context allows (e.g. minimum language
+     version). If unspecified, pick a conservative floor (Python 3.10+, ES2020+).
+  - Preserve behaviour: same results, same side effects, same edge cases.
+  - Do NOT introduce new third-party dependencies — stick to stdlib / built-ins.
+  - Keep the public API stable.
+
+  Output: the modernized source code only, no surrounding prose, fenced with ```{language}.
+variables:
+  - name: code
+    description: "Code to refactor"
+    type: string
+    required: true
+  - name: language
+    description: "Programming language"
+    type: string
+    required: true
+  - name: parameters
+    description: "Target version, idiom allowlist, etc."
+    type: string
+    required: false
+    default: ""
+  - name: context
+    description: "Project constraints (min supported language version, style guide)"
+    type: string
+    required: false
+    default: ""
+optimization_hints:
+  - idiomatic_modern_code
+  - stdlib_first
+  - behaviour_preservation

--- a/collegue/prompts/templates/tools/refactoring_optimize/default.yaml
+++ b/collegue/prompts/templates/tools/refactoring_optimize/default.yaml
@@ -1,0 +1,66 @@
+name: refactoring_optimize_default
+version: 1.0.0
+description: Template pour le refactoring de type 'optimize' — amélioration de la complexité algorithmique ou mémoire.
+tags:
+  - refactoring
+  - optimize
+  - performance
+template: |
+  You are an expert software engineer specializing in performance refactoring for {language} code.
+
+  Original code:
+  ```{language}
+  {code}
+  ```
+
+  Optimize parameters: {parameters}
+
+  Additional context: {context}
+
+  Your task: apply an OPTIMIZE refactoring only.
+
+  Optimization targets, in order of likely impact:
+  1. Algorithmic complexity — replace O(n²) scans with O(n) lookups (use a set/dict),
+     avoid repeated work inside loops (hoist invariants), precompute shared results.
+  2. Data structures — pick the right one: `set` for membership, `dict` for keyed access,
+     `collections.Counter` for frequency, generators for streaming large data.
+  3. I/O — batch network/database calls, stream instead of loading everything, use
+     context managers so resources close promptly.
+  4. Memory — avoid building large intermediate lists (`list(...)`), use generator
+     expressions where the caller only iterates once.
+  5. Language idioms with known perf wins — comprehensions over manual loops, `join`
+     over string concatenation, local variable binding of hot attributes.
+
+  Hard constraints:
+  - Preserve behaviour: same results, same exception semantics, same ordering (unless
+     `parameters` explicitly authorises unordered output).
+  - Do NOT introduce new dependencies without justification.
+  - Do NOT micro-optimise at the expense of readability when the wins are negligible
+     (e.g. swapping `x + y` for bit tricks).
+  - If the optimisation changes complexity class, briefly mark the hot path with a
+     one-line comment explaining the before/after complexity.
+
+  Output: the optimized source code only, no surrounding prose, fenced with ```{language}.
+variables:
+  - name: code
+    description: "Code to refactor"
+    type: string
+    required: true
+  - name: language
+    description: "Programming language"
+    type: string
+    required: true
+  - name: parameters
+    description: "Optional target (hotspots, complexity budget, allow_reorder)"
+    type: string
+    required: false
+    default: ""
+  - name: context
+    description: "Profiling hints or usage patterns"
+    type: string
+    required: false
+    default: ""
+optimization_hints:
+  - algorithmic_complexity
+  - idiomatic_language_features
+  - preserve_semantics

--- a/collegue/prompts/templates/tools/refactoring_rename/default.yaml
+++ b/collegue/prompts/templates/tools/refactoring_rename/default.yaml
@@ -1,0 +1,54 @@
+name: refactoring_rename_default
+version: 1.0.0
+description: Template pour le refactoring de type 'rename' — renommage d'identifiants.
+tags:
+  - refactoring
+  - rename
+template: |
+  You are an expert software engineer specializing in rename refactoring for {language} code.
+
+  Original code:
+  ```{language}
+  {code}
+  ```
+
+  Rename parameters: {parameters}
+
+  Additional context: {context}
+
+  Your task: apply a RENAME refactoring only.
+
+  Rules:
+  1. Change ONLY the identifier(s) described in `parameters` (e.g. `{"from": "foo", "to": "bar"}`).
+     If `parameters` is empty, infer the best single rename that most improves clarity.
+  2. Update EVERY occurrence of the renamed symbol in the provided code, including:
+     - definitions, calls, imports, type hints, docstrings, string references and comments
+       where it clearly refers to the identifier (not unrelated matches).
+  3. Do NOT change program behaviour, do NOT reorder imports, do NOT reformat untouched lines.
+  4. Respect {language} naming conventions (PEP 8 for python, camelCase for JS/TS, etc.)
+     when inferring the target name.
+  5. Keep all other code exactly as provided — single-purpose refactoring.
+
+  Output: the refactored source code only, no surrounding prose, fenced with ```{language}.
+variables:
+  - name: code
+    description: "Code to refactor"
+    type: string
+    required: true
+  - name: language
+    description: "Programming language"
+    type: string
+    required: true
+  - name: parameters
+    description: "Rename spec, typically {'from': '...', 'to': '...'}"
+    type: string
+    required: false
+    default: ""
+  - name: context
+    description: "Optional extra context (call sites, usages)"
+    type: string
+    required: false
+    default: ""
+optimization_hints:
+  - naming_conventions
+  - minimal_diff

--- a/collegue/prompts/templates/tools/refactoring_simplify/default.yaml
+++ b/collegue/prompts/templates/tools/refactoring_simplify/default.yaml
@@ -1,0 +1,61 @@
+name: refactoring_simplify_default
+version: 1.0.0
+description: Template pour le refactoring de type 'simplify' — réduction de la complexité cognitive.
+tags:
+  - refactoring
+  - simplify
+template: |
+  You are an expert software engineer specializing in simplification refactoring for {language} code.
+
+  Original code:
+  ```{language}
+  {code}
+  ```
+
+  Simplify parameters: {parameters}
+
+  Additional context: {context}
+
+  Your task: apply a SIMPLIFY refactoring only.
+
+  Techniques to consider, in order of preference:
+  1. Collapse duplicated `if/elif` branches that return the same shape — use a mapping,
+     a lookup table, or a single expression.
+  2. Invert negative conditions (`if not x: ...; else: ...` → early return on `x`).
+  3. Replace nested conditionals with guard clauses and early returns.
+  4. Replace temporary accumulator loops with comprehensions / built-ins (`sum`, `any`,
+     `all`, `map`, `filter`) — but only when readability improves.
+  5. Remove redundant `else` after `return`/`raise`, unnecessary parentheses, and
+     dead assignments that are never read.
+  6. Simplify boolean expressions: `if x == True:` → `if x:`, `if len(xs) > 0:` → `if xs:`.
+
+  Hard constraints:
+  - Preserve behaviour exactly (same return values, same side effects, same exceptions).
+  - Do NOT rename identifiers (that's a different refactoring).
+  - Do NOT introduce new dependencies.
+  - The simplified output must be SHORTER (fewer lines OR lower cyclomatic complexity).
+
+  Output: the refactored source code only, no surrounding prose, fenced with ```{language}.
+variables:
+  - name: code
+    description: "Code to refactor"
+    type: string
+    required: true
+  - name: language
+    description: "Programming language"
+    type: string
+    required: true
+  - name: parameters
+    description: "Optional hints (target function, max_lines, etc.)"
+    type: string
+    required: false
+    default: ""
+  - name: context
+    description: "Additional context"
+    type: string
+    required: false
+    default: ""
+optimization_hints:
+  - cognitive_complexity_reduction
+  - guard_clauses
+  - behavioural_equivalence

--- a/tests/test_refactoring_prompt_templates.py
+++ b/tests/test_refactoring_prompt_templates.py
@@ -1,0 +1,94 @@
+"""Regression test for issue #209: every refactoring subtype must have a
+dedicated prompt template in `collegue/prompts/templates/tools/`.
+
+Before this fix, `smart_orchestrator`'s refactoring invocations hit the
+EnhancedPromptEngine with `tool_name="refactoring_simplify"` (and similar),
+which logged ``WARNING:tools.RefactoringTool:Erreur lors de la préparation
+du prompt optimisé: Aucun template trouvé pour l'outil refactoring_simplify``
+on every call and degraded the generated code quality via the fallback path.
+
+This suite enforces two contracts:
+  1. Every refactoring subtype declared by the tool has at least one YAML
+     template (directory + loadable file).
+  2. The EnhancedPromptEngine can resolve that template end-to-end through
+     ``get_optimized_prompt(tool_name=f"refactoring_{subtype}", ...)``.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from collegue.prompts.engine.enhanced_prompt_engine import EnhancedPromptEngine
+from collegue.tools.refactoring.tool import RefactoringTool
+
+
+TEMPLATES_DIR = Path("collegue/prompts/templates/tools")
+
+
+def _supported_subtypes() -> list[str]:
+    """Read the canonical list of refactoring subtypes from the tool itself."""
+    return RefactoringTool().get_supported_refactoring_types()
+
+
+@pytest.mark.parametrize("subtype", _supported_subtypes())
+def test_refactoring_subtype_has_template_directory(subtype: str):
+    """Each declared subtype (rename, extract, simplify, clean, optimize,
+    modernize) needs its own template subdirectory with at least one YAML."""
+    tool_dir = TEMPLATES_DIR / f"refactoring_{subtype}"
+    assert tool_dir.is_dir(), (
+        f"Missing template directory: {tool_dir}. "
+        f"Create {tool_dir}/default.yaml"
+    )
+    yamls = list(tool_dir.glob("*.yaml"))
+    assert yamls, (
+        f"No YAML templates in {tool_dir}. Expected at least "
+        f"refactoring_{subtype}/default.yaml"
+    )
+
+
+@pytest.mark.parametrize("subtype", _supported_subtypes())
+def test_prompt_engine_resolves_refactoring_subtype(subtype: str):
+    """EnhancedPromptEngine.get_optimized_prompt must return a non-empty
+    prompt for every refactoring_<subtype>, proving that the category
+    `tool/refactoring_<subtype>` is registered and formatable."""
+    engine = EnhancedPromptEngine()
+
+    tool_name = f"refactoring_{subtype}"
+    context = {
+        "code": "def f():\n    return 1\n",
+        "language": "python",
+        "parameters": "{}",
+        "context": "",
+    }
+
+    prompt, version = asyncio.new_event_loop().run_until_complete(
+        engine.get_optimized_prompt(tool_name=tool_name, context=context)
+    )
+
+    assert prompt, f"Empty prompt returned for {tool_name}"
+    # The refactoring verb for the subtype should appear somewhere in the
+    # prompt, confirming the template is subtype-specific rather than the
+    # generic fallback.
+    assert subtype in prompt.lower() or subtype[:5] in prompt.lower(), (
+        f"Prompt for {tool_name} does not mention the subtype: "
+        f"{prompt[:200]!r}"
+    )
+    assert version, "Version id missing"
+
+
+def test_all_refactoring_template_yamls_are_valid():
+    """Every refactoring_<subtype>/*.yaml file must parse cleanly and expose
+    the minimum fields the engine consumes (``name`` and ``template``)."""
+    import yaml
+
+    for subtype_dir in TEMPLATES_DIR.glob("refactoring_*"):
+        if not subtype_dir.is_dir():
+            continue
+        for yaml_file in subtype_dir.glob("*.yaml"):
+            with open(yaml_file, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+            assert isinstance(data, dict), f"{yaml_file} is not a mapping"
+            assert data.get("name"), f"{yaml_file} missing 'name'"
+            assert data.get("template"), f"{yaml_file} missing 'template'"


### PR DESCRIPTION
## Contexte

Closes #209.

`RefactoringTool` appelle `prepare_prompt(request, f"refactoring_{request.refactoring_type}")` ([tool.py:240,305](https://github.com/VynoDePal/Collegue/blob/main/collegue/tools/refactoring/tool.py#L240)), ce qui transmet à `EnhancedPromptEngine.get_optimized_prompt()` un `tool_name` de la forme `refactoring_simplify`, `refactoring_clean`, etc. Le moteur cherche la catégorie `tool/<tool_name>` → **n'existait que `tool/refactoring`**.

Conséquence observée pendant l'audit stress : à chaque appel, le log
```
WARNING:tools.RefactoringTool:Erreur lors de la préparation du prompt optimisé: Aucun template trouvé pour l'outil refactoring_simplify
```
puis fallback silencieux sur `_build_prompt()`. Le `PromptVersionManager` (A/B testing) restait inopérant pour les 6 sous-types de refactoring.

## Changements

### 6 nouveaux répertoires de templates

Chaque sous-type déclaré dans `RefactoringTool.get_supported_refactoring_types()` a maintenant son propre répertoire + `default.yaml` :

| Sous-type | Focus |
|---|---|
| `refactoring_rename/default.yaml` | Renommage d'identifiants, respect des conventions |
| `refactoring_extract/default.yaml` | Extract function / variable / class, SRP |
| `refactoring_simplify/default.yaml` | Guard clauses, collapse branches identiques |
| `refactoring_clean/default.yaml` | Imports inutilisés, dead code, debug artifacts |
| `refactoring_optimize/default.yaml` | Complexité algorithmique, bonnes structures |
| `refactoring_modernize/default.yaml` | f-strings, dataclass, pathlib, async/await (JS) |

Chaque template garde le même contrat de variables (`code`, `language`, `parameters`, `context`) que le `refactoring/default.yaml` générique — **aucun changement côté appelant**.

### Suite pytest de régression

Nouveau `tests/test_refactoring_prompt_templates.py` (13 tests, 2.21 s) :
- 6 tests paramétriques : chaque sous-type a un répertoire + un YAML
- 6 tests paramétriques : `EnhancedPromptEngine.get_optimized_prompt(tool_name="refactoring_<subtype>")` résout réellement vers un prompt spécifique (vérifié en cherchant le verbe du sous-type dans la sortie)
- 1 test global : tous les YAML refactoring_* parsent et exposent au moins `name` + `template`

```
============================== 13 passed in 2.21s ==============================
```

### Impact / non-régression

- Aucun caller existant modifié.
- La catégorie `tool/refactoring` et ses 3 templates (default/v2/experimental) restent en place pour les flux qui utilisent `prepare_prompt()` sans `template_name` spécifique.
- Le PromptVersionManager peut maintenant enregistrer des versions A/B sur chaque sous-type indépendamment.

## Test plan

- [x] `PYTHONPATH=. pytest tests/test_refactoring_prompt_templates.py -v` → 13 passed
- [x] `EnhancedPromptEngine._load_tool_templates()` charge les 6 nouveaux YAML (6 lignes `INFO: Template refactoring_<subtype>_default chargé`)
- [x] `get_optimized_prompt(tool_name="refactoring_simplify", ...)` retourne un prompt spécialisé "simplification refactoring" (vérifié par test paramétrique)
- [ ] En production : vérifier l'absence des warnings `Aucun template trouvé pour l'outil refactoring_*` après redémarrage du conteneur

## Bonus / points d'attention

- Les warnings observés dans `code_documentation` et `test_generation` **n'existent pas** : ces deux outils utilisent `_engine.build_prompt()` directement, pas `prepare_prompt()`. Pas de template manquant pour eux.
- La tâche CI du bonus reste portée par **#212** (mise en place `.github/workflows/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)