### PR TITLE
fix(prompts): don't fake A/B randomness over identical version clones (#232)

### DIFF
--- a/collegue/prompts/engine/enhanced_prompt_engine.py
+++ b/collegue/prompts/engine/enhanced_prompt_engine.py
@@ -19,6 +19,26 @@ logger = logging.getLogger(__name__)
 class EnhancedPromptEngine(PromptEngine):
 
     def __init__(self, templates_dir: str = None, storage_dir: str = None):
+        """Construct the engine and load seed templates from ``templates_dir``.
+
+        A/B testing (``ab_testing_enabled=True``) runs a ε-greedy bandit on
+        the versions attached to each template. The bandit is only *actually*
+        exploratory when a template has **≥ 2 versions with distinct content**
+        (see :meth:`_select_version_ab_testing`) — otherwise the single
+        available version is returned deterministically. This safety guard
+        was added under #232 to stop the selection from faking randomness
+        over identical clones (which happened before #231 dedup).
+
+        Parameters
+        ----------
+        templates_dir:
+            Override for the YAML seed directory. Defaults to the
+            ``collegue/prompts/templates/tools`` tree in the installed package.
+        storage_dir:
+            Override for the on-disk JSON store. Defaults to the package
+            ``collegue/prompts/templates`` directory (``versions/versions.json``
+            lives alongside).
+        """
         super().__init__(storage_path=storage_dir)
         self.version_manager = PromptVersionManager(storage_dir)
         self.language_optimizer = LanguageOptimizer()
@@ -30,6 +50,30 @@ class EnhancedPromptEngine(PromptEngine):
             os.path.dirname(__file__), '..', 'templates', 'tools'
         )
         self._load_tool_templates()
