### PR TITLE
refactor(orchestrator): lifespan-scoped ToolsRegistry (removes _TOOLS_CACHE global)

### DIFF
--- a/collegue/app.py
+++ b/collegue/app.py
@@ -222,17 +222,31 @@ async def core_lifespan(server):
     global _lazy_engine_instance
     from collegue.core.parser import CodeParser
     from collegue.core.resource_manager import ResourceManager
+    from collegue.core.tools_registry import ToolsRegistry, discover_tools
 
     startup_start = time.time()
     logger.info("🔄 Démarrage du core_lifespan...")
-    
+
     # Validation stricte du LLM au démarrage
     await validate_llm_config()
+
+    # Eager tool discovery — runs once at startup. Before #211 this was driven
+    # lazily by the first `smart_orchestrator` call through a module-level
+    # ``_TOOLS_CACHE`` global, which had no lock around initialisation. Running
+    # it here means: (a) no cold-start race under concurrent load, and
+    # (b) startup logs surface any broken tool before the first request.
+    discovery_start = time.time()
+    tools_registry = ToolsRegistry(initial=discover_tools())
+    logger.info(
+        "🔎 Tool registry construit en %.2fs — %d outils disponibles",
+        time.time() - discovery_start, len(await tools_registry.get()),
+    )
 
     state = {
         "parser": CodeParser(),
         "resource_manager": ResourceManager(),
         "prompt_engine": None,
+        "tools_registry": tools_registry,
     }
 
     # Initialisation rapide des composants essentiels
@@ -251,6 +265,7 @@ async def core_lifespan(server):
     logger.info(f"   - Parser: disponible")
     logger.info(f"   - ResourceManager: disponible")
     logger.info(f"   - PromptEngine: initialisation en cours (lazy)")
+    logger.info(f"   - ToolsRegistry: pré-chargé ({len(await tools_registry.get())} outils)")
     
     print(f"✅ Composants initialisés via lifespan context: {list(state.keys())}")
     yield state

--- a/collegue/core/meta_orchestrator.py
+++ b/collegue/core/meta_orchestrator.py
@@ -1,11 +1,19 @@
 """
 Meta Orchestrator - Tool intelligent utilisant FastMCP sampling with tools
+
+Tool discovery was previously driven by a module-level ``_TOOLS_CACHE`` global
+populated lazily on the first request. That global was replaced (issue #211)
+by a lifespan-injected :class:`~collegue.core.tools_registry.ToolsRegistry`
+that is built once at server startup. See ``collegue/core/tools_registry.py``
+for the discovery logic and the concurrency-safe wrapper used as a fallback
+when the handler is invoked outside of a proper lifespan context (tests,
+ad-hoc scripts).
 """
 
 from typing import List, Dict, Any, Optional
 from pydantic import BaseModel, Field
 
-from .memory_manager import TTLCache
+from .tools_registry import ToolsRegistry
 
 try:
     from fastmcp import FastMCP, Context
@@ -13,10 +21,11 @@ except ImportError:
     FastMCP = Any
     Context = Any
 
-# Cache global pour les outils découverts (avec TTL de 1 heure)
-_TOOLS_CACHE = None
-_MAX_TOOLS_CACHE_SIZE = 50
-_TOOLS_CACHE_TTL = 3600  # 1 heure
+# Fallback registry used only when ``ctx.lifespan_context`` does not already
+# carry one (e.g. in unit tests that invoke the handler directly). The
+# ``ToolsRegistry`` itself is asyncio-safe, so concurrent cold-start requests
+# will trigger at most one discovery.
+_FALLBACK_REGISTRY: ToolsRegistry = ToolsRegistry()
 
 
 class OrchestratorStep(BaseModel):
