### PR TITLE
fix(tools): route test_generation + code_documentation through template + A/B engine (#233)

### DIFF
--- a/collegue/tools/base.py
+++ b/collegue/tools/base.py
@@ -285,6 +285,21 @@ class BaseTool(ABC):
             raise ToolQuotaError(str(e))
 
     async def prepare_prompt(self, request: BaseModel, template_name: Optional[str] = None) -> str:
+        """Resolve a prompt for ``request`` via the template + A/B infrastructure.
+
+        Stores ``self._last_prompt_template_id`` and ``self._last_prompt_version``
+        on the instance when the prompt comes from :class:`EnhancedPromptEngine`.
+        Callers can then feed performance telemetry back via
+        :meth:`track_last_prompt_performance` after the LLM call completes.
+        Fallback paths (no engine configured, engine error) leave the
+        tracking attributes set to ``None`` — the helper is a no-op in that
+        case.
+        """
+        # Reset tracking state on every call so stale ids from a previous
+        # request never leak into the next track_last_prompt_performance().
+        self._last_prompt_template_id: Optional[str] = None
+        self._last_prompt_version: Optional[str] = None
+
         if not self.prompt_engine:
             if hasattr(self, '_build_prompt'):
                 self.logger.warning("Prompt engine non disponible, utilisation du fallback")
@@ -313,6 +328,14 @@ class BaseTool(ABC):
                         language=language
                     )
 
+                # Resolve the owning template id so track_performance can key
+                # it correctly. ``version`` here is the PromptVersion UUID,
+                # which only track_performance understands if we pass the
+                # version string (semver) instead — keep both.
+                self._last_prompt_template_id, self._last_prompt_version = (
+                    self._resolve_prompt_tracking(tool_name, version)
+                )
+
                 self.logger.info(f"Prompt préparé avec version {version} pour {tool_name}")
                 return prompt
             except Exception as e:
@@ -336,6 +359,72 @@ class BaseTool(ABC):
                 return self._build_prompt(request)
 
             raise ToolExecutionError(f"Aucun template trouvé pour l'outil {tool_name}")
+
+    def _resolve_prompt_tracking(
+        self,
+        tool_name: str,
+        version_id: Optional[str],
+    ) -> "tuple[Optional[str], Optional[str]]":
+        """Map a ``(tool_name, PromptVersion.id)`` pair to a
+        ``(template_id, version_string)`` pair ready for
+        :meth:`EnhancedPromptEngine.track_performance`.
+
+        ``EnhancedPromptEngine.get_optimized_prompt`` returns the version
+        *UUID* but ``track_performance`` expects the version *semver string*
+        (e.g. ``"1.0.0"``). This helper bridges the two. Returns ``(None, None)``
+        when any lookup fails so the tracking call becomes a no-op rather
+        than raising.
+        """
+        if not version_id or not self.prompt_engine:
+            return (None, None)
+
+        try:
+            category = f"tool/{tool_name.lower()}"
+            templates = self.prompt_engine.get_templates_by_category(category)
+            if not templates:
+                return (None, None)
+            template_id = templates[0].id
+            vm = getattr(self.prompt_engine, "version_manager", None)
+            if vm is None:
+                return (template_id, None)
+            for v in vm.get_all_versions(template_id):
+                if v.id == version_id:
+                    return (template_id, v.version)
+            return (template_id, None)
+        except Exception:
+            return (None, None)
+
+    def track_last_prompt_performance(
+        self,
+        execution_time: float,
+        tokens_used: int,
+        success: bool,
+        user_feedback: Optional[float] = None,
+    ) -> None:
+        """Feed telemetry for the last :meth:`prepare_prompt` call.
+
+        No-op when ``prepare_prompt`` took a fallback path (no engine, no
+        template found) — in that case the tracking attributes are ``None``
+        and there is nothing meaningful to attribute the metric to.
+        """
+        template_id = getattr(self, "_last_prompt_template_id", None)
+        version = getattr(self, "_last_prompt_version", None)
+        if not template_id or not version or not self.prompt_engine:
+            return
+        track = getattr(self.prompt_engine, "track_performance", None)
+        if track is None:
+            return
+        try:
+            track(
+                template_id=template_id,
+                version=version,
+                execution_time=execution_time,
+                tokens_used=tokens_used,
+                success=success,
+                user_feedback=user_feedback,
+            )
+        except Exception as exc:
+            self.logger.warning(f"track_performance failed (non-fatal): {exc}")
 
     def validate_language(self, language: str) -> bool:
         supported = self.get_supported_languages()

