### PR TITLE
fix(prompts): make _load_tool_templates idempotent across restarts (#231)

### DIFF
--- a/collegue/prompts/engine/enhanced_prompt_engine.py
+++ b/collegue/prompts/engine/enhanced_prompt_engine.py
@@ -1,16 +1,17 @@
 """
 Enhanced Prompt Engine avec versioning, optimisation et tracking de performance
 """
-import os
-import json
+import datetime
 import logging
-from typing import Dict, List, Optional, Any, Tuple
-from pathlib import Path
+import os
 import random
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
 
-from .prompt_engine import PromptEngine, PromptTemplate
-from .versioning import PromptVersionManager, PromptVersion
+from .models import PromptVariable
 from .optimizer import LanguageOptimizer
+from .prompt_engine import PromptEngine, PromptTemplate
+from .versioning import PromptVersion, PromptVersionManager
 
 logger = logging.getLogger(__name__)
 
@@ -25,51 +26,138 @@ class EnhancedPromptEngine(PromptEngine):
         self.exploration_rate = 0.1
         self.performance_cache: Dict[str, Dict[str, float]] = {}
         self.templates: Dict[str, PromptTemplate] = {}
-        self.tool_templates_dir = os.path.join(
+        self.tool_templates_dir = templates_dir or os.path.join(
             os.path.dirname(__file__), '..', 'templates', 'tools'
         )
         self._load_tool_templates()
 
     def _load_tool_templates(self) -> None:
+        """Load YAML seed templates from ``tool_templates_dir`` — idempotently.
 
+        Before #231 this method created a brand-new UUID for every YAML on
+        every server startup, accumulating 132× duplicates after 132 restarts.
+        The fix keyed on the template ``name`` (set in the YAML frontmatter) :
+
+        - **Same name, same content** → skip. The in-memory entry already
+          exists because ``PromptEngine._load_library()`` just read the JSON
+          from disk. Nothing to write.
+        - **Same name, content changed** → update the existing template in
+          place, preserving the UUID so any accumulated ``performance_score``
+          / ``usage_count`` survive the edit.
+        - **New name** → create as before.
+
+        Same logic applies to the version_manager via :meth:`_ensure_version`
+        — we don't append a new ``PromptVersion`` when the current content
+        is already represented.
+        """
         if not os.path.exists(self.tool_templates_dir):
             Path(self.tool_templates_dir).mkdir(parents=True, exist_ok=True)
             return
 
+        import yaml
+
+        # Build a name → canonical-template index from whatever was loaded
+        # from disk by the parent class. When legacy duplicates exist on
+        # disk (pre-#231), several templates share the same name — pick the
+        # first one; the purge script handles the cleanup separately.
+        existing_by_name: Dict[str, PromptTemplate] = {}
+        for template in self.library.templates.values():
+            existing_by_name.setdefault(template.name, template)
+
+        created = updated = skipped = 0
+
         for tool_dir in Path(self.tool_templates_dir).iterdir():
-            if tool_dir.is_dir():
-                tool_name = tool_dir.name
+            if not tool_dir.is_dir():
+                continue
+            tool_name = tool_dir.name
 
-                for yaml_file in tool_dir.glob("*.yaml"):
-                    try:
-                        import yaml
-                        with open(yaml_file, 'r', encoding='utf-8') as f:
-                            template_data = yaml.safe_load(f)
+            for yaml_file in tool_dir.glob("*.yaml"):
+                try:
+                    with open(yaml_file, 'r', encoding='utf-8') as f:
+                        template_data = yaml.safe_load(f)
 
-                        template = self.create_template({
-                            "name": template_data.get("name"),
-                            "description": template_data.get("description", ""),
-                            "template": template_data.get("template"),
-                            "variables": template_data.get("variables", []),
-                            "category": f"tool/{tool_name}",
-                            "tags": template_data.get("tags", []),
-                            "provider_specific": template_data.get("provider_specific", {})
-                        })
-
-                        template_key = f"{tool_name}_{yaml_file.stem}"
-                        self.templates[template_key] = template
-
-                        self.version_manager.create_version(
-                            template_id=template.id,
-                            content=template_data.get("template"),
-                            variables=template_data.get("variables", []),
-                            version=template_data.get("version", "1.0.0")
+                    name = template_data.get("name")
+                    if not name:
+                        logger.warning(
+                            "Template YAML %s has no 'name' key, skipped", yaml_file
                         )
+                        continue
 
-                        logger.info(f"Template {template.name} chargé depuis {yaml_file}")
+                    yaml_content = template_data.get("template", "")
+                    key = f"{tool_name}_{yaml_file.stem}"
+                    existing = existing_by_name.get(name)
 
-                    except Exception as e:
-                        logger.error(f"Erreur lors du chargement de {yaml_file}: {e}")
+                    if existing and existing.template == yaml_content:
+                        # Already loaded and identical — nothing to persist.
+                        self.templates[key] = existing
+                        skipped += 1
+                        continue
+
+                    if existing:
+                        # Same name, content drifted → update in place.
+                        existing.template = yaml_content
+                        existing.description = template_data.get(
+                            "description", existing.description
+                        )
+                        existing.variables = [
+                            PromptVariable(**var) if isinstance(var, dict) else var
+                            for var in template_data.get("variables", [])
+                        ]
+                        existing.tags = template_data.get("tags", existing.tags)
+                        existing.updated_at = datetime.datetime.now()
+                        self._save_library()
+                        self.templates[key] = existing
+                        self._ensure_version(existing.id, yaml_content, template_data)
+                        updated += 1
+                        logger.info(
+                            "Template '%s' updated from %s (UUID preserved)",
+                            name, yaml_file,
+                        )
+                        continue
+
+                    # Brand-new template: create fresh.
+                    template = self.create_template({
+                        "name": name,
+                        "description": template_data.get("description", ""),
+                        "template": yaml_content,
+                        "variables": template_data.get("variables", []),
+                        "category": f"tool/{tool_name}",
+                        "tags": template_data.get("tags", []),
+                        "provider_specific": template_data.get("provider_specific", {}),
+                    })
+                    self.templates[key] = template
+                    existing_by_name[name] = template
+                    self._ensure_version(template.id, yaml_content, template_data)
+                    created += 1
+                    logger.info("Template '%s' created from %s", name, yaml_file)
+
+                except Exception as exc:
+                    logger.error("Erreur lors du chargement de %s: %s", yaml_file, exc)
+
+        logger.info(
+            "Tool templates loaded: %d created, %d updated, %d skipped (already loaded)",
+            created, updated, skipped,
+        )
+
+    def _ensure_version(
+        self,
+        template_id: str,
+        content: str,
+        template_data: Dict[str, Any],
+    ) -> None:
+        """Create a ``PromptVersion`` for this template only if no existing
+        version already has the same content. Called from the YAML loader
+        to keep ``versions.json`` idempotent across restarts.
+        """
+        existing = self.version_manager.get_all_versions(template_id)
+        if any(v.content == content for v in existing):
+            return
+        self.version_manager.create_version(
+            template_id=template_id,
+            content=content,
+            variables=template_data.get("variables", []),
+            version=template_data.get("version", "1.0.0"),
+        )
 
     async def get_optimized_prompt(
         self,

--- a/scripts/purge_prompt_duplicates.py
+++ b/scripts/purge_prompt_duplicates.py
@@ -1,0 +1,152 @@
+"""One-shot cleanup for the prompt template storage (#231).
+
+Before the fix, every server startup wrote new UUID-keyed JSON copies of
+the 16 YAML seed templates into ``collegue/prompts/templates/templates/``.
+The audit found 2112 files on disk — 132 copies of each of the 16 unique
+template names, all with identical content and all with ``performance_score
+= 0.0`` / ``usage_count = 0``.
+
+This script consolidates the storage :
+
+1. Group on-disk JSONs by ``name``.
+2. For each name, keep **one canonical template** — preferring the entry
+   with a non-zero ``usage_count`` (if any), otherwise the one most recently
+   updated.
+3. Delete the duplicates.
+4. Rebuild ``collegue/prompts/versions/versions.json`` so it only references
+   template IDs that still exist on disk, and dedupe identical-content
+   versions within each template.
+
+Usage::
+
+    python scripts/purge_prompt_duplicates.py --dry-run   # show plan only
+    python scripts/purge_prompt_duplicates.py             # apply
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATES_DIR = REPO_ROOT / "collegue" / "prompts" / "templates" / "templates"
+VERSIONS_FILE = REPO_ROOT / "collegue" / "prompts" / "versions" / "versions.json"
+
+
+def _rank_entry(entry: Tuple[Path, Dict]) -> Tuple[int, str]:
+    """Higher-rank entry wins the keeper slot.
+
+    Priority : non-zero ``usage_count`` > most recent ``updated_at`` >
+    most recent ``created_at``.
+    """
+    _, data = entry
+    usage = data.get("usage_count") or 0
+    stamp = data.get("updated_at") or data.get("created_at") or ""
+    return (usage, stamp)
+
+
+def _plan_template_purge(templates_dir: Path) -> Tuple[Dict[str, str], List[Path]]:
+    """Group templates by name, decide which UUID survives per name.
+
+    Returns (keep_by_name, to_delete_paths).
+    """
+    by_name: Dict[str, List[Tuple[Path, Dict]]] = defaultdict(list)
+    for json_file in templates_dir.glob("*.json"):
+        try:
+            data = json.loads(json_file.read_text(encoding="utf-8"))
+        except Exception as exc:
+            print(f"[WARN] cannot parse {json_file.name}: {exc}", file=sys.stderr)
+            continue
+        by_name[data.get("name", "<unknown>")].append((json_file, data))
+
+    keep_by_name: Dict[str, str] = {}
+    to_delete: List[Path] = []
+    for name, entries in by_name.items():
+        entries.sort(key=_rank_entry, reverse=True)
+        winner_path, winner_data = entries[0]
+        keep_by_name[name] = winner_data["id"]
+        for loser_path, _ in entries[1:]:
+            to_delete.append(loser_path)
+
+    return keep_by_name, to_delete
+
+
+def _rebuild_versions(kept_ids: set, versions_file: Path) -> Tuple[int, int]:
+    """Drop orphaned template_ids from versions.json, dedupe by content.
+
+    Returns (count_before, count_after).
+    """
+    if not versions_file.exists():
+        return (0, 0)
+
+    versions = json.loads(versions_file.read_text(encoding="utf-8"))
+    total_before = sum(len(v) for v in versions.values())
+
+    cleaned: Dict[str, List[Dict]] = {}
+    for tid, vs in versions.items():
+        if tid not in kept_ids:
+            continue
+        seen_contents: set = set()
+        unique_vs: List[Dict] = []
+        for v in vs:
+            content = v.get("content", "")
+            if content in seen_contents:
+                continue
+            seen_contents.add(content)
+            unique_vs.append(v)
+        cleaned[tid] = unique_vs
+
+    versions_file.write_text(
+        json.dumps(cleaned, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    total_after = sum(len(v) for v in cleaned.values())
+    return total_before, total_after
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the plan without touching the filesystem",
+    )
+    args = ap.parse_args()
+
+    if not TEMPLATES_DIR.is_dir():
+        print(f"[ERROR] {TEMPLATES_DIR} does not exist (run from repo root)", file=sys.stderr)
+        return 2
+
+    total_before = len(list(TEMPLATES_DIR.glob("*.json")))
+    keep_by_name, to_delete = _plan_template_purge(TEMPLATES_DIR)
+
+    print(f"Templates on disk: {total_before}")
+    print(f"Unique names:      {len(keep_by_name)}")
+    print(f"Duplicates to drop: {len(to_delete)}")
+
+    if args.dry_run:
+        print("\n[DRY RUN] no files deleted.")
+        print("Top 5 names by duplicate count would be trimmed to 1 each.")
+        return 0
+
+    for path in to_delete:
+        path.unlink()
+    total_after = len(list(TEMPLATES_DIR.glob("*.json")))
+    print(f"\nDeleted {len(to_delete)} duplicate JSONs.")
+    print(f"Templates on disk: {total_before} → {total_after}")
+
+    kept_ids = set(keep_by_name.values())
+    v_before, v_after = _rebuild_versions(kept_ids, VERSIONS_FILE)
+    print(f"versions.json: {v_before} → {v_after} entries (orphans + content dupes removed)")
+
+    print("\nDone. Restart the MCP server — the refactored `_load_tool_templates` will now")
+    print("recognise the canonical templates and skip creating duplicates.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_prompt_engine_idempotence.py
+++ b/tests/test_prompt_engine_idempotence.py
@@ -1,0 +1,165 @@
+"""Regression tests for #231 — EnhancedPromptEngine must load YAML seeds
+idempotently across repeated instantiations.
+
+Before the fix, each call to ``EnhancedPromptEngine()`` rewrote fresh
+UUID-keyed JSON copies of the same YAML templates to disk. The audit
+found 2112 JSONs (132× × 16 names) accumulated across server restarts.
+These tests guard against that regression by spinning the engine up
+several times against a throwaway storage dir and asserting the on-disk
+count stays equal to the number of YAML seeds.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from collegue.prompts.engine.enhanced_prompt_engine import EnhancedPromptEngine
+
+
+def _write_yaml_seed(tools_root: Path, tool: str, name: str, template: str) -> Path:
+    tool_dir = tools_root / tool
+    tool_dir.mkdir(parents=True, exist_ok=True)
+    yaml_file = tool_dir / f"{name}.yaml"
+    yaml_file.write_text(
+        yaml.safe_dump(
+            {
+                "name": f"{tool}_{name}",
+                "description": f"test seed for {tool}/{name}",
+                "template": template,
+                "variables": [
+                    {"name": "code", "description": "x", "type": "string", "required": True},
+                ],
+                "tags": [tool],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return yaml_file
+
+
+def _json_count(storage_dir: Path) -> int:
+    return len(list((storage_dir / "templates").glob("*.json")))
+
+
+@pytest.fixture
+def isolated_engine(tmp_path, monkeypatch):
+    """Build a throwaway EnhancedPromptEngine rooted in tmp_path.
+
+    We patch the YAML seed directory so the engine only sees what the
+    test put there — avoids contamination from the repo's real templates.
+    """
+    storage = tmp_path / "storage"
+    storage.mkdir()
+    (storage / "templates").mkdir()
+
+    yaml_root = tmp_path / "yaml_seeds"
+
+    def _factory(seeds_present: bool = True) -> EnhancedPromptEngine:
+        if seeds_present and not yaml_root.exists():
+            yaml_root.mkdir(parents=True)
+        engine = EnhancedPromptEngine(
+            templates_dir=str(yaml_root),
+            storage_dir=str(storage),
+        )
+        return engine
+
+    return {
+        "factory": _factory,
+        "storage": storage,
+        "yaml_root": yaml_root,
+    }
+
+
+def test_repeated_init_does_not_duplicate_templates(isolated_engine):
+    """Three consecutive EnhancedPromptEngine() calls must end with exactly
+    one JSON per YAML seed on disk, not 3× per seed."""
+    factory = isolated_engine["factory"]
+    storage = isolated_engine["storage"]
+    yaml_root = isolated_engine["yaml_root"]
+
+    _write_yaml_seed(yaml_root, "toolA", "default", "Hello {code}")
+    _write_yaml_seed(yaml_root, "toolB", "default", "Explain {code}")
+
+    for _ in range(3):
+        factory()
+
+    assert _json_count(storage) == 2, (
+        f"Expected exactly 2 JSONs on disk (one per YAML seed) after 3 inits; "
+        f"got {_json_count(storage)}"
+    )
+
+
+def test_yaml_content_change_updates_existing_template_in_place(isolated_engine):
+    """When a YAML's content is edited between runs, the engine must update
+    the existing template (same UUID) rather than create a new one."""
+    factory = isolated_engine["factory"]
+    storage = isolated_engine["storage"]
+    yaml_root = isolated_engine["yaml_root"]
+
+    seed = _write_yaml_seed(yaml_root, "toolA", "default", "Version 1 prompt for {code}")
+    engine_v1 = factory()
+    before = list(engine_v1.library.templates.values())
+    assert len(before) == 1
+    original_id = before[0].id
+    assert "Version 1" in before[0].template
+
+    # Edit the YAML on disk.
+    data = yaml.safe_load(seed.read_text())
+    data["template"] = "Version 2 rewritten prompt for {code}"
+    seed.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+    engine_v2 = factory()
+    after = list(engine_v2.library.templates.values())
+    # Still one template, same UUID, updated content.
+    assert len(after) == 1, f"Expected 1 template, got {len(after)}"
+    assert after[0].id == original_id, (
+        "UUID must be preserved on content-drift update — otherwise any "
+        "accumulated performance_score would be lost on every restart"
+    )
+    assert "Version 2" in after[0].template
+    assert _json_count(storage) == 1
+
+
+def test_versions_not_duplicated_on_reload(isolated_engine):
+    """versions.json must not grow on repeated inits of the same YAML."""
+    factory = isolated_engine["factory"]
+    yaml_root = isolated_engine["yaml_root"]
+
+    _write_yaml_seed(yaml_root, "toolA", "default", "Hello {code}")
+
+    for _ in range(4):
+        engine = factory()
+
+    # The single template should have exactly one version (the initial one).
+    template_ids = list(engine.library.templates.keys())
+    assert len(template_ids) == 1
+    versions = engine.version_manager.get_all_versions(template_ids[0])
+    assert len(versions) == 1, (
+        f"Expected 1 PromptVersion, got {len(versions)} — the version manager "
+        f"is not idempotent across reloads"
+    )
+
+
+def test_missing_name_is_skipped_not_fatal(isolated_engine, caplog):
+    """A malformed YAML (no `name:` field) must be skipped with a warning,
+    not crash the engine startup."""
+    factory = isolated_engine["factory"]
+    yaml_root = isolated_engine["yaml_root"]
+    yaml_root.mkdir(parents=True, exist_ok=True)
+    broken = yaml_root / "tool_broken" / "nameless.yaml"
+    broken.parent.mkdir()
+    broken.write_text(
+        yaml.safe_dump({"description": "I forgot my name", "template": "hi"}),
+        encoding="utf-8",
+    )
+    _write_yaml_seed(yaml_root, "toolA", "default", "Valid {code}")
+
+    import logging
+    with caplog.at_level(logging.WARNING):
+        engine = factory()
+
+    # Only the well-formed YAML produced a template.
+    assert len(engine.library.templates) == 1
+    assert any("no 'name' key" in rec.message for rec in caplog.records)


### PR DESCRIPTION
Closes [#231](https://github.com/VynoDePal/Collegue/issues/231).

## Preuve mesurée avant fix

```
$ ls collegue/prompts/templates/templates/*.json | wc -l
2112

$ cat versions.json | jq 'keys | length' # entries
2134
```

132 redémarrages du serveur × 16 templates YAML = 2112 JSON identiques, tous à `performance_score=0.0` et `usage_count=0`. L'A/B testing ne pouvait rien apprendre parce qu'il pickait entre des clones parfaits.

## Livré

### 1. Refactor `_load_tool_templates()` → idempotent

[collegue/prompts/engine/enhanced_prompt_engine.py](collegue/prompts/engine/enhanced_prompt_engine.py#L33-L150) key désormais sur le champ `name` du YAML :

| Cas | Comportement |
|---|---|
| Same name + same content | **skip** — JSON déjà sur disque, rien à persister |
| Same name + content drifted | **update in place** — UUID préservé, `performance_score` accumulé survit à l'édition du YAML |
| Fresh name | **create** — comportement historique |

Helper `_ensure_version()` factorisé pour que `versions.json` suive la même logique (append uniquement si aucune version n'a déjà ce contenu).

### 2. Script de purge one-shot

[scripts/purge_prompt_duplicates.py](scripts/purge_prompt_duplicates.py) consolide les installations existantes :
- Groupe les JSON par `name`
- Garde 1 "gagnant" par nom (prioritise `usage_count > 0` → `updated_at` récent → `created_at` récent)
- Supprime les perdants
- Reconstruit `versions.json` : drop les orphelins + dedupe par contenu

```
$ python scripts/purge_prompt_duplicates.py
Templates on disk: 2112 → 16
versions.json: 2134 → 16 entries
```

### 3. Tests de non-régression

[tests/test_prompt_engine_idempotence.py](tests/test_prompt_engine_idempotence.py) — 4 cas rootés dans un `tmp_path` isolé :

- `test_repeated_init_does_not_duplicate_templates` — 3 inits sur 2 YAML produisent 2 JSONs (pas 6)
- `test_yaml_content_change_updates_existing_template_in_place` — édite le YAML, UUID préservé, contenu mis à jour
- `test_versions_not_duplicated_on_reload` — 4 inits sur le même YAML laissent `versions_cache` à length=1
- `test_missing_name_is_skipped_not_fatal` — YAML sans `name:` → warning + continue sur les valides

## Validation live sur le storage réel

```
Before 3 EnhancedPromptEngine() inits: 16 JSONs
After  3 EnhancedPromptEngine() inits: 16 JSONs
Delta: 0
```

Avant ce fix : même séquence aurait produit 48 JSONs.

## Impact pytest

| Métrique | Avant | Après |
|---|---|---|
| Passed | 562 | **566** (+4 nouveaux tests) |
| Failed | 0 | **0** |
| Skipped | 27 | 27 |

## Ce que ça débloque

- **#232** (A/B testing vide) — maintenant que les duplicates sont supprimés, toute variante `v2.yaml` ou `experimental.yaml` crée une vraie entrée distincte que le bandit peut réellement comparer.
- **#233** (wiring des tools) — on peut wirer `test_generation`, `code_documentation`, `debug_agent` sans craindre que chaque redémarrage efface le `performance_score` accumulé (les UUID sont désormais stables).

## Test plan

- [x] `pytest tests/test_prompt_engine_idempotence.py` → 4 passed
- [x] `pytest tests/` → 566 passed, 0 failed, 27 skipped, 1 deselected
- [x] `scripts/purge_prompt_duplicates.py --dry-run` → plan correct affiché
- [x] `scripts/purge_prompt_duplicates.py` → 2112→16 templates sans perte sémantique
- [x] Live : 3 inits successifs du vrai engine → 0 JSON supplémentaire créé

🤖 Generated with [Claude Code](https://claude.com/claude-code)