@@ -80,91 +89,27 @@ def register_meta_orchestrator(app: FastMCP):
         """
         import time
         import json
-        import importlib
-        import inspect
-        import pkgutil
-        import collegue.tools
-        from collegue.tools.base import BaseTool
 
-        global _TOOLS_CACHE, _MAX_TOOLS_CACHE_SIZE, _TOOLS_CACHE_TTL
         start_time = time.time()
         await ctx.info(
             f"Démarrage orchestration (mode v4 robust): {request.query[:100]}..."
         )
 
-        # 1. Découverte des tools (avec Cache TTL)
-        # Relancer la discovery si le cache est None ou vide (après expiration)
-        if _TOOLS_CACHE is None or len(_TOOLS_CACHE) == 0:
-            # Construire le cache dans une variable locale pour éviter les race conditions
-            _tools_cache_local = TTLCache(
-                max_size=_MAX_TOOLS_CACHE_SIZE,
-                ttl_seconds=_TOOLS_CACHE_TTL,
-                name="tools_discovery"
-            )
-            try:
-                for _, name, _ in pkgutil.iter_modules(collegue.tools.__path__):
-                    if name.startswith("_") or name == "base":
-                        continue
-                    try:
-                        module = importlib.import_module(f"collegue.tools.{name}")
-                        for _, obj in inspect.getmembers(module):
-                            if (
-                                inspect.isclass(obj)
-                                and issubclass(obj, BaseTool)
-                                and obj != BaseTool
-                                and obj.__module__ == module.__name__
-                            ):
-                                temp_instance = None
-                                try:
-                                    # Instantiation temporaire pour métadonnées
-                                    temp_instance = obj({})
-                                    tool_name = temp_instance.get_name()
-                                    if tool_name == "smart_orchestrator":
-                                        continue
-
-                                    schema = temp_instance.get_request_model().model_json_schema()
-                                    props = schema.get("properties", {})
-                                    required = schema.get("required", [])
-
-                                    args_desc = []
-                                    for prop_name, prop_info in props.items():
-                                        req_mark = (
-                                            "(REQUIS)"
-                                            if prop_name in required
-                                            else "(optionnel)"
-                                        )
-                                        prop_type = prop_info.get("type", "any")
-                                        prop_desc = prop_info.get("description", "")
-                                        args_desc.append(
-                                            f"    - {prop_name} ({prop_type}): {prop_desc} {req_mark}"
-                                        )
-
-                                    formatted_args = "\\n".join(args_desc)
-
-                                    _tools_cache_local.set(tool_name, {
-                                        "class": obj,
-                                        "description": temp_instance.get_description(),
-                                        "prompt_desc": f"{tool_name}: {temp_instance.get_description()}\\n  Arguments:\\n{formatted_args}",
-                                        "schema": schema,
-                                    })
-
-                                except Exception as e:
-                                    await ctx.warning(f"Skip {name}: {e}")
-                                finally:
-                                    # Nettoyer explicitement l'instance temporaire (même en cas d'erreur)
-                                    if temp_instance is not None:
-                                        if hasattr(temp_instance, 'cleanup'):
-                                            temp_instance.cleanup()
-                                        del temp_instance
-                    except Exception:
-                        pass
-            except Exception as e:
-                await ctx.error(f"Erreur discovery: {e}")
-            
-            # Assigner le cache complet une fois rempli (évite les race conditions)
-            _TOOLS_CACHE = _tools_cache_local
-
-        available_tools = _TOOLS_CACHE
+        # 1. Tool registry — populated once by core_lifespan at startup and
+        # injected via ``ctx.lifespan_context``. When the handler is called
+        # outside of a full lifespan (unit tests, scripts), fall back to a
+        # module-level ``ToolsRegistry`` whose lock prevents concurrent
+        # cold-start races.
+        lc = ctx.lifespan_context or {}
+        injected = lc.get("tools_registry")
+        if isinstance(injected, ToolsRegistry):
+            available_tools = await injected.get()
+        elif isinstance(injected, dict):
+            # Accept a raw dict too: convenient for unit tests that just want
+            # to stub a fixed set of tools without wrapping in ToolsRegistry.
+            available_tools = injected
+        else:
+            available_tools = await _FALLBACK_REGISTRY.get()
         tools_desc = "\\n".join(
             [info["prompt_desc"] for name, info in available_tools.items()]
         )
@@ -172,8 +117,7 @@ def register_meta_orchestrator(app: FastMCP):
         # 2. Étape PLANIFICATION (avec Structured Output)
         await ctx.info("Phase 1: Planification...")
 
-        # Récupération du prompt engine depuis le contexte
-        lc = ctx.lifespan_context or {}
+        # Récupération du prompt engine depuis le même contexte que le registry
         prompt_engine = lc.get("prompt_engine")
 
         # Construction du prompt

--- a/collegue/core/tools_registry.py
+++ b/collegue/core/tools_registry.py
@@ -1,0 +1,171 @@
+"""Tool discovery + registry, decoupled from the orchestrator handler.
+
+Rationale (issue #211)
+----------------------
+The previous implementation kept a mutable module-level ``_TOOLS_CACHE``
+variable inside ``meta_orchestrator`` that was populated lazily by the first
+request to ``smart_orchestrator``. That design had four downsides:
+
+1. No lock around the initialisation — a burst of concurrent cold-start
+   requests could populate the cache twice or corrupt it.
+2. No way to refresh / invalidate without restarting the process.
+3. The name "global" suggested cross-replica state; it was actually
+   per-process, which confused contributors.
+4. Tests had to reach into the module and monkey-patch the global to inject
+   fake tools.
+
+This module exposes two pieces of public API:
+
+* :func:`discover_tools` — a pure-sync function that walks ``collegue.tools``,
+  instantiates every ``BaseTool`` subclass once to extract its metadata and
+  returns a ``{tool_name: {class, description, prompt_desc, schema}}`` dict.
+* :class:`ToolsRegistry` — a thin wrapper around that dict that guards lazy
+  rediscovery with an ``asyncio.Lock``, so callers that don't (or can't) rely
+  on the lifespan-injected registry never race with each other.
+
+The orchestrator reads the registry via ``ctx.lifespan_context['tools_registry']``
+— the old ``_TOOLS_CACHE`` global is gone.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib
+import inspect
+import logging
+import pkgutil
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+#: A discovered tool entry. ``class`` is the un-instantiated BaseTool subclass;
+#: ``prompt_desc`` is a pre-formatted block ready to paste into the LLM prompt.
+ToolEntry = Dict[str, Any]
+
+#: Mapping from tool name (e.g. ``"code_documentation"``) to its entry.
+ToolsRegistryDict = Dict[str, ToolEntry]
+
+# The orchestrator itself must NOT be listed among the registered tools —
+# otherwise the LLM would try to plan calls to itself.
+_EXCLUDED_TOOL_NAMES = {"smart_orchestrator"}
+
+
+def _build_prompt_desc(tool_name: str, description: str, schema: Dict[str, Any]) -> str:
+    """Render the same prompt description format the orchestrator used inline."""
+    props = schema.get("properties", {})
+    required = schema.get("required", [])
+    args_desc: list[str] = []
+    for prop_name, prop_info in props.items():
+        req_mark = "(REQUIS)" if prop_name in required else "(optionnel)"
+        prop_type = prop_info.get("type", "any")
+        prop_desc = prop_info.get("description", "")
+        args_desc.append(f"    - {prop_name} ({prop_type}): {prop_desc} {req_mark}")
+    formatted_args = "\n".join(args_desc)
+    return f"{tool_name}: {description}\n  Arguments:\n{formatted_args}"
+
+
+def discover_tools() -> ToolsRegistryDict:
+    """Walk the ``collegue.tools`` package and return all registered tools.
+
+    This function is synchronous on purpose: it is meant to be called once
+    during ``core_lifespan`` startup (before ``yield``). Import failures of
+    individual tool modules are logged and skipped; they do NOT abort
+    discovery so one broken tool doesn't take down the whole orchestrator.
+    """
+    import collegue.tools as tools_pkg
+    from collegue.tools.base import BaseTool
+
+    registry: ToolsRegistryDict = {}
+
+    for _, name, _ in pkgutil.iter_modules(tools_pkg.__path__):
+        if name.startswith("_") or name == "base":
+            continue
+
+        try:
+            module = importlib.import_module(f"collegue.tools.{name}")
+        except Exception as exc:
+            logger.warning("Tool module '%s' failed to import, skipping: %s", name, exc)
+            continue
+
+        for _, obj in inspect.getmembers(module):
+            if not (
+                inspect.isclass(obj)
+                and issubclass(obj, BaseTool)
+                and obj is not BaseTool
+                and obj.__module__.startswith(module.__name__)
+            ):
+                continue
+
+            instance = None
+            try:
+                instance = obj({})
+                tool_name = instance.get_name()
+
+                if tool_name in _EXCLUDED_TOOL_NAMES:
+                    continue
+
+                schema = instance.get_request_model().model_json_schema()
+                registry[tool_name] = {
+                    "class": obj,
+                    "description": instance.get_description(),
+                    "prompt_desc": _build_prompt_desc(
+                        tool_name, instance.get_description(), schema
+                    ),
+                    "schema": schema,
+                }
+            except Exception as exc:
+                logger.warning(
+                    "Skipping tool class %s in module %s: %s",
+                    obj.__name__, name, exc,
+                )
+            finally:
+                # Release any resources held by the temporary instance so we
+                # don't leak connection pools, file handles, etc.
+                if instance is not None and hasattr(instance, "cleanup"):
+                    try:
+                        instance.cleanup()
+                    except Exception:
+                        pass
+
+    logger.info("Tools registry discovered %d tool(s): %s",
+                 len(registry), sorted(registry.keys()))
+    return registry
+
+
+class ToolsRegistry:
+    """Asyncio-safe wrapper around a tools registry dict.
+
+    The lifespan-injected registry is the primary path; this wrapper only
+    matters for the degraded cases (tests, ad-hoc scripts) where the
+    orchestrator is invoked without an initialised ``ctx.lifespan_context``.
+    It guarantees that concurrent callers trigger at most one ``discover_tools``
+    invocation.
+    """
+
+    def __init__(self, initial: ToolsRegistryDict | None = None):
+        self._registry: ToolsRegistryDict | None = dict(initial) if initial else None
+        self._lock = asyncio.Lock()
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._registry is not None
+
+    async def get(self) -> ToolsRegistryDict:
+        """Return the registry, discovering once if needed."""
+        if self._registry is not None:
+            return self._registry
+        async with self._lock:
+            # Double-checked locking: another coroutine may have populated it
+            # while we were waiting on the lock.
+            if self._registry is None:
+                # ``discover_tools`` is sync; run it in a thread so we do not
+                # stall the event loop during cold start.
+                self._registry = await asyncio.to_thread(discover_tools)
+            return self._registry
+
+    def set(self, registry: ToolsRegistryDict) -> None:
+        """Replace the backing dict (used by tests and by the lifespan)."""
+        self._registry = dict(registry)
+
+    def clear(self) -> None:
+        """Force the next ``get()`` call to re-run discovery."""
+        self._registry = None