--- a/collegue/tools/code_documentation/tool.py
+++ b/collegue/tools/code_documentation/tool.py
@@ -7,6 +7,7 @@ et styles : Markdown, RST, HTML, docstring, JSON.
 Refactorisé: Le fichier original faisait 668 lignes, maintenant ~180 lignes.
 """
 
+import time
 from typing import List, Dict, Any
 from ..base import BaseTool, ToolError
 from ...core.shared import run_async_from_sync
@@ -156,6 +157,53 @@ class DocumentationTool(BaseTool):
 
         return True
 
+    def _build_prompt(self, request: DocumentationRequest) -> str:
+        """Fallback prompt builder when the template engine is unavailable.
+
+        Preserves the exact historical prompt shape so offline callers
+        (unit tests without ``prompt_engine`` injected) keep producing the
+        same output they did before #233.
+        """
+        code_elements = self._engine.analyze_code_elements(
+            request.code, request.language, None
+        )
+        return self._engine.build_prompt(
+            request.code,
+            request.language,
+            request.doc_style or "standard",
+            request.doc_format or "markdown",
+            request.include_examples or False,
+            request.focus_on or "all",
+            code_elements,
+        )
+
+    def _enrich_context_with_elements(
+        self,
+        request: DocumentationRequest,
+        code_elements: List[Dict[str, Any]],
+    ) -> DocumentationRequest:
+        """Fold AST-extracted ``code_elements`` into the request's
+        ``context`` field so the YAML template's ``{context}`` placeholder
+        carries the same element list the hardcoded prompt used to inject.
+        """
+        lines: List[str] = []
+        if request.doc_style:
+            lines.append(f"Doc style: {request.doc_style}")
+        if request.doc_format:
+            lines.append(f"Doc format: {request.doc_format}")
+        if request.focus_on:
+            lines.append(f"Focus: {request.focus_on}")
+        if code_elements:
+            lines.append("Elements to document:")
+            for e in code_elements[:10]:
+                lines.append(f"- {e.get('type', 'item')}: {e.get('name', '?')}")
+        existing = getattr(request, "context", None) or ""
+        merged = (existing + "\n" + "\n".join(lines)).strip() if lines else existing
+        try:
+            return request.model_copy(update={"context": merged})
+        except Exception:
+            return request
+
     def _execute_core_logic(
         self, request: DocumentationRequest, **kwargs
     ) -> DocumentationResponse:
@@ -170,31 +218,27 @@ class DocumentationTool(BaseTool):
 
         if ctx:
             try:
-                # Construire et envoyer le prompt au LLM
-                prompt = self._engine.build_prompt(
-                    request.code,
-                    request.language,
-                    request.doc_style or "standard",
-                    request.doc_format or "markdown",
-                    request.include_examples or False,
-                    request.focus_on or "all",
-                    code_elements,
+                # Préparer le prompt via le pipeline template + A/B (#233).
+                enriched = self._enrich_context_with_elements(request, code_elements)
+                prompt = run_async_from_sync(
+                    self.prepare_prompt(enriched, template_name="documentation")
                 )
 
-                system_prompt = f"""Tu es un expert en documentation de code {request.language}.
-Génère une documentation claire, complète et bien structurée au format {request.doc_format or "markdown"}.
-Style de documentation: {request.doc_style or "standard"}."""
-
+                started = time.monotonic()
                 result = run_async_from_sync(
                     ctx.sample(
                         messages=prompt,
-                        system_prompt=system_prompt,
                         temperature=0.5,
                         max_tokens=2000,
                     )
                 )
-
-                generated_docs = result.text
+                elapsed = time.monotonic() - started
+                generated_docs = result.text or ""
+                self.track_last_prompt_performance(
+                    execution_time=elapsed,
+                    tokens_used=len(generated_docs) // 4,
+                    success=bool(generated_docs),
+                )
 
                 # Formater et finaliser la documentation
                 formatted_docs = self._engine.format_documentation(
@@ -244,32 +288,27 @@ Style de documentation: {request.doc_style or "standard"}."""
             request.code, request.language, parser
         )
 
