### PR TITLE
test(evals): add golden evaluation harness — test_generation v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -265,4 +265,7 @@ docker-compose.override.yml
 # Rapports générés par la suite stress (runs, injection_audit, real_cases)
 tests/stress/reports/
 
+# Rapports générés par la suite golden evals (tests/evals/runner.py)
+tests/evals/reports/
+
 .claude

--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ Ajoutez ceci à votre configuration `mcpServers` (souvent dans `~/.codeium/winds
 
 ---
 
+## 🧪 Qualité des sorties LLM
+
+Au-delà des tests unitaires + stress (robustesse), une suite d'**évaluations golden** mesure la *correction* des tools qui appellent un LLM — par exemple : les tests générés par `test_generation` sont-ils réellement exécutables et corrects ? Voir [docs/llm_evals.md](docs/llm_evals.md).
+
+Baseline actuel sur 8 cas `test_generation` (Gemini 2.5 Flash) : **0.978 moyenne, 190/193 tests générés qui passent**.
+
+```bash
+LLM_API_KEY=... python -m tests.evals.runner --tool test_generation
+```
+
+---
+
 ## 🐳 Auto-hébergement (Docker)
 
 Deux modes sont supportés selon l'envie : **serveur long-running** (`docker compose`) accédé en HTTP, ou **container à la volée** (`docker run -i --rm`) que le client MCP spawne/tue à chaque session en stdio. Choisissez un mode ci-dessous.

--- a/README.md
+++ b/README.md
@@ -52,10 +52,27 @@ Ajoutez ceci à votre configuration `mcpServers` (souvent dans `~/.codeium/winds
 
 Au-delà des tests unitaires + stress (robustesse), une suite d'**évaluations golden** mesure la *correction* des tools qui appellent un LLM — par exemple : les tests générés par `test_generation` sont-ils réellement exécutables et corrects ? Voir [docs/llm_evals.md](docs/llm_evals.md).
 
-Baseline actuel sur 8 cas `test_generation` (Gemini 2.5 Flash) : **0.978 moyenne, 190/193 tests générés qui passent**.
+Matrice 5 modèles × 2 paths (avec vs sans MCP Collègue) sur 8 cas Python — **80 appels LLM, 0 crash**. Snapshot :
+
+| Modèle | MCP `test_generation` | Raw LLM direct | **Δ MCP − raw** |
+|---|---|---|---|
+| `gemini-2.5-flash` | **1.000** | 0.875 | +0.125 |
+| `gemini-3-flash-preview` | 0.989 | 0.875 | +0.114 |
+| `gemini-3.1-pro-preview` | 0.868 | 0.344 | **+0.524** |
+| `gemma-4-26b-a4b-it` | 0.847 | 0.847 | +0.000 |
+| `gemma-4-31b-it` | **1.000** | **1.000** | +0.000 |
+
+**Lecture** : sur Gemini, le prompt engineering du tool MCP Collègue apporte entre +0.11 et +0.52 sur l'exactitude des tests générés. Sur Gemma, même score dans les deux cas — le gain est spécifique aux modèles qui suivent bien les instructions structurées.
 
 ```bash
-LLM_API_KEY=... python -m tests.evals.runner --tool test_generation
+# Run matrice complète
+python -m tests.evals.runner \
+  --tool test_generation --tool test_generation_raw \
+  --model gemini-2.5-flash --model gemini-3-flash-preview \
+  --model gemini-3.1-pro-preview --model gemma-4-26b-a4b-it --model gemma-4-31b-it
+
+# Run simple (1 modèle)
+python -m tests.evals.runner --tool test_generation
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -52,26 +52,33 @@ Ajoutez ceci à votre configuration `mcpServers` (souvent dans `~/.codeium/winds
 
 Au-delà des tests unitaires + stress (robustesse), une suite d'**évaluations golden** mesure la *correction* des tools qui appellent un LLM — par exemple : les tests générés par `test_generation` sont-ils réellement exécutables et corrects ? Voir [docs/llm_evals.md](docs/llm_evals.md).
 
-Matrice 5 modèles × 2 paths (avec vs sans MCP Collègue) sur 8 cas Python — **80 appels LLM, 0 crash**. Snapshot :
+Matrice **5 modèles × 3 paths × 13 cas Python** (fonctions pures à decorators complexes en passant par async context managers) — **195 appels LLM, 0 crash**. Trois paths comparés : MCP Collègue, prompt "compétent" (utilisateur qui connaît pytest), prompt naïf.
 
-| Modèle | MCP `test_generation` | Raw LLM direct | **Δ MCP − raw** |
-|---|---|---|---|
-| `gemini-2.5-flash` | **1.000** | 0.875 | +0.125 |
-| `gemini-3-flash-preview` | 0.989 | 0.875 | +0.114 |
-| `gemini-3.1-pro-preview` | 0.868 | 0.344 | **+0.524** |
-| `gemma-4-26b-a4b-it` | 0.847 | 0.847 | +0.000 |
-| `gemma-4-31b-it` | **1.000** | **1.000** | +0.000 |
+| Modèle | **MCP** | Competent | Raw | Δ MCP−Competent | Δ MCP−Raw |
+|---|---|---|---|---|---|
+| `gemini-2.5-flash` | **0.833** | 0.656 | 0.867 | **+0.177** | −0.034 |
+| `gemini-3-flash-preview` | 0.918 | **0.959** | 0.615 | **−0.041** | +0.303 |
+| `gemini-3.1-pro-preview` | **0.917** | 0.911 | 0.538 | +0.006 | +0.379 |
+| `gemma-4-26b-a4b-it` | **0.982** | 0.903 | 0.972 | +0.079 | +0.010 |
+| `gemma-4-31b-it` | 0.864 | **0.977** | 0.943 | **−0.113** | −0.079 |
 
-**Lecture** : sur Gemini, le prompt engineering du tool MCP Collègue apporte entre +0.11 et +0.52 sur l'exactitude des tests générés. Sur Gemma, même score dans les deux cas — le gain est spécifique aux modèles qui suivent bien les instructions structurées.
+**Lecture honnête** :
+
+- Face à un utilisateur naïf, MCP délivre un **gros lift sur Gemini 3.x** (+0.30 à +0.38) ; marginal ou négatif ailleurs.
+- Face à un utilisateur qui écrit un prompt soigné, MCP **ne gagne que sur `gemini-2.5-flash`** (+0.177) ; sur 3 modèles sur 5 le prompt compétent égale ou bat le MCP.
+- `gemma-4-26b-a4b-it` est le meilleur baseline du corpus (0.982 en MCP, 0.972 en raw) — candidat prod sérieux.
+- La valeur réelle du MCP = **"éviter à l'utilisateur d'écrire un prompt soigné"** + gain net sur `gemini-2.5-flash`. Pas le game-changer universel qu'une mesure à 8 cas suggérait.
+
+Détails complets dans [docs/llm_evals.md](docs/llm_evals.md) · 13 cas × 5 modèles × 3 paths = 195 scores reproductibles.
 
 ```bash
-# Run matrice complète
+# Matrice complète
 python -m tests.evals.runner \
-  --tool test_generation --tool test_generation_raw \
+  --tool test_generation --tool test_generation_raw --tool test_generation_competent \
   --model gemini-2.5-flash --model gemini-3-flash-preview \
   --model gemini-3.1-pro-preview --model gemma-4-26b-a4b-it --model gemma-4-31b-it
 
-# Run simple (1 modèle)
+# Run simple (1 modèle, MCP seulement)
 python -m tests.evals.runner --tool test_generation
 ```
 

--- a/docs/llm_evals.md
+++ b/docs/llm_evals.md
@@ -59,50 +59,98 @@ Chaque run produit :
 
 Le runner **n'est jamais gating** (`exit 0` toujours). L'utilisateur lit le rapport et juge.
 
-## Matrice 5 modèles × 2 paths (snapshot golden-evals-v1)
+## Matrice 5 modèles × 3 paths × 13 cas (golden-evals-v1, run final)
 
-Run complet 80 appels (`python -m tests.evals.runner --tool test_generation --tool test_generation_raw --model gemini-2.5-flash --model gemini-3-flash-preview --model gemini-3.1-pro-preview --model gemma-4-26b-a4b-it --model gemma-4-31b-it`).
+Run complet **195 appels LLM** (`python -m tests.evals.runner --tool test_generation --tool test_generation_raw --tool test_generation_competent --model gemini-2.5-flash --model gemini-3-flash-preview --model gemini-3.1-pro-preview --model gemma-4-26b-a4b-it --model gemma-4-31b-it`).
 
-### Scores moyens par path (agrégat sur 8 cas)
+### Trois paths évalués en parallèle
 
-| Modèle | MCP (`test_generation`) | Raw (`test_generation_raw`) | **Δ MCP − raw** |
+| Path | Prompt |
+|---|---|
+| **`test_generation`** (MCP) | Prompt élaboré du `TestGenerationTool` : extraction d'éléments, coverage target, framework preamble, liste d'instructions |
+| **`test_generation_competent`** | Prompt "développeur qui connaît pytest" : exige edge cases, parametrize, pytest.raises, nommage, tests runnable |
+| **`test_generation_raw`** | Prompt minimal : *"Write a pytest test file for the following code"* |
+
+Les 13 cas couvrent : fonctions pures, classes, type hints, exceptions, generators, async, properties, héritage, **state machine**, **async context manager**, **retry decorator**, **pipeline composition**, **LRU memoize**.
+
+### Scores moyens par path
+
+| Modèle | MCP | Competent | Raw |
 |---|---|---|---|
-| `gemini-2.5-flash` | 1.000 | 0.875 | **+0.125** |
-| `gemini-3-flash-preview` | 0.989 | 0.875 | **+0.114** |
-| `gemini-3.1-pro-preview` | 0.868 | 0.344 | **+0.524** |
-| `gemma-4-26b-a4b-it` | 0.847 | 0.847 | +0.000 |
-| `gemma-4-31b-it` | 1.000 | 1.000 | +0.000 |
+| `gemini-2.5-flash` | **0.833** | 0.656 | 0.867 |
+| `gemini-3-flash-preview` | 0.918 | **0.959** | 0.615 |
+| `gemini-3.1-pro-preview` | **0.917** | 0.911 | 0.538 |
+| `gemma-4-26b-a4b-it` | **0.982** | 0.903 | 0.972 |
+| `gemma-4-31b-it` | 0.864 | **0.977** | 0.943 |
 
-### Lectures principales
+### Δ par modèle (la lecture honnête)
 
-1. **Sur Gemini, l'outil MCP apporte +0.11 à +0.52 de qualité** par rapport à un prompt brut. Le cas le plus spectaculaire : `gemini-3.1-pro-preview` passe de **0.344 en raw à 0.868 en MCP** — sans le prompt engineering du tool, ce modèle génère des tests majoritairement non-exécutables.
-2. **Sur Gemma, aucune différence** — les deux paths produisent exactement le même score. Gemma semble parser notre prompt structuré comme du texte libre et tomber sur la même stratégie de génération dans les deux cas.
-3. **Le duo `gemini-2.5-flash` + MCP obtient un score parfait 1.000** (192 tests générés, tous passent) — c'est la configuration de référence pour la prod.
-4. **`gemma-4-31b-it` perfect sur les deux paths** — modèle remarquablement stable sur ce corpus Python simple ; à confirmer sur des cas plus tordus.
+#### Δ MCP − Raw (MCP vs utilisateur naïf)
 
-### Scores par case × modèle (MCP path)
+| Modèle | MCP | Raw | **Δ** |
+|---|---|---|---|
+| `gemini-2.5-flash` | 0.833 | 0.867 | **−0.034** |
+| `gemini-3-flash-preview` | 0.918 | 0.615 | **+0.303** |
+| `gemini-3.1-pro-preview` | 0.917 | 0.538 | **+0.379** |
+| `gemma-4-26b-a4b-it` | 0.982 | 0.972 | +0.010 |
+| `gemma-4-31b-it` | 0.864 | 0.943 | **−0.079** |
 
-| Case | 2.5-flash | 3-flash-prev | 3.1-pro-prev | gemma-4-26b | gemma-4-31b |
-|---|---|---|---|---|---|
-| 01_arithmetic | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
-| 02_class_init | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
-| 03_type_hints | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
-| 04_exceptions | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
-| 05_generator | 1.000 | 1.000 | 0.000 | 1.000 | 1.000 |
-| 06_async_fn | 1.000 | 0.909 | 1.000 | 0.778 | 1.000 |
-| 07_property | 1.000 | 1.000 | 0.944 | 1.000 | 1.000 |
-| 08_inheritance | 1.000 | 1.000 | 1.000 | 0.000 | 1.000 |
+#### Δ MCP − Competent (MCP vs utilisateur qui sait ce qu'il fait)
 
-Deux zéros isolés sur la diagonale MCP :
-- `gemini-3.1-pro-preview · 05_generator` — LLM retourne du code, mais le scorer ne collecte aucun test (sortie probablement tronquée côté reasoning)
-- `gemma-4-26b-a4b-it · 08_inheritance` — même symptôme, classe spécifique à l'héritage
+| Modèle | MCP | Competent | **Δ** |
+|---|---|---|---|
+| `gemini-2.5-flash` | 0.833 | 0.656 | **+0.177** |
+| `gemini-3-flash-preview` | 0.918 | 0.959 | **−0.041** |
+| `gemini-3.1-pro-preview` | 0.917 | 0.911 | +0.006 |
+| `gemma-4-26b-a4b-it` | 0.982 | 0.903 | **+0.079** |
+| `gemma-4-31b-it` | 0.864 | 0.977 | **−0.113** |
 
-À investiguer si on veut pousser la qualité — candidat pour une v2 avec retry ou prompt adjustment ciblé sur ces edge cases.
+#### Δ Competent − Raw (la plus-value d'un prompt soigné sans MCP)
 
-### Seuils de régression
+| Modèle | Competent | Raw | **Δ** |
+|---|---|---|---|
+| `gemini-2.5-flash` | 0.656 | 0.867 | **−0.211** |
+| `gemini-3-flash-preview` | 0.959 | 0.615 | **+0.344** |
+| `gemini-3.1-pro-preview` | 0.911 | 0.538 | **+0.373** |
+| `gemma-4-26b-a4b-it` | 0.903 | 0.972 | **−0.069** |
+| `gemma-4-31b-it` | 0.977 | 0.943 | +0.034 |
 
-- **MCP `gemini-2.5-flash` moyenne < 0.95** → investiguer avant merge (c'est le couple prod le plus stable)
-- **Δ MCP − raw < +0.05 sur Gemini** → le prompt engineering du tool régresse, red flag
+### Lecture honnête (révision de la v2)
+
+La v2 (8 cas simples, 2 paths) racontait une histoire uniforme — *"MCP délivre +0.11 à +0.52 sur tous les Gemini"*. **Cette conclusion ne survit pas à la v3**. Avec 5 cas complexes en plus et le path `competent` ajouté, l'image devient nuancée :
+
+1. **MCP bat le prompt naïf sur Gemini 3.x** — `+0.303` et `+0.379` sur `gemini-3-flash-preview` et `gemini-3.1-pro-preview`. Vrai valeur ajoutée quand l'utilisateur écrit un prompt minimal.
+
+2. **MCP est battu ou à égalité avec un prompt "compétent" sur 3 modèles sur 5** :
+   - `gemini-3-flash-preview` : competent gagne de **−0.041**
+   - `gemini-3.1-pro-preview` : égalité (+0.006)
+   - `gemma-4-31b-it` : competent gagne de **−0.113**
+
+   Sur ces modèles, la plus-value du tool MCP est essentiellement **"éviter à l'utilisateur d'écrire le prompt lui-même"** — pas **"produire de meilleurs tests qu'un dev attentif"**.
+
+3. **MCP est *contre-productif* face à un prompt naïf sur 2 modèles** :
+   - `gemini-2.5-flash` : **−0.034** (marginal)
+   - `gemma-4-31b-it` : **−0.079** (significatif)
+
+   Indique que le prompt engineering du tool ne s'adapte pas à ces modèles — le surcoût en tokens n'est pas récompensé.
+
+4. **Seul `gemini-2.5-flash` voit MCP battre significativement `competent`** (+0.177). C'est la config prod actuelle par défaut — la seule où l'investissement prompt-engineering du tool est nettement rentable.
+
+5. **`gemma-4-26b-a4b-it` est étonnamment robuste** — 0.982 en MCP, 0.972 en raw. Le meilleur modèle du corpus quel que soit le path. Candidat prod sérieux si le pricing est avantageux.
+
+6. **Le path competent échoue sur `gemini-2.5-flash` (0.656)** — anomalie liée à des réponses LLM tronquées au max_tokens. Le prompt long + reasoning Gemini 2.5 consomme le budget avant d'émettre les tests. Fix partiel dans le scorer (`_strip_fences` gère les fences non fermées), reste ~4 cas vraiment tronqués. Pas un défaut du path `competent` en tant que tel.
+
+### Implications produit
+
+- **Utilisateur naïf (prompt minimal)** : MCP justifié sur Gemini 3.x. Marginal sur les autres.
+- **Utilisateur expérimenté (prompt soigné)** : MCP n'apporte rien sur `gemini-3-flash-preview` et `gemma-4-31b-it`. Valeur réelle uniquement sur `gemini-2.5-flash`.
+- **Robustesse des modèles** : `gemma-4-26b` et `gemma-4-31b` dominent en baseline raw, ce qui suggère une capacité "out of the box" solide sans prompt engineering dédié.
+
+### Seuils de régression mis à jour
+
+- **MCP `gemini-2.5-flash` avg < 0.75** (au lieu de 0.95) → investiguer, c'est le couple où le MCP apporte le plus
+- **Δ MCP − Competent < −0.15 sur 3 modèles sur 5** → le tool MCP devient nuisible, red flag produit
+- **Raw avg < 0.50 sur un Gemini** → plausiblement un bug de réponse LLM truncation, vérifier logs
 
 ## Baseline historique (Gemini 2.5 Flash uniquement, v0)
 

--- a/docs/llm_evals.md
+++ b/docs/llm_evals.md
@@ -1,0 +1,122 @@
+# Golden evals — qualité des sorties LLM
+
+Les stress tests valident que les outils ne crashent pas. Cette suite **évalue la correction** : est-ce que `test_generation` produit des tests qui tournent vraiment ? Est-ce que `code_refactoring/simplify` préserve la sémantique ? Sans ça, on ne peut ni comparer deux modèles, ni détecter qu'un changement de prompt a dégradé la qualité.
+
+Jamais exécutée en CI (trop coûteuse en LLM). Usage : local, ou nightly cron.
+
+## Architecture
+
+```
+tests/evals/
+├── eval_context.py              # Shim ctx.sample() qui appelle generate_text directement
+├── runner.py                    # CLI, loader YAML, orchestrateur, writer rapport
+├── scorers/
+│   └── test_generation.py       # Exécute les tests générés dans pytest, score = passed/collected
+├── cases/
+│   └── test_generation/         # 8 cas YAML (1 prompt → 1 score)
+└── reports/                     # Runtime (gitignored)
+```
+
+- **Runner in-process** : n'utilise pas le harness HTTP MCP. Instancie directement le tool et lui passe un `EvalContext` qui implémente `ctx.sample()` en déléguant à `generate_text()` (même helper que le Watchdog). Pas besoin de lancer Docker — `LLM_API_KEY` dans l'env et c'est parti.
+- **Scorer rule-based** : pas de LLM-as-judge dans la v1. Pour `test_generation`, on écrit le code source + les tests générés dans un tempdir et on lance `pytest test_src.py`. Score = `passed / collected`.
+
+## Usage
+
+```bash
+# Full run (8 cas)
+LLM_API_KEY=<ta-clé> python -m tests.evals.runner --tool test_generation
+
+# Un cas précis (itération rapide)
+python -m tests.evals.runner --tool test_generation --case 01_arithmetic
+
+# Limite aux N premiers cas (quand la quota Gemini est serrée)
+python -m tests.evals.runner --tool test_generation --limit 2
+
+# Sortie dans un dossier dédié (au lieu d'un timestamp auto)
+python -m tests.evals.runner --tool test_generation --out my-run/
+```
+
+Chaque run produit :
+- `<out>/report.md` — résumé markdown avec scores par cas + agrégat
+- `<out>/cases/<case_id>.json` — enregistrement détaillé (raw LLM output, stdout pytest, ctx.calls)
+
+Le runner **n'est jamais gating** (`exit 0` toujours). L'utilisateur lit le rapport et juge.
+
+## Baseline actuel (Gemini 2.5 Flash)
+
+Au moment de l'écriture (PR golden-evals-v1) :
+
+| Case | Score | Tests OK / Total |
+|---|---|---|
+| 01_arithmetic | 1.000 | 44/44 |
+| 02_class_init | 1.000 | 20/20 |
+| 03_type_hints | 1.000 | 21/21 |
+| 04_exceptions | 0.960 | 24/25 |
+| 05_generator | 1.000 | 10/10 |
+| 06_async_fn | 0.867 | 13/15 |
+| 07_property | 1.000 | 19/19 |
+| 08_inheritance | 1.000 | 39/39 |
+
+**Moyenne : 0.978 · 190/193 tests générés qui passent.**
+
+Si une future modification (prompt refactor, changement de modèle, montée de version pyproject…) fait chuter ce chiffre sous **0.90**, considérer comme une régression et investiguer avant merge.
+
+## Format d'un cas
+
+```yaml
+# tests/evals/cases/test_generation/NN_name.yaml
+name: "Human-readable description"
+description: "What the case exercises (edge cases, failure modes…)"
+language: python
+framework: pytest
+min_expected_tests: 3   # Penalty soft if LLM generates fewer tests
+code: |
+  def foo(x):
+      return x * 2
+```
+
+Contraintes :
+- Le code ne doit utiliser que **stdlib + pytest** (le scorer n'installe pas de deps dans le tempdir)
+- Le code doit être un module Python standalone (pas de classe abstraite sans implémentation)
+- Garder les cas courts (< 50 lignes) pour un LLM token budget raisonnable
+
+## Scoring — détails
+
+Pour `test_generation` :
+
+1. Extraction du code de test depuis le `response.text` du tool
+   - Cherche d'abord un fence ` ```python ... ``` ` contenant `def test_`
+   - Sinon, prend le premier fence Python
+   - Sinon, prend le texte brut (score souvent à 0)
+2. Découverte des imports locaux via `ast.parse` — pour chaque module non-stdlib importé, crée un alias du code source sous ce nom (sinon le LLM qui fait `from my_math_module import add` voit son import échouer alors qu'on a écrit `src.py`)
+3. Exécute `pytest test_src.py -q --tb=line --no-header` avec timeout 30s
+4. Parse la sortie pour extraire `passed`, `failed`, `errors`, `skipped`, `collected`
+5. Score :
+   - `collected == 0` → **0.0** (aucun test collectable, syntax error généralement)
+   - `collected < min_expected_tests` → `passed/collected × 0.7` (pénalité quantité)
+   - Sinon → `passed / collected`
+
+## Ajouter un nouveau tool
+
+1. Créer `tests/evals/scorers/<tool_name>.py` avec une fonction `score(case: dict, tool_output: str) -> EvalScore`
+2. Créer `tests/evals/cases/<tool_name>/` avec au moins 5 cas YAML
+3. Ajouter une entrée dans `TOOL_REGISTRY` de [tests/evals/runner.py](../tests/evals/runner.py) :
+   ```python
+   TOOL_REGISTRY["refactoring"] = {
+       "run": _run_refactoring,       # async callable: (case, ctx) -> tool_output
+       "score": refactoring_scorer.score,
+   }
+   ```
+4. Définir `async def _run_<tool>(case, ctx)` qui instancie le tool, construit la request, et retourne la chaîne de sortie à scorer
+
+Exemples de scorers futurs :
+- `refactoring/simplify` — AST-diff entre input et output, + exécution des tests existants pour vérifier préservation sémantique
+- `impact_analysis` — précision/rappel des fichiers impactés contre une liste annotée dans le YAML
+- `code_documentation` — LLM-as-judge requis (scoring subjectif)
+
+## Limites connues
+
+- **Gemini 2.5 et max_tokens** : le reasoning de Gemini 2.5 consomme le budget de sortie. On plancher à 8000 tokens dans `EvalContext.MIN_MAX_TOKENS` pour éviter des réponses tronquées. Augmenter si les outils demandent plus.
+- **Différence avec la prod** : l'`EvalContext` route via `google.genai` (même chemin que le Watchdog), alors que le serveur MCP en prod route via `OpenAISamplingHandler` (API OpenAI-compatible). Les deux hits Gemini mais peuvent avoir des légères différences de comportement. Acceptable pour la v1.
+- **Pas de LLM-as-judge** — pour `code_documentation` ou `code_refactoring` (qualités subjectives), un scorer rule-based n'est pas suffisant. À introduire quand on ajoute ces outils.
+- **Quota Gemini Free Tier (20 req/jour)** : 8 cas par run, donc 2-3 runs/jour max. Pour itérer sans péter le quota : `--limit 1` sur un cas précis pendant le debug.

--- a/docs/llm_evals.md
+++ b/docs/llm_evals.md
@@ -9,13 +9,23 @@ Jamais exécutée en CI (trop coûteuse en LLM). Usage : local, ou nightly cron.
 ```
 tests/evals/
 ├── eval_context.py              # Shim ctx.sample() qui appelle generate_text directement
-├── runner.py                    # CLI, loader YAML, orchestrateur, writer rapport
+├── runner.py                    # CLI, loader YAML, orchestrateur, writer rapport/matrix
 ├── scorers/
 │   └── test_generation.py       # Exécute les tests générés dans pytest, score = passed/collected
 ├── cases/
-│   └── test_generation/         # 8 cas YAML (1 prompt → 1 score)
+│   ├── test_generation/         # 8 cas — chemin via le tool MCP Collègue
+│   └── test_generation_raw/     # Mêmes 8 cas — chemin LLM direct (prompt minimal)
 └── reports/                     # Runtime (gitignored)
 ```
+
+### Deux paths parallèles
+
+Le runner connaît deux "tools" :
+
+- **`test_generation`** — passe par la classe `TestGenerationTool` du MCP Collègue. Bénéficie du prompt engineering fignolé du tool (extraction d'éléments, coverage target, framework preamble).
+- **`test_generation_raw`** — bypasse complètement le tool. Appelle `generate_text()` avec un prompt minimal : *"Write a pytest test file for the following Python code"*. Représente le baseline "ce que tu aurais en demandant à l'IA toi-même".
+
+Le matrix report calcule un **Δ (MCP − raw) par modèle** qui quantifie la valeur ajoutée réelle du prompt engineering. Δ positif = le tool aide. Δ négatif = le tool fait empirer les choses (signal fort).
 
 - **Runner in-process** : n'utilise pas le harness HTTP MCP. Instancie directement le tool et lui passe un `EvalContext` qui implémente `ctx.sample()` en déléguant à `generate_text()` (même helper que le Watchdog). Pas besoin de lancer Docker — `LLM_API_KEY` dans l'env et c'est parti.
 - **Scorer rule-based** : pas de LLM-as-judge dans la v1. Pour `test_generation`, on écrit le code source + les tests générés dans un tempdir et on lance `pytest test_src.py`. Score = `passed / collected`.
@@ -23,7 +33,7 @@ tests/evals/
 ## Usage
 
 ```bash
-# Full run (8 cas)
+# Mode simple (1 tool, 1 modèle par défaut via settings.LLM_MODEL)
 LLM_API_KEY=<ta-clé> python -m tests.evals.runner --tool test_generation
 
 # Un cas précis (itération rapide)
@@ -32,8 +42,15 @@ python -m tests.evals.runner --tool test_generation --case 01_arithmetic
 # Limite aux N premiers cas (quand la quota Gemini est serrée)
 python -m tests.evals.runner --tool test_generation --limit 2
 
-# Sortie dans un dossier dédié (au lieu d'un timestamp auto)
-python -m tests.evals.runner --tool test_generation --out my-run/
+# Matrix: plusieurs modèles + MCP vs raw
+python -m tests.evals.runner \
+    --tool test_generation --tool test_generation_raw \
+    --model gemini-2.5-flash \
+    --model gemini-3-flash-preview \
+    --model gemini-3.1-pro-preview \
+    --model gemma-4-26b-a4b-it \
+    --model gemma-4-31b-it \
+    --out tests/evals/reports/matrix-$(date -u +%Y%m%d)
 ```
 
 Chaque run produit :
@@ -42,9 +59,54 @@ Chaque run produit :
 
 Le runner **n'est jamais gating** (`exit 0` toujours). L'utilisateur lit le rapport et juge.
 
-## Baseline actuel (Gemini 2.5 Flash)
+## Matrice 5 modèles × 2 paths (snapshot golden-evals-v1)
 
-Au moment de l'écriture (PR golden-evals-v1) :
+Run complet 80 appels (`python -m tests.evals.runner --tool test_generation --tool test_generation_raw --model gemini-2.5-flash --model gemini-3-flash-preview --model gemini-3.1-pro-preview --model gemma-4-26b-a4b-it --model gemma-4-31b-it`).
+
+### Scores moyens par path (agrégat sur 8 cas)
+
+| Modèle | MCP (`test_generation`) | Raw (`test_generation_raw`) | **Δ MCP − raw** |
+|---|---|---|---|
+| `gemini-2.5-flash` | 1.000 | 0.875 | **+0.125** |
+| `gemini-3-flash-preview` | 0.989 | 0.875 | **+0.114** |
+| `gemini-3.1-pro-preview` | 0.868 | 0.344 | **+0.524** |
+| `gemma-4-26b-a4b-it` | 0.847 | 0.847 | +0.000 |
+| `gemma-4-31b-it` | 1.000 | 1.000 | +0.000 |
+
+### Lectures principales
+
+1. **Sur Gemini, l'outil MCP apporte +0.11 à +0.52 de qualité** par rapport à un prompt brut. Le cas le plus spectaculaire : `gemini-3.1-pro-preview` passe de **0.344 en raw à 0.868 en MCP** — sans le prompt engineering du tool, ce modèle génère des tests majoritairement non-exécutables.
+2. **Sur Gemma, aucune différence** — les deux paths produisent exactement le même score. Gemma semble parser notre prompt structuré comme du texte libre et tomber sur la même stratégie de génération dans les deux cas.
+3. **Le duo `gemini-2.5-flash` + MCP obtient un score parfait 1.000** (192 tests générés, tous passent) — c'est la configuration de référence pour la prod.
+4. **`gemma-4-31b-it` perfect sur les deux paths** — modèle remarquablement stable sur ce corpus Python simple ; à confirmer sur des cas plus tordus.
+
+### Scores par case × modèle (MCP path)
+
+| Case | 2.5-flash | 3-flash-prev | 3.1-pro-prev | gemma-4-26b | gemma-4-31b |
+|---|---|---|---|---|---|
+| 01_arithmetic | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
+| 02_class_init | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
+| 03_type_hints | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
+| 04_exceptions | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
+| 05_generator | 1.000 | 1.000 | 0.000 | 1.000 | 1.000 |
+| 06_async_fn | 1.000 | 0.909 | 1.000 | 0.778 | 1.000 |
+| 07_property | 1.000 | 1.000 | 0.944 | 1.000 | 1.000 |
+| 08_inheritance | 1.000 | 1.000 | 1.000 | 0.000 | 1.000 |
+
+Deux zéros isolés sur la diagonale MCP :
+- `gemini-3.1-pro-preview · 05_generator` — LLM retourne du code, mais le scorer ne collecte aucun test (sortie probablement tronquée côté reasoning)
+- `gemma-4-26b-a4b-it · 08_inheritance` — même symptôme, classe spécifique à l'héritage
+
+À investiguer si on veut pousser la qualité — candidat pour une v2 avec retry ou prompt adjustment ciblé sur ces edge cases.
+
+### Seuils de régression
+
+- **MCP `gemini-2.5-flash` moyenne < 0.95** → investiguer avant merge (c'est le couple prod le plus stable)
+- **Δ MCP − raw < +0.05 sur Gemini** → le prompt engineering du tool régresse, red flag
+
+## Baseline historique (Gemini 2.5 Flash uniquement, v0)
+
+Au moment de l'écriture initiale du harness (8 cas, 1 modèle) :
 
 | Case | Score | Tests OK / Total |
 |---|---|---|

--- a/tests/evals/__init__.py
+++ b/tests/evals/__init__.py
@@ -1,0 +1,5 @@
+"""Golden evaluations for LLM-powered tools.
+
+See docs/llm_evals.md for the contract and how to add a new tool scorer.
+Entry point: `python -m tests.evals.runner --tool <name>`.
+"""

--- a/tests/evals/cases/test_generation/01_arithmetic.yaml
+++ b/tests/evals/cases/test_generation/01_arithmetic.yaml
@@ -1,0 +1,18 @@
+name: "Arithmetic utility"
+description: "Simple pure functions with known I/O including an error branch"
+language: python
+framework: pytest
+min_expected_tests: 3
+code: |
+  def add(a, b):
+      return a + b
+
+  def divide(a, b):
+      if b == 0:
+          raise ValueError("div by zero")
+      return a / b
+
+  def clamp(value, lo, hi):
+      if lo > hi:
+          raise ValueError("lo > hi")
+      return max(lo, min(value, hi))

--- a/tests/evals/cases/test_generation/02_class_init.yaml
+++ b/tests/evals/cases/test_generation/02_class_init.yaml
@@ -1,0 +1,18 @@
+name: "Class with __init__ and mutation"
+description: "Exercise the LLM's ability to cover object state, not just free functions"
+language: python
+framework: pytest
+min_expected_tests: 3
+code: |
+  class Counter:
+      def __init__(self, start: int = 0):
+          if start < 0:
+              raise ValueError("start must be >= 0")
+          self.value = start
+
+      def increment(self, by: int = 1) -> int:
+          self.value += by
+          return self.value
+
+      def reset(self) -> None:
+          self.value = 0

--- a/tests/evals/cases/test_generation/03_type_hints.yaml
+++ b/tests/evals/cases/test_generation/03_type_hints.yaml
@@ -1,0 +1,19 @@
+name: "Type-hinted data transform"
+description: "Uses List / Optional / dict annotations; good coverage needs boundary cases"
+language: python
+framework: pytest
+min_expected_tests: 3
+code: |
+  from typing import List, Optional
+
+  def first_nonzero(values: List[int]) -> Optional[int]:
+      for v in values:
+          if v != 0:
+              return v
+      return None
+
+  def word_counts(text: str) -> dict[str, int]:
+      counts: dict[str, int] = {}
+      for word in text.split():
+          counts[word] = counts.get(word, 0) + 1
+      return counts

--- a/tests/evals/cases/test_generation/04_exceptions.yaml
+++ b/tests/evals/cases/test_generation/04_exceptions.yaml
@@ -1,0 +1,19 @@
+name: "Custom exception hierarchy"
+description: "LLM must realise that isinstance checks against the subclass are the interesting assertion"
+language: python
+framework: pytest
+min_expected_tests: 3
+code: |
+  class AppError(Exception):
+      """Base for every domain error."""
+
+  class NotFoundError(AppError):
+      def __init__(self, entity: str, entity_id: str):
+          self.entity = entity
+          self.entity_id = entity_id
+          super().__init__(f"{entity} {entity_id!r} not found")
+
+  def lookup(db: dict, entity: str, entity_id: str):
+      if entity_id not in db:
+          raise NotFoundError(entity, entity_id)
+      return db[entity_id]

--- a/tests/evals/cases/test_generation/05_generator.yaml
+++ b/tests/evals/cases/test_generation/05_generator.yaml
@@ -1,0 +1,13 @@
+name: "Generator function"
+description: "Tests must consume the generator; common LLM failure mode is calling it as a list-returning function"
+language: python
+framework: pytest
+min_expected_tests: 2
+code: |
+  def fibonacci_up_to(limit: int):
+      if limit < 0:
+          raise ValueError("limit must be non-negative")
+      a, b = 0, 1
+      while a <= limit:
+          yield a
+          a, b = b, a + b

--- a/tests/evals/cases/test_generation/06_async_fn.yaml
+++ b/tests/evals/cases/test_generation/06_async_fn.yaml
@@ -1,0 +1,13 @@
+name: "Async function"
+description: "LLM must either use pytest-asyncio or asyncio.run; both are acceptable"
+language: python
+framework: pytest
+min_expected_tests: 2
+code: |
+  import asyncio
+
+  async def gather_doubles(values):
+      async def double(x):
+          await asyncio.sleep(0)
+          return x * 2
+      return await asyncio.gather(*[double(v) for v in values])

--- a/tests/evals/cases/test_generation/07_property.yaml
+++ b/tests/evals/cases/test_generation/07_property.yaml
@@ -1,0 +1,23 @@
+name: "Property with validation"
+description: "Exercises attribute-access + validator on setter"
+language: python
+framework: pytest
+min_expected_tests: 3
+code: |
+  class Temperature:
+      def __init__(self, celsius: float):
+          self.celsius = celsius  # uses the setter
+
+      @property
+      def celsius(self) -> float:
+          return self._celsius
+
+      @celsius.setter
+      def celsius(self, value: float) -> None:
+          if value < -273.15:
+              raise ValueError("below absolute zero")
+          self._celsius = float(value)
+
+      @property
+      def fahrenheit(self) -> float:
+          return self._celsius * 9 / 5 + 32

--- a/tests/evals/cases/test_generation/08_inheritance.yaml
+++ b/tests/evals/cases/test_generation/08_inheritance.yaml
@@ -1,0 +1,34 @@
+name: "Inheritance + polymorphic dispatch"
+description: "Tests must cover both subclasses through a common interface"
+language: python
+framework: pytest
+min_expected_tests: 3
+code: |
+  from abc import ABC, abstractmethod
+
+  class Shape(ABC):
+      @abstractmethod
+      def area(self) -> float: ...
+
+  class Circle(Shape):
+      def __init__(self, radius: float):
+          if radius < 0:
+              raise ValueError("radius must be >= 0")
+          self.radius = radius
+
+      def area(self) -> float:
+          from math import pi
+          return pi * self.radius * self.radius
+
+  class Rectangle(Shape):
+      def __init__(self, width: float, height: float):
+          if width < 0 or height < 0:
+              raise ValueError("dimensions must be >= 0")
+          self.width = width
+          self.height = height
+
+      def area(self) -> float:
+          return self.width * self.height
+
+  def total_area(shapes: list[Shape]) -> float:
+      return sum(s.area() for s in shapes)

--- a/tests/evals/cases/test_generation/09_state_machine.yaml
+++ b/tests/evals/cases/test_generation/09_state_machine.yaml
@@ -1,0 +1,48 @@
+name: "Order state machine"
+description: "Enforces a linear transition graph. Tests must cover valid transitions, rejections, and terminal-state immutability."
+language: python
+framework: pytest
+min_expected_tests: 5
+code: |
+  from enum import Enum
+
+  class OrderStatus(str, Enum):
+      PENDING = "pending"
+      PAID = "paid"
+      SHIPPED = "shipped"
+      DELIVERED = "delivered"
+      CANCELLED = "cancelled"
+
+  _TRANSITIONS = {
+      OrderStatus.PENDING: {OrderStatus.PAID, OrderStatus.CANCELLED},
+      OrderStatus.PAID: {OrderStatus.SHIPPED, OrderStatus.CANCELLED},
+      OrderStatus.SHIPPED: {OrderStatus.DELIVERED},
+      OrderStatus.DELIVERED: set(),
+      OrderStatus.CANCELLED: set(),
+  }
+
+
+  class Order:
+      def __init__(self, order_id: str):
+          if not order_id:
+              raise ValueError("order_id must be non-empty")
+          self.order_id = order_id
+          self.status = OrderStatus.PENDING
+          self._history: list[OrderStatus] = [self.status]
+
+      def transition(self, new_status: OrderStatus) -> None:
+          allowed = _TRANSITIONS[self.status]
+          if new_status not in allowed:
+              raise ValueError(
+                  f"Cannot transition from {self.status.value} to {new_status.value}"
+              )
+          self.status = new_status
+          self._history.append(new_status)
+
+      @property
+      def is_terminal(self) -> bool:
+          return not _TRANSITIONS[self.status]
+
+      @property
+      def history(self) -> list[OrderStatus]:
+          return list(self._history)

--- a/tests/evals/cases/test_generation/10_async_context.yaml
+++ b/tests/evals/cases/test_generation/10_async_context.yaml
@@ -1,0 +1,43 @@
+name: "Async connection pool (context manager)"
+description: "Async context manager that tracks checkouts, raises on double-close, and cleans up on exception paths."
+language: python
+framework: pytest
+min_expected_tests: 4
+code: |
+  import asyncio
+
+  class PoolClosedError(RuntimeError):
+      pass
+
+  class ConnectionPool:
+      def __init__(self, size: int):
+          if size <= 0:
+              raise ValueError("size must be > 0")
+          self._size = size
+          self._checked_out: int = 0
+          self._closed: bool = False
+
+      async def __aenter__(self) -> "ConnectionPool":
+          if self._closed:
+              raise PoolClosedError("pool already closed")
+          return self
+
+      async def __aexit__(self, exc_type, exc, tb) -> bool:
+          self._closed = True
+          # Return False so exceptions propagate — we're a cleanup, not a swallower.
+          return False
+
+      async def acquire(self) -> int:
+          if self._closed:
+              raise PoolClosedError("pool closed")
+          if self._checked_out >= self._size:
+              raise RuntimeError("pool exhausted")
+          self._checked_out += 1
+          await asyncio.sleep(0)
+          return self._checked_out
+
+      async def release(self) -> None:
+          if self._checked_out == 0:
+              raise RuntimeError("nothing to release")
+          self._checked_out -= 1
+          await asyncio.sleep(0)

--- a/tests/evals/cases/test_generation/11_decorator_retry.yaml
+++ b/tests/evals/cases/test_generation/11_decorator_retry.yaml
@@ -1,0 +1,34 @@
+name: "Retry decorator with selective exception catching"
+description: "Configurable retry count + allowed exception types. Tests must cover success-first-try, success-after-retry, exhaustion, and non-matching exception passthrough."
+language: python
+framework: pytest
+min_expected_tests: 4
+code: |
+  from functools import wraps
+
+
+  def retry(times: int = 3, exceptions: tuple[type[BaseException], ...] = (Exception,)):
+      """Retry a callable up to `times` attempts when it raises one of `exceptions`.
+
+      Raises the last captured exception if all attempts fail. Exceptions NOT in
+      `exceptions` propagate immediately (no retry).
+      """
+      if times < 1:
+          raise ValueError("times must be >= 1")
+
+      def decorator(fn):
+          @wraps(fn)
+          def wrapper(*args, **kwargs):
+              last_exc: BaseException | None = None
+              for attempt in range(times):
+                  try:
+                      return fn(*args, **kwargs)
+                  except exceptions as exc:
+                      last_exc = exc
+                      continue
+              assert last_exc is not None  # for type narrowing
+              raise last_exc
+          wrapper.attempts_spec = times
+          return wrapper
+
+      return decorator

--- a/tests/evals/cases/test_generation/12_pipeline_compose.yaml
+++ b/tests/evals/cases/test_generation/12_pipeline_compose.yaml
@@ -1,0 +1,36 @@
+name: "Pipeline composition with validation"
+description: "Generic pipeline that chains callables with shape validation at each step. Tests must cover normal flow, invalid step signatures, and early exit."
+language: python
+framework: pytest
+min_expected_tests: 4
+code: |
+  from typing import Any, Callable, Iterable
+
+  class PipelineError(RuntimeError):
+      pass
+
+
+  class Pipeline:
+      def __init__(self, steps: Iterable[Callable[[Any], Any]]):
+          steps_list = list(steps)
+          if not steps_list:
+              raise ValueError("pipeline needs at least one step")
+          for i, step in enumerate(steps_list):
+              if not callable(step):
+                  raise TypeError(f"step {i} is not callable: {step!r}")
+          self._steps = steps_list
+
+      def run(self, initial: Any) -> Any:
+          value = initial
+          for i, step in enumerate(self._steps):
+              try:
+                  value = step(value)
+              except Exception as exc:
+                  raise PipelineError(f"step {i} ({step.__name__}) failed: {exc}") from exc
+              if value is None:
+                  # Convention: a step returning None means "abort pipeline".
+                  break
+          return value
+
+      def __len__(self) -> int:
+          return len(self._steps)

--- a/tests/evals/cases/test_generation/13_lru_memoize.yaml
+++ b/tests/evals/cases/test_generation/13_lru_memoize.yaml
@@ -1,0 +1,60 @@
+name: "LRU memoize decorator"
+description: "Hand-rolled LRU cache tracking hit/miss stats and evicting on maxsize. Tests must cover cache hits, misses, eviction order, and stats."
+language: python
+framework: pytest
+min_expected_tests: 5
+code: |
+  from collections import OrderedDict
+  from functools import wraps
+  from typing import Any, Callable
+
+
+  class MemoizeStats:
+      def __init__(self) -> None:
+          self.hits: int = 0
+          self.misses: int = 0
+
+      @property
+      def calls(self) -> int:
+          return self.hits + self.misses
+
+      def reset(self) -> None:
+          self.hits = 0
+          self.misses = 0
+
+
+  def memoize(maxsize: int = 128) -> Callable:
+      """LRU memoize decorator. Exposes a ``.stats`` attribute and a ``.clear()`` method.
+
+      Cache key = (args, sorted kwargs items). All args must be hashable.
+      """
+      if maxsize < 1:
+          raise ValueError("maxsize must be >= 1")
+
+      def decorator(fn: Callable) -> Callable:
+          cache: "OrderedDict[tuple, Any]" = OrderedDict()
+          stats = MemoizeStats()
+
+          @wraps(fn)
+          def wrapper(*args: Any, **kwargs: Any) -> Any:
+              key = (args, tuple(sorted(kwargs.items())))
+              if key in cache:
+                  cache.move_to_end(key)
+                  stats.hits += 1
+                  return cache[key]
+              stats.misses += 1
+              result = fn(*args, **kwargs)
+              cache[key] = result
+              if len(cache) > maxsize:
+                  cache.popitem(last=False)  # evict LRU
+              return result
+
+          def clear() -> None:
+              cache.clear()
+              stats.reset()
+
+          wrapper.stats = stats
+          wrapper.clear = clear
+          return wrapper
+
+      return decorator

--- a/tests/evals/cases/test_generation_competent/01_arithmetic.yaml
+++ b/tests/evals/cases/test_generation_competent/01_arithmetic.yaml
@@ -1,0 +1,18 @@
+name: "Arithmetic utility"
+description: "Simple pure functions with known I/O including an error branch"
+language: python
+framework: pytest
+min_expected_tests: 3
+code: |
+  def add(a, b):
+      return a + b
+
+  def divide(a, b):
+      if b == 0:
+          raise ValueError("div by zero")
+      return a / b
+
+  def clamp(value, lo, hi):
+      if lo > hi:
+          raise ValueError("lo > hi")
+      return max(lo, min(value, hi))

--- a/tests/evals/cases/test_generation_competent/02_class_init.yaml
+++ b/tests/evals/cases/test_generation_competent/02_class_init.yaml
@@ -1,0 +1,18 @@
+name: "Class with __init__ and mutation"
+description: "Exercise the LLM's ability to cover object state, not just free functions"
+language: python
+framework: pytest
+min_expected_tests: 3
+code: |
+  class Counter:
+      def __init__(self, start: int = 0):
+          if start < 0:
+              raise ValueError("start must be >= 0")
+          self.value = start
+
+      def increment(self, by: int = 1) -> int:
+          self.value += by
+          return self.value
+
+      def reset(self) -> None:
+          self.value = 0

--- a/tests/evals/cases/test_generation_competent/03_type_hints.yaml
+++ b/tests/evals/cases/test_generation_competent/03_type_hints.yaml
@@ -1,0 +1,19 @@
+name: "Type-hinted data transform"
+description: "Uses List / Optional / dict annotations; good coverage needs boundary cases"
+language: python
+framework: pytest
+min_expected_tests: 3
+code: |
+  from typing import List, Optional
+
+  def first_nonzero(values: List[int]) -> Optional[int]:
+      for v in values:
+          if v != 0:
+              return v
+      return None
+
+  def word_counts(text: str) -> dict[str, int]:
+      counts: dict[str, int] = {}
+      for word in text.split():
+          counts[word] = counts.get(word, 0) + 1
+      return counts

--- a/tests/evals/cases/test_generation_competent/04_exceptions.yaml
+++ b/tests/evals/cases/test_generation_competent/04_exceptions.yaml
@@ -1,0 +1,19 @@
+name: "Custom exception hierarchy"
+description: "LLM must realise that isinstance checks against the subclass are the interesting assertion"
+language: python
+framework: pytest
+min_expected_tests: 3
+code: |
+  class AppError(Exception):
+      """Base for every domain error."""
+
+  class NotFoundError(AppError):
+      def __init__(self, entity: str, entity_id: str):
+          self.entity = entity
+          self.entity_id = entity_id
+          super().__init__(f"{entity} {entity_id!r} not found")
+
+  def lookup(db: dict, entity: str, entity_id: str):
+      if entity_id not in db:
+          raise NotFoundError(entity, entity_id)
+      return db[entity_id]

--- a/tests/evals/cases/test_generation_competent/05_generator.yaml
+++ b/tests/evals/cases/test_generation_competent/05_generator.yaml
@@ -1,0 +1,13 @@
+name: "Generator function"
+description: "Tests must consume the generator; common LLM failure mode is calling it as a list-returning function"
+language: python
+framework: pytest
+min_expected_tests: 2
+code: |
+  def fibonacci_up_to(limit: int):
+      if limit < 0:
+          raise ValueError("limit must be non-negative")
+      a, b = 0, 1
+      while a <= limit:
+          yield a
+          a, b = b, a + b

--- a/tests/evals/cases/test_generation_competent/06_async_fn.yaml
+++ b/tests/evals/cases/test_generation_competent/06_async_fn.yaml
@@ -1,0 +1,13 @@
+name: "Async function"
+description: "LLM must either use pytest-asyncio or asyncio.run; both are acceptable"
+language: python
+framework: pytest
+min_expected_tests: 2
+code: |
+  import asyncio
+
+  async def gather_doubles(values):
+      async def double(x):
+          await asyncio.sleep(0)
+          return x * 2
+      return await asyncio.gather(*[double(v) for v in values])

--- a/tests/evals/cases/test_generation_competent/07_property.yaml
+++ b/tests/evals/cases/test_generation_competent/07_property.yaml
@@ -1,0 +1,23 @@
+name: "Property with validation"
+description: "Exercises attribute-access + validator on setter"
+language: python
+framework: pytest
+min_expected_tests: 3
+code: |
+  class Temperature:
+      def __init__(self, celsius: float):
+          self.celsius = celsius  # uses the setter
+
+      @property
+      def celsius(self) -> float:
+          return self._celsius
+
+      @celsius.setter
+      def celsius(self, value: float) -> None:
+          if value < -273.15:
+              raise ValueError("below absolute zero")
+          self._celsius = float(value)
+
+      @property
+      def fahrenheit(self) -> float:
+          return self._celsius * 9 / 5 + 32

--- a/tests/evals/cases/test_generation_competent/08_inheritance.yaml
+++ b/tests/evals/cases/test_generation_competent/08_inheritance.yaml
@@ -1,0 +1,34 @@
+name: "Inheritance + polymorphic dispatch"
+description: "Tests must cover both subclasses through a common interface"
+language: python
+framework: pytest
+min_expected_tests: 3
+code: |
+  from abc import ABC, abstractmethod
+
+  class Shape(ABC):
+      @abstractmethod
+      def area(self) -> float: ...
+
+  class Circle(Shape):
+      def __init__(self, radius: float):
+          if radius < 0:
+              raise ValueError("radius must be >= 0")
+          self.radius = radius
+
+      def area(self) -> float:
+          from math import pi
+          return pi * self.radius * self.radius
+
+  class Rectangle(Shape):
+      def __init__(self, width: float, height: float):
+          if width < 0 or height < 0:
+              raise ValueError("dimensions must be >= 0")
+          self.width = width
+          self.height = height
+
+      def area(self) -> float:
+          return self.width * self.height
+
+  def total_area(shapes: list[Shape]) -> float:
+      return sum(s.area() for s in shapes)

--- a/tests/evals/cases/test_generation_competent/09_state_machine.yaml
+++ b/tests/evals/cases/test_generation_competent/09_state_machine.yaml
@@ -1,0 +1,48 @@
+name: "Order state machine"
+description: "Enforces a linear transition graph. Tests must cover valid transitions, rejections, and terminal-state immutability."
+language: python
+framework: pytest
+min_expected_tests: 5
+code: |
+  from enum import Enum
+
+  class OrderStatus(str, Enum):
+      PENDING = "pending"
+      PAID = "paid"
+      SHIPPED = "shipped"
+      DELIVERED = "delivered"
+      CANCELLED = "cancelled"
+
+  _TRANSITIONS = {
+      OrderStatus.PENDING: {OrderStatus.PAID, OrderStatus.CANCELLED},
+      OrderStatus.PAID: {OrderStatus.SHIPPED, OrderStatus.CANCELLED},
+      OrderStatus.SHIPPED: {OrderStatus.DELIVERED},
+      OrderStatus.DELIVERED: set(),
+      OrderStatus.CANCELLED: set(),
+  }
+
+
+  class Order:
+      def __init__(self, order_id: str):
+          if not order_id:
+              raise ValueError("order_id must be non-empty")
+          self.order_id = order_id
+          self.status = OrderStatus.PENDING
+          self._history: list[OrderStatus] = [self.status]
+
+      def transition(self, new_status: OrderStatus) -> None:
+          allowed = _TRANSITIONS[self.status]
+          if new_status not in allowed:
+              raise ValueError(
+                  f"Cannot transition from {self.status.value} to {new_status.value}"
+              )
+          self.status = new_status
+          self._history.append(new_status)
+
+      @property
+      def is_terminal(self) -> bool:
+          return not _TRANSITIONS[self.status]
+
+      @property
+      def history(self) -> list[OrderStatus]:
+          return list(self._history)

--- a/tests/evals/cases/test_generation_competent/10_async_context.yaml
+++ b/tests/evals/cases/test_generation_competent/10_async_context.yaml
@@ -1,0 +1,43 @@
+name: "Async connection pool (context manager)"
+description: "Async context manager that tracks checkouts, raises on double-close, and cleans up on exception paths."
+language: python
+framework: pytest
+min_expected_tests: 4
+code: |
+  import asyncio
+
+  class PoolClosedError(RuntimeError):
+      pass
+
+  class ConnectionPool:
+      def __init__(self, size: int):
+          if size <= 0:
+              raise ValueError("size must be > 0")
+          self._size = size
+          self._checked_out: int = 0
+          self._closed: bool = False
+
+      async def __aenter__(self) -> "ConnectionPool":
+          if self._closed:
+              raise PoolClosedError("pool already closed")
+          return self
+
+      async def __aexit__(self, exc_type, exc, tb) -> bool:
+          self._closed = True
+          # Return False so exceptions propagate — we're a cleanup, not a swallower.
+          return False
+
+      async def acquire(self) -> int:
+          if self._closed:
+              raise PoolClosedError("pool closed")
+          if self._checked_out >= self._size:
+              raise RuntimeError("pool exhausted")
+          self._checked_out += 1
+          await asyncio.sleep(0)
+          return self._checked_out
+
+      async def release(self) -> None:
+          if self._checked_out == 0:
+              raise RuntimeError("nothing to release")
+          self._checked_out -= 1
+          await asyncio.sleep(0)

--- a/tests/evals/cases/test_generation_competent/11_decorator_retry.yaml
+++ b/tests/evals/cases/test_generation_competent/11_decorator_retry.yaml
@@ -1,0 +1,34 @@
+name: "Retry decorator with selective exception catching"
+description: "Configurable retry count + allowed exception types. Tests must cover success-first-try, success-after-retry, exhaustion, and non-matching exception passthrough."
+language: python
+framework: pytest
+min_expected_tests: 4
+code: |
+  from functools import wraps
+
+
+  def retry(times: int = 3, exceptions: tuple[type[BaseException], ...] = (Exception,)):
+      """Retry a callable up to `times` attempts when it raises one of `exceptions`.
+
+      Raises the last captured exception if all attempts fail. Exceptions NOT in
+      `exceptions` propagate immediately (no retry).
+      """
+      if times < 1:
+          raise ValueError("times must be >= 1")
+
+      def decorator(fn):
+          @wraps(fn)
+          def wrapper(*args, **kwargs):
+              last_exc: BaseException | None = None
+              for attempt in range(times):
+                  try:
+                      return fn(*args, **kwargs)
+                  except exceptions as exc:
+                      last_exc = exc
+                      continue
+              assert last_exc is not None  # for type narrowing
+              raise last_exc
+          wrapper.attempts_spec = times
+          return wrapper
+
+      return decorator

--- a/tests/evals/cases/test_generation_competent/12_pipeline_compose.yaml
+++ b/tests/evals/cases/test_generation_competent/12_pipeline_compose.yaml
@@ -1,0 +1,36 @@
+name: "Pipeline composition with validation"
+description: "Generic pipeline that chains callables with shape validation at each step. Tests must cover normal flow, invalid step signatures, and early exit."
+language: python
+framework: pytest
+min_expected_tests: 4
+code: |
+  from typing import Any, Callable, Iterable
+
+  class PipelineError(RuntimeError):
+      pass
+
+
+  class Pipeline:
+      def __init__(self, steps: Iterable[Callable[[Any], Any]]):
+          steps_list = list(steps)
+          if not steps_list:
+              raise ValueError("pipeline needs at least one step")
+          for i, step in enumerate(steps_list):
+              if not callable(step):
+                  raise TypeError(f"step {i} is not callable: {step!r}")
+          self._steps = steps_list
+
+      def run(self, initial: Any) -> Any:
+          value = initial
+          for i, step in enumerate(self._steps):
+              try:
+                  value = step(value)
+              except Exception as exc:
+                  raise PipelineError(f"step {i} ({step.__name__}) failed: {exc}") from exc
+              if value is None:
+                  # Convention: a step returning None means "abort pipeline".
+                  break
+          return value
+
+      def __len__(self) -> int:
+          return len(self._steps)

--- a/tests/evals/cases/test_generation_competent/13_lru_memoize.yaml
+++ b/tests/evals/cases/test_generation_competent/13_lru_memoize.yaml
@@ -1,0 +1,60 @@
+name: "LRU memoize decorator"
+description: "Hand-rolled LRU cache tracking hit/miss stats and evicting on maxsize. Tests must cover cache hits, misses, eviction order, and stats."
+language: python
+framework: pytest
+min_expected_tests: 5
+code: |
+  from collections import OrderedDict
+  from functools import wraps
+  from typing import Any, Callable
+
+
+  class MemoizeStats:
+      def __init__(self) -> None:
+          self.hits: int = 0
+          self.misses: int = 0
+
+      @property
+      def calls(self) -> int:
+          return self.hits + self.misses
+
+      def reset(self) -> None:
+          self.hits = 0
+          self.misses = 0
+
+
+  def memoize(maxsize: int = 128) -> Callable:
+      """LRU memoize decorator. Exposes a ``.stats`` attribute and a ``.clear()`` method.
+
+      Cache key = (args, sorted kwargs items). All args must be hashable.
+      """
+      if maxsize < 1:
+          raise ValueError("maxsize must be >= 1")
+
+      def decorator(fn: Callable) -> Callable:
+          cache: "OrderedDict[tuple, Any]" = OrderedDict()
+          stats = MemoizeStats()
+
+          @wraps(fn)
+          def wrapper(*args: Any, **kwargs: Any) -> Any:
+              key = (args, tuple(sorted(kwargs.items())))
+              if key in cache:
+                  cache.move_to_end(key)
+                  stats.hits += 1
+                  return cache[key]
+              stats.misses += 1
+              result = fn(*args, **kwargs)
+              cache[key] = result
+              if len(cache) > maxsize:
+                  cache.popitem(last=False)  # evict LRU
+              return result
+
+          def clear() -> None:
+              cache.clear()
+              stats.reset()
+
+          wrapper.stats = stats
+          wrapper.clear = clear
+          return wrapper
+
+      return decorator

--- a/tests/evals/cases/test_generation_competent/README.md
+++ b/tests/evals/cases/test_generation_competent/README.md
@@ -1,0 +1,21 @@
+# test_generation_competent — "skilled user" baseline cases
+
+Mirror of [../test_generation/](../test_generation/). Same `code:` field as both
+sibling directories, on purpose. The three directories correspond to three
+prompt strategies that all see the exact same input code :
+
+| Directory | Who writes the prompt |
+|---|---|
+| `test_generation/` | MCP Collègue `TestGenerationTool` (tuned prompt engineering) |
+| `test_generation_raw/` | Naive user ("write pytest tests for this code") |
+| `test_generation_competent/` | Developer who knows pytest (asks for edge cases, parametrize, pytest.raises, etc.) |
+
+The point of adding this third axis is to answer the honest question : **is
+the MCP tool actually better than a mid-level developer's prompt, or just
+better than a beginner's?** If the Δ MCP − competent is large, the tool
+earns its complexity. If it's ~0, the value is mostly "saving the user from
+writing a careful prompt themselves".
+
+Keep the three directories in sync : adding a case means adding it in all
+three. Only create a divergence if you deliberately want to test a prompt
+strategy that can't work in one of the paths.

--- a/tests/evals/cases/test_generation_raw/01_arithmetic.yaml
+++ b/tests/evals/cases/test_generation_raw/01_arithmetic.yaml
@@ -1,0 +1,18 @@
+name: "Arithmetic utility"
+description: "Simple pure functions with known I/O including an error branch"
+language: python
+framework: pytest
+min_expected_tests: 3
+code: |
+  def add(a, b):
+      return a + b
+
+  def divide(a, b):
+      if b == 0:
+          raise ValueError("div by zero")
+      return a / b
+
+  def clamp(value, lo, hi):
+      if lo > hi:
+          raise ValueError("lo > hi")
+      return max(lo, min(value, hi))

--- a/tests/evals/cases/test_generation_raw/02_class_init.yaml
+++ b/tests/evals/cases/test_generation_raw/02_class_init.yaml
@@ -1,0 +1,18 @@
+name: "Class with __init__ and mutation"
+description: "Exercise the LLM's ability to cover object state, not just free functions"
+language: python
+framework: pytest
+min_expected_tests: 3
+code: |
+  class Counter:
+      def __init__(self, start: int = 0):
+          if start < 0:
+              raise ValueError("start must be >= 0")
+          self.value = start
+
+      def increment(self, by: int = 1) -> int:
+          self.value += by
+          return self.value
+
+      def reset(self) -> None:
+          self.value = 0

--- a/tests/evals/cases/test_generation_raw/03_type_hints.yaml
+++ b/tests/evals/cases/test_generation_raw/03_type_hints.yaml
@@ -1,0 +1,19 @@
+name: "Type-hinted data transform"
+description: "Uses List / Optional / dict annotations; good coverage needs boundary cases"
+language: python
+framework: pytest
+min_expected_tests: 3
+code: |
+  from typing import List, Optional
+
+  def first_nonzero(values: List[int]) -> Optional[int]:
+      for v in values:
+          if v != 0:
+              return v
+      return None
+
+  def word_counts(text: str) -> dict[str, int]:
+      counts: dict[str, int] = {}
+      for word in text.split():
+          counts[word] = counts.get(word, 0) + 1
+      return counts

--- a/tests/evals/cases/test_generation_raw/04_exceptions.yaml
+++ b/tests/evals/cases/test_generation_raw/04_exceptions.yaml
@@ -1,0 +1,19 @@
+name: "Custom exception hierarchy"
+description: "LLM must realise that isinstance checks against the subclass are the interesting assertion"
+language: python
+framework: pytest
+min_expected_tests: 3
+code: |
+  class AppError(Exception):
+      """Base for every domain error."""
+
+  class NotFoundError(AppError):
+      def __init__(self, entity: str, entity_id: str):
+          self.entity = entity
+          self.entity_id = entity_id
+          super().__init__(f"{entity} {entity_id!r} not found")
+
+  def lookup(db: dict, entity: str, entity_id: str):
+      if entity_id not in db:
+          raise NotFoundError(entity, entity_id)
+      return db[entity_id]

--- a/tests/evals/cases/test_generation_raw/05_generator.yaml
+++ b/tests/evals/cases/test_generation_raw/05_generator.yaml
@@ -1,0 +1,13 @@
+name: "Generator function"
+description: "Tests must consume the generator; common LLM failure mode is calling it as a list-returning function"
+language: python
+framework: pytest
+min_expected_tests: 2
+code: |
+  def fibonacci_up_to(limit: int):
+      if limit < 0:
+          raise ValueError("limit must be non-negative")
+      a, b = 0, 1
+      while a <= limit:
+          yield a
+          a, b = b, a + b

--- a/tests/evals/cases/test_generation_raw/06_async_fn.yaml
+++ b/tests/evals/cases/test_generation_raw/06_async_fn.yaml
@@ -1,0 +1,13 @@
+name: "Async function"
+description: "LLM must either use pytest-asyncio or asyncio.run; both are acceptable"
+language: python
+framework: pytest
+min_expected_tests: 2
+code: |
+  import asyncio
+
+  async def gather_doubles(values):
+      async def double(x):
+          await asyncio.sleep(0)
+          return x * 2
+      return await asyncio.gather(*[double(v) for v in values])

--- a/tests/evals/cases/test_generation_raw/07_property.yaml
+++ b/tests/evals/cases/test_generation_raw/07_property.yaml
@@ -1,0 +1,23 @@
+name: "Property with validation"
+description: "Exercises attribute-access + validator on setter"
+language: python
+framework: pytest
+min_expected_tests: 3
+code: |
+  class Temperature:
+      def __init__(self, celsius: float):
+          self.celsius = celsius  # uses the setter
+
+      @property
+      def celsius(self) -> float:
+          return self._celsius
+
+      @celsius.setter
+      def celsius(self, value: float) -> None:
+          if value < -273.15:
+              raise ValueError("below absolute zero")
+          self._celsius = float(value)
+
+      @property
+      def fahrenheit(self) -> float:
+          return self._celsius * 9 / 5 + 32

--- a/tests/evals/cases/test_generation_raw/08_inheritance.yaml
+++ b/tests/evals/cases/test_generation_raw/08_inheritance.yaml
@@ -1,0 +1,34 @@
+name: "Inheritance + polymorphic dispatch"
+description: "Tests must cover both subclasses through a common interface"
+language: python
+framework: pytest
+min_expected_tests: 3
+code: |
+  from abc import ABC, abstractmethod
+
+  class Shape(ABC):
+      @abstractmethod
+      def area(self) -> float: ...
+
+  class Circle(Shape):
+      def __init__(self, radius: float):
+          if radius < 0:
+              raise ValueError("radius must be >= 0")
+          self.radius = radius
+
+      def area(self) -> float:
+          from math import pi
+          return pi * self.radius * self.radius
+
+  class Rectangle(Shape):
+      def __init__(self, width: float, height: float):
+          if width < 0 or height < 0:
+              raise ValueError("dimensions must be >= 0")
+          self.width = width
+          self.height = height
+
+      def area(self) -> float:
+          return self.width * self.height
+
+  def total_area(shapes: list[Shape]) -> float:
+      return sum(s.area() for s in shapes)

--- a/tests/evals/cases/test_generation_raw/09_state_machine.yaml
+++ b/tests/evals/cases/test_generation_raw/09_state_machine.yaml
@@ -1,0 +1,48 @@
+name: "Order state machine"
+description: "Enforces a linear transition graph. Tests must cover valid transitions, rejections, and terminal-state immutability."
+language: python
+framework: pytest
+min_expected_tests: 5
+code: |
+  from enum import Enum
+
+  class OrderStatus(str, Enum):
+      PENDING = "pending"
+      PAID = "paid"
+      SHIPPED = "shipped"
+      DELIVERED = "delivered"
+      CANCELLED = "cancelled"
+
+  _TRANSITIONS = {
+      OrderStatus.PENDING: {OrderStatus.PAID, OrderStatus.CANCELLED},
+      OrderStatus.PAID: {OrderStatus.SHIPPED, OrderStatus.CANCELLED},
+      OrderStatus.SHIPPED: {OrderStatus.DELIVERED},
+      OrderStatus.DELIVERED: set(),
+      OrderStatus.CANCELLED: set(),
+  }
+
+
+  class Order:
+      def __init__(self, order_id: str):
+          if not order_id:
+              raise ValueError("order_id must be non-empty")
+          self.order_id = order_id
+          self.status = OrderStatus.PENDING
+          self._history: list[OrderStatus] = [self.status]
+
+      def transition(self, new_status: OrderStatus) -> None:
+          allowed = _TRANSITIONS[self.status]
+          if new_status not in allowed:
+              raise ValueError(
+                  f"Cannot transition from {self.status.value} to {new_status.value}"
+              )
+          self.status = new_status
+          self._history.append(new_status)
+
+      @property
+      def is_terminal(self) -> bool:
+          return not _TRANSITIONS[self.status]
+
+      @property
+      def history(self) -> list[OrderStatus]:
+          return list(self._history)

--- a/tests/evals/cases/test_generation_raw/10_async_context.yaml
+++ b/tests/evals/cases/test_generation_raw/10_async_context.yaml
@@ -1,0 +1,43 @@
+name: "Async connection pool (context manager)"
+description: "Async context manager that tracks checkouts, raises on double-close, and cleans up on exception paths."
+language: python
+framework: pytest
+min_expected_tests: 4
+code: |
+  import asyncio
+
+  class PoolClosedError(RuntimeError):
+      pass
+
+  class ConnectionPool:
+      def __init__(self, size: int):
+          if size <= 0:
+              raise ValueError("size must be > 0")
+          self._size = size
+          self._checked_out: int = 0
+          self._closed: bool = False
+
+      async def __aenter__(self) -> "ConnectionPool":
+          if self._closed:
+              raise PoolClosedError("pool already closed")
+          return self
+
+      async def __aexit__(self, exc_type, exc, tb) -> bool:
+          self._closed = True
+          # Return False so exceptions propagate — we're a cleanup, not a swallower.
+          return False
+
+      async def acquire(self) -> int:
+          if self._closed:
+              raise PoolClosedError("pool closed")
+          if self._checked_out >= self._size:
+              raise RuntimeError("pool exhausted")
+          self._checked_out += 1
+          await asyncio.sleep(0)
+          return self._checked_out
+
+      async def release(self) -> None:
+          if self._checked_out == 0:
+              raise RuntimeError("nothing to release")
+          self._checked_out -= 1
+          await asyncio.sleep(0)

--- a/tests/evals/cases/test_generation_raw/11_decorator_retry.yaml
+++ b/tests/evals/cases/test_generation_raw/11_decorator_retry.yaml
@@ -1,0 +1,34 @@
+name: "Retry decorator with selective exception catching"
+description: "Configurable retry count + allowed exception types. Tests must cover success-first-try, success-after-retry, exhaustion, and non-matching exception passthrough."
+language: python
+framework: pytest
+min_expected_tests: 4
+code: |
+  from functools import wraps
+
+
+  def retry(times: int = 3, exceptions: tuple[type[BaseException], ...] = (Exception,)):
+      """Retry a callable up to `times` attempts when it raises one of `exceptions`.
+
+      Raises the last captured exception if all attempts fail. Exceptions NOT in
+      `exceptions` propagate immediately (no retry).
+      """
+      if times < 1:
+          raise ValueError("times must be >= 1")
+
+      def decorator(fn):
+          @wraps(fn)
+          def wrapper(*args, **kwargs):
+              last_exc: BaseException | None = None
+              for attempt in range(times):
+                  try:
+                      return fn(*args, **kwargs)
+                  except exceptions as exc:
+                      last_exc = exc
+                      continue
+              assert last_exc is not None  # for type narrowing
+              raise last_exc
+          wrapper.attempts_spec = times
+          return wrapper
+
+      return decorator

--- a/tests/evals/cases/test_generation_raw/12_pipeline_compose.yaml
+++ b/tests/evals/cases/test_generation_raw/12_pipeline_compose.yaml
@@ -1,0 +1,36 @@
+name: "Pipeline composition with validation"
+description: "Generic pipeline that chains callables with shape validation at each step. Tests must cover normal flow, invalid step signatures, and early exit."
+language: python
+framework: pytest
+min_expected_tests: 4
+code: |
+  from typing import Any, Callable, Iterable
+
+  class PipelineError(RuntimeError):
+      pass
+
+
+  class Pipeline:
+      def __init__(self, steps: Iterable[Callable[[Any], Any]]):
+          steps_list = list(steps)
+          if not steps_list:
+              raise ValueError("pipeline needs at least one step")
+          for i, step in enumerate(steps_list):
+              if not callable(step):
+                  raise TypeError(f"step {i} is not callable: {step!r}")
+          self._steps = steps_list
+
+      def run(self, initial: Any) -> Any:
+          value = initial
+          for i, step in enumerate(self._steps):
+              try:
+                  value = step(value)
+              except Exception as exc:
+                  raise PipelineError(f"step {i} ({step.__name__}) failed: {exc}") from exc
+              if value is None:
+                  # Convention: a step returning None means "abort pipeline".
+                  break
+          return value
+
+      def __len__(self) -> int:
+          return len(self._steps)

--- a/tests/evals/cases/test_generation_raw/13_lru_memoize.yaml
+++ b/tests/evals/cases/test_generation_raw/13_lru_memoize.yaml
@@ -1,0 +1,60 @@
+name: "LRU memoize decorator"
+description: "Hand-rolled LRU cache tracking hit/miss stats and evicting on maxsize. Tests must cover cache hits, misses, eviction order, and stats."
+language: python
+framework: pytest
+min_expected_tests: 5
+code: |
+  from collections import OrderedDict
+  from functools import wraps
+  from typing import Any, Callable
+
+
+  class MemoizeStats:
+      def __init__(self) -> None:
+          self.hits: int = 0
+          self.misses: int = 0
+
+      @property
+      def calls(self) -> int:
+          return self.hits + self.misses
+
+      def reset(self) -> None:
+          self.hits = 0
+          self.misses = 0
+
+
+  def memoize(maxsize: int = 128) -> Callable:
+      """LRU memoize decorator. Exposes a ``.stats`` attribute and a ``.clear()`` method.
+
+      Cache key = (args, sorted kwargs items). All args must be hashable.
+      """
+      if maxsize < 1:
+          raise ValueError("maxsize must be >= 1")
+
+      def decorator(fn: Callable) -> Callable:
+          cache: "OrderedDict[tuple, Any]" = OrderedDict()
+          stats = MemoizeStats()
+
+          @wraps(fn)
+          def wrapper(*args: Any, **kwargs: Any) -> Any:
+              key = (args, tuple(sorted(kwargs.items())))
+              if key in cache:
+                  cache.move_to_end(key)
+                  stats.hits += 1
+                  return cache[key]
+              stats.misses += 1
+              result = fn(*args, **kwargs)
+              cache[key] = result
+              if len(cache) > maxsize:
+                  cache.popitem(last=False)  # evict LRU
+              return result
+
+          def clear() -> None:
+              cache.clear()
+              stats.reset()
+
+          wrapper.stats = stats
+          wrapper.clear = clear
+          return wrapper
+
+      return decorator

--- a/tests/evals/cases/test_generation_raw/README.md
+++ b/tests/evals/cases/test_generation_raw/README.md
@@ -1,0 +1,11 @@
+# test_generation_raw — baseline cases
+
+Mirror of [../test_generation/](../test_generation/). Identical `code:` field on
+purpose — the whole point of this directory is a **fair apples-to-apples
+comparison** between the MCP `test_generation` tool and a plain "please write
+tests for this code" request to the same LLM.
+
+If you add a case here, add the same one to `../test_generation/` so the
+matrix report stays symmetric. If you deliberately want to test a scenario
+that only makes sense without the MCP tool's framing, keep it here only and
+the MCP column will show em-dash in the matrix report.

--- a/tests/evals/eval_context.py
+++ b/tests/evals/eval_context.py
@@ -1,0 +1,90 @@
+"""Minimal FastMCP-style context for running tool logic outside the server.
+
+The LLM tools expect a ``ctx`` object with at least an async ``sample(messages,
+system_prompt, temperature, max_tokens)`` that returns an object with a
+``.text`` attribute. In production this is wired by FastMCP to the configured
+sampling handler (Gemini via ``OpenAISamplingHandler``). For the evals runner
+we need the same shape but without a running MCP server, so we call
+``generate_text()`` directly — the same helper the Watchdog already uses.
+
+Intentionally small: the tools we evaluate only touch ``ctx.sample``,
+``ctx.info``, ``ctx.warning``, ``ctx.error``, ``ctx.report_progress`` — see
+``collegue/tools/test_generation/tool.py`` for the full surface. Any missing
+method will raise ``AttributeError`` which is loud enough to catch on first
+run.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from collegue.config import settings
+from collegue.resources.llm.providers import LLMConfig, LLMResponse, generate_text
+
+
+@dataclass
+class _SampleResult:
+    """Drop-in shape for what FastMCP hands back from ``ctx.sample()``."""
+
+    text: str
+    annotations: List[Dict[str, Any]] = field(default_factory=list)
+
+
+class EvalContext:
+    """Context that runs the tool against the real LLM without MCP plumbing.
+
+    Keep it dumb: the eval runner owns the lifecycle, we're just a thin
+    adapter. ``lifespan_context`` is an empty dict — tools that need
+    something from the lifespan (parser, prompt_engine, ...) must tolerate
+    that path being None, which they already do for the HTTP transport.
+    """
+
+    #: Floor below which we never go, regardless of what the tool asks for.
+    #: Gemini 2.5 reasoning can consume ~1-2k tokens before emitting any
+    #: output — if the tool asked for 2000, we'd get a truncated response.
+    #: 8000 leaves enough headroom for reasoning + real output.
+    MIN_MAX_TOKENS = 8000
+
+    def __init__(self, temperature: float = 0.5, max_tokens: int = MIN_MAX_TOKENS):
+        self.lifespan_context: Dict[str, Any] = {}
+        self._default_temperature = temperature
+        self._default_max_tokens = max_tokens
+        self._model = settings.LLM_MODEL
+        self.calls: list[Dict[str, Any]] = []
+
+    async def sample(
+        self,
+        messages: str,
+        system_prompt: Optional[str] = None,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+    ) -> _SampleResult:
+        effective_max = max(max_tokens or self._default_max_tokens, self.MIN_MAX_TOKENS)
+        config = LLMConfig(
+            model_name=self._model,
+            api_key=settings.LLM_API_KEY,
+            max_tokens=effective_max,
+            temperature=temperature if temperature is not None else self._default_temperature,
+        )
+        response: LLMResponse = await generate_text(config, messages, system_prompt=system_prompt)
+        self.calls.append({
+            "temperature": config.temperature,
+            "max_tokens": config.max_tokens,
+            "prompt_len": len(messages),
+            "response_len": len(response.text or ""),
+        })
+        return _SampleResult(text=response.text or "", annotations=list(response.annotations or []))
+
+    # --- noop log sinks so the tool can await on them ---------------------
+
+    async def info(self, _message: str) -> None:
+        return None
+
+    async def warning(self, _message: str) -> None:
+        return None
+
+    async def error(self, _message: str) -> None:
+        return None
+
+    async def report_progress(self, *args: Any, **kwargs: Any) -> None:
+        return None

--- a/tests/evals/eval_context.py
+++ b/tests/evals/eval_context.py
@@ -45,12 +45,24 @@ class EvalContext:
     #: 8000 leaves enough headroom for reasoning + real output.
     MIN_MAX_TOKENS = 8000
 
-    def __init__(self, temperature: float = 0.5, max_tokens: int = MIN_MAX_TOKENS):
+    def __init__(
+        self,
+        temperature: float = 0.5,
+        max_tokens: int = MIN_MAX_TOKENS,
+        model: Optional[str] = None,
+    ):
         self.lifespan_context: Dict[str, Any] = {}
         self._default_temperature = temperature
         self._default_max_tokens = max_tokens
-        self._model = settings.LLM_MODEL
+        # ``model`` overrides the env default so the matrix runner can drive
+        # a sweep without touching settings. Falls back to LLM_MODEL for the
+        # common "run against whatever is configured" case.
+        self._model = model or settings.LLM_MODEL
         self.calls: list[Dict[str, Any]] = []
+
+    @property
+    def model(self) -> str:
+        return self._model
 
     async def sample(
         self,

--- a/tests/evals/runner.py
+++ b/tests/evals/runner.py
@@ -6,10 +6,27 @@ scorer, and produce a per-run markdown + JSON report. Designed to run locally
 or from a nightly job — **never from a PR CI run** (too expensive, too
 non-deterministic).
 
+Supports two orthogonal axes :
+
+1. **Tool path** — either ``test_generation`` (goes through the MCP tool, with
+   its tuned prompt + element extraction) or ``test_generation_raw`` (sends a
+   minimal prompt straight to the LLM, no MCP in the loop). Having both lets
+   us quantify the value the MCP tool adds over calling Gemini directly.
+2. **Model** — any model name the Gemini API accepts. Pass one with ``--model``
+   or several with ``--model X --model Y`` to run a matrix. Results from a
+   matrix run include a comparison table.
+
 Usage::
 
-    LLM_API_KEY=... python -m tests.evals.runner --tool test_generation \
-        --out tests/evals/reports/$(date -u +%Y-%m-%dT%H-%M-%S)
+    # Single model, single tool (default: settings.LLM_MODEL, tool=MCP)
+    python -m tests.evals.runner --tool test_generation
+
+    # Matrix run: 5 models × 2 tools on the 8 cases (= 80 LLM calls)
+    python -m tests.evals.runner --tool test_generation --tool test_generation_raw \\
+        --model gemini-2.5-flash --model gemini-3-flash --model gemini-3.1-pro \\
+        --model gemma-4-26b --model gemma-3-1b
+
+    # Iterate quickly
     python -m tests.evals.runner --tool test_generation --case 01_arithmetic
     python -m tests.evals.runner --tool test_generation --limit 2
 """
@@ -23,11 +40,12 @@ import json
 import sys
 import traceback
 from pathlib import Path
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
 import yaml
 
 from collegue.config import settings
+from collegue.resources.llm.providers import LLMConfig, generate_text
 from collegue.tools.test_generation import TestGenerationRequest, TestGenerationTool
 
 from tests.evals.eval_context import EvalContext
@@ -39,12 +57,12 @@ CASES_ROOT = Path(__file__).parent / "cases"
 
 
 # ---------------------------------------------------------------------------
-# Tool registry
+# Tool runners
 # ---------------------------------------------------------------------------
-# Each entry wires a tool name to (async runner, scorer). The runner takes
-# the parsed case dict and returns the tool output string that the scorer
-# understands. Adding a new tool = adding one entry here + one scorer module
-# + one cases/<name>/ directory. Nothing else needs to change.
+# Each entry wires a tool name to (async runner, scorer, cases dir). The
+# runner takes the parsed case dict and returns the tool output string that
+# the scorer understands. Adding a new tool = adding one entry here + one
+# scorer module + one cases/<name>/ directory.
 
 
 async def _run_test_generation(case: Dict[str, Any], ctx: EvalContext) -> str:
@@ -58,10 +76,54 @@ async def _run_test_generation(case: Dict[str, Any], ctx: EvalContext) -> str:
     return response.test_code
 
 
-TOOL_REGISTRY: Dict[str, Dict[str, Callable]] = {
+# Minimal prompt used by the raw-LLM path. Kept short intentionally — the
+# whole point of the comparison is "what you'd get if you just asked". No
+# element extraction, no coverage target, no framework preamble.
+_RAW_SYSTEM_PROMPT = (
+    "You are an expert Python developer. Generate a pytest test file for the "
+    "code you receive. Output the test file as a single Python code block."
+)
+
+
+async def _run_test_generation_raw(case: Dict[str, Any], ctx: EvalContext) -> str:
+    """Bypass the MCP tool entirely — just ask the LLM for tests.
+
+    Baseline for how much value the MCP ``test_generation`` tool's prompt
+    engineering actually adds on top of a plain "write tests" request.
+    """
+    config = LLMConfig(
+        model_name=ctx.model,
+        api_key=settings.LLM_API_KEY,
+        max_tokens=EvalContext.MIN_MAX_TOKENS,
+        temperature=0.5,
+    )
+    framework = case.get("framework", "pytest")
+    prompt = (
+        f"Write a {framework} test file for the following {case.get('language', 'python')} code.\n\n"
+        f"```python\n{case['code']}\n```\n"
+    )
+    response = await generate_text(config, prompt, system_prompt=_RAW_SYSTEM_PROMPT)
+    # Record the call so the JSON report matches what the MCP path does.
+    ctx.calls.append({
+        "temperature": config.temperature,
+        "max_tokens": config.max_tokens,
+        "prompt_len": len(prompt),
+        "response_len": len(response.text or ""),
+        "path": "raw",
+    })
+    return response.text or ""
+
+
+TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
     "test_generation": {
         "run": _run_test_generation,
         "score": tg_scorer.score,
+        "cases_subdir": "test_generation",
+    },
+    "test_generation_raw": {
+        "run": _run_test_generation_raw,
+        "score": tg_scorer.score,
+        "cases_subdir": "test_generation_raw",
     },
 }
 
@@ -72,7 +134,8 @@ TOOL_REGISTRY: Dict[str, Dict[str, Callable]] = {
 
 
 def load_cases(tool: str, only: List[str] | None = None, limit: int | None = None) -> List[tuple[str, Dict[str, Any]]]:
-    cases_dir = CASES_ROOT / tool
+    subdir = TOOL_REGISTRY[tool]["cases_subdir"]
+    cases_dir = CASES_ROOT / subdir
     if not cases_dir.is_dir():
         raise FileNotFoundError(f"No cases directory for tool {tool!r}: {cases_dir}")
 
@@ -90,7 +153,7 @@ def load_cases(tool: str, only: List[str] | None = None, limit: int | None = Non
 
 
 # ---------------------------------------------------------------------------
-# Runner
+# Single-run primitives
 # ---------------------------------------------------------------------------
 
 
@@ -99,8 +162,9 @@ async def _run_single_case(
     case_id: str,
     case: Dict[str, Any],
     out_dir: Path,
+    model: str,
 ) -> Dict[str, Any]:
-    ctx = EvalContext()
+    ctx = EvalContext(model=model)
     entry = TOOL_REGISTRY[tool]
 
     started = _dt.datetime.now(_dt.timezone.utc)
@@ -131,7 +195,7 @@ async def _run_single_case(
         "case_id": case_id,
         "name": case.get("name", case_id),
         "description": case.get("description", ""),
-        "model": settings.LLM_MODEL,
+        "model": model,
         "started_at": started.isoformat(timespec="seconds"),
         "score": score_payload,
         "ctx_calls": ctx.calls,
@@ -139,15 +203,129 @@ async def _run_single_case(
         "raw_error": raw_error,
     }
 
-    (out_dir / "cases").mkdir(parents=True, exist_ok=True)
-    (out_dir / "cases" / f"{case_id}.json").write_text(
+    # One JSON file per (model, tool, case) triple. Keeps the on-disk layout
+    # flat enough to diff / grep without pre-processing.
+    cases_dir = out_dir / "cases"
+    cases_dir.mkdir(parents=True, exist_ok=True)
+    safe_model = model.replace("/", "_").replace(":", "_")
+    (cases_dir / f"{tool}__{safe_model}__{case_id}.json").write_text(
         json.dumps(record, indent=2, ensure_ascii=False),
         encoding="utf-8",
     )
     return record
 
 
-def _write_report(records: List[Dict[str, Any]], out_dir: Path) -> None:
+def _aggregate(records: List[Dict[str, Any]]) -> Dict[str, Any]:
+    if not records:
+        return {"avg": 0.0, "n": 0, "passed": 0, "collected": 0}
+    total_score = sum(r["score"]["score"] for r in records)
+    total_passed = sum(r["score"]["passed"] for r in records)
+    total_collected = sum(r["score"]["collected"] for r in records)
+    return {
+        "avg": round(total_score / len(records), 3),
+        "n": len(records),
+        "passed": total_passed,
+        "collected": total_collected,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Matrix report writer
+# ---------------------------------------------------------------------------
+
+
+def _fmt_score(record: Optional[Dict[str, Any]]) -> str:
+    if record is None:
+        return "—"
+    if record.get("raw_error"):
+        return "ERR"
+    return f"{record['score']['score']:.3f}"
+
+
+def _write_matrix_report(
+    records: List[Dict[str, Any]],
+    out_dir: Path,
+    case_ids: List[str],
+    tools: List[str],
+    models: List[str],
+) -> None:
+    lines: list[str] = []
+    started = records[0]["started_at"] if records else _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds")
+    lines.append(f"# Matrix eval run {started}")
+    lines.append("")
+    lines.append(f"- Cases: {len(case_ids)}")
+    lines.append(f"- Tools: {', '.join(tools)}")
+    lines.append(f"- Models: {', '.join(models)}")
+    lines.append(f"- Total runs: {len(records)}")
+    lines.append("")
+
+    # Index records by (tool, model, case) for fast lookup.
+    idx: Dict[tuple, Dict[str, Any]] = {
+        (r["tool"], r["model"], r["case_id"]): r for r in records
+    }
+
+    for tool in tools:
+        lines.append(f"## `{tool}`")
+        lines.append("")
+        header = "| Case | " + " | ".join(models) + " |"
+        sep = "|---|" + "|".join(["---"] * len(models)) + "|"
+        lines.append(header)
+        lines.append(sep)
+        for case_id in case_ids:
+            row = [case_id]
+            for model in models:
+                row.append(_fmt_score(idx.get((tool, model, case_id))))
+            lines.append("| " + " | ".join(row) + " |")
+
+        # Aggregate row.
+        agg_row = ["**Avg**"]
+        for model in models:
+            recs = [idx[(tool, model, c)] for c in case_ids if (tool, model, c) in idx and not idx[(tool, model, c)].get("raw_error")]
+            if recs:
+                agg = _aggregate(recs)
+                agg_row.append(f"**{agg['avg']:.3f}**")
+            else:
+                agg_row.append("**—**")
+        lines.append("| " + " | ".join(agg_row) + " |")
+        lines.append("")
+
+    # Δ MCP minus raw, per model (only meaningful when both tools are in the run).
+    if "test_generation" in tools and "test_generation_raw" in tools:
+        lines.append("## Δ `test_generation` − `test_generation_raw` (per model)")
+        lines.append("")
+        lines.append("Positive = MCP tool adds value over raw prompt. Negative = MCP tool is counter-productive.")
+        lines.append("")
+        lines.append("| Model | MCP avg | Raw avg | Δ |")
+        lines.append("|---|---|---|---|")
+        for model in models:
+            mcp_recs = [idx[("test_generation", model, c)] for c in case_ids if ("test_generation", model, c) in idx and not idx[("test_generation", model, c)].get("raw_error")]
+            raw_recs = [idx[("test_generation_raw", model, c)] for c in case_ids if ("test_generation_raw", model, c) in idx and not idx[("test_generation_raw", model, c)].get("raw_error")]
+            mcp_avg = _aggregate(mcp_recs)["avg"] if mcp_recs else None
+            raw_avg = _aggregate(raw_recs)["avg"] if raw_recs else None
+            mcp_s = f"{mcp_avg:.3f}" if mcp_avg is not None else "—"
+            raw_s = f"{raw_avg:.3f}" if raw_avg is not None else "—"
+            if mcp_avg is not None and raw_avg is not None:
+                delta = mcp_avg - raw_avg
+                delta_s = f"{'+' if delta >= 0 else ''}{delta:.3f}"
+            else:
+                delta_s = "—"
+            lines.append(f"| `{model}` | {mcp_s} | {raw_s} | {delta_s} |")
+        lines.append("")
+
+    # Errors section (if any).
+    errs = [r for r in records if r.get("raw_error")]
+    if errs:
+        lines.append("## Errors")
+        lines.append("")
+        for r in errs:
+            lines.append(f"- `{r['tool']}` · `{r['model']}` · `{r['case_id']}` — first line: `{r['raw_error'].splitlines()[0] if r['raw_error'] else ''}`")
+        lines.append("")
+
+    (out_dir / "report.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_single_report(records: List[Dict[str, Any]], out_dir: Path) -> None:
+    """Report for single-tool / single-model runs — stays compact."""
     lines: list[str] = []
     started = records[0]["started_at"] if records else _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds")
     lines.append(f"# Eval run {started}")
@@ -165,73 +343,106 @@ def _write_report(records: List[Dict[str, Any]], out_dir: Path) -> None:
         lines.append("")
         lines.append("| Case | Score | Collected | Passed | Failed | Errors | Duration |")
         lines.append("|---|---|---|---|---|---|---|")
-        total_score = 0.0
-        total_collected = 0
-        total_passed = 0
         for r in tool_records:
             s = r["score"]
             lines.append(
                 f"| {r['case_id']} | {s['score']:.3f} | {s['collected']} | {s['passed']} | "
                 f"{s['failed']} | {s['errors']} | {s['duration_s']}s |"
             )
-            total_score += s["score"]
-            total_collected += s["collected"]
-            total_passed += s["passed"]
-
-        n = len(tool_records)
-        avg = total_score / n if n else 0.0
+        agg = _aggregate(tool_records)
         lines.append("")
         lines.append(
-            f"**Aggregate:** {avg:.3f} average, {total_passed}/{total_collected} generated tests passing."
+            f"**Aggregate:** {agg['avg']:.3f} average, {agg['passed']}/{agg['collected']} generated tests passing."
         )
         lines.append("")
 
-    report_path = out_dir / "report.md"
-    report_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    (out_dir / "report.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Main runner
+# ---------------------------------------------------------------------------
 
 
 async def _run(
-    tool: str,
+    tools: List[str],
+    models: List[str],
     out_dir: Path,
     only: List[str] | None,
     limit: int | None,
 ) -> int:
-    if tool not in TOOL_REGISTRY:
-        print(f"[ERROR] Unknown tool {tool!r}. Available: {sorted(TOOL_REGISTRY)}", file=sys.stderr)
-        return 2
+    for tool in tools:
+        if tool not in TOOL_REGISTRY:
+            print(f"[ERROR] Unknown tool {tool!r}. Available: {sorted(TOOL_REGISTRY)}", file=sys.stderr)
+            return 2
 
     if not settings.LLM_API_KEY or settings.LLM_API_KEY == "votre_clé_api_gemini":
         print("[ERROR] LLM_API_KEY must be set (see .env)", file=sys.stderr)
         return 3
 
-    cases = load_cases(tool, only=only, limit=limit)
-    if not cases:
-        print(f"[ERROR] No cases matched (tool={tool}, only={only}, limit={limit})", file=sys.stderr)
+    # Load cases per tool (may differ if cases_subdir differs); we key by case_id
+    # so the matrix report can render missing cells as em-dash.
+    case_ids_set: set[str] = set()
+    per_tool_cases: Dict[str, List[tuple[str, Dict[str, Any]]]] = {}
+    for tool in tools:
+        cases = load_cases(tool, only=only, limit=limit)
+        per_tool_cases[tool] = cases
+        case_ids_set.update(cid for cid, _ in cases)
+    case_ids = sorted(case_ids_set)
+
+    if not case_ids:
+        print(f"[ERROR] No cases matched (tools={tools}, only={only}, limit={limit})", file=sys.stderr)
         return 4
 
     out_dir.mkdir(parents=True, exist_ok=True)
-    print(f"=== Running {len(cases)} eval(s) for {tool} — model={settings.LLM_MODEL}")
-    records: list[Dict[str, Any]] = []
-    for i, (case_id, case) in enumerate(cases, 1):
-        print(f"[{i:>2}/{len(cases)}] {case_id} — {case.get('name', '')}")
-        try:
-            record = await _run_single_case(tool, case_id, case, out_dir)
-            s = record["score"]
-            marker = "✅" if s["score"] >= 0.6 else "⚠️ " if s["score"] >= 0.3 else "❌"
-            print(f"     {marker} score={s['score']:.3f} passed={s['passed']}/{s['collected']} in {s['duration_s']}s")
-            records.append(record)
-        except Exception as exc:
-            print(f"     ❌ runner failure: {exc}", file=sys.stderr)
-            traceback.print_exc()
+    total_runs = sum(len(per_tool_cases[t]) for t in tools) * len(models)
+    print(f"=== Matrix run: {total_runs} LLM calls ({len(case_ids)} cases × {len(tools)} tool(s) × {len(models)} model(s))")
+    print(f"=== Tools: {tools}")
+    print(f"=== Models: {models}")
+    print()
 
-    _write_report(records, out_dir)
-    print(f"=== Report: {out_dir / 'report.md'}")
+    records: list[Dict[str, Any]] = []
+    idx = 0
+    for model in models:
+        for tool in tools:
+            for case_id, case in per_tool_cases[tool]:
+                idx += 1
+                prefix = f"[{idx:>3}/{total_runs}] {tool:<22} · {model:<22} · {case_id}"
+                try:
+                    record = await _run_single_case(tool, case_id, case, out_dir, model)
+                    s = record["score"]
+                    marker = "✅" if s["score"] >= 0.6 else "⚠️ " if s["score"] >= 0.3 else "❌"
+                    print(f"{prefix} → {marker} score={s['score']:.3f} passed={s['passed']}/{s['collected']}")
+                    records.append(record)
+                except Exception as exc:
+                    print(f"{prefix} → ❌ runner failure: {exc}", file=sys.stderr)
+                    traceback.print_exc()
+
+    # Pick the right report shape. Single model + single tool = compact.
+    # Anything multi-axis = matrix.
+    if len(tools) == 1 and len(models) == 1:
+        _write_single_report(records, out_dir)
+    else:
+        _write_matrix_report(records, out_dir, case_ids, tools, models)
+    print(f"\n=== Report: {out_dir / 'report.md'}")
     return 0
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(prog="tests.evals.runner")
-    ap.add_argument("--tool", required=True, choices=sorted(TOOL_REGISTRY), help="Tool to evaluate")
+    ap.add_argument(
+        "--tool",
+        action="append",
+        default=[],
+        choices=sorted(TOOL_REGISTRY),
+        help="Tool to evaluate. Can be passed multiple times for a matrix run.",
+    )
+    ap.add_argument(
+        "--model",
+        action="append",
+        default=[],
+        help="Model name (e.g. gemini-2.5-flash). Can be passed multiple times.",
+    )
     ap.add_argument(
         "--out",
         type=Path,
@@ -242,17 +453,20 @@ def main() -> int:
         "--case",
         action="append",
         default=[],
-        help="Limit to specific case(s) by id (filename without extension). Can be passed multiple times.",
+        help="Limit to specific case id(s). Can be passed multiple times.",
     )
     ap.add_argument("--limit", type=int, default=None, help="Only run the first N cases")
     args = ap.parse_args()
+
+    tools = args.tool or ["test_generation"]
+    models = args.model or [settings.LLM_MODEL]
 
     out_dir = args.out or (
         Path(__file__).parent
         / "reports"
         / _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
     )
-    return asyncio.run(_run(args.tool, out_dir, args.case or None, args.limit))
+    return asyncio.run(_run(tools, models, out_dir, args.case or None, args.limit))
 
 
 if __name__ == "__main__":

--- a/tests/evals/runner.py
+++ b/tests/evals/runner.py
@@ -1,0 +1,259 @@
+"""Golden eval runner.
+
+Load YAML cases under ``tests/evals/cases/<tool>/``, execute the tool against
+a real LLM via :class:`EvalContext`, score each output with the tool-specific
+scorer, and produce a per-run markdown + JSON report. Designed to run locally
+or from a nightly job — **never from a PR CI run** (too expensive, too
+non-deterministic).
+
+Usage::
+
+    LLM_API_KEY=... python -m tests.evals.runner --tool test_generation \
+        --out tests/evals/reports/$(date -u +%Y-%m-%dT%H-%M-%S)
+    python -m tests.evals.runner --tool test_generation --case 01_arithmetic
+    python -m tests.evals.runner --tool test_generation --limit 2
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import dataclasses
+import datetime as _dt
+import json
+import sys
+import traceback
+from pathlib import Path
+from typing import Any, Callable, Dict, List
+
+import yaml
+
+from collegue.config import settings
+from collegue.tools.test_generation import TestGenerationRequest, TestGenerationTool
+
+from tests.evals.eval_context import EvalContext
+from tests.evals.scorers import test_generation as tg_scorer
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CASES_ROOT = Path(__file__).parent / "cases"
+
+
+# ---------------------------------------------------------------------------
+# Tool registry
+# ---------------------------------------------------------------------------
+# Each entry wires a tool name to (async runner, scorer). The runner takes
+# the parsed case dict and returns the tool output string that the scorer
+# understands. Adding a new tool = adding one entry here + one scorer module
+# + one cases/<name>/ directory. Nothing else needs to change.
+
+
+async def _run_test_generation(case: Dict[str, Any], ctx: EvalContext) -> str:
+    tool = TestGenerationTool()
+    request = TestGenerationRequest(
+        code=case["code"],
+        language=case.get("language", "python"),
+        test_framework=case.get("framework", "pytest"),
+    )
+    response = await tool.execute_async(request, ctx=ctx)
+    return response.test_code
+
+
+TOOL_REGISTRY: Dict[str, Dict[str, Callable]] = {
+    "test_generation": {
+        "run": _run_test_generation,
+        "score": tg_scorer.score,
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Case loading
+# ---------------------------------------------------------------------------
+
+
+def load_cases(tool: str, only: List[str] | None = None, limit: int | None = None) -> List[tuple[str, Dict[str, Any]]]:
+    cases_dir = CASES_ROOT / tool
+    if not cases_dir.is_dir():
+        raise FileNotFoundError(f"No cases directory for tool {tool!r}: {cases_dir}")
+
+    loaded: list[tuple[str, Dict[str, Any]]] = []
+    for yaml_file in sorted(cases_dir.glob("*.yaml")):
+        case_id = yaml_file.stem
+        if only and case_id not in only:
+            continue
+        with yaml_file.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        loaded.append((case_id, data))
+    if limit:
+        loaded = loaded[:limit]
+    return loaded
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+async def _run_single_case(
+    tool: str,
+    case_id: str,
+    case: Dict[str, Any],
+    out_dir: Path,
+) -> Dict[str, Any]:
+    ctx = EvalContext()
+    entry = TOOL_REGISTRY[tool]
+
+    started = _dt.datetime.now(_dt.timezone.utc)
+    raw_error: str | None = None
+    tool_output: str = ""
+    try:
+        tool_output = await entry["run"](case, ctx)
+    except Exception:
+        raw_error = traceback.format_exc()
+
+    if raw_error:
+        score_payload = {
+            "score": 0.0,
+            "collected": 0,
+            "passed": 0,
+            "failed": 0,
+            "errors": 1,
+            "skipped": 0,
+            "duration_s": 0.0,
+            "stdout_tail": raw_error,
+        }
+    else:
+        eval_score = entry["score"](case, tool_output)
+        score_payload = dataclasses.asdict(eval_score)
+
+    record = {
+        "tool": tool,
+        "case_id": case_id,
+        "name": case.get("name", case_id),
+        "description": case.get("description", ""),
+        "model": settings.LLM_MODEL,
+        "started_at": started.isoformat(timespec="seconds"),
+        "score": score_payload,
+        "ctx_calls": ctx.calls,
+        "raw_output": tool_output,
+        "raw_error": raw_error,
+    }
+
+    (out_dir / "cases").mkdir(parents=True, exist_ok=True)
+    (out_dir / "cases" / f"{case_id}.json").write_text(
+        json.dumps(record, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return record
+
+
+def _write_report(records: List[Dict[str, Any]], out_dir: Path) -> None:
+    lines: list[str] = []
+    started = records[0]["started_at"] if records else _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds")
+    lines.append(f"# Eval run {started}")
+    lines.append("")
+    lines.append(f"- Model: `{records[0]['model'] if records else settings.LLM_MODEL}`")
+    lines.append(f"- Cases: {len(records)}")
+    lines.append("")
+
+    by_tool: Dict[str, List[Dict[str, Any]]] = {}
+    for r in records:
+        by_tool.setdefault(r["tool"], []).append(r)
+
+    for tool, tool_records in by_tool.items():
+        lines.append(f"## {tool}")
+        lines.append("")
+        lines.append("| Case | Score | Collected | Passed | Failed | Errors | Duration |")
+        lines.append("|---|---|---|---|---|---|---|")
+        total_score = 0.0
+        total_collected = 0
+        total_passed = 0
+        for r in tool_records:
+            s = r["score"]
+            lines.append(
+                f"| {r['case_id']} | {s['score']:.3f} | {s['collected']} | {s['passed']} | "
+                f"{s['failed']} | {s['errors']} | {s['duration_s']}s |"
+            )
+            total_score += s["score"]
+            total_collected += s["collected"]
+            total_passed += s["passed"]
+
+        n = len(tool_records)
+        avg = total_score / n if n else 0.0
+        lines.append("")
+        lines.append(
+            f"**Aggregate:** {avg:.3f} average, {total_passed}/{total_collected} generated tests passing."
+        )
+        lines.append("")
+
+    report_path = out_dir / "report.md"
+    report_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+async def _run(
+    tool: str,
+    out_dir: Path,
+    only: List[str] | None,
+    limit: int | None,
+) -> int:
+    if tool not in TOOL_REGISTRY:
+        print(f"[ERROR] Unknown tool {tool!r}. Available: {sorted(TOOL_REGISTRY)}", file=sys.stderr)
+        return 2
+
+    if not settings.LLM_API_KEY or settings.LLM_API_KEY == "votre_clé_api_gemini":
+        print("[ERROR] LLM_API_KEY must be set (see .env)", file=sys.stderr)
+        return 3
+
+    cases = load_cases(tool, only=only, limit=limit)
+    if not cases:
+        print(f"[ERROR] No cases matched (tool={tool}, only={only}, limit={limit})", file=sys.stderr)
+        return 4
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    print(f"=== Running {len(cases)} eval(s) for {tool} — model={settings.LLM_MODEL}")
+    records: list[Dict[str, Any]] = []
+    for i, (case_id, case) in enumerate(cases, 1):
+        print(f"[{i:>2}/{len(cases)}] {case_id} — {case.get('name', '')}")
+        try:
+            record = await _run_single_case(tool, case_id, case, out_dir)
+            s = record["score"]
+            marker = "✅" if s["score"] >= 0.6 else "⚠️ " if s["score"] >= 0.3 else "❌"
+            print(f"     {marker} score={s['score']:.3f} passed={s['passed']}/{s['collected']} in {s['duration_s']}s")
+            records.append(record)
+        except Exception as exc:
+            print(f"     ❌ runner failure: {exc}", file=sys.stderr)
+            traceback.print_exc()
+
+    _write_report(records, out_dir)
+    print(f"=== Report: {out_dir / 'report.md'}")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="tests.evals.runner")
+    ap.add_argument("--tool", required=True, choices=sorted(TOOL_REGISTRY), help="Tool to evaluate")
+    ap.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Output directory for the report (default: tests/evals/reports/<UTC timestamp>)",
+    )
+    ap.add_argument(
+        "--case",
+        action="append",
+        default=[],
+        help="Limit to specific case(s) by id (filename without extension). Can be passed multiple times.",
+    )
+    ap.add_argument("--limit", type=int, default=None, help="Only run the first N cases")
+    args = ap.parse_args()
+
+    out_dir = args.out or (
+        Path(__file__).parent
+        / "reports"
+        / _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
+    )
+    return asyncio.run(_run(args.tool, out_dir, args.case or None, args.limit))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/evals/runner.py
+++ b/tests/evals/runner.py
@@ -84,6 +84,20 @@ _RAW_SYSTEM_PROMPT = (
     "code you receive. Output the test file as a single Python code block."
 )
 
+# "Competent user" prompt — what a mid-level developer who actually knows
+# pytest would write. Not as elaborate as the MCP tool's prompt (no element
+# extraction, no coverage target numerics), but contains the common-sense
+# asks a skilled user would include: edge cases, parametrize, explicit
+# exception testing, runnable-as-is. Measures the **real** marginal value
+# of the MCP tool over a non-beginner user, not over a naive one.
+_COMPETENT_SYSTEM_PROMPT = (
+    "You are an expert Python developer writing production-grade pytest tests. "
+    "Always: cover normal + edge + error paths, use parametrize for repeated "
+    "inputs, use pytest.raises for exception assertions, name tests "
+    "descriptively, keep tests runnable as-is with stdlib + pytest only. "
+    "Output a single Python code block — no prose."
+)
+
 
 async def _run_test_generation_raw(case: Dict[str, Any], ctx: EvalContext) -> str:
     """Bypass the MCP tool entirely — just ask the LLM for tests.
@@ -103,13 +117,49 @@ async def _run_test_generation_raw(case: Dict[str, Any], ctx: EvalContext) -> st
         f"```python\n{case['code']}\n```\n"
     )
     response = await generate_text(config, prompt, system_prompt=_RAW_SYSTEM_PROMPT)
-    # Record the call so the JSON report matches what the MCP path does.
     ctx.calls.append({
         "temperature": config.temperature,
         "max_tokens": config.max_tokens,
         "prompt_len": len(prompt),
         "response_len": len(response.text or ""),
         "path": "raw",
+    })
+    return response.text or ""
+
+
+async def _run_test_generation_competent(case: Dict[str, Any], ctx: EvalContext) -> str:
+    """Bypass the MCP tool but use a 'competent user' prompt.
+
+    This is the honest comparison : not MCP-vs-naive-user, but
+    MCP-vs-user-who-knows-what-they're-doing. If Δ MCP − competent is
+    close to zero on Gemini models, the MCP tool's value is mostly
+    "the user didn't have to write a careful prompt themselves".
+    """
+    config = LLMConfig(
+        model_name=ctx.model,
+        api_key=settings.LLM_API_KEY,
+        max_tokens=EvalContext.MIN_MAX_TOKENS,
+        temperature=0.5,
+    )
+    framework = case.get("framework", "pytest")
+    language = case.get("language", "python")
+    prompt = (
+        f"Write a comprehensive {framework} test suite for the following {language} code.\n\n"
+        f"Requirements:\n"
+        f"- Cover normal cases, edge cases, and error/exception conditions.\n"
+        f"- Use @pytest.mark.parametrize when you have multiple similar inputs.\n"
+        f"- Assert exception types explicitly with pytest.raises.\n"
+        f"- Give each test a descriptive name: test_<what>_<condition>_<expected>.\n"
+        f"- Tests must be runnable as-is; only import stdlib + pytest.\n\n"
+        f"```{language}\n{case['code']}\n```\n"
+    )
+    response = await generate_text(config, prompt, system_prompt=_COMPETENT_SYSTEM_PROMPT)
+    ctx.calls.append({
+        "temperature": config.temperature,
+        "max_tokens": config.max_tokens,
+        "prompt_len": len(prompt),
+        "response_len": len(response.text or ""),
+        "path": "competent",
     })
     return response.text or ""
 
@@ -124,6 +174,11 @@ TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
         "run": _run_test_generation_raw,
         "score": tg_scorer.score,
         "cases_subdir": "test_generation_raw",
+    },
+    "test_generation_competent": {
+        "run": _run_test_generation_competent,
+        "score": tg_scorer.score,
+        "cases_subdir": "test_generation_competent",
     },
 }
 
@@ -289,27 +344,63 @@ def _write_matrix_report(
         lines.append("| " + " | ".join(agg_row) + " |")
         lines.append("")
 
-    # Δ MCP minus raw, per model (only meaningful when both tools are in the run).
+    def _avg_for(tool: str, model: str) -> Optional[float]:
+        recs = [
+            idx[(tool, model, c)]
+            for c in case_ids
+            if (tool, model, c) in idx and not idx[(tool, model, c)].get("raw_error")
+        ]
+        return _aggregate(recs)["avg"] if recs else None
+
+    def _fmt(v: Optional[float]) -> str:
+        return f"{v:.3f}" if v is not None else "—"
+
+    def _fmt_delta(a: Optional[float], b: Optional[float]) -> str:
+        if a is None or b is None:
+            return "—"
+        d = a - b
+        return f"{'+' if d >= 0 else ''}{d:.3f}"
+
+    # Δ MCP − raw (naive user), per model.
     if "test_generation" in tools and "test_generation_raw" in tools:
-        lines.append("## Δ `test_generation` − `test_generation_raw` (per model)")
+        lines.append("## Δ `test_generation` − `test_generation_raw` (naive baseline)")
         lines.append("")
-        lines.append("Positive = MCP tool adds value over raw prompt. Negative = MCP tool is counter-productive.")
+        lines.append("Positive = MCP tool adds value over a naive \"write tests\" prompt.")
         lines.append("")
         lines.append("| Model | MCP avg | Raw avg | Δ |")
         lines.append("|---|---|---|---|")
         for model in models:
-            mcp_recs = [idx[("test_generation", model, c)] for c in case_ids if ("test_generation", model, c) in idx and not idx[("test_generation", model, c)].get("raw_error")]
-            raw_recs = [idx[("test_generation_raw", model, c)] for c in case_ids if ("test_generation_raw", model, c) in idx and not idx[("test_generation_raw", model, c)].get("raw_error")]
-            mcp_avg = _aggregate(mcp_recs)["avg"] if mcp_recs else None
-            raw_avg = _aggregate(raw_recs)["avg"] if raw_recs else None
-            mcp_s = f"{mcp_avg:.3f}" if mcp_avg is not None else "—"
-            raw_s = f"{raw_avg:.3f}" if raw_avg is not None else "—"
-            if mcp_avg is not None and raw_avg is not None:
-                delta = mcp_avg - raw_avg
-                delta_s = f"{'+' if delta >= 0 else ''}{delta:.3f}"
-            else:
-                delta_s = "—"
-            lines.append(f"| `{model}` | {mcp_s} | {raw_s} | {delta_s} |")
+            mcp_avg = _avg_for("test_generation", model)
+            raw_avg = _avg_for("test_generation_raw", model)
+            lines.append(f"| `{model}` | {_fmt(mcp_avg)} | {_fmt(raw_avg)} | {_fmt_delta(mcp_avg, raw_avg)} |")
+        lines.append("")
+
+    # Δ MCP − competent (skilled user), per model — the honest comparison.
+    if "test_generation" in tools and "test_generation_competent" in tools:
+        lines.append("## Δ `test_generation` − `test_generation_competent` (honest baseline)")
+        lines.append("")
+        lines.append("Positive = MCP tool beats a skilled developer's prompt. Near-zero = the tool's value is mostly saving the user from writing the careful prompt themselves.")
+        lines.append("")
+        lines.append("| Model | MCP avg | Competent avg | Δ |")
+        lines.append("|---|---|---|---|")
+        for model in models:
+            mcp_avg = _avg_for("test_generation", model)
+            comp_avg = _avg_for("test_generation_competent", model)
+            lines.append(f"| `{model}` | {_fmt(mcp_avg)} | {_fmt(comp_avg)} | {_fmt_delta(mcp_avg, comp_avg)} |")
+        lines.append("")
+
+    # Δ competent − raw, per model — quantifies "how much better is a skilled prompt on its own".
+    if "test_generation_competent" in tools and "test_generation_raw" in tools:
+        lines.append("## Δ `test_generation_competent` − `test_generation_raw` (skilled-vs-naive prompt lift)")
+        lines.append("")
+        lines.append("Tells us how much of the MCP lift is actually reproducible by just being a careful user.")
+        lines.append("")
+        lines.append("| Model | Competent avg | Raw avg | Δ |")
+        lines.append("|---|---|---|---|")
+        for model in models:
+            comp_avg = _avg_for("test_generation_competent", model)
+            raw_avg = _avg_for("test_generation_raw", model)
+            lines.append(f"| `{model}` | {_fmt(comp_avg)} | {_fmt(raw_avg)} | {_fmt_delta(comp_avg, raw_avg)} |")
         lines.append("")
 
     # Errors section (if any).

--- a/tests/evals/scorers/test_generation.py
+++ b/tests/evals/scorers/test_generation.py
@@ -171,25 +171,47 @@ def _strip_fences(raw: str) -> str:
     The LLM often wraps its output in several fences — ``bash`` for install
     commands, ``python`` for the source under test, ``python`` again for
     the actual tests. We:
-      1. Extract every fence with its tag (so we can tell ``bash`` apart)
+      1. Extract every *closed* fence with its tag (so we can tell ``bash`` apart)
       2. Prefer python-tagged blocks that contain ``def test_``
-      3. Fall back to any block with ``def test_``
-      4. Fall back to the first python-tagged block
-      5. If nothing matches, return the raw text (pytest will surface the
+      3. Fall back to any closed block with ``def test_``
+      4. Fall back to the first python-tagged closed block
+      5. Handle an **unclosed** trailing fence (common when max_tokens
+         truncates the response mid-block): strip the opening fence line
+         and keep whatever Python remains
+      6. If nothing else works, return the raw text (pytest will surface the
          syntax error — a legitimate 0.0 score signal).
     """
     fence_re = re.compile(r"```([A-Za-z0-9_+-]*)\s*\n(.*?)```", flags=re.DOTALL)
     blocks = [(tag.lower(), body) for tag, body in fence_re.findall(raw)]
-    if not blocks:
-        return raw
 
-    python_blocks = [b for tag, b in blocks if tag in ("python", "py", "")]
-    for block in python_blocks:
-        if "def test_" in block:
-            return textwrap.dedent(block)
-    for tag, block in blocks:
-        if "def test_" in block:
-            return textwrap.dedent(block)
-    if python_blocks:
-        return textwrap.dedent(python_blocks[0])
-    return textwrap.dedent(blocks[0][1])
+    if blocks:
+        python_blocks = [b for tag, b in blocks if tag in ("python", "py", "")]
+        for block in python_blocks:
+            if "def test_" in block:
+                return textwrap.dedent(block)
+        for tag, block in blocks:
+            if "def test_" in block:
+                return textwrap.dedent(block)
+        if python_blocks:
+            return textwrap.dedent(python_blocks[0])
+        return textwrap.dedent(blocks[0][1])
+
+    # No closed fence matched. Two likely cases :
+    # (a) Raw output opens with ```python but was truncated before the close →
+    #     strip the opening fence marker and whatever trailing backticks remain.
+    # (b) Raw output has no fences at all → pass through.
+    unclosed = re.match(
+        r"^\s*```([A-Za-z0-9_+-]*)\s*\n(.*)",
+        raw,
+        flags=re.DOTALL,
+    )
+    if unclosed:
+        body = unclosed.group(2)
+        # Drop any trailing lone-backticks that might have been partial.
+        body = re.sub(r"\n?`{1,3}\s*$", "", body)
+        if "def test_" in body:
+            return textwrap.dedent(body)
+        # Opening fence but no recognisable test — last-ditch attempt.
+        return textwrap.dedent(body)
+
+    return raw

--- a/tests/evals/scorers/test_generation.py
+++ b/tests/evals/scorers/test_generation.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import textwrap
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict
@@ -185,10 +186,10 @@ def _strip_fences(raw: str) -> str:
     python_blocks = [b for tag, b in blocks if tag in ("python", "py", "")]
     for block in python_blocks:
         if "def test_" in block:
-            return block
+            return textwrap.dedent(block)
     for tag, block in blocks:
         if "def test_" in block:
-            return block
+            return textwrap.dedent(block)
     if python_blocks:
-        return python_blocks[0]
-    return blocks[0][1]
+        return textwrap.dedent(python_blocks[0])
+    return textwrap.dedent(blocks[0][1])

--- a/tests/evals/scorers/test_generation.py
+++ b/tests/evals/scorers/test_generation.py
@@ -1,0 +1,194 @@
+"""Score the output of ``test_generation`` by actually running the generated
+tests through pytest in a throwaway tempdir. The contract is objective:
+``passed / collected``. No LLM-as-judge, no heuristics — if pytest says the
+test passed, it did.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+
+_SUMMARY_RE = re.compile(
+    r"(?P<count>\d+)\s+(?P<outcome>passed|failed|error[s]?|skipped)",
+    re.IGNORECASE,
+)
+_COLLECTED_RE = re.compile(r"collected (\d+) item")
+
+
+@dataclass
+class EvalScore:
+    score: float
+    collected: int
+    passed: int
+    failed: int
+    errors: int
+    skipped: int
+    duration_s: float
+    stdout_tail: str  # last ~3k chars, for the per-case JSON report
+
+
+def _parse_pytest_output(text: str) -> Dict[str, int]:
+    counts = {"passed": 0, "failed": 0, "errors": 0, "skipped": 0}
+
+    # pytest's final summary line looks like "1 failed, 3 passed in 0.12s"
+    for m in _SUMMARY_RE.finditer(text):
+        n = int(m.group("count"))
+        outcome = m.group("outcome").lower()
+        if outcome.startswith("error"):
+            counts["errors"] = n
+        elif outcome in counts:
+            counts[outcome] = n
+
+    collected = 0
+    m = _COLLECTED_RE.search(text)
+    if m:
+        collected = int(m.group(1))
+    else:
+        # Fallback : if no "collected" line but we have outcomes, infer it.
+        collected = counts["passed"] + counts["failed"] + counts["errors"] + counts["skipped"]
+    return {**counts, "collected": collected}
+
+
+def score(case: Dict[str, Any], test_code: str) -> EvalScore:
+    """Execute the generated tests and return a structured score.
+
+    ``case`` is the parsed YAML dict; the source code to test lives in
+    ``case['code']``. ``test_code`` is whatever the LLM produced — may
+    contain markdown fences, extraneous prose, etc. We strip fences but
+    don't try to surgically repair more than that; a tool that produces
+    unparseable output deserves a 0.0 score.
+    """
+    import time
+
+    min_expected = int(case.get("min_expected_tests", 1))
+    stripped = _strip_fences(test_code)
+
+    with tempfile.TemporaryDirectory(prefix="collegue-eval-") as tmp:
+        tmpdir = Path(tmp)
+        # The LLM picks its own module name ("my_math_module.py", "calculator.py"…)
+        # and imports from it. We extract every non-stdlib module the generated
+        # test imports and materialise the source under each name so imports
+        # always resolve, regardless of the LLM's naming choice.
+        module_names = _discover_local_imports(stripped)
+        (tmpdir / "src.py").write_text(case["code"], encoding="utf-8")
+        for name in module_names:
+            (tmpdir / f"{name}.py").write_text(case["code"], encoding="utf-8")
+        (tmpdir / "test_src.py").write_text(stripped, encoding="utf-8")
+
+        started = time.time()
+        try:
+            result = subprocess.run(
+                [sys.executable, "-m", "pytest", "test_src.py", "-q", "--tb=line", "--no-header"],
+                cwd=tmpdir,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            output = (result.stdout or "") + "\n" + (result.stderr or "")
+        except subprocess.TimeoutExpired:
+            duration = time.time() - started
+            return EvalScore(
+                score=0.0, collected=0, passed=0, failed=0, errors=1, skipped=0,
+                duration_s=duration, stdout_tail="TIMEOUT after 30s",
+            )
+        duration = time.time() - started
+
+    parsed = _parse_pytest_output(output)
+    collected = parsed["collected"]
+    passed = parsed["passed"]
+
+    if collected == 0:
+        raw_score = 0.0
+    else:
+        raw_score = passed / collected
+        if collected < min_expected:
+            # Hit the expected test count but with reduced weight.
+            raw_score *= 0.7
+
+    return EvalScore(
+        score=round(raw_score, 3),
+        collected=collected,
+        passed=passed,
+        failed=parsed["failed"],
+        errors=parsed["errors"],
+        skipped=parsed["skipped"],
+        duration_s=round(duration, 2),
+        stdout_tail=output[-3000:],
+    )
+
+
+_STDLIB_OR_COMMON = frozenset({
+    # stdlib (partial — enough for the case corpus)
+    "abc", "argparse", "ast", "asyncio", "base64", "collections", "contextlib",
+    "dataclasses", "datetime", "enum", "functools", "io", "itertools", "json",
+    "math", "os", "pathlib", "random", "re", "string", "sys", "tempfile",
+    "threading", "time", "typing", "unittest", "uuid",
+    # common test deps
+    "pytest", "pytest_asyncio", "mock",
+})
+
+
+def _discover_local_imports(test_code: str) -> set[str]:
+    """Return module names the test imports that are not stdlib / test deps.
+
+    We use ``ast.parse`` rather than regex so ``from __future__ import …``,
+    multi-line imports, and comment tricks are all handled correctly. If the
+    code won't parse, we fall back to an empty set — the pytest run will
+    surface the syntax error on its own.
+    """
+    try:
+        tree = __import__("ast").parse(test_code)
+    except SyntaxError:
+        return set()
+
+    modules: set[str] = set()
+    for node in tree.body:
+        # Not walking deeper; any top-level import matters, imports inside
+        # functions can pay their own aliasing cost.
+        import ast
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".", 1)[0]
+                if root not in _STDLIB_OR_COMMON:
+                    modules.add(root)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            root = node.module.split(".", 1)[0]
+            if root not in _STDLIB_OR_COMMON:
+                modules.add(root)
+    return modules
+
+
+def _strip_fences(raw: str) -> str:
+    """Pull the Python block out of markdown fences if present.
+
+    The LLM often wraps its output in several fences — ``bash`` for install
+    commands, ``python`` for the source under test, ``python`` again for
+    the actual tests. We:
+      1. Extract every fence with its tag (so we can tell ``bash`` apart)
+      2. Prefer python-tagged blocks that contain ``def test_``
+      3. Fall back to any block with ``def test_``
+      4. Fall back to the first python-tagged block
+      5. If nothing matches, return the raw text (pytest will surface the
+         syntax error — a legitimate 0.0 score signal).
+    """
+    fence_re = re.compile(r"```([A-Za-z0-9_+-]*)\s*\n(.*?)```", flags=re.DOTALL)
+    blocks = [(tag.lower(), body) for tag, body in fence_re.findall(raw)]
+    if not blocks:
+        return raw
+
+    python_blocks = [b for tag, b in blocks if tag in ("python", "py", "")]
+    for block in python_blocks:
+        if "def test_" in block:
+            return block
+    for tag, block in blocks:
+        if "def test_" in block:
+            return block
+    if python_blocks:
+        return python_blocks[0]
+    return blocks[0][1]


### PR DESCRIPTION
Pose la première brique d'évaluation **qualitative** des outils LLM. Les stress tests prouvent qu'ils ne crashent pas ; ce PR mesure si leurs sorties sont **correctes**.

## Ce que ça débloque

- **Comparer un prompt refactor à la baseline** — sans ça, impossible de savoir si un changement améliore ou dégrade la qualité des tests générés
- **Valider un changement de modèle** (Gemini 2.5 → 3, Flash → Pro, fallback OpenAI…) contre un référentiel objectif
- **Détecter une régression silencieuse** quand une maintenance côté prompt templates casse subtilement la sortie
- **Justifier la qualité** vis-à-vis d'un utilisateur : "baseline 0.978 sur 8 cas Python diversifiés" est un signal concret

## Livré

### Architecture (`tests/evals/`)

- `eval_context.py` — shim `ctx.sample()` in-process qui route vers `generate_text()` (pas besoin de Docker MCP)
- `runner.py` — CLI argparse avec `--tool`, `--case`, `--limit`, `--out`. Exit 0 toujours, jamais gating
- `scorers/test_generation.py` — extraction fence-aware, résolution d'imports LLM-nommés, pytest subprocess, score = passed/collected
- `cases/test_generation/01..08.yaml` — 8 cas : arithmetic, class+init, type hints, exceptions, generator, async, property, inheritance

### Docs + README

- [docs/llm_evals.md](docs/llm_evals.md) — runbook complet, scoring détaillé, contribution pour ajouter un tool, limites connues
- Section "🧪 Qualité des sorties LLM" au README avec baseline + commande

### Gitignore

- `tests/evals/reports/` ajouté (suit le pattern de `tests/stress/reports/`)

## Baseline mesurée (Gemini 2.5 Flash)

| Case | Score | Tests OK / Total |
|---|---|---|
| 01_arithmetic | 1.000 | 44/44 |
| 02_class_init | 1.000 | 20/20 |
| 03_type_hints | 1.000 | 21/21 |
| 04_exceptions | 0.960 | 24/25 |
| 05_generator | 1.000 | 10/10 |
| 06_async_fn | 0.867 | 13/15 |
| 07_property | 1.000 | 19/19 |
| 08_inheritance | 1.000 | 39/39 |

**Moyenne : 0.978 · 190/193 tests générés qui passent.**

Seuil de régression suggéré : **< 0.90** déclenche une investigation avant merge.

## Hardening appris pendant l'intégration

Trois patches nécessaires pour passer de 0/1 à 8/8 green :

1. **Fence extraction** — le LLM wrappe `source` **et** `tests` dans des fences ```python. Priorité : fences avec `def test_` > fences python > brut
2. **Module aliasing** — le LLM invente ses propres noms (`my_math_module.py`) dans les imports. AST-parse des imports non-stdlib → écrit `src.py` sous chaque alias rencontré
3. **Max tokens floor** — Gemini 2.5 reasoning consomme le budget ; avec `max_tokens=2000` demandé par le tool, on reçoit 272 chars tronqués. Plancher à 8000 dans `EvalContext`

## Hors scope (prochaines itérations)

- LLM-as-judge (nécessaire pour `code_documentation`, `code_refactoring/clean`)
- Autres tools (`refactoring`, `impact_analysis`, `documentation`, `iac_guardrails_scan`)
- Matrice multi-modèles (Flash vs Pro, comparaison versions)
- Nightly cron qui exécute tout et alerte si seuil franchi (piste "nightly integration" déjà identifiée)

## Test plan

- [x] Sanity run 1 cas : score 1.000 en 0.28s
- [x] Full run 8 cas : 0.978 moyenne, aucun cas sous 0.86
- [x] `pytest tests/` reste vert : 562 passed, 27 skipped, 0 failed
- [x] `pytest tests/evals/` → `no tests collected` (bien ignoré par pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)