--- a/tests/test_orchestrator_fixes.py
+++ b/tests/test_orchestrator_fixes.py
@@ -38,7 +38,8 @@ async def test_orchestrator_planning_and_execution():
     tool_decorator = app.tool.return_value
     smart_orchestrator_func = tool_decorator.call_args[0][0]
     
-    # Mock _TOOLS_CACHE
+    # Inject a fake tools registry via the lifespan_context — same pattern
+    # the orchestrator uses in production now that _TOOLS_CACHE is gone (#211).
     mock_tools_cache = {
         "mock_tool": {
             "class": lambda x: MockToolInstance(),
@@ -47,10 +48,9 @@ async def test_orchestrator_planning_and_execution():
             "schema": {}
         }
     }
-    
-    mo._TOOLS_CACHE = mock_tools_cache
-    
+
     mock_ctx = MockContext()
+    mock_ctx.lifespan_context = {"tools_registry": mock_tools_cache}
     
     # Plan response
     plan_response = MagicMock()

--- a/tests/test_tools_registry.py
+++ b/tests/test_tools_registry.py
@@ -1,0 +1,237 @@
+"""Regression tests for ToolsRegistry / lifespan-scoped tool discovery (#211).
+
+Three things we need to guarantee:
+
+1. ``discover_tools`` walks ``collegue.tools`` and surfaces every
+   ``BaseTool`` subclass that currently ships with the project (including
+   those re-exported from sub-packages such as ``collegue.tools.secret_scan.tool``).
+2. ``ToolsRegistry`` only runs ``discover_tools`` once even when dozens of
+   coroutines hit ``.get()`` concurrently during cold start — the previous
+   ``_TOOLS_CACHE`` global could race.
+3. The orchestrator handler reads the registry injected via
+   ``ctx.lifespan_context["tools_registry"]`` and no longer depends on any
+   module-level global.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import collegue.core.meta_orchestrator as mo
+from collegue.core.tools_registry import (
+    ToolsRegistry,
+    discover_tools,
+)
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+# ---------------------------------------------------------------------------
+# discover_tools
+# ---------------------------------------------------------------------------
+
+def test_discover_tools_returns_all_registered_tools():
+    """Every shipping tool must be discoverable through the public API.
+
+    The assertion is on a conservative subset — we just want to catch the
+    class of bug where a new sub-package stops being picked up. The exact
+    count is not frozen because the project keeps adding tools.
+    """
+    registry = discover_tools()
+
+    expected_monolithic = {
+        "github_ops",
+        "sentry_monitor",
+        "postgres_db",
+        "kubernetes_ops",
+    }
+    expected_modular = {
+        "secret_scan",
+        "dependency_guard",
+        "iac_guardrails_scan",
+        "repo_consistency_check",
+        "impact_analysis",
+        "code_documentation",
+        "test_generation",
+        "code_refactoring",
+    }
+
+    missing_mono = expected_monolithic - registry.keys()
+    assert not missing_mono, f"Monolithic tools missing: {missing_mono}"
+
+    # Modular tools may fail to import on Python < 3.12 (PEP 701 fstring with
+    # backslashes in repo_consistency_check). Tolerate up to 2 absences so
+    # the test is portable across supported Python versions.
+    missing_modular = expected_modular - registry.keys()
+    assert len(missing_modular) <= 2, (
+        f"Too many modular tools missing: {missing_modular}. "
+        f"The startswith(module.__name__) fix should surface most of "
+        f"{expected_modular}."
+    )
+
+
+def test_discovered_entry_has_expected_shape():
+    """Every entry must expose the 4 fields the orchestrator renders."""
+    registry = discover_tools()
+    assert registry, "discovery returned an empty dict — check the traversal"
+
+    # Pick any entry (secret_scan almost certainly present) and verify shape.
+    sample_name = next(iter(registry))
+    entry = registry[sample_name]
+    assert "class" in entry
+    assert "description" in entry
+    assert "prompt_desc" in entry
+    assert "schema" in entry
+    assert sample_name in entry["prompt_desc"]  # name must be in the prompt
+
+
+def test_discover_does_not_include_smart_orchestrator():
+    """The orchestrator must not recommend itself — infinite loop risk."""
+    registry = discover_tools()
+    assert "smart_orchestrator" not in registry
+
+
+# ---------------------------------------------------------------------------
+# ToolsRegistry — concurrency + caching
+# ---------------------------------------------------------------------------
+
+def test_registry_returns_injected_dict_without_calling_discovery(monkeypatch):
+    """An initial dict is returned as-is; discover_tools is NOT called."""
+    called = {"n": 0}
+
+    def _fail_if_called():
+        called["n"] += 1
+        return {}
+
+    monkeypatch.setattr(
+        "collegue.core.tools_registry.discover_tools", _fail_if_called
+    )
+
+    registry = ToolsRegistry(initial={"fake": {"prompt_desc": "fake desc"}})
+    result = _run(registry.get())
+    assert result == {"fake": {"prompt_desc": "fake desc"}}
+    assert called["n"] == 0
+
+
+def test_registry_cold_start_triggers_discovery_exactly_once(monkeypatch):
+    """``asyncio.gather`` on an empty registry: N waiters, 1 discovery."""
+    called = {"n": 0}
+
+    def _count_discovery():
+        called["n"] += 1
+        # Returning a predictable shape so we can assert callers see it.
+        return {"probe_tool": {"prompt_desc": "probe"}}
+
+    monkeypatch.setattr(
+        "collegue.core.tools_registry.discover_tools", _count_discovery
+    )
+
+    registry = ToolsRegistry()
+
+    async def _hammer(n: int):
+        return await asyncio.gather(*[registry.get() for _ in range(n)])
+
+    results = _run(_hammer(30))
+
+    assert called["n"] == 1, (
+        f"discover_tools was called {called['n']} times for 30 concurrent "
+        f"waiters — the lock around cold-start initialisation is broken."
+    )
+    for r in results:
+        assert r == {"probe_tool": {"prompt_desc": "probe"}}
+
+
+def test_registry_clear_forces_fresh_discovery(monkeypatch):
+    """``clear()`` invalidates the cache and lets the next ``get()`` rediscover."""
+    calls = []
+
+    def _tick():
+        calls.append(None)
+        return {"snap": {"prompt_desc": f"tick-{len(calls)}"}}
+
+    monkeypatch.setattr(
+        "collegue.core.tools_registry.discover_tools", _tick
+    )
+
+    registry = ToolsRegistry()
+    _run(registry.get())   # first discovery
+    _run(registry.get())   # cached
+    registry.clear()
+    _run(registry.get())   # second discovery
+
+    assert len(calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# meta_orchestrator uses the lifespan-injected registry
+# ---------------------------------------------------------------------------
+
+def test_orchestrator_reads_registry_from_lifespan_context():
+    """The handler must NOT fall back to discovery when ``ctx.lifespan_context``
+    already carries a ``tools_registry``."""
+    # Register the orchestrator on a stub app to capture the handler coroutine.
+    app = MagicMock()
+    mo.register_meta_orchestrator(app)
+    handler = app.tool.return_value.call_args[0][0]
+
+    # A stub tool the plan will reference
+    class _StubTool:
+        def __init__(self, *_a, **_k):
+            pass
+
+        def get_request_model(self):
+            from pydantic import BaseModel
+            class _R(BaseModel):
+                model_config = {"extra": "allow"}
+            return _R
+
+        async def execute_async(self, request, **kwargs):
+            class _Res:
+                def dict(self_inner):
+                    return {"ok": True}
+            return _Res()
+
+    injected = {
+        "fake_tool": {
+            "class": _StubTool,
+            "description": "fake",
+            "prompt_desc": "fake_tool: fake\n  Arguments: none",
+            "schema": {},
+        }
+    }
+
+    ctx = MagicMock()
+    ctx.lifespan_context = {"tools_registry": injected}
+    ctx.info = AsyncMock()
+    ctx.warning = AsyncMock()
+    ctx.error = AsyncMock()
+    ctx.sample = AsyncMock()
+
+    plan_resp = MagicMock()
+    plan_resp.result = mo.OrchestratorPlan(steps=[
+        mo.OrchestratorStep(tool="fake_tool", reason="t", params={})
+    ])
+    synth_resp = MagicMock(); synth_resp.text = "done"
+    ctx.sample.side_effect = [plan_resp, synth_resp]
+
+    response = _run(handler(mo.OrchestratorRequest(query="hello"), ctx))
+    assert response.tools_used == ["fake_tool"]
+
+
+def test_orchestrator_no_longer_imports_global_tools_cache():
+    """Guard against regressions: the module must not expose ``_TOOLS_CACHE``
+    anymore. If someone reintroduces it, this test fails loudly."""
+    assert not hasattr(mo, "_TOOLS_CACHE"), (
+        "Module-level _TOOLS_CACHE is back — revert to the lifespan-scoped "
+        "registry (see #211) instead of reintroducing a global mutable."
+    )
+    assert not hasattr(mo, "_MAX_TOOLS_CACHE_SIZE")
+    assert not hasattr(mo, "_TOOLS_CACHE_TTL")


### PR DESCRIPTION
## Contexte

Closes #211.

`meta_orchestrator` tenait un cache `_TOOLS_CACHE` au niveau module, populé paresseusement au premier appel de `smart_orchestrator`. Les quatre problèmes signalés dans l'issue :

1. Aucun lock autour de la discovery → des requêtes concurrentes en cold-start pouvaient doublement initialiser ou corrompre le cache.
2. Pas de moyen de rafraîchir / invalider sans redémarrer le process.
3. Confusion sémantique : « global » suggérait un état partagé cross-replica, alors que c'était per-process.
4. Difficulté à mocker dans les tests (qui devaient patcher directement `mo._TOOLS_CACHE`).

## Nouvelle architecture

### `collegue/core/tools_registry.py` (nouveau)

- **`discover_tools()`** — fonction sync pure qui parcourt `collegue.tools`, trouve tous les `BaseTool` subclasses (y compris ceux re-exportés depuis des sous-packages comme `collegue.tools.secret_scan.tool`) et renvoie le même dict `{tool_name: {class, description, prompt_desc, schema}}` que l'ancienne discovery. Les échecs d'import par module sont maintenant loggés et skippés proprement (avant : silencieusement avalés).
- **`ToolsRegistry`** — wrapper asyncio-safe autour du dict, avec `asyncio.Lock` pour garantir qu'un cold-start concurrent ne lance qu'une seule discovery. Expose `set()` / `clear()` pour les tests + hot-reload potentiel.

### `collegue/app.py`

- `core_lifespan` appelle `discover_tools()` **eagerly** au démarrage et stocke un `ToolsRegistry` sous `state["tools_registry"]`. Conséquences :
  - Plus aucune race au cold-start : à la 1ʳᵉ requête, le registre est déjà peuplé.
  - Les tools cassés remontent dans les logs au démarrage, pas au premier appel.
  - Ligne de log supplémentaire : `🔎 Tool registry construit en X.XXs — N outils disponibles`.

### `collegue/core/meta_orchestrator.py`

- Suppression des trois globals : `_TOOLS_CACHE`, `_MAX_TOOLS_CACHE_SIZE`, `_TOOLS_CACHE_TTL`.
- Suppression du bloc de discovery inline (~80 lignes).
- Le handler lit `ctx.lifespan_context["tools_registry"]` en premier ; si absent (tests, scripts ad-hoc), fallback sur un `ToolsRegistry()` module-level toujours protégé par un lock.
- Accepte à la fois un `ToolsRegistry` **et** un dict simple dans `lifespan_context` (pratique pour les tests qui veulent juste stubber).

## Tests

### `tests/test_tools_registry.py` (nouveau, 8 tests, 1.01 s)

| Test | Vérifie |
|---|---|
| `test_discover_tools_returns_all_registered_tools` | Discovery surface les 4 monolithiques + ≥ 6/8 modulaires (tolérance pour Py3.11 qui échoue sur `repo_consistency_check` à cause d'un f-string backslash) |
| `test_discovered_entry_has_expected_shape` | Chaque entry a `class` / `description` / `prompt_desc` / `schema`, et le nom est dans `prompt_desc` |
| `test_discover_does_not_include_smart_orchestrator` | L'orchestrateur n'apparaît pas lui-même dans son registre |
| `test_registry_returns_injected_dict_without_calling_discovery` | `ToolsRegistry(initial=...)` n'appelle **pas** `discover_tools` |
| `test_registry_cold_start_triggers_discovery_exactly_once` | **30 appels concurrents** à `.get()` sur un registre vide → **1 seule** discovery (le lock fonctionne) |
| `test_registry_clear_forces_fresh_discovery` | `clear()` puis `get()` relance la discovery |
| `test_orchestrator_reads_registry_from_lifespan_context` | Le handler utilise le registre injecté via `ctx.lifespan_context` |
| `test_orchestrator_no_longer_imports_global_tools_cache` | Garde contre régression : `mo._TOOLS_CACHE` n'existe plus |

### `tests/test_orchestrator_fixes.py` (migré)

Le test existant mockait `mo._TOOLS_CACHE = ...` directement. Migré vers le nouveau pattern d'injection via `ctx.lifespan_context["tools_registry"] = fake_dict`. Pas de changement de comportement fonctionnel du test.

Sortie :
```
PYTHONPATH=. pytest tests/test_tools_registry.py -v
→ 8 passed in 1.01s
```

## Test plan

- [x] Unit tests (8 PASS)
- [x] Import smoke test : `collegue.core.meta_orchestrator` — `_TOOLS_CACHE` absent, `_FALLBACK_REGISTRY` présent, discovery trouve 11 outils sur Py3.11 (12 sur Py3.12)
- [ ] Test intégration Docker : vérifier que les logs de startup contiennent `Tool registry construit en X.XXs — N outils` et que la 1ʳᵉ requête `smart_orchestrator` est plus rapide (pas de cold-start discovery)

## Migration pour les consommateurs

Aucune API publique n'a changé côté client MCP. Les seuls impacts sont internes :

- **Tests existants qui faisaient `mo._TOOLS_CACHE = {...}`** → passer par `ctx.lifespan_context["tools_registry"] = {...}`. Un seul test (`test_orchestrator_fixes.py`) était concerné et a été migré.
- **Code qui importait `_TOOLS_CACHE`** → aucun trouvé dans le repo.

## Commandes

```bash
PYTHONPATH=. pytest tests/test_tools_registry.py -v

# Startup log check après rebuild :
docker compose up -d --build collegue-app
docker logs collegue-collegue-app-1 | grep -i "Tool registry"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)