-        # Construire le prompt
-        prompt = self._engine.build_prompt(
-            request.code,
-            request.language,
-            request.doc_style or "standard",
-            request.doc_format or "markdown",
-            request.include_examples or False,
-            request.focus_on or "all",
-            code_elements,
-        )
-
-        system_prompt = f"""Tu es un expert en documentation de code {request.language}.
-Génère une documentation claire, complète et bien structurée au format {request.doc_format or "markdown"}.
-Style de documentation: {request.doc_style or "standard"}."""
+        # Préparer le prompt via le pipeline template + A/B (#233).
+        enriched = self._enrich_context_with_elements(request, code_elements)
+        prompt = await self.prepare_prompt(enriched, template_name="documentation")
 
         if ctx:
             await ctx.info("Génération de la documentation via LLM...")
 
         try:
+            started = time.monotonic()
             result = await ctx.sample(
                 messages=prompt,
-                system_prompt=system_prompt,
                 temperature=0.5,
                 max_tokens=2000,
             )
-            generated_docs = result.text
+            elapsed = time.monotonic() - started
+            generated_docs = result.text or ""
+            self.track_last_prompt_performance(
+                execution_time=elapsed,
+                tokens_used=len(generated_docs) // 4,
+                success=bool(generated_docs),
+            )
 
             if ctx:
                 await ctx.info("Documentation générée, formatage...")

--- a/collegue/tools/test_generation/tool.py
+++ b/collegue/tools/test_generation/tool.py
@@ -7,6 +7,7 @@ avec différents frameworks et options de personnalisation.
 Refactorisé: Le fichier original faisait 767 lignes, maintenant ~200 lignes.
 """
 
+import time
 from typing import List, Dict, Any, Optional
 import pathlib
 
@@ -151,6 +152,60 @@ class TestGenerationTool(BaseTool):
         """Indique si le tool est long à exécuter."""
         return True
 
+    def _build_prompt(self, request: TestGenerationRequest) -> str:
+        """Fallback prompt builder used when ``prompt_engine`` is unavailable.
+
+        Delegates to :class:`TestGenerationEngine.build_prompt` so the
+        offline path (unit tests, engine init error) preserves the exact
+        historical prompt shape — no behavioural regression for callers
+        that never had the engine wired in the first place.
+        """
+        framework = self._engine.detect_framework(
+            request.language, request.test_framework
+        )
+        elements = self._engine.extract_code_elements(
+            request.code, request.language
+        )
+        return self._engine.build_prompt(
+            request.code,
+            request.language,
+            framework,
+            request.include_mocks or False,
+            request.coverage_target or 0.8,
+            elements,
+        )
+
+    def _enrich_context_with_elements(
+        self,
+        request: TestGenerationRequest,
+        framework: str,
+        elements: List[Dict[str, Any]],
+    ) -> TestGenerationRequest:
+        """Fold the AST-extracted ``elements`` list and the resolved
+        ``framework`` into the request's ``context`` field so the YAML
+        template's ``{context}`` placeholder carries the same information
+        the hardcoded prompt used to inject inline. Keeps the "MCP value
+        add" of element extraction alive even after wiring to templates.
+        """
+        lines: List[str] = []
+        if framework:
+            lines.append(f"Target test framework: {framework}")
+        if elements:
+            lines.append("Elements to cover:")
+            for e in elements[:10]:
+                if e.get("type") == "function":
+                    params = ", ".join(e.get("params", []))
+                    lines.append(f"- function {e['name']}({params})")
+                elif e.get("type") in ("class", "Class"):
+                    methods = ", ".join(e.get("methods", [])[:5])
+                    suffix = f" (methods: {methods})" if methods else ""
+                    lines.append(f"- class {e['name']}{suffix}")
+                else:
+                    lines.append(f"- {e.get('type', 'item')} {e.get('name')}")
+        existing = getattr(request, "context", None) or ""
+        merged = (existing + "\n" + "\n".join(lines)).strip() if lines else existing
+        return request.model_copy(update={"context": merged})
+
     def _execute_core_logic(
         self, request: TestGenerationRequest, **kwargs
     ) -> TestGenerationResponse:
@@ -167,31 +222,27 @@ class TestGenerationTool(BaseTool):
 
         if ctx:
             try:
-                # Construire le prompt
-                prompt = self._engine.build_prompt(
-                    request.code,
-                    request.language,
-                    framework,
-                    request.include_mocks or False,
-                    request.coverage_target or 0.8,
-                    elements,
+                # Préparer le prompt via le pipeline template + A/B (#233).
+                enriched = self._enrich_context_with_elements(request, framework, elements)
+                prompt = run_async_from_sync(
+                    self.prepare_prompt(enriched, template_name="test_generation")
                 )
 
-                system_prompt = f"""Tu es un expert en tests unitaires {request.language}.
-Génère des tests complets, exécutables et bien structurés.
-Utilise le framework {framework}.
-Vise une couverture de {request.coverage_target or 0.8:.0%}."""
-
+                started = time.monotonic()
                 result = run_async_from_sync(
                     ctx.sample(
                         messages=prompt,
-                        system_prompt=system_prompt,
                         temperature=0.5,
                         max_tokens=2000,
                     )
                 )
-
-                test_code = result.text
+                elapsed = time.monotonic() - started
+                test_code = result.text or ""
+                self.track_last_prompt_performance(
+                    execution_time=elapsed,
+                    tokens_used=len(test_code) // 4,  # rough token proxy
+                    success=bool(test_code),
+                )
 
                 # Compter les tests générés
                 test_count = test_code.count("def test_") + test_code.count("@Test")
@@ -247,27 +298,24 @@ Vise une couverture de {request.coverage_target or 0.8:.0%}."""
         # Extraire les éléments
         elements = self._engine.extract_code_elements(request.code, request.language)
 
