### PR TITLE
feat(evals): scaffold code_documentation eval pipeline with stub scorer (#246)

### DIFF
--- a/tests/evals/cases/code_documentation/01_arithmetic.yaml
+++ b/tests/evals/cases/code_documentation/01_arithmetic.yaml
@@ -1,0 +1,12 @@
+name: Arithmetic utility
+description: Simple pure functions with known I/O including an error branch
+language: python
+doc_format: markdown
+must_document:
+- add
+- divide
+- clamp
+code: "def add(a, b):\n    return a + b\n\ndef divide(a, b):\n    if b == 0:\n   \
+  \     raise ValueError(\"div by zero\")\n    return a / b\n\ndef clamp(value, lo,\
+  \ hi):\n    if lo > hi:\n        raise ValueError(\"lo > hi\")\n    return max(lo,\
+  \ min(value, hi))\n"

--- a/tests/evals/cases/code_documentation/02_class_init.yaml
+++ b/tests/evals/cases/code_documentation/02_class_init.yaml
@@ -1,0 +1,11 @@
+name: Class with __init__ and mutation
+description: Exercise the LLM's ability to cover object state, not just free functions
+language: python
+doc_format: markdown
+must_document:
+- Counter
+code: "class Counter:\n    def __init__(self, start: int = 0):\n        if start <\
+  \ 0:\n            raise ValueError(\"start must be >= 0\")\n        self.value =\
+  \ start\n\n    def increment(self, by: int = 1) -> int:\n        self.value += by\n\
+  \        return self.value\n\n    def reset(self) -> None:\n        self.value =\
+  \ 0\n"

--- a/tests/evals/cases/code_documentation/03_type_hints.yaml
+++ b/tests/evals/cases/code_documentation/03_type_hints.yaml
@@ -1,0 +1,13 @@
+name: Type-hinted data transform
+description: Uses List / Optional / dict annotations; good coverage needs boundary
+  cases
+language: python
+doc_format: markdown
+must_document:
+- first_nonzero
+- word_counts
+code: "from typing import List, Optional\n\ndef first_nonzero(values: List[int]) ->\
+  \ Optional[int]:\n    for v in values:\n        if v != 0:\n            return v\n\
+  \    return None\n\ndef word_counts(text: str) -> dict[str, int]:\n    counts: dict[str,\
+  \ int] = {}\n    for word in text.split():\n        counts[word] = counts.get(word,\
+  \ 0) + 1\n    return counts\n"

--- a/tests/evals/cases/code_documentation/04_exceptions.yaml
+++ b/tests/evals/cases/code_documentation/04_exceptions.yaml
@@ -1,0 +1,15 @@
+name: Custom exception hierarchy
+description: LLM must realise that isinstance checks against the subclass are the
+  interesting assertion
+language: python
+doc_format: markdown
+must_document:
+- AppError
+- NotFoundError
+- lookup
+code: "class AppError(Exception):\n    \"\"\"Base for every domain error.\"\"\"\n\n\
+  class NotFoundError(AppError):\n    def __init__(self, entity: str, entity_id: str):\n\
+  \        self.entity = entity\n        self.entity_id = entity_id\n        super().__init__(f\"\
+  {entity} {entity_id!r} not found\")\n\ndef lookup(db: dict, entity: str, entity_id:\
+  \ str):\n    if entity_id not in db:\n        raise NotFoundError(entity, entity_id)\n\
+  \    return db[entity_id]\n"

--- a/tests/evals/cases/code_documentation/05_generator.yaml
+++ b/tests/evals/cases/code_documentation/05_generator.yaml
@@ -1,0 +1,10 @@
+name: Generator function
+description: Tests must consume the generator; common LLM failure mode is calling
+  it as a list-returning function
+language: python
+doc_format: markdown
+must_document:
+- fibonacci_up_to
+code: "def fibonacci_up_to(limit: int):\n    if limit < 0:\n        raise ValueError(\"\
+  limit must be non-negative\")\n    a, b = 0, 1\n    while a <= limit:\n        yield\
+  \ a\n        a, b = b, a + b\n"

--- a/tests/evals/cases/code_documentation/06_async_fn.yaml
+++ b/tests/evals/cases/code_documentation/06_async_fn.yaml
@@ -1,0 +1,9 @@
+name: Async function
+description: LLM must either use pytest-asyncio or asyncio.run; both are acceptable
+language: python
+doc_format: markdown
+must_document:
+- gather_doubles
+code: "import asyncio\n\nasync def gather_doubles(values):\n    async def double(x):\n\
+  \        await asyncio.sleep(0)\n        return x * 2\n    return await asyncio.gather(*[double(v)\
+  \ for v in values])\n"

--- a/tests/evals/cases/code_documentation/07_property.yaml
+++ b/tests/evals/cases/code_documentation/07_property.yaml
@@ -1,0 +1,12 @@
+name: Property with validation
+description: Exercises attribute-access + validator on setter
+language: python
+doc_format: markdown
+must_document:
+- Temperature
+code: "class Temperature:\n    def __init__(self, celsius: float):\n        self.celsius\
+  \ = celsius  # uses the setter\n\n    @property\n    def celsius(self) -> float:\n\
+  \        return self._celsius\n\n    @celsius.setter\n    def celsius(self, value:\
+  \ float) -> None:\n        if value < -273.15:\n            raise ValueError(\"\
+  below absolute zero\")\n        self._celsius = float(value)\n\n    @property\n\
+  \    def fahrenheit(self) -> float:\n        return self._celsius * 9 / 5 + 32\n"

--- a/tests/evals/cases/code_documentation/08_inheritance.yaml
+++ b/tests/evals/cases/code_documentation/08_inheritance.yaml
@@ -1,0 +1,19 @@
+name: Inheritance + polymorphic dispatch
+description: Tests must cover both subclasses through a common interface
+language: python
+doc_format: markdown
+must_document:
+- Shape
+- Circle
+- Rectangle
+- total_area
+code: "from abc import ABC, abstractmethod\n\nclass Shape(ABC):\n    @abstractmethod\n\
+  \    def area(self) -> float: ...\n\nclass Circle(Shape):\n    def __init__(self,\
+  \ radius: float):\n        if radius < 0:\n            raise ValueError(\"radius\
+  \ must be >= 0\")\n        self.radius = radius\n\n    def area(self) -> float:\n\
+  \        from math import pi\n        return pi * self.radius * self.radius\n\n\
+  class Rectangle(Shape):\n    def __init__(self, width: float, height: float):\n\
+  \        if width < 0 or height < 0:\n            raise ValueError(\"dimensions\
+  \ must be >= 0\")\n        self.width = width\n        self.height = height\n\n\
+  \    def area(self) -> float:\n        return self.width * self.height\n\ndef total_area(shapes:\
+  \ list[Shape]) -> float:\n    return sum(s.area() for s in shapes)\n"

--- a/tests/evals/cases/code_documentation/09_state_machine.yaml
+++ b/tests/evals/cases/code_documentation/09_state_machine.yaml
@@ -1,0 +1,24 @@
+name: Order state machine
+description: Enforces a linear transition graph. Tests must cover valid transitions,
+  rejections, and terminal-state immutability.
+language: python
+doc_format: markdown
+must_document:
+- OrderStatus
+- Order
+code: "from enum import Enum\n\nclass OrderStatus(str, Enum):\n    PENDING = \"pending\"\
+  \n    PAID = \"paid\"\n    SHIPPED = \"shipped\"\n    DELIVERED = \"delivered\"\n\
+  \    CANCELLED = \"cancelled\"\n\n_TRANSITIONS = {\n    OrderStatus.PENDING: {OrderStatus.PAID,\
+  \ OrderStatus.CANCELLED},\n    OrderStatus.PAID: {OrderStatus.SHIPPED, OrderStatus.CANCELLED},\n\
+  \    OrderStatus.SHIPPED: {OrderStatus.DELIVERED},\n    OrderStatus.DELIVERED: set(),\n\
+  \    OrderStatus.CANCELLED: set(),\n}\n\n\nclass Order:\n    def __init__(self,\
+  \ order_id: str):\n        if not order_id:\n            raise ValueError(\"order_id\
+  \ must be non-empty\")\n        self.order_id = order_id\n        self.status =\
+  \ OrderStatus.PENDING\n        self._history: list[OrderStatus] = [self.status]\n\
+  \n    def transition(self, new_status: OrderStatus) -> None:\n        allowed =\
+  \ _TRANSITIONS[self.status]\n        if new_status not in allowed:\n           \
+  \ raise ValueError(\n                f\"Cannot transition from {self.status.value}\
+  \ to {new_status.value}\"\n            )\n        self.status = new_status\n   \
+  \     self._history.append(new_status)\n\n    @property\n    def is_terminal(self)\
+  \ -> bool:\n        return not _TRANSITIONS[self.status]\n\n    @property\n    def\
+  \ history(self) -> list[OrderStatus]:\n        return list(self._history)\n"

--- a/tests/evals/cases/code_documentation/10_async_context.yaml
+++ b/tests/evals/cases/code_documentation/10_async_context.yaml
@@ -1,0 +1,22 @@
+name: Async connection pool (context manager)
+description: Async context manager that tracks checkouts, raises on double-close,
+  and cleans up on exception paths.
+language: python
+doc_format: markdown
+must_document:
+- PoolClosedError
+- ConnectionPool
+code: "import asyncio\n\nclass PoolClosedError(RuntimeError):\n    pass\n\nclass ConnectionPool:\n\
+  \    def __init__(self, size: int):\n        if size <= 0:\n            raise ValueError(\"\
+  size must be > 0\")\n        self._size = size\n        self._checked_out: int =\
+  \ 0\n        self._closed: bool = False\n\n    async def __aenter__(self) -> \"\
+  ConnectionPool\":\n        if self._closed:\n            raise PoolClosedError(\"\
+  pool already closed\")\n        return self\n\n    async def __aexit__(self, exc_type,\
+  \ exc, tb) -> bool:\n        self._closed = True\n        # Return False so exceptions\
+  \ propagate — we're a cleanup, not a swallower.\n        return False\n\n    async\
+  \ def acquire(self) -> int:\n        if self._closed:\n            raise PoolClosedError(\"\
+  pool closed\")\n        if self._checked_out >= self._size:\n            raise RuntimeError(\"\
+  pool exhausted\")\n        self._checked_out += 1\n        await asyncio.sleep(0)\n\
+  \        return self._checked_out\n\n    async def release(self) -> None:\n    \
+  \    if self._checked_out == 0:\n            raise RuntimeError(\"nothing to release\"\
+  )\n        self._checked_out -= 1\n        await asyncio.sleep(0)\n"

--- a/tests/evals/cases/code_documentation/11_decorator_retry.yaml
+++ b/tests/evals/cases/code_documentation/11_decorator_retry.yaml
@@ -1,0 +1,19 @@
+name: Retry decorator with selective exception catching
+description: Configurable retry count + allowed exception types. Tests must cover
+  success-first-try, success-after-retry, exhaustion, and non-matching exception passthrough.
+language: python
+doc_format: markdown
+must_document:
+- retry
+code: "from functools import wraps\n\n\ndef retry(times: int = 3, exceptions: tuple[type[BaseException],\
+  \ ...] = (Exception,)):\n    \"\"\"Retry a callable up to `times` attempts when\
+  \ it raises one of `exceptions`.\n\n    Raises the last captured exception if all\
+  \ attempts fail. Exceptions NOT in\n    `exceptions` propagate immediately (no retry).\n\
+  \    \"\"\"\n    if times < 1:\n        raise ValueError(\"times must be >= 1\"\
+  )\n\n    def decorator(fn):\n        @wraps(fn)\n        def wrapper(*args, **kwargs):\n\
+  \            last_exc: BaseException | None = None\n            for attempt in range(times):\n\
+  \                try:\n                    return fn(*args, **kwargs)\n        \
+  \        except exceptions as exc:\n                    last_exc = exc\n       \
+  \             continue\n            assert last_exc is not None  # for type narrowing\n\
+  \            raise last_exc\n        wrapper.attempts_spec = times\n        return\
+  \ wrapper\n\n    return decorator\n"

--- a/tests/evals/cases/code_documentation/12_pipeline_compose.yaml
+++ b/tests/evals/cases/code_documentation/12_pipeline_compose.yaml
@@ -1,0 +1,21 @@
+name: Pipeline composition with validation
+description: Generic pipeline that chains callables with shape validation at each
+  step. Tests must cover normal flow, invalid step signatures, and early exit.
+language: python
+doc_format: markdown
+must_document:
+- PipelineError
+- Pipeline
+code: "from typing import Any, Callable, Iterable\n\nclass PipelineError(RuntimeError):\n\
+  \    pass\n\n\nclass Pipeline:\n    def __init__(self, steps: Iterable[Callable[[Any],\
+  \ Any]]):\n        steps_list = list(steps)\n        if not steps_list:\n      \
+  \      raise ValueError(\"pipeline needs at least one step\")\n        for i, step\
+  \ in enumerate(steps_list):\n            if not callable(step):\n              \
+  \  raise TypeError(f\"step {i} is not callable: {step!r}\")\n        self._steps\
+  \ = steps_list\n\n    def run(self, initial: Any) -> Any:\n        value = initial\n\
+  \        for i, step in enumerate(self._steps):\n            try:\n            \
+  \    value = step(value)\n            except Exception as exc:\n               \
+  \ raise PipelineError(f\"step {i} ({step.__name__}) failed: {exc}\") from exc\n\
+  \            if value is None:\n                # Convention: a step returning None\
+  \ means \"abort pipeline\".\n                break\n        return value\n\n   \
+  \ def __len__(self) -> int:\n        return len(self._steps)\n"

--- a/tests/evals/cases/code_documentation/13_lru_memoize.yaml
+++ b/tests/evals/cases/code_documentation/13_lru_memoize.yaml
@@ -1,0 +1,27 @@
+name: LRU memoize decorator
+description: Hand-rolled LRU cache tracking hit/miss stats and evicting on maxsize.
+  Tests must cover cache hits, misses, eviction order, and stats.
+language: python
+doc_format: markdown
+must_document:
+- MemoizeStats
+- memoize
+code: "from collections import OrderedDict\nfrom functools import wraps\nfrom typing\
+  \ import Any, Callable\n\n\nclass MemoizeStats:\n    def __init__(self) -> None:\n\
+  \        self.hits: int = 0\n        self.misses: int = 0\n\n    @property\n   \
+  \ def calls(self) -> int:\n        return self.hits + self.misses\n\n    def reset(self)\
+  \ -> None:\n        self.hits = 0\n        self.misses = 0\n\n\ndef memoize(maxsize:\
+  \ int = 128) -> Callable:\n    \"\"\"LRU memoize decorator. Exposes a ``.stats``\
+  \ attribute and a ``.clear()`` method.\n\n    Cache key = (args, sorted kwargs items).\
+  \ All args must be hashable.\n    \"\"\"\n    if maxsize < 1:\n        raise ValueError(\"\
+  maxsize must be >= 1\")\n\n    def decorator(fn: Callable) -> Callable:\n      \
+  \  cache: \"OrderedDict[tuple, Any]\" = OrderedDict()\n        stats = MemoizeStats()\n\
+  \n        @wraps(fn)\n        def wrapper(*args: Any, **kwargs: Any) -> Any:\n \
+  \           key = (args, tuple(sorted(kwargs.items())))\n            if key in cache:\n\
+  \                cache.move_to_end(key)\n                stats.hits += 1\n     \
+  \           return cache[key]\n            stats.misses += 1\n            result\
+  \ = fn(*args, **kwargs)\n            cache[key] = result\n            if len(cache)\
+  \ > maxsize:\n                cache.popitem(last=False)  # evict LRU\n         \
+  \   return result\n\n        def clear() -> None:\n            cache.clear()\n \
+  \           stats.reset()\n\n        wrapper.stats = stats\n        wrapper.clear\
+  \ = clear\n        return wrapper\n\n    return decorator\n"

--- a/tests/evals/cases/code_documentation_competent/01_arithmetic.yaml
+++ b/tests/evals/cases/code_documentation_competent/01_arithmetic.yaml
@@ -1,0 +1,12 @@
+name: Arithmetic utility
+description: Simple pure functions with known I/O including an error branch
+language: python
+doc_format: markdown
+must_document:
+- add
+- divide
+- clamp
+code: "def add(a, b):\n    return a + b\n\ndef divide(a, b):\n    if b == 0:\n   \
+  \     raise ValueError(\"div by zero\")\n    return a / b\n\ndef clamp(value, lo,\
+  \ hi):\n    if lo > hi:\n        raise ValueError(\"lo > hi\")\n    return max(lo,\
+  \ min(value, hi))\n"

--- a/tests/evals/cases/code_documentation_competent/02_class_init.yaml
+++ b/tests/evals/cases/code_documentation_competent/02_class_init.yaml
@@ -1,0 +1,11 @@
+name: Class with __init__ and mutation
+description: Exercise the LLM's ability to cover object state, not just free functions
+language: python
+doc_format: markdown
+must_document:
+- Counter
+code: "class Counter:\n    def __init__(self, start: int = 0):\n        if start <\
+  \ 0:\n            raise ValueError(\"start must be >= 0\")\n        self.value =\
+  \ start\n\n    def increment(self, by: int = 1) -> int:\n        self.value += by\n\
+  \        return self.value\n\n    def reset(self) -> None:\n        self.value =\
+  \ 0\n"

--- a/tests/evals/cases/code_documentation_competent/03_type_hints.yaml
+++ b/tests/evals/cases/code_documentation_competent/03_type_hints.yaml
@@ -1,0 +1,13 @@
+name: Type-hinted data transform
+description: Uses List / Optional / dict annotations; good coverage needs boundary
+  cases
+language: python
+doc_format: markdown
+must_document:
+- first_nonzero
+- word_counts
+code: "from typing import List, Optional\n\ndef first_nonzero(values: List[int]) ->\
+  \ Optional[int]:\n    for v in values:\n        if v != 0:\n            return v\n\
+  \    return None\n\ndef word_counts(text: str) -> dict[str, int]:\n    counts: dict[str,\
+  \ int] = {}\n    for word in text.split():\n        counts[word] = counts.get(word,\
+  \ 0) + 1\n    return counts\n"

--- a/tests/evals/cases/code_documentation_competent/04_exceptions.yaml
+++ b/tests/evals/cases/code_documentation_competent/04_exceptions.yaml
@@ -1,0 +1,15 @@
+name: Custom exception hierarchy
+description: LLM must realise that isinstance checks against the subclass are the
+  interesting assertion
+language: python
+doc_format: markdown
+must_document:
+- AppError
+- NotFoundError
+- lookup
+code: "class AppError(Exception):\n    \"\"\"Base for every domain error.\"\"\"\n\n\
+  class NotFoundError(AppError):\n    def __init__(self, entity: str, entity_id: str):\n\
+  \        self.entity = entity\n        self.entity_id = entity_id\n        super().__init__(f\"\
+  {entity} {entity_id!r} not found\")\n\ndef lookup(db: dict, entity: str, entity_id:\
+  \ str):\n    if entity_id not in db:\n        raise NotFoundError(entity, entity_id)\n\
+  \    return db[entity_id]\n"

--- a/tests/evals/cases/code_documentation_competent/05_generator.yaml
+++ b/tests/evals/cases/code_documentation_competent/05_generator.yaml
@@ -1,0 +1,10 @@
+name: Generator function
+description: Tests must consume the generator; common LLM failure mode is calling
+  it as a list-returning function
+language: python
+doc_format: markdown
+must_document:
+- fibonacci_up_to
+code: "def fibonacci_up_to(limit: int):\n    if limit < 0:\n        raise ValueError(\"\
+  limit must be non-negative\")\n    a, b = 0, 1\n    while a <= limit:\n        yield\
+  \ a\n        a, b = b, a + b\n"

--- a/tests/evals/cases/code_documentation_competent/06_async_fn.yaml
+++ b/tests/evals/cases/code_documentation_competent/06_async_fn.yaml
@@ -1,0 +1,9 @@
+name: Async function
+description: LLM must either use pytest-asyncio or asyncio.run; both are acceptable
+language: python
+doc_format: markdown
+must_document:
+- gather_doubles
+code: "import asyncio\n\nasync def gather_doubles(values):\n    async def double(x):\n\
+  \        await asyncio.sleep(0)\n        return x * 2\n    return await asyncio.gather(*[double(v)\
+  \ for v in values])\n"

--- a/tests/evals/cases/code_documentation_competent/07_property.yaml
+++ b/tests/evals/cases/code_documentation_competent/07_property.yaml
@@ -1,0 +1,12 @@
+name: Property with validation
+description: Exercises attribute-access + validator on setter
+language: python
+doc_format: markdown
+must_document:
+- Temperature
+code: "class Temperature:\n    def __init__(self, celsius: float):\n        self.celsius\
+  \ = celsius  # uses the setter\n\n    @property\n    def celsius(self) -> float:\n\
+  \        return self._celsius\n\n    @celsius.setter\n    def celsius(self, value:\
+  \ float) -> None:\n        if value < -273.15:\n            raise ValueError(\"\
+  below absolute zero\")\n        self._celsius = float(value)\n\n    @property\n\
+  \    def fahrenheit(self) -> float:\n        return self._celsius * 9 / 5 + 32\n"

--- a/tests/evals/cases/code_documentation_competent/08_inheritance.yaml
+++ b/tests/evals/cases/code_documentation_competent/08_inheritance.yaml
@@ -1,0 +1,19 @@
+name: Inheritance + polymorphic dispatch
+description: Tests must cover both subclasses through a common interface
+language: python
+doc_format: markdown
+must_document:
+- Shape
+- Circle
+- Rectangle
+- total_area
+code: "from abc import ABC, abstractmethod\n\nclass Shape(ABC):\n    @abstractmethod\n\
+  \    def area(self) -> float: ...\n\nclass Circle(Shape):\n    def __init__(self,\
+  \ radius: float):\n        if radius < 0:\n            raise ValueError(\"radius\
+  \ must be >= 0\")\n        self.radius = radius\n\n    def area(self) -> float:\n\
+  \        from math import pi\n        return pi * self.radius * self.radius\n\n\
+  class Rectangle(Shape):\n    def __init__(self, width: float, height: float):\n\
+  \        if width < 0 or height < 0:\n            raise ValueError(\"dimensions\
+  \ must be >= 0\")\n        self.width = width\n        self.height = height\n\n\
+  \    def area(self) -> float:\n        return self.width * self.height\n\ndef total_area(shapes:\
+  \ list[Shape]) -> float:\n    return sum(s.area() for s in shapes)\n"

--- a/tests/evals/cases/code_documentation_competent/09_state_machine.yaml
+++ b/tests/evals/cases/code_documentation_competent/09_state_machine.yaml
@@ -1,0 +1,24 @@
+name: Order state machine
+description: Enforces a linear transition graph. Tests must cover valid transitions,
+  rejections, and terminal-state immutability.
+language: python
+doc_format: markdown
+must_document:
+- OrderStatus
+- Order
+code: "from enum import Enum\n\nclass OrderStatus(str, Enum):\n    PENDING = \"pending\"\
+  \n    PAID = \"paid\"\n    SHIPPED = \"shipped\"\n    DELIVERED = \"delivered\"\n\
+  \    CANCELLED = \"cancelled\"\n\n_TRANSITIONS = {\n    OrderStatus.PENDING: {OrderStatus.PAID,\
+  \ OrderStatus.CANCELLED},\n    OrderStatus.PAID: {OrderStatus.SHIPPED, OrderStatus.CANCELLED},\n\
+  \    OrderStatus.SHIPPED: {OrderStatus.DELIVERED},\n    OrderStatus.DELIVERED: set(),\n\
+  \    OrderStatus.CANCELLED: set(),\n}\n\n\nclass Order:\n    def __init__(self,\
+  \ order_id: str):\n        if not order_id:\n            raise ValueError(\"order_id\
+  \ must be non-empty\")\n        self.order_id = order_id\n        self.status =\
+  \ OrderStatus.PENDING\n        self._history: list[OrderStatus] = [self.status]\n\
+  \n    def transition(self, new_status: OrderStatus) -> None:\n        allowed =\
+  \ _TRANSITIONS[self.status]\n        if new_status not in allowed:\n           \
+  \ raise ValueError(\n                f\"Cannot transition from {self.status.value}\
+  \ to {new_status.value}\"\n            )\n        self.status = new_status\n   \
+  \     self._history.append(new_status)\n\n    @property\n    def is_terminal(self)\
+  \ -> bool:\n        return not _TRANSITIONS[self.status]\n\n    @property\n    def\
+  \ history(self) -> list[OrderStatus]:\n        return list(self._history)\n"

--- a/tests/evals/cases/code_documentation_competent/10_async_context.yaml
+++ b/tests/evals/cases/code_documentation_competent/10_async_context.yaml
@@ -1,0 +1,22 @@
+name: Async connection pool (context manager)
+description: Async context manager that tracks checkouts, raises on double-close,
+  and cleans up on exception paths.
+language: python
+doc_format: markdown
+must_document:
+- PoolClosedError
+- ConnectionPool
+code: "import asyncio\n\nclass PoolClosedError(RuntimeError):\n    pass\n\nclass ConnectionPool:\n\
+  \    def __init__(self, size: int):\n        if size <= 0:\n            raise ValueError(\"\
+  size must be > 0\")\n        self._size = size\n        self._checked_out: int =\
+  \ 0\n        self._closed: bool = False\n\n    async def __aenter__(self) -> \"\
+  ConnectionPool\":\n        if self._closed:\n            raise PoolClosedError(\"\
+  pool already closed\")\n        return self\n\n    async def __aexit__(self, exc_type,\
+  \ exc, tb) -> bool:\n        self._closed = True\n        # Return False so exceptions\
+  \ propagate — we're a cleanup, not a swallower.\n        return False\n\n    async\
+  \ def acquire(self) -> int:\n        if self._closed:\n            raise PoolClosedError(\"\
+  pool closed\")\n        if self._checked_out >= self._size:\n            raise RuntimeError(\"\
+  pool exhausted\")\n        self._checked_out += 1\n        await asyncio.sleep(0)\n\
+  \        return self._checked_out\n\n    async def release(self) -> None:\n    \
+  \    if self._checked_out == 0:\n            raise RuntimeError(\"nothing to release\"\
+  )\n        self._checked_out -= 1\n        await asyncio.sleep(0)\n"

--- a/tests/evals/cases/code_documentation_competent/11_decorator_retry.yaml
+++ b/tests/evals/cases/code_documentation_competent/11_decorator_retry.yaml
@@ -1,0 +1,19 @@
+name: Retry decorator with selective exception catching
+description: Configurable retry count + allowed exception types. Tests must cover
+  success-first-try, success-after-retry, exhaustion, and non-matching exception passthrough.
+language: python
+doc_format: markdown
+must_document:
+- retry
+code: "from functools import wraps\n\n\ndef retry(times: int = 3, exceptions: tuple[type[BaseException],\
+  \ ...] = (Exception,)):\n    \"\"\"Retry a callable up to `times` attempts when\
+  \ it raises one of `exceptions`.\n\n    Raises the last captured exception if all\
+  \ attempts fail. Exceptions NOT in\n    `exceptions` propagate immediately (no retry).\n\
+  \    \"\"\"\n    if times < 1:\n        raise ValueError(\"times must be >= 1\"\
+  )\n\n    def decorator(fn):\n        @wraps(fn)\n        def wrapper(*args, **kwargs):\n\
+  \            last_exc: BaseException | None = None\n            for attempt in range(times):\n\
+  \                try:\n                    return fn(*args, **kwargs)\n        \
+  \        except exceptions as exc:\n                    last_exc = exc\n       \
+  \             continue\n            assert last_exc is not None  # for type narrowing\n\
+  \            raise last_exc\n        wrapper.attempts_spec = times\n        return\
+  \ wrapper\n\n    return decorator\n"

--- a/tests/evals/cases/code_documentation_competent/12_pipeline_compose.yaml
+++ b/tests/evals/cases/code_documentation_competent/12_pipeline_compose.yaml
@@ -1,0 +1,21 @@
+name: Pipeline composition with validation
+description: Generic pipeline that chains callables with shape validation at each
+  step. Tests must cover normal flow, invalid step signatures, and early exit.
+language: python
+doc_format: markdown
+must_document:
+- PipelineError
+- Pipeline
+code: "from typing import Any, Callable, Iterable\n\nclass PipelineError(RuntimeError):\n\
+  \    pass\n\n\nclass Pipeline:\n    def __init__(self, steps: Iterable[Callable[[Any],\
+  \ Any]]):\n        steps_list = list(steps)\n        if not steps_list:\n      \
+  \      raise ValueError(\"pipeline needs at least one step\")\n        for i, step\
+  \ in enumerate(steps_list):\n            if not callable(step):\n              \
+  \  raise TypeError(f\"step {i} is not callable: {step!r}\")\n        self._steps\
+  \ = steps_list\n\n    def run(self, initial: Any) -> Any:\n        value = initial\n\
+  \        for i, step in enumerate(self._steps):\n            try:\n            \
+  \    value = step(value)\n            except Exception as exc:\n               \
+  \ raise PipelineError(f\"step {i} ({step.__name__}) failed: {exc}\") from exc\n\
+  \            if value is None:\n                # Convention: a step returning None\
+  \ means \"abort pipeline\".\n                break\n        return value\n\n   \
+  \ def __len__(self) -> int:\n        return len(self._steps)\n"

--- a/tests/evals/cases/code_documentation_competent/13_lru_memoize.yaml
+++ b/tests/evals/cases/code_documentation_competent/13_lru_memoize.yaml
@@ -1,0 +1,27 @@
+name: LRU memoize decorator
+description: Hand-rolled LRU cache tracking hit/miss stats and evicting on maxsize.
+  Tests must cover cache hits, misses, eviction order, and stats.
+language: python
+doc_format: markdown
+must_document:
+- MemoizeStats
+- memoize
+code: "from collections import OrderedDict\nfrom functools import wraps\nfrom typing\
+  \ import Any, Callable\n\n\nclass MemoizeStats:\n    def __init__(self) -> None:\n\
+  \        self.hits: int = 0\n        self.misses: int = 0\n\n    @property\n   \
+  \ def calls(self) -> int:\n        return self.hits + self.misses\n\n    def reset(self)\
+  \ -> None:\n        self.hits = 0\n        self.misses = 0\n\n\ndef memoize(maxsize:\
+  \ int = 128) -> Callable:\n    \"\"\"LRU memoize decorator. Exposes a ``.stats``\
+  \ attribute and a ``.clear()`` method.\n\n    Cache key = (args, sorted kwargs items).\
+  \ All args must be hashable.\n    \"\"\"\n    if maxsize < 1:\n        raise ValueError(\"\
+  maxsize must be >= 1\")\n\n    def decorator(fn: Callable) -> Callable:\n      \
+  \  cache: \"OrderedDict[tuple, Any]\" = OrderedDict()\n        stats = MemoizeStats()\n\
+  \n        @wraps(fn)\n        def wrapper(*args: Any, **kwargs: Any) -> Any:\n \
+  \           key = (args, tuple(sorted(kwargs.items())))\n            if key in cache:\n\
+  \                cache.move_to_end(key)\n                stats.hits += 1\n     \
+  \           return cache[key]\n            stats.misses += 1\n            result\
+  \ = fn(*args, **kwargs)\n            cache[key] = result\n            if len(cache)\
+  \ > maxsize:\n                cache.popitem(last=False)  # evict LRU\n         \
+  \   return result\n\n        def clear() -> None:\n            cache.clear()\n \
+  \           stats.reset()\n\n        wrapper.stats = stats\n        wrapper.clear\
+  \ = clear\n        return wrapper\n\n    return decorator\n"

--- a/tests/evals/cases/code_documentation_raw/01_arithmetic.yaml
+++ b/tests/evals/cases/code_documentation_raw/01_arithmetic.yaml
@@ -1,0 +1,12 @@
+name: Arithmetic utility
+description: Simple pure functions with known I/O including an error branch
+language: python
+doc_format: markdown
+must_document:
+- add
+- divide
+- clamp
+code: "def add(a, b):\n    return a + b\n\ndef divide(a, b):\n    if b == 0:\n   \
+  \     raise ValueError(\"div by zero\")\n    return a / b\n\ndef clamp(value, lo,\
+  \ hi):\n    if lo > hi:\n        raise ValueError(\"lo > hi\")\n    return max(lo,\
+  \ min(value, hi))\n"

--- a/tests/evals/cases/code_documentation_raw/02_class_init.yaml
+++ b/tests/evals/cases/code_documentation_raw/02_class_init.yaml
@@ -1,0 +1,11 @@
+name: Class with __init__ and mutation
+description: Exercise the LLM's ability to cover object state, not just free functions
+language: python
+doc_format: markdown
+must_document:
+- Counter
+code: "class Counter:\n    def __init__(self, start: int = 0):\n        if start <\
+  \ 0:\n            raise ValueError(\"start must be >= 0\")\n        self.value =\
+  \ start\n\n    def increment(self, by: int = 1) -> int:\n        self.value += by\n\
+  \        return self.value\n\n    def reset(self) -> None:\n        self.value =\
+  \ 0\n"

--- a/tests/evals/cases/code_documentation_raw/03_type_hints.yaml
+++ b/tests/evals/cases/code_documentation_raw/03_type_hints.yaml
@@ -1,0 +1,13 @@
+name: Type-hinted data transform
+description: Uses List / Optional / dict annotations; good coverage needs boundary
+  cases
+language: python
+doc_format: markdown
+must_document:
+- first_nonzero
+- word_counts
+code: "from typing import List, Optional\n\ndef first_nonzero(values: List[int]) ->\
+  \ Optional[int]:\n    for v in values:\n        if v != 0:\n            return v\n\
+  \    return None\n\ndef word_counts(text: str) -> dict[str, int]:\n    counts: dict[str,\
+  \ int] = {}\n    for word in text.split():\n        counts[word] = counts.get(word,\
+  \ 0) + 1\n    return counts\n"

--- a/tests/evals/cases/code_documentation_raw/04_exceptions.yaml
+++ b/tests/evals/cases/code_documentation_raw/04_exceptions.yaml
@@ -1,0 +1,15 @@
+name: Custom exception hierarchy
+description: LLM must realise that isinstance checks against the subclass are the
+  interesting assertion
+language: python
+doc_format: markdown
+must_document:
+- AppError
+- NotFoundError
+- lookup
+code: "class AppError(Exception):\n    \"\"\"Base for every domain error.\"\"\"\n\n\
+  class NotFoundError(AppError):\n    def __init__(self, entity: str, entity_id: str):\n\
+  \        self.entity = entity\n        self.entity_id = entity_id\n        super().__init__(f\"\
+  {entity} {entity_id!r} not found\")\n\ndef lookup(db: dict, entity: str, entity_id:\
+  \ str):\n    if entity_id not in db:\n        raise NotFoundError(entity, entity_id)\n\
+  \    return db[entity_id]\n"

--- a/tests/evals/cases/code_documentation_raw/05_generator.yaml
+++ b/tests/evals/cases/code_documentation_raw/05_generator.yaml
@@ -1,0 +1,10 @@
+name: Generator function
+description: Tests must consume the generator; common LLM failure mode is calling
+  it as a list-returning function
+language: python
+doc_format: markdown
+must_document:
+- fibonacci_up_to
+code: "def fibonacci_up_to(limit: int):\n    if limit < 0:\n        raise ValueError(\"\
+  limit must be non-negative\")\n    a, b = 0, 1\n    while a <= limit:\n        yield\
+  \ a\n        a, b = b, a + b\n"

--- a/tests/evals/cases/code_documentation_raw/06_async_fn.yaml
+++ b/tests/evals/cases/code_documentation_raw/06_async_fn.yaml
@@ -1,0 +1,9 @@
+name: Async function
+description: LLM must either use pytest-asyncio or asyncio.run; both are acceptable
+language: python
+doc_format: markdown
+must_document:
+- gather_doubles
+code: "import asyncio\n\nasync def gather_doubles(values):\n    async def double(x):\n\
+  \        await asyncio.sleep(0)\n        return x * 2\n    return await asyncio.gather(*[double(v)\
+  \ for v in values])\n"

--- a/tests/evals/cases/code_documentation_raw/07_property.yaml
+++ b/tests/evals/cases/code_documentation_raw/07_property.yaml
@@ -1,0 +1,12 @@
+name: Property with validation
+description: Exercises attribute-access + validator on setter
+language: python
+doc_format: markdown
+must_document:
+- Temperature
+code: "class Temperature:\n    def __init__(self, celsius: float):\n        self.celsius\
+  \ = celsius  # uses the setter\n\n    @property\n    def celsius(self) -> float:\n\
+  \        return self._celsius\n\n    @celsius.setter\n    def celsius(self, value:\
+  \ float) -> None:\n        if value < -273.15:\n            raise ValueError(\"\
+  below absolute zero\")\n        self._celsius = float(value)\n\n    @property\n\
+  \    def fahrenheit(self) -> float:\n        return self._celsius * 9 / 5 + 32\n"

--- a/tests/evals/cases/code_documentation_raw/08_inheritance.yaml
+++ b/tests/evals/cases/code_documentation_raw/08_inheritance.yaml
@@ -1,0 +1,19 @@
+name: Inheritance + polymorphic dispatch
+description: Tests must cover both subclasses through a common interface
+language: python
+doc_format: markdown
+must_document:
+- Shape
+- Circle
+- Rectangle
+- total_area
+code: "from abc import ABC, abstractmethod\n\nclass Shape(ABC):\n    @abstractmethod\n\
+  \    def area(self) -> float: ...\n\nclass Circle(Shape):\n    def __init__(self,\
+  \ radius: float):\n        if radius < 0:\n            raise ValueError(\"radius\
+  \ must be >= 0\")\n        self.radius = radius\n\n    def area(self) -> float:\n\
+  \        from math import pi\n        return pi * self.radius * self.radius\n\n\
+  class Rectangle(Shape):\n    def __init__(self, width: float, height: float):\n\
+  \        if width < 0 or height < 0:\n            raise ValueError(\"dimensions\
+  \ must be >= 0\")\n        self.width = width\n        self.height = height\n\n\
+  \    def area(self) -> float:\n        return self.width * self.height\n\ndef total_area(shapes:\
+  \ list[Shape]) -> float:\n    return sum(s.area() for s in shapes)\n"

--- a/tests/evals/cases/code_documentation_raw/09_state_machine.yaml
+++ b/tests/evals/cases/code_documentation_raw/09_state_machine.yaml
@@ -1,0 +1,24 @@
+name: Order state machine
+description: Enforces a linear transition graph. Tests must cover valid transitions,
+  rejections, and terminal-state immutability.
+language: python
+doc_format: markdown
+must_document:
+- OrderStatus
+- Order
+code: "from enum import Enum\n\nclass OrderStatus(str, Enum):\n    PENDING = \"pending\"\
+  \n    PAID = \"paid\"\n    SHIPPED = \"shipped\"\n    DELIVERED = \"delivered\"\n\
+  \    CANCELLED = \"cancelled\"\n\n_TRANSITIONS = {\n    OrderStatus.PENDING: {OrderStatus.PAID,\
+  \ OrderStatus.CANCELLED},\n    OrderStatus.PAID: {OrderStatus.SHIPPED, OrderStatus.CANCELLED},\n\
+  \    OrderStatus.SHIPPED: {OrderStatus.DELIVERED},\n    OrderStatus.DELIVERED: set(),\n\
+  \    OrderStatus.CANCELLED: set(),\n}\n\n\nclass Order:\n    def __init__(self,\
+  \ order_id: str):\n        if not order_id:\n            raise ValueError(\"order_id\
+  \ must be non-empty\")\n        self.order_id = order_id\n        self.status =\
+  \ OrderStatus.PENDING\n        self._history: list[OrderStatus] = [self.status]\n\
+  \n    def transition(self, new_status: OrderStatus) -> None:\n        allowed =\
+  \ _TRANSITIONS[self.status]\n        if new_status not in allowed:\n           \
+  \ raise ValueError(\n                f\"Cannot transition from {self.status.value}\
+  \ to {new_status.value}\"\n            )\n        self.status = new_status\n   \
+  \     self._history.append(new_status)\n\n    @property\n    def is_terminal(self)\
+  \ -> bool:\n        return not _TRANSITIONS[self.status]\n\n    @property\n    def\
+  \ history(self) -> list[OrderStatus]:\n        return list(self._history)\n"

--- a/tests/evals/cases/code_documentation_raw/10_async_context.yaml
+++ b/tests/evals/cases/code_documentation_raw/10_async_context.yaml
@@ -1,0 +1,22 @@
+name: Async connection pool (context manager)
+description: Async context manager that tracks checkouts, raises on double-close,
+  and cleans up on exception paths.
+language: python
+doc_format: markdown
+must_document:
+- PoolClosedError
+- ConnectionPool
+code: "import asyncio\n\nclass PoolClosedError(RuntimeError):\n    pass\n\nclass ConnectionPool:\n\
+  \    def __init__(self, size: int):\n        if size <= 0:\n            raise ValueError(\"\
+  size must be > 0\")\n        self._size = size\n        self._checked_out: int =\
+  \ 0\n        self._closed: bool = False\n\n    async def __aenter__(self) -> \"\
+  ConnectionPool\":\n        if self._closed:\n            raise PoolClosedError(\"\
+  pool already closed\")\n        return self\n\n    async def __aexit__(self, exc_type,\
+  \ exc, tb) -> bool:\n        self._closed = True\n        # Return False so exceptions\
+  \ propagate — we're a cleanup, not a swallower.\n        return False\n\n    async\
+  \ def acquire(self) -> int:\n        if self._closed:\n            raise PoolClosedError(\"\
+  pool closed\")\n        if self._checked_out >= self._size:\n            raise RuntimeError(\"\
+  pool exhausted\")\n        self._checked_out += 1\n        await asyncio.sleep(0)\n\
+  \        return self._checked_out\n\n    async def release(self) -> None:\n    \
+  \    if self._checked_out == 0:\n            raise RuntimeError(\"nothing to release\"\
+  )\n        self._checked_out -= 1\n        await asyncio.sleep(0)\n"

--- a/tests/evals/cases/code_documentation_raw/11_decorator_retry.yaml
+++ b/tests/evals/cases/code_documentation_raw/11_decorator_retry.yaml
@@ -1,0 +1,19 @@
+name: Retry decorator with selective exception catching
+description: Configurable retry count + allowed exception types. Tests must cover
+  success-first-try, success-after-retry, exhaustion, and non-matching exception passthrough.
+language: python
+doc_format: markdown
+must_document:
+- retry
+code: "from functools import wraps\n\n\ndef retry(times: int = 3, exceptions: tuple[type[BaseException],\
+  \ ...] = (Exception,)):\n    \"\"\"Retry a callable up to `times` attempts when\
+  \ it raises one of `exceptions`.\n\n    Raises the last captured exception if all\
+  \ attempts fail. Exceptions NOT in\n    `exceptions` propagate immediately (no retry).\n\
+  \    \"\"\"\n    if times < 1:\n        raise ValueError(\"times must be >= 1\"\
+  )\n\n    def decorator(fn):\n        @wraps(fn)\n        def wrapper(*args, **kwargs):\n\
+  \            last_exc: BaseException | None = None\n            for attempt in range(times):\n\
+  \                try:\n                    return fn(*args, **kwargs)\n        \
+  \        except exceptions as exc:\n                    last_exc = exc\n       \
+  \             continue\n            assert last_exc is not None  # for type narrowing\n\
+  \            raise last_exc\n        wrapper.attempts_spec = times\n        return\
+  \ wrapper\n\n    return decorator\n"

--- a/tests/evals/cases/code_documentation_raw/12_pipeline_compose.yaml
+++ b/tests/evals/cases/code_documentation_raw/12_pipeline_compose.yaml
@@ -1,0 +1,21 @@
+name: Pipeline composition with validation
+description: Generic pipeline that chains callables with shape validation at each
+  step. Tests must cover normal flow, invalid step signatures, and early exit.
+language: python
+doc_format: markdown
+must_document:
+- PipelineError
+- Pipeline
+code: "from typing import Any, Callable, Iterable\n\nclass PipelineError(RuntimeError):\n\
+  \    pass\n\n\nclass Pipeline:\n    def __init__(self, steps: Iterable[Callable[[Any],\
+  \ Any]]):\n        steps_list = list(steps)\n        if not steps_list:\n      \
+  \      raise ValueError(\"pipeline needs at least one step\")\n        for i, step\
+  \ in enumerate(steps_list):\n            if not callable(step):\n              \
+  \  raise TypeError(f\"step {i} is not callable: {step!r}\")\n        self._steps\
+  \ = steps_list\n\n    def run(self, initial: Any) -> Any:\n        value = initial\n\
+  \        for i, step in enumerate(self._steps):\n            try:\n            \
+  \    value = step(value)\n            except Exception as exc:\n               \
+  \ raise PipelineError(f\"step {i} ({step.__name__}) failed: {exc}\") from exc\n\
+  \            if value is None:\n                # Convention: a step returning None\
+  \ means \"abort pipeline\".\n                break\n        return value\n\n   \
+  \ def __len__(self) -> int:\n        return len(self._steps)\n"

--- a/tests/evals/cases/code_documentation_raw/13_lru_memoize.yaml
+++ b/tests/evals/cases/code_documentation_raw/13_lru_memoize.yaml
@@ -1,0 +1,27 @@
+name: LRU memoize decorator
+description: Hand-rolled LRU cache tracking hit/miss stats and evicting on maxsize.
+  Tests must cover cache hits, misses, eviction order, and stats.
+language: python
+doc_format: markdown
+must_document:
+- MemoizeStats
+- memoize
+code: "from collections import OrderedDict\nfrom functools import wraps\nfrom typing\
+  \ import Any, Callable\n\n\nclass MemoizeStats:\n    def __init__(self) -> None:\n\
+  \        self.hits: int = 0\n        self.misses: int = 0\n\n    @property\n   \
+  \ def calls(self) -> int:\n        return self.hits + self.misses\n\n    def reset(self)\
+  \ -> None:\n        self.hits = 0\n        self.misses = 0\n\n\ndef memoize(maxsize:\
+  \ int = 128) -> Callable:\n    \"\"\"LRU memoize decorator. Exposes a ``.stats``\
+  \ attribute and a ``.clear()`` method.\n\n    Cache key = (args, sorted kwargs items).\
+  \ All args must be hashable.\n    \"\"\"\n    if maxsize < 1:\n        raise ValueError(\"\
+  maxsize must be >= 1\")\n\n    def decorator(fn: Callable) -> Callable:\n      \
+  \  cache: \"OrderedDict[tuple, Any]\" = OrderedDict()\n        stats = MemoizeStats()\n\
+  \n        @wraps(fn)\n        def wrapper(*args: Any, **kwargs: Any) -> Any:\n \
+  \           key = (args, tuple(sorted(kwargs.items())))\n            if key in cache:\n\
+  \                cache.move_to_end(key)\n                stats.hits += 1\n     \
+  \           return cache[key]\n            stats.misses += 1\n            result\
+  \ = fn(*args, **kwargs)\n            cache[key] = result\n            if len(cache)\
+  \ > maxsize:\n                cache.popitem(last=False)  # evict LRU\n         \
+  \   return result\n\n        def clear() -> None:\n            cache.clear()\n \
+  \           stats.reset()\n\n        wrapper.stats = stats\n        wrapper.clear\
+  \ = clear\n        return wrapper\n\n    return decorator\n"

--- a/tests/evals/runner.py
+++ b/tests/evals/runner.py
@@ -46,9 +46,11 @@ import yaml
 
 from collegue.config import settings
 from collegue.resources.llm.providers import LLMConfig, generate_text
+from collegue.tools.code_documentation import DocumentationRequest, DocumentationTool
 from collegue.tools.test_generation import TestGenerationRequest, TestGenerationTool
 
 from tests.evals.eval_context import EvalContext
+from tests.evals.scorers import code_documentation as doc_scorer
 from tests.evals.scorers import test_generation as tg_scorer
 
 
@@ -190,6 +192,95 @@ async def _run_test_generation_competent(case: Dict[str, Any], ctx: EvalContext)
     return response.text or ""
 
 
+# ---------------------------------------------------------------------------
+# code_documentation runners (PR #246) — mirror the test_generation trio.
+# The scorer is currently a stub that returns 1.0 (PR B); PR C replaces it
+# with an LLM-as-judge on a 4-axis rubric.
+# ---------------------------------------------------------------------------
+
+
+async def _run_code_documentation(case: Dict[str, Any], ctx: EvalContext) -> str:
+    tool = DocumentationTool()
+    tool.prompt_engine = _get_shared_prompt_engine()
+    request = DocumentationRequest(
+        code=case["code"],
+        language=case.get("language", "python"),
+        doc_format=case.get("doc_format", "markdown"),
+    )
+    response = await tool.execute_async(request, ctx=ctx)
+    return response.documentation
+
+
+_DOC_RAW_SYSTEM_PROMPT = (
+    "You are an expert developer. Write documentation for the code you "
+    "receive. Output the documentation as markdown — nothing else."
+)
+
+_DOC_COMPETENT_SYSTEM_PROMPT = (
+    "You are an expert developer writing reference documentation. Always: "
+    "describe every public function/class/method with its purpose, "
+    "parameters (name + type + meaning), return value, and exceptions "
+    "raised; give at least one runnable usage example per public entry "
+    "point; use consistent terminology; output pure markdown, no prose "
+    "preamble."
+)
+
+
+async def _run_code_documentation_raw(case: Dict[str, Any], ctx: EvalContext) -> str:
+    """Bypass the MCP tool — just ask the LLM for markdown docs."""
+    config = LLMConfig(
+        model_name=ctx.model,
+        api_key=settings.LLM_API_KEY,
+        max_tokens=EvalContext.MIN_MAX_TOKENS,
+        temperature=0.5,
+    )
+    language = case.get("language", "python")
+    prompt = (
+        f"Write markdown documentation for the following {language} code.\n\n"
+        f"```{language}\n{case['code']}\n```\n"
+    )
+    response = await generate_text(config, prompt, system_prompt=_DOC_RAW_SYSTEM_PROMPT)
+    ctx.calls.append({
+        "temperature": config.temperature,
+        "max_tokens": config.max_tokens,
+        "prompt_len": len(prompt),
+        "response_len": len(response.text or ""),
+        "path": "raw",
+    })
+    return response.text or ""
+
+
+async def _run_code_documentation_competent(case: Dict[str, Any], ctx: EvalContext) -> str:
+    """Bypass the MCP tool but use a careful 'competent user' prompt."""
+    config = LLMConfig(
+        model_name=ctx.model,
+        api_key=settings.LLM_API_KEY,
+        max_tokens=EvalContext.MIN_MAX_TOKENS,
+        temperature=0.5,
+    )
+    language = case.get("language", "python")
+    prompt = (
+        f"Write reference markdown documentation for the following {language} code.\n\n"
+        f"Requirements:\n"
+        f"- For every public symbol, document purpose, parameters (with types), "
+        f"return value, and exceptions raised.\n"
+        f"- Include at least one runnable usage example per public entry point.\n"
+        f"- Use descriptive section headers; keep terminology consistent.\n"
+        f"- Do not restate the source code; assume the reader has it.\n"
+        f"- Output pure markdown only.\n\n"
+        f"```{language}\n{case['code']}\n```\n"
+    )
+    response = await generate_text(config, prompt, system_prompt=_DOC_COMPETENT_SYSTEM_PROMPT)
+    ctx.calls.append({
+        "temperature": config.temperature,
+        "max_tokens": config.max_tokens,
+        "prompt_len": len(prompt),
+        "response_len": len(response.text or ""),
+        "path": "competent",
+    })
+    return response.text or ""
+
+
 TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
     "test_generation": {
         "run": _run_test_generation,
@@ -205,6 +296,21 @@ TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
         "run": _run_test_generation_competent,
         "score": tg_scorer.score,
         "cases_subdir": "test_generation_competent",
+    },
+    "code_documentation": {
+        "run": _run_code_documentation,
+        "score": doc_scorer.score,
+        "cases_subdir": "code_documentation",
+    },
+    "code_documentation_raw": {
+        "run": _run_code_documentation_raw,
+        "score": doc_scorer.score,
+        "cases_subdir": "code_documentation_raw",
+    },
+    "code_documentation_competent": {
+        "run": _run_code_documentation_competent,
+        "score": doc_scorer.score,
+        "cases_subdir": "code_documentation_competent",
     },
 }
 

