### PR TITLE
test: close out #218 — last 2 failures fixed, _KNOWN_FAILURES empty

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,26 +1,26 @@
 """pytest configuration for the Collegue test suite.
 
-Known pre-existing failures are listed in ``_KNOWN_FAILURES`` and skipped at
-collection time so CI stays green while they are triaged under issue #218.
-When a test is fixed, remove its nodeid from the set — pytest will re-collect
-it automatically on the next run.
+The ``_KNOWN_FAILURES`` set was introduced to unblock CI (#212) while the
+32 pre-existing test failures exposed by the new pipeline were triaged in
+#218. All of them have now been fixed, so the set is empty.
 
-Do NOT add unrelated tests here. Every entry must correspond to a documented
-failure in issue #218.
+The mechanism stays in place as a pattern: if a future regression temporarily
+breaks a test that cannot be fixed immediately, add its nodeid here with a
+follow-up issue reference, then remove it once the fix lands. Keep the set
+as close to empty as possible — every entry is a silenced red flag.
 """
 from __future__ import annotations
 
 import pytest
 
-_KNOWN_FAILURES: frozenset[str] = frozenset({
-    "tests/test_secret_scan.py::TestSecretScanTool::test_scan_batch_files",
-    "tests/test_test_generation_fixes.py::test_test_generation_success",
-})
+_KNOWN_FAILURES: frozenset[str] = frozenset()
 
-_SKIP_REASON = "pre-existing failure, tracked in #218"
+_SKIP_REASON = "pre-existing failure — document in a tracking issue before adding"
 
 
 def pytest_collection_modifyitems(config, items):
+    if not _KNOWN_FAILURES:
+        return
     for item in items:
         if item.nodeid in _KNOWN_FAILURES:
             item.add_marker(pytest.mark.skip(reason=_SKIP_REASON))

--- a/tests/test_secret_scan.py
+++ b/tests/test_secret_scan.py
@@ -128,11 +128,11 @@ class TestSecretScanTool:
 
     def test_scan_batch_files(self, tool):
         """Test le scan batch de fichiers."""
-        from collegue.core.shared import FileContent
+        from collegue.tools.secret_scan.models import SecretScanFile
         # Clé AWS valide (20 caractères après AKIA)
         files = [
-            FileContent(path="config.py", content="api_key = 'AKIAIOSFODNN7EXAMPLE'"),
-            FileContent(path="clean.py", content="print('hello')")
+            SecretScanFile(path="config.py", content="api_key = 'AKIAIOSFODNN7EXAMPLE'"),
+            SecretScanFile(path="clean.py", content="print('hello')")
         ]
         request = SecretScanRequest(files=files, severity_threshold="low")
         response = tool._execute_core_logic(request)

--- a/tests/test_test_generation_fixes.py
+++ b/tests/test_test_generation_fixes.py
@@ -1,46 +1,40 @@
 import pytest
-from unittest.mock import MagicMock, AsyncMock, patch
-from collegue.tools.test_generation import TestGenerationTool, TestGenerationRequest, TestGenerationResponse, LLMTestGenerationResult
+from unittest.mock import MagicMock, AsyncMock
+from collegue.tools.test_generation import TestGenerationTool, TestGenerationRequest, TestGenerationResponse
 
 @pytest.mark.asyncio
 async def test_test_generation_success():
+    """Quand ctx.sample() renvoie du texte LLM exploitable, le tool doit le
+    propager tel quel dans `response.test_code`. Le chemin structuré
+    (LLMTestGenerationResult) n'est plus câblé dans
+    `_execute_core_logic_async` — le tool lit `result.text`.
+    """
     tool = TestGenerationTool()
-    
-    # Mock context
+
     mock_ctx = MagicMock()
     mock_ctx.info = AsyncMock()
     mock_ctx.sample = AsyncMock()
     mock_ctx.report_progress = AsyncMock()
-    
-    # Mock LLM result (structured)
+
     mock_result = MagicMock()