-        prompt = self._engine.build_prompt(
-            request.code,
-            request.language,
-            framework,
-            request.include_mocks or False,
-            request.coverage_target or 0.8,
-            elements,
-        )
-
-        system_prompt = f"""Tu es un expert en tests unitaires {request.language}.
-Génère des tests complets, exécutables et bien structurés.
-Utilise le framework {framework}."""
+        # Préparer le prompt via le pipeline template + A/B (#233).
+        enriched = self._enrich_context_with_elements(request, framework, elements)
+        prompt = await self.prepare_prompt(enriched, template_name="test_generation")
 
         try:
+            started = time.monotonic()
             result = await ctx.sample(
                 messages=prompt,
-                system_prompt=system_prompt,
                 temperature=0.5,
                 max_tokens=2000,
             )
-            test_code = result.text
+            elapsed = time.monotonic() - started
+            test_code = result.text or ""
+            self.track_last_prompt_performance(
+                execution_time=elapsed,
+                tokens_used=len(test_code) // 4,
+                success=bool(test_code),
+            )
 
             if ctx:
                 await ctx.info("Tests générés, calcul de la couverture...")

--- a/tests/test_tool_prompt_wiring.py
+++ b/tests/test_tool_prompt_wiring.py
@@ -1,0 +1,229 @@
+"""Regression tests for #233 — test_generation and code_documentation must
+route their prompt construction through ``BaseTool.prepare_prompt`` (which
+reaches the EnhancedPromptEngine + its templates + A/B bandit) and must
+feed telemetry back via ``track_last_prompt_performance``.
+
+Pre-#233, both tools called ``self._engine.build_prompt(...)`` directly,
+bypassing the whole template system. The tests here verify :
+
+- The tool reaches ``prepare_prompt`` when a ``prompt_engine`` is present.
+- The tool reaches its fallback ``_build_prompt`` when no engine is
+  configured (preserves offline test behaviour).
+- After ``ctx.sample``, ``track_performance`` is called on the engine
+  with a plausible template_id / version pair.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from collegue.tools.code_documentation import DocumentationRequest, DocumentationTool
+from collegue.tools.test_generation import TestGenerationRequest, TestGenerationTool
+
+
+# ---------------------------------------------------------------------------
+# Shared fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeVersion:
+    id: str
+    version: str
+    content: str
+
+
+class _FakeVersionManager:
+    def __init__(self, template_id: str, version: _FakeVersion):
+        self._template_id = template_id
+        self._version = version
+
+    def get_all_versions(self, template_id: str) -> List[_FakeVersion]:
+        if template_id == self._template_id:
+            return [self._version]
+        return []
+
+
+class _FakeTemplate:
+    def __init__(self, tid: str, name: str):
+        self.id = tid
+        self.name = name
+
+
+def _make_fake_engine(tool_name: str, rendered_prompt: str):
+    """Return a real :class:`EnhancedPromptEngine` subclass instance with
+    the three methods that :meth:`BaseTool.prepare_prompt` touches stubbed
+    out. Subclassing (vs MagicMock(spec=...)) is what makes
+    ``isinstance(engine, EnhancedPromptEngine)`` return True in base.py.
+    """
+    from collegue.prompts.engine.enhanced_prompt_engine import EnhancedPromptEngine
+
+    class _FakeEngine(EnhancedPromptEngine):
+        # Skip the real __init__ so we don't touch the filesystem.
+        def __init__(self) -> None:  # noqa: D401 — intentional no-op
+            self._tool_name = tool_name
+            self._rendered = rendered_prompt
+            self._template = _FakeTemplate(
+                f"tpl-{tool_name}", f"{tool_name}_default"
+            )
+            self._version = _FakeVersion(
+                id=f"ver-{tool_name}",
+                version="1.0.0",
+                content=rendered_prompt,
+            )
+            self.version_manager = _FakeVersionManager(
+                self._template.id, self._version
+            )
+            self.track_performance = MagicMock()
+
+        async def get_optimized_prompt(
+            self,
+            tool_name: str,
+            context: Dict[str, Any],
+            language: Optional[str] = None,
+            version: Optional[str] = None,
+        ):
+            return self._rendered, self._version.id
+
+        def get_templates_by_category(self, category: str):
+            if self._tool_name in category:
+                return [self._template]
+            return []
+
+    return _FakeEngine()
+
+
+# ---------------------------------------------------------------------------
+# test_generation tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_test_generation_routes_through_prepare_prompt():
+    tool = TestGenerationTool()
+    engine = _make_fake_engine("test_generation", "YAML_RENDERED_PROMPT")
+    tool.prompt_engine = engine
+
+    ctx = MagicMock()
+    ctx.info = AsyncMock()
+    ctx.warning = AsyncMock()
+    ctx.error = AsyncMock()
+    ctx.sample = AsyncMock()
+    ctx.report_progress = AsyncMock()
+    sample_result = MagicMock()
+    sample_result.text = "def test_foo():\n    assert True"
+    ctx.sample.return_value = sample_result
+
+    request = TestGenerationRequest(code="def foo(): pass", language="python")
+    response = await tool.execute_async(request, ctx=ctx)
+
+    # The prompt sent to ctx.sample must be what the engine rendered, not
+    # the hardcoded French prompt.
+    ctx.sample.assert_awaited_once()
+    sent_prompt = ctx.sample.await_args.kwargs["messages"]
+    assert sent_prompt == "YAML_RENDERED_PROMPT"
+    # System prompt should NOT be re-injected when the template owns the role.
+    assert "system_prompt" not in ctx.sample.await_args.kwargs
+
+    # Telemetry must have been fed back with the right template/version.
+    engine.track_performance.assert_called_once()
+    call_kwargs = engine.track_performance.call_args.kwargs
+    assert call_kwargs["template_id"] == "tpl-test_generation"
+    assert call_kwargs["version"] == "1.0.0"
+    assert call_kwargs["success"] is True
+    assert call_kwargs["execution_time"] >= 0
+    assert response.test_code == sample_result.text
+
+
+def test_test_generation_fallback_when_no_engine():
+    """Without a prompt_engine, the tool must delegate to ``_build_prompt``
+    (which wraps the engine's hardcoded prompt) instead of crashing."""
+    tool = TestGenerationTool()
+    assert tool.prompt_engine is None  # default
+
+    request = TestGenerationRequest(code="def foo(): return 1", language="python")
+    prompt = tool._build_prompt(request)
+    # Hardcoded FR prompt preserved for offline fallback.
+    assert "Génère des tests unitaires" in prompt
+    assert "def foo()" in prompt
+
+
+# ---------------------------------------------------------------------------
+# code_documentation tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_code_documentation_routes_through_prepare_prompt():
+    tool = DocumentationTool()
+    engine = _make_fake_engine("documentation", "DOC_YAML_PROMPT")
+    tool.prompt_engine = engine
+
+    ctx = MagicMock()
+    ctx.info = AsyncMock()
+    ctx.warning = AsyncMock()
+    ctx.error = AsyncMock()
+    ctx.sample = AsyncMock()
+    ctx.report_progress = AsyncMock()
+    sample_result = MagicMock()
+    sample_result.text = "# foo\n\nDoes something."
+    ctx.sample.return_value = sample_result
+
+    request = DocumentationRequest(
+        code="def foo():\n    return 1",
+        language="python",
+        doc_format="markdown",
+    )
+    response = await tool.execute_async(request, ctx=ctx)
+
+    ctx.sample.assert_awaited_once()
+    sent_prompt = ctx.sample.await_args.kwargs["messages"]
+    assert sent_prompt == "DOC_YAML_PROMPT"
+    assert "system_prompt" not in ctx.sample.await_args.kwargs
+
+    engine.track_performance.assert_called_once()
+    call_kwargs = engine.track_performance.call_args.kwargs
+    assert call_kwargs["template_id"] == "tpl-documentation"
+    assert call_kwargs["version"] == "1.0.0"
+    assert call_kwargs["success"] is True
+
+
+def test_code_documentation_fallback_when_no_engine():
+    tool = DocumentationTool()
+    assert tool.prompt_engine is None
+
+    request = DocumentationRequest(
+        code="def foo(): return 1",
+        language="python",
+        doc_format="markdown",
+    )
+    prompt = tool._build_prompt(request)
+    # Fallback must include the code and be non-empty.
+    assert "def foo" in prompt
+    assert len(prompt) > 50
+
+
+# ---------------------------------------------------------------------------
+# BaseTool tracking plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_track_last_prompt_noop_when_ids_missing():
+    """The tracking helper must silently no-op when ``prepare_prompt`` fell
+    back (no engine configured). Used by tools that route everything through
+    ``track_last_prompt_performance`` unconditionally."""
+    tool = TestGenerationTool()  # no engine
+    tool.prompt_engine = MagicMock()
+    tool.prompt_engine.track_performance = MagicMock()
+    # Simulate no successful prepare_prompt call ever.
+    tool._last_prompt_template_id = None
+    tool._last_prompt_version = None
+
+    tool.track_last_prompt_performance(
+        execution_time=0.1, tokens_used=42, success=True
+    )
+    tool.prompt_engine.track_performance.assert_not_called()


### PR DESCRIPTION
Closes [#233](https://github.com/VynoDePal/Collegue/issues/233). Dernier maillon de la chaîne #231 → #232 → #233.

## Le bug supprimé

```python
# AVANT : dans test_generation/tool.py et code_documentation/tool.py
prompt = self._engine.build_prompt(...)          # ❌ FR hardcodé 614 chars
system_prompt = "Tu es un expert..."             # ❌ double voix avec le template
result = await ctx.sample(messages=prompt, system_prompt=system_prompt, ...)
```

```python
# APRÈS
enriched = self._enrich_context_with_elements(request, ...)
prompt = await self.prepare_prompt(enriched, template_name="test_generation")
started = time.monotonic()
result = await ctx.sample(messages=prompt, ...)                # ✅ template EN 1145 chars
elapsed = time.monotonic() - started
self.track_last_prompt_performance(elapsed, tokens, success)   # ✅ A/B feedback
```

## Fichiers touchés

### [collegue/tools/base.py](collegue/tools/base.py)
- `prepare_prompt` capture désormais `(template_id, version_string)` via un nouveau `_resolve_prompt_tracking` helper qui bridge le mismatch d'API entre `get_optimized_prompt` (retourne UUID) et `track_performance` (attend semver).
- Nouveau `track_last_prompt_performance(execution_time, tokens_used, success, user_feedback)` qui no-op silencieusement quand le fallback a été pris (ids à `None`).
- **Non-breaking** : `prepare_prompt` retourne toujours `str`.

### [collegue/tools/test_generation/tool.py](collegue/tools/test_generation/tool.py) + [collegue/tools/code_documentation/tool.py](collegue/tools/code_documentation/tool.py)
Même pattern sur les deux :
- Nouveau `_build_prompt(request)` — fallback qui délègue à l'engine historique (préserve le comportement offline des tests unitaires sans engine).
- Nouveau `_enrich_context_with_elements(request, ...)` — injecte la liste d'éléments AST extraits dans `request.context` pour que le placeholder `{context}` du YAML transporte l'info que le prompt hardcodé mettait inline. **Préserve la valeur ajoutée de l'extraction AST** même en passant par les templates.
- Remplace les 2 call sites `self._engine.build_prompt(...)` (sync + async) par `await self.prepare_prompt(enriched, template_name=...)`.
- **Supprime le `system_prompt=` passé à `ctx.sample`** — le YAML template contient déjà "You are an expert..." au début. Injecter les deux dédouble le rôle.
- Appelle `self.track_last_prompt_performance(elapsed, tokens, success)` après chaque `ctx.sample` → le bandit A/B commence enfin à collecter de vraies stats.

## Tests (5 nouveaux cas)

[tests/test_tool_prompt_wiring.py](tests/test_tool_prompt_wiring.py) avec un fake `EnhancedPromptEngine` subclass (pour que `isinstance` réponde True) :

| Test | Vérifie |
|---|---|
| `test_test_generation_routes_through_prepare_prompt` | `ctx.sample` reçoit le prompt YAML rendu, pas de `system_prompt=`, `track_performance` appelé avec `template_id` + `version` corrects |
| `test_code_documentation_routes_through_prepare_prompt` | même contrat pour documentation |
| `test_test_generation_fallback_when_no_engine` | `_build_prompt` sans engine = prompt FR historique préservé |
| `test_code_documentation_fallback_when_no_engine` | idem pour documentation |
| `test_track_last_prompt_noop_when_ids_missing` | `track_last_prompt_performance` no-op quand les ids sont `None` |

## Impact pytest

| Métrique | Avant | Après |
|---|---|---|
| Passed | 570 | **575** (+5) |
| Failed | 0 | 0 |
| Skipped | 27 | 27 |

## Ce que ça débloque concrètement

1. **La matrice golden-evals (PR #230) peut être re-run honnêtement** — la colonne "MCP" pointera enfin sur le YAML template EN de 1145 chars (via le pipeline complet), pas sur le fallback FR 614 chars.
2. **Le compteur `_log_ab_readiness` de #232** passera de "0 templates with ≥ 2 real variants" à non-zéro dès qu'un second YAML (v2/experimental) avec contenu différent sera authored pour un tool wiré.
3. **`performance_score` + `usage_count` sortent de 0** — le bandit ε-greedy a enfin un signal à apprendre.

## Hors scope (follow-ups)

- Le YAML `collegue/prompts/templates/tools/debug_agent/` est **orphelin** : il n'y a pas de module `collegue/tools/debug_agent/`. Seul le Watchdog (`collegue/autonomous/watchdog.py`) appelle `generate_text` directement sans passer par l'engine. À traiter dans une issue de nettoyage dédiée (supprimer le YAML ou wirer le Watchdog).
- Le tool `refactoring` **utilise déjà** `prepare_prompt` mais n'appelle pas `track_last_prompt_performance`. Wiring du tracking = 3 lignes à ajouter — candidat pour un petit PR de suite.

## Test plan

- [x] `pytest tests/test_tool_prompt_wiring.py` → 5 passed
- [x] `pytest tests/` → 575 passed, 0 failed
- [x] `grep "self._engine.build_prompt" collegue/tools/test_generation/ collegue/tools/code_documentation/` → 2 occurrences restantes, toutes dans `_build_prompt` (fallback), aucune dans les call sites principaux
- [x] Fake engine subclass permet à `isinstance(engine, EnhancedPromptEngine)` de retourner True sans toucher au filesystem

🤖 Generated with [Claude Code](https://claude.com/claude-code)