--- a/tests/evals/scorers/code_documentation.py
+++ b/tests/evals/scorers/code_documentation.py
@@ -1,0 +1,36 @@
+"""Stub scorer for ``code_documentation``.
+
+PR B ships the pipeline plumbing — case files, runner registry entries, and
+this stub that returns a fixed 1.0 so a matrix run end-to-end produces a
+valid report. The **real** LLM-as-judge scorer lands in PR C (#246 tracker),
+which will replace `score` below without changing its signature.
+
+Keeping the scorer API identical to `test_generation.score` — same
+``EvalScore`` shape — means the runner and report renderer need zero
+schema-aware branching.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from tests.evals.scorers.test_generation import EvalScore
+
+
+def score(case: Dict[str, Any], doc_output: str) -> EvalScore:
+    """Stub — always returns a clean 1.0.
+
+    The real scorer (PR C) will run an LLM-as-judge over ``doc_output``
+    with a 4-axis rubric (accuracy, completeness, clarity, usefulness) on
+    0-5 scale and return ``score = mean/5``. For PR B we only need the
+    pipeline to render reports, so we short-circuit.
+    """
+    return EvalScore(
+        score=1.0,
+        collected=4,   # 4 axes (stub convention)
+        passed=4,
+        failed=0,
+        errors=0,
+        skipped=0,
+        duration_s=0.0,
+        stdout_tail="[stub scorer — replace in PR C with real LLM-as-judge]",
+    )


### PR DESCRIPTION
Closes partiellement [#246](https://github.com/VynoDePal/Collegue/issues/246) (PR B du chantier). PR A mergée en #245. PR C (vrai scorer + matrice) arrive ensuite.

## Ce que fait cette PR

Scaffolding complet du pipeline eval `code_documentation`. Pipeline end-to-end marche — **avec un stub scorer qui retourne 1.0**. PR C remplacera juste le body de la fonction `score()` sans toucher à rien d'autre.

## Changements

### [tests/evals/runner.py](tests/evals/runner.py)

- Import `DocumentationTool` / `DocumentationRequest` + nouveau module `code_documentation` scorer
- 3 nouvelles fonctions `_run_code_documentation*` (mirror exact du trio test_generation) :
  - **MCP path** : instancie `DocumentationTool`, injecte le shared engine, retourne `response.documentation`
  - **Raw path** : bypass MCP, prompt 2 lignes *"Write markdown documentation for this code"*
  - **Competent path** : bypass MCP, prompt *"every public symbol documented, runnable examples, consistent terminology"*
- 3 nouvelles entrées `TOOL_REGISTRY` pointant sur le stub scorer
- argparse `--tool` choices se met à jour automatiquement (dérivé de `TOOL_REGISTRY.keys()`)

### [tests/evals/scorers/code_documentation.py](tests/evals/scorers/code_documentation.py) (nouveau)

Stub scorer, ~30 lignes. Retourne `EvalScore(score=1.0, collected=4, passed=4, ...)`. Le `collected=4` anticipe la rubric 4-axes (accuracy, completeness, clarity, usefulness) de PR C. Réutilise `EvalScore` de `test_generation.py` — **même shape = zéro schema-aware branching dans le report renderer**.

### tests/evals/cases/code_documentation{,_raw,_competent}/ (nouveaux)

13 YAML × 3 répertoires = **39 fichiers** générés via un script one-shot depuis le corpus `test_generation`. Pour chaque cas :
- `code` block copié verbatim (apples-to-apples entre tools)
- `doc_format: markdown` (consommé par `DocumentationRequest`)
- `must_document: [list]` — top-level public `def`s et `class`es extraits via AST. **PR C utilise cette liste pour ancrer l'axe Completeness du judge.**

Exemple de case :
```yaml
name: "Arithmetic utility"
description: "Simple pure functions with known I/O including an error branch"
language: python
doc_format: markdown
must_document: [add, divide, clamp]
code: |
  def add(a, b):
      return a + b
  ...
```

## Smoke test

```
$ python -m tests.evals.runner \
    --tool code_documentation \
    --tool code_documentation_raw \
    --tool code_documentation_competent \
    --model gemini-2.5-flash --case 01_arithmetic

[1/3] code_documentation             · gemini-2.5-flash · 01_arithmetic → ✅ 1.000 passed=4/4
[2/3] code_documentation_raw         · gemini-2.5-flash · 01_arithmetic → ✅ 1.000 passed=4/4
[3/3] code_documentation_competent   · gemini-2.5-flash · 01_arithmetic → ✅ 1.000 passed=4/4
```

3 paths distincts observés :
- MCP : prompt 1071 chars (via template YAML)
- Raw : prompt 313 chars (minimal)
- Competent : prompt 668 chars (développeur soigneux)

Chacun produit un output markdown différent. Pipeline sain.

## Impact pytest

| Métrique | Avant | Après |
|---|---|---|
| Passed | 571 | **571** |
| Failed | 0 | 0 |

## Ce que ça ne fait PAS

**Les scores 1.000 ci-dessus sont du stub, pas de la vraie mesure.** Ils prouvent que le plumbing marche, ils **ne mesurent pas** la qualité de la doc.

PR C ajoutera le body réel de `score()` :
- 4-axis rubric (accuracy, completeness, clarity, usefulness) × 0-5
- Judge = `gemini-2.5-flash` pinné, temperature 0.0
- Prompt G-Eval style avec `reasoning` CoT ≤ 60 mots avant les scores
- Fallback : JSON invalide → `errors=1, score=0.0`
- Matrice 2 modèles × 13 × 3 paths = 156 LLM calls (~$1, ~15 min)
- Numbers dans le body de PR C

## Test plan

- [x] `pytest tests/` → 571 passed, 0 failed
- [x] Smoke `python -m tests.evals.runner --tool code_documentation* --case 01_arithmetic` → 3 paths marchent
- [x] Report.md se rend correctement avec les scores stub
- [x] 3 paths produisent des outputs distincts (prompts différents, responses différentes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)