-    mock_result.result = LLMTestGenerationResult(
-        test_code="def test_add(): assert 1+1==2",
-        test_count=1,
-        coverage_estimate=1.0,
-        tested_functions=["add"],
-        tested_classes=[],
-        imports_required=["pytest"]
-    )
+    mock_result.text = "def test_add(): assert 1+1==2"
     mock_ctx.sample.return_value = mock_result
-    
+
     request = TestGenerationRequest(
         code="def add(a,b): return a+b",
         language="python",
-        test_framework="pytest"
+        test_framework="pytest",
     )
-    
-    # Execute
+
     response = await tool.execute_async(request, ctx=mock_ctx)
-    
+
     assert response.test_code == "def test_add(): assert 1+1==2"
     assert response.language == "python"
     assert response.framework == "pytest"
-    assert response.estimated_coverage == 1.0
-    assert len(response.tested_elements) == 1
-    assert response.tested_elements[0]["name"] == "add"
-    
-    # Verify prompt engine usage (via ctx.sample being called)
+    # Le tool compte les def test_ dans le texte → 1 fonction détectée
+    assert len(response.tested_elements) >= 1
+    assert any(e["name"] == "add" for e in response.tested_elements)
+
     mock_ctx.sample.assert_called_once()
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Round 6 (final) sur [#218](https://github.com/VynoDePal/Collegue/issues/218). 🎉

## Diagnostic

### `tests/test_secret_scan.py::TestSecretScanTool::test_scan_batch_files`
Même cause que #225 / #226 : `SecretScanRequest.files` attend des `SecretScanFile` (local au module), le test passait des `FileContent` (alias pour `FileInput` de `collegue.core.shared`). Pydantic v2 rejette.

### `tests/test_test_generation_fixes.py::test_test_generation_success`
Le test mockait `result.result = LLMTestGenerationResult(...)` comme si le tool lisait un output structuré, mais `_execute_core_logic_async` lit uniquement `result.text`. D'où l'erreur `'<' not supported between instances of 'MagicMock' and 'float'` : `estimate_coverage` comparait un attribut MagicMock à un seuil, le tool tombait en fallback déterministe, et l'assertion sur le texte LLM attendu échouait.

Réécrit pour mocker `result.text` (le pattern est déjà présent dans le sibling test `test_test_generation_fallback_text` du même fichier) et assouplissement des assertions sur les éléments détectés.

## Changements

- Swap `FileContent` → `SecretScanFile` dans `test_scan_batch_files`
- Rewrite `test_test_generation_success` pour coller au contrat `result.text`
- Vide `_KNOWN_FAILURES` dans [tests/conftest.py](tests/conftest.py), met à jour la docstring et garde le hook comme pattern réutilisable

## Vérification

| Commande | Résultat |
|---|---|
| `pytest tests/test_secret_scan.py::TestSecretScanTool::test_scan_batch_files` | ✅ |
| `pytest tests/test_test_generation_fixes.py` | ✅ 2/2 |
| `pytest tests/` | **553 passed, 27 skipped, 0 failed** en 3:16 |

Les 27 skips restants sont tous des tests d'intégration legacy (endpoints FastAPI supprimés, serveur MCP local requis, etc.) skippés au niveau module — aucun lien avec #218.

## Rétrospective de #218

| Round | PR | Tests résolus | Cumul |
|---|---|---|---|
| R1 | #222 | 4 quick wins | 4 / 32 |
| R2 | #223 | Suppression `test_security_tools.py` redondant | 14 / 32 |
| R3 | #224 | Pollution `sys.modules` | 20 / 32 |
| R4 | #225 | `ConsistencyFile` vs `FileInput` | 26 / 32 |
| R5 | #226 | `ImpactFile` vs `FileInput` | 30 / 32 |
| **R6** | **#227** (ce PR) | 2 derniers tests | **32 / 32** |

Closes #218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)