+        self._log_ab_readiness()
+
+    def _log_ab_readiness(self) -> None:
+        """Count templates with real variants vs clones and log the breakdown.
+
+        Gives operators a one-line signal at startup : if the count of
+        "A/B enabled" templates is 0, the fancy bandit is not doing anything —
+        someone needs to author variant YAMLs (v2, experimental, …) with
+        different content.
+        """
+        active = 0
+        single_variant = 0
+        for template in self.library.templates.values():
+            versions = self.version_manager.get_all_versions(template.id)
+            unique = {v.content for v in versions}
+            if len(unique) >= 2:
+                active += 1
+            else:
+                single_variant += 1
+        logger.info(
+            "A/B testing status: %d template(s) with ≥ 2 real variants, "
+            "%d with a single variant (bandit returns deterministically for these)",
+            active, single_variant,
+        )
 
     def _load_tool_templates(self) -> None:
         """Load YAML seed templates from ``tool_templates_dir`` — idempotently.
@@ -217,19 +261,41 @@ class EnhancedPromptEngine(PromptEngine):
         return prompt, prompt_version.id
 
     def _select_version_ab_testing(self, template_id: str) -> Optional[PromptVersion]:
+        """Pick a :class:`PromptVersion` for ``template_id``.
+
+        A/B-safe selection policy (added under #232) :
+
+        1. Gather all versions attached to this template.
+        2. Compute the set of **distinct contents**. If there is only one
+           unique content, skip the bandit entirely and return the best
+           (or latest) version deterministically. No fake randomness over
+           clones.
+        3. Otherwise run the ε-greedy bandit : ``exploration_rate`` of the
+           time, pick a random version (explore); the rest of the time,
+           pick the current best (exploit).
+
+        Without step 2, before #231 fixed the loader, this function would
+        pick between 132 identical JSON copies — spending CPU on a coin
+        flip that couldn't change the output. After #231, templates are
+        distinct but most tools still have only 1 version, so the guard
+        keeps the path deterministic until someone authors real variants.
+        """
+        versions = self.version_manager.get_all_versions(template_id)
+        if not versions:
+            return None
+
+        unique_contents = {v.content for v in versions}
+        if len(unique_contents) < 2:
+            # No real variation to explore — return a stable choice.
+            best = self.version_manager.get_best_version(template_id)
+            return best or versions[-1]
 
         if not self.ab_testing_enabled:
             return self.version_manager.get_best_version(template_id)
 
-
         if random.random() < self.exploration_rate:
-            versions = self.version_manager.get_all_versions(template_id)
-            if versions:
-                return random.choice(versions)
-        else:
-            return self.version_manager.get_best_version(template_id)
-
-        return None
+            return random.choice(versions)
+        return self.version_manager.get_best_version(template_id)
 
     def _format_version_prompt(self, version: PromptVersion, variables: Dict[str, Any]) -> str:
 

--- a/tests/test_prompt_engine_ab_guard.py
+++ b/tests/test_prompt_engine_ab_guard.py
@@ -1,0 +1,169 @@
+"""Regression tests for #232 — the ε-greedy bandit in EnhancedPromptEngine
+must *not* introduce randomness when every version attached to a template
+has identical content.
+
+Before #232, ``_select_version_ab_testing`` happily picked one of 132
+UUID-distinct-but-content-identical clones per exploration tick. No signal
+could ever be learned because every outcome attached to a different UUID
+despite being produced by the same prompt. The fix keys the bandit gate
+on ``len({v.content for v in versions})`` instead of ``len(versions)``.
+"""
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+import pytest
+import yaml
+
+from collegue.prompts.engine.enhanced_prompt_engine import EnhancedPromptEngine
+
+
+def _write_yaml_seed(tools_root: Path, tool: str, name: str, template_body: str) -> Path:
+    tool_dir = tools_root / tool
+    tool_dir.mkdir(parents=True, exist_ok=True)
+    yaml_file = tool_dir / f"{name}.yaml"
+    yaml_file.write_text(
+        yaml.safe_dump(
+            {
+                "name": f"{tool}_{name}",
+                "description": f"test seed for {tool}/{name}",
+                "template": template_body,
+                "variables": [
+                    {"name": "code", "description": "x", "type": "string", "required": True},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return yaml_file
+
+
+@pytest.fixture
+def isolated_engine(tmp_path):
+    """Build an EnhancedPromptEngine in a clean tmp_path."""
+    storage = tmp_path / "storage"
+    storage.mkdir()
+    (storage / "templates").mkdir()
+    yaml_root = tmp_path / "yaml_seeds"
+
+    def _factory() -> EnhancedPromptEngine:
+        if not yaml_root.exists():
+            yaml_root.mkdir()
+        return EnhancedPromptEngine(
+            templates_dir=str(yaml_root),
+            storage_dir=str(storage),
+        )
+
+    return {"factory": _factory, "yaml_root": yaml_root}
+
+
+def _add_clone_versions(engine: EnhancedPromptEngine, template_id: str, content: str, n: int) -> None:
+    """Append N versions with identical content to simulate the pre-#231 state."""
+    for _ in range(n):
+        engine.version_manager.create_version(
+            template_id=template_id,
+            content=content,
+            variables=[],
+            version="1.0.0",
+        )
+
+
+def test_ab_testing_skips_when_all_clones(isolated_engine):
+    """10 versions with identical content → ``_select_version_ab_testing``
+    must return the same PromptVersion on every call. No randomness over
+    clones — otherwise the bandit wastes CPU on coin flips that cannot
+    change the outcome."""
+    _write_yaml_seed(isolated_engine["yaml_root"], "toolA", "default", "Hello {code}")
+    engine = isolated_engine["factory"]()
+    template_id = next(iter(engine.library.templates.keys()))
+
+    # The YAML loader already added 1 version; pad with 9 identical clones.
+    _add_clone_versions(engine, template_id, "Hello {code}", n=9)
+    assert len(engine.version_manager.get_all_versions(template_id)) >= 10
+
+    # Force deterministic randomness to make the assertion crisp.
+    random.seed(42)
+    chosen_ids = {
+        engine._select_version_ab_testing(template_id).id
+        for _ in range(100)
+    }
+    assert len(chosen_ids) == 1, (
+        f"Expected the bandit to return the SAME version on all 100 calls "
+        f"when versions are content-identical clones; got {len(chosen_ids)} distinct picks"
+    )
+
+
+def test_ab_testing_active_when_variants_differ(isolated_engine):
+    """2 versions with distinct content → over 200 calls with a moderate
+    exploration_rate the bandit must visit **both** versions at least once.
+    Proves the guard doesn't inadvertently freeze the policy when real
+    variants exist."""
+    _write_yaml_seed(isolated_engine["yaml_root"], "toolA", "default", "Variant A: analyse {code}")
+    engine = isolated_engine["factory"]()
+    engine.exploration_rate = 0.5  # force the explore branch half the time
+
+    template_id = next(iter(engine.library.templates.keys()))
+    # Append a SECOND version with truly different content.
+    engine.version_manager.create_version(
+        template_id=template_id,
+        content="Variant B: rewrite {code}",
+        variables=[],
+        version="2.0.0",
+    )
+    assert {v.content for v in engine.version_manager.get_all_versions(template_id)} == {
+        "Variant A: analyse {code}",
+        "Variant B: rewrite {code}",
+    }
+
+    random.seed(0)
+    contents_seen = set()
+    for _ in range(200):
+        v = engine._select_version_ab_testing(template_id)
+        contents_seen.add(v.content)
+
+    assert contents_seen == {
+        "Variant A: analyse {code}",
+        "Variant B: rewrite {code}",
+    }, (
+        f"Expected the bandit to visit BOTH variants over 200 calls with "
+        f"exploration_rate=0.5; only saw {contents_seen}"
+    )
+
+
+def test_guard_falls_back_to_best_version_when_clones(isolated_engine):
+    """When all versions are clones, the guard should return
+    ``get_best_version()`` if available, not random.choice. Makes the
+    behaviour stable even if ab_testing_enabled flips between runs."""
+    _write_yaml_seed(isolated_engine["yaml_root"], "toolA", "default", "Hello {code}")
+    engine = isolated_engine["factory"]()
+    template_id = next(iter(engine.library.templates.keys()))
+    _add_clone_versions(engine, template_id, "Hello {code}", n=4)
+
+    # Toggle ab_testing_enabled off and on; the result must be identical.
+    engine.ab_testing_enabled = True
+    pick_with_ab = engine._select_version_ab_testing(template_id)
+    engine.ab_testing_enabled = False
+    pick_without_ab = engine._select_version_ab_testing(template_id)
+
+    assert pick_with_ab.content == pick_without_ab.content, (
+        "When versions are clones, the returned content must be stable "
+        "regardless of ab_testing_enabled"
+    )
+
+
+def test_startup_log_reports_zero_active_when_all_clones(isolated_engine, caplog):
+    """The INFO log at startup must correctly count templates by variant
+    status — 0 active, N single-variant when no variants exist."""
+    _write_yaml_seed(isolated_engine["yaml_root"], "toolA", "default", "Hello {code}")
+    _write_yaml_seed(isolated_engine["yaml_root"], "toolB", "default", "World {code}")
+
+    import logging
+    with caplog.at_level(logging.INFO):
+        isolated_engine["factory"]()
+
+    status_logs = [r for r in caplog.records if "A/B testing status" in r.message]
+    assert status_logs, "Expected one INFO log announcing A/B readiness"
+    msg = status_logs[0].message
+    assert "0 template(s) with ≥ 2 real variants" in msg, msg
+    assert "2 with a single variant" in msg, msg


### PR DESCRIPTION
Closes [#232](https://github.com/VynoDePal/Collegue/issues/232). Suite directe de #231 (#234 mergée).

## Le problème concret

Avant ce fix, `_select_version_ab_testing(template_id)` appelait gaiement `random.choice(versions)` ou `get_best_version()` sur N entrées `PromptVersion` qui partageaient toutes le même champ `content`. Le bandit ε-greedy tournait sur 132 clones-UUID parfaits — aucun signal apprenable parce que chaque "exploration" attachait son outcome à un UUID différent *pour le même texte de prompt*. CPU et log-spam pour rien.

## Fix

Le garde-fou check `len({v.content for v in versions})` au lieu de `len(versions)`.

- **Clones uniquement** (1 seul contenu distinct, même si N versions UUID) → retourne `get_best_version() or versions[-1]` **déterministiquement**. Pas de `random.choice`, pas d'exploration, pas de fausse randomness.
- **Vraies variantes** (≥ 2 contenus distincts) → le bandit ε-greedy s'exerce normalement.

Cette condition était l'invariant implicite du système — jamais atteint avant #231 à cause des duplicates, toujours pas atteint après #231 tant que personne n'a rédigé de `v2.yaml` avec un vrai contenu différent.

## Signal pour l'opérateur

Nouveau log INFO au démarrage, via `_log_ab_readiness()` :

```
INFO  A/B testing status: 0 template(s) with ≥ 2 real variants,
                         16 with a single variant (bandit returns
                         deterministically for these)
```

Si ce nombre de "real variants" reste à 0, l'infra A/B ne sert à rien — signal clair pour ajouter des variantes ou désactiver le bandit.

## Docstring

`EnhancedPromptEngine.__init__` et `_select_version_ab_testing` documentent désormais la condition de déclenchement réelle du bandit. Un futur lecteur qui se demande *"pourquoi le bandit ne fait rien ?"* tombe directement sur l'explication.

## Tests (4 nouveaux cas)

[tests/test_prompt_engine_ab_guard.py](tests/test_prompt_engine_ab_guard.py) rootés dans un `tmp_path` isolé :

| Test | Ce qu'il prouve |
|---|---|
| `test_ab_testing_skips_when_all_clones` | 10 versions identiques + 100 appels → **1 seul résultat distinct** |
| `test_ab_testing_active_when_variants_differ` | 2 contenus différents + 200 appels (exploration_rate=0.5) → les **deux** contenus sont visités |
| `test_guard_falls_back_to_best_version_when_clones` | Toggle `ab_testing_enabled` entre les appels → réponse stable sur clones |
| `test_startup_log_reports_zero_active_when_all_clones` | Format du log INFO (0 active / 2 single-variant) |

## Impact pytest

| Métrique | Avant | Après |
|---|---|---|
| Passed | 566 | **570** (+4) |
| Failed | 0 | 0 |
| Skipped | 27 | 27 |

## Débloque

- **#233** (wiring des tools) — plus de souci que `test_generation` / `code_documentation` / `debug_agent` routent leur sortie à travers une layer A/B qui introduit de l'aléatoire sur rien
- Authoring de vraies variantes (v2.yaml / experimental.yaml avec contenu différent, ou script de génération) commence à produire un signal mesurable

## Test plan

- [x] `pytest tests/test_prompt_engine_ab_guard.py` → 4 passed
- [x] `pytest tests/` → 570 passed, 0 failed
- [x] Log INFO vérifié avec format attendu
- [x] Garde-fou stable indépendamment de `ab_testing_enabled` sur clones

🤖 Generated with [Claude Code](https://claude.com/claude-code)