### PR TITLE
test: fix impact_analysis ImpactFile usage (#218)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,10 +13,6 @@ from __future__ import annotations
 import pytest
 
 _KNOWN_FAILURES: frozenset[str] = frozenset({
-    "tests/test_impact_analysis.py::TestImpactAnalysisRequest::test_request_creation",
-    "tests/test_impact_analysis.py::TestImpactAnalysisRequest::test_request_defaults",
-    "tests/test_impact_analysis.py::TestImpactAnalysisTool::test_execute_core_logic",
-    "tests/test_impact_analysis.py::TestImpactAnalysisTool::test_validate_request_valid",
     "tests/test_secret_scan.py::TestSecretScanTool::test_scan_batch_files",
     "tests/test_test_generation_fixes.py::test_test_generation_success",
 })

--- a/tests/test_impact_analysis.py
+++ b/tests/test_impact_analysis.py
@@ -12,6 +12,7 @@ from collegue.tools.impact_analysis import (
     RiskNote,
     ImpactAnalysisEngine
 )
+from collegue.tools.impact_analysis.models import ImpactFile
 from collegue.core.shared import FileInput
 
 
@@ -155,7 +156,7 @@ class TestImpactAnalysisTool:
         """Test la validation d'une requête valide."""
         request = ImpactAnalysisRequest(
             change_intent="Renommer UserService",
-            files=[FileInput(path="test.py", content="class UserService: pass")]
+            files=[ImpactFile(path="test.py", content="class UserService: pass")]
         )
         assert tool.validate_request(request) is True
 
@@ -174,8 +175,8 @@ class TestImpactAnalysisTool:
         request = ImpactAnalysisRequest(
             change_intent="Renommer UserService en AuthService",
             files=[
-                FileInput(path="services/user.py", content="class UserService: pass"),
-                FileInput(path="api/auth.py", content="from services.user import UserService")
+                ImpactFile(path="services/user.py", content="class UserService: pass"),
+                ImpactFile(path="api/auth.py", content="from services.user import UserService")
             ]
         )
         
@@ -193,7 +194,7 @@ class TestImpactAnalysisRequest:
         """Test la création d'une requête."""
         request = ImpactAnalysisRequest(
             change_intent="Modifier l'API /users",
-            files=[FileInput(path="api.py", content="...")],
+            files=[ImpactFile(path="api.py", content="...")],
             confidence_mode="balanced",
             analysis_depth="fast"
         )
@@ -204,7 +205,7 @@ class TestImpactAnalysisRequest:
         """Test les valeurs par défaut."""
         request = ImpactAnalysisRequest(
             change_intent="Test",
-            files=[FileInput(path="test.py", content="")]
+            files=[ImpactFile(path="test.py", content="")]
         )
         assert request.confidence_mode == "balanced"
         assert request.analysis_depth == "fast"


### PR DESCRIPTION
Round 5 sur [#218](https://github.com/VynoDePal/Collegue/issues/218). Même cause et même fix que #225.

## Diagnostic

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for ImpactAnalysisRequest
files.0
  Input should be a valid dictionary or instance of ImpactFile
  [type=model_type, input_value=FileInput(path='test.py'...), input_type=FileInput]
```

Les 4 tests (`TestImpactAnalysisTool::test_validate_request_valid`, `test_execute_core_logic`, `TestImpactAnalysisRequest::test_request_creation`, `test_request_defaults`) utilisent `FileInput` de `collegue.core.shared` pour construire des `ImpactAnalysisRequest`, mais le modèle attend des `ImpactFile` locaux.

## Changements

- Ajoute `from collegue.tools.impact_analysis.models import ImpactFile`
- Swap `FileInput(...)` → `ImpactFile(...)` dans les 4 tests qui construisent la request
- Retire 4 nodeids de `_KNOWN_FAILURES`

## Vérification

| Commande | Résultat |
|---|---|
| `pytest tests/test_impact_analysis.py` | **20 passed** (16 déjà verts + 4 unskippés) |
| `pytest tests/` | 551 passed, 29 skipped, 0 failed |

## Progression de #218

| | R0 | R1 | R2 | R3 | R4 | R5 (ce PR) |
|---|---|---|---|---|---|---|
| PR | — | #222 | #223 | #224 | #225 | **#226** |
| `_KNOWN_FAILURES` | 32 | 28 | 18 | 12 | 6 | **2** |
| % résolu | 0 % | 13 % | 44 % | 63 % | 81 % | **94 %** |

## Restant (2 tests sur 2 fichiers)

- `test_secret_scan.py::TestSecretScanTool::test_scan_batch_files` — 1 test
- `test_test_generation_fixes.py::test_test_generation_success` — 1 test

🤖 Generated with [Claude Code](https://claude.com/claude-code)