### PR TITLE
test: fix repo_consistency_check ConsistencyFile usage (#218)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,12 +17,6 @@ _KNOWN_FAILURES: frozenset[str] = frozenset({
     "tests/test_impact_analysis.py::TestImpactAnalysisRequest::test_request_defaults",
     "tests/test_impact_analysis.py::TestImpactAnalysisTool::test_execute_core_logic",
     "tests/test_impact_analysis.py::TestImpactAnalysisTool::test_validate_request_valid",
-    "tests/test_repo_consistency_check.py::TestConsistencyCheckRequest::test_request_language_auto",
-    "tests/test_repo_consistency_check.py::TestConsistencyCheckRequest::test_request_validation_checks",
-    "tests/test_repo_consistency_check.py::TestRepoConsistencyCheckTool::test_mode_validation",
-    "tests/test_repo_consistency_check.py::TestRepoConsistencyCheckTool::test_scan_multiple_files",
-    "tests/test_repo_consistency_check.py::TestRepoConsistencyCheckTool::test_scan_no_issues",
-    "tests/test_repo_consistency_check.py::TestRepoConsistencyCheckTool::test_scan_unused_imports_python",
     "tests/test_secret_scan.py::TestSecretScanTool::test_scan_batch_files",
     "tests/test_test_generation_fixes.py::test_test_generation_success",
 })

--- a/tests/test_repo_consistency_check.py
+++ b/tests/test_repo_consistency_check.py
@@ -10,6 +10,7 @@ from collegue.tools.repo_consistency_check import (
     ConsistencyCheckResponse
 )
 from collegue.tools.repo_consistency_check.engine import ConsistencyAnalysisEngine
+from collegue.tools.repo_consistency_check.models import ConsistencyFile
 from collegue.core.shared import FileInput, ConsistencyIssue
 
 
@@ -112,7 +113,7 @@ class TestRepoConsistencyCheckTool:
     def test_scan_unused_imports_python(self, tool):
         """Test la détection d'imports non utilisés en Python."""
         files = [
-            FileInput(path="test.py", content="import os\nimport sys\nprint('hello')")
+            ConsistencyFile(path="test.py", content="import os\nimport sys\nprint('hello')")
         ]
         request = ConsistencyCheckRequest(
             files=files,
@@ -130,7 +131,7 @@ class TestRepoConsistencyCheckTool:
     def test_scan_no_issues(self, tool):
         """Test le scan sans problèmes."""
         files = [
-            FileInput(path="test.py", content="print('hello')")
+            ConsistencyFile(path="test.py", content="print('hello')")
         ]
         request = ConsistencyCheckRequest(
             files=files,
@@ -145,8 +146,8 @@ class TestRepoConsistencyCheckTool:
     def test_scan_multiple_files(self, tool):
         """Test le scan de plusieurs fichiers."""
         files = [
-            FileInput(path="file1.py", content="x = 1"),
-            FileInput(path="file2.py", content="y = 2")
+            ConsistencyFile(path="file1.py", content="x = 1"),
+            ConsistencyFile(path="file2.py", content="y = 2")
         ]
         request = ConsistencyCheckRequest(
             files=files,
@@ -158,7 +159,7 @@ class TestRepoConsistencyCheckTool:
 
     def test_mode_validation(self, tool):
         """Test la validation du mode."""
-        files = [FileInput(path="test.py", content="pass")]
+        files = [ConsistencyFile(path="test.py", content="pass")]
         request = ConsistencyCheckRequest(files=files, language="python", mode="deep")
         assert request.mode == "deep"
         
@@ -171,7 +172,7 @@ class TestConsistencyCheckRequest:
 
     def test_request_validation_checks(self):
         """Test la validation des checks."""
-        files = [FileInput(path="test.py", content="pass")]
+        files = [ConsistencyFile(path="test.py", content="pass")]
         request = ConsistencyCheckRequest(
             files=files,
             language="python",
@@ -188,6 +189,6 @@ class TestConsistencyCheckRequest:
 
     def test_request_language_auto(self):
         """Test la détection auto du langage."""
-        files = [FileInput(path="test.py", content="pass")]
+        files = [ConsistencyFile(path="test.py", content="pass")]
         request = ConsistencyCheckRequest(files=files, language="auto")
         assert request.language == "auto"


### PR DESCRIPTION
Round 4 sur [#218](https://github.com/VynoDePal/Collegue/issues/218).

## Diagnostic

Les 6 tests du fichier échouaient avec :

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for ConsistencyCheckRequest
files.0
  Input should be a valid dictionary or instance of ConsistencyFile
  [type=model_type, input_value=FileInput(path='test.py'...), input_type=FileInput]
```

Cause : le test construit des `FileInput` (de `collegue.core.shared`), mais `ConsistencyCheckRequest.files` attend des `ConsistencyFile` (défini localement dans [collegue/tools/repo_consistency_check/models.py](collegue/tools/repo_consistency_check/models.py#L40)). Les deux modèles ont **la même shape** (`path`, `content`, `language` optionnel) mais Pydantic les traite comme des types distincts à la validation.

## Changements

- Ajoute `from collegue.tools.repo_consistency_check.models import ConsistencyFile`
- Remplace `FileInput(...)` par `ConsistencyFile(...)` dans les 6 tests qui construisent une `ConsistencyCheckRequest`
- **Garde** `FileInput` dans les tests qui attaquent directement l'engine (`TestConsistencyAnalysisEngine::test_analyze_duplication` etc.) — l'engine accepte les deux par duck-typing
- Retire les 6 nodeids de `_KNOWN_FAILURES`

## Vérification

| Commande | Résultat |
|---|---|
| `pytest tests/test_repo_consistency_check.py` | **15 passed** (6 précédemment skippés passent maintenant) |
| `pytest tests/` | 547 passed, 33 skipped, 0 failed |

## Progression globale de #218

| | R0 | R1 #222 | R2 #223 | R3 #224 | R4 (ce PR) |
|---|---|---|---|---|---|
| Entrées dans `_KNOWN_FAILURES` | 32 | 28 | 18 | 12 | **6** |
| % résolu | 0 % | 13 % | 44 % | 63 % | **81 %** |

## Restant à trier (6 tests sur 2 fichiers)

- `test_impact_analysis.py` — 4 tests (modèle Pydantic drifté, similaire à ce PR)
- `test_secret_scan.py` — 1 test
- `test_test_generation_fixes.py` — 1 test

🤖 Generated with [Claude Code](https://claude.com/claude-code)