### PR TITLE
feat(evals): LLM-as-judge scorer for code_documentation + matrix v1 (#246)

### DIFF
--- a/docs/llm_evals.md
+++ b/docs/llm_evals.md
@@ -11,11 +11,15 @@ tests/evals/
 ├── eval_context.py              # Shim ctx.sample() qui appelle generate_text directement
 ├── runner.py                    # CLI, loader YAML, orchestrateur, writer rapport/matrix
 ├── scorers/
-│   └── test_generation.py       # Exécute les tests générés dans pytest, score = passed/collected
+│   ├── test_generation.py       # Rule-based — lance pytest, score = passed/collected
+│   └── code_documentation.py    # LLM-as-judge — 4-axis rubric, gemini-2.5-flash fixed
 ├── cases/
 │   ├── test_generation/             # 13 cas — chemin via le tool MCP Collègue
 │   ├── test_generation_raw/         # Mêmes 13 cas — chemin LLM direct (prompt minimal)
-│   └── test_generation_competent/   # Mêmes 13 cas — chemin LLM avec prompt "utilisateur qui sait pytest"
+│   ├── test_generation_competent/   # Mêmes 13 cas — chemin LLM avec prompt "utilisateur qui sait pytest"
+│   ├── code_documentation/          # 13 cas — chemin via le tool MCP code_documentation
+│   ├── code_documentation_raw/      # Mêmes 13 cas — chemin LLM direct
+│   └── code_documentation_competent/# Mêmes 13 cas — chemin LLM "dev qui connaît la doc ref"
 └── reports/                     # Runtime (gitignored)
 ```
 
@@ -37,7 +41,9 @@ Le matrix report calcule deux Δ qui sont les vraies mesures de valeur :
 ### Caractéristiques
 
 - **Runner in-process** : n'utilise pas le harness HTTP MCP. Instancie directement le tool et lui passe un `EvalContext` qui implémente `ctx.sample()` en déléguant à `generate_text()` (même helper que le Watchdog). Pas besoin de lancer Docker — `LLM_API_KEY` dans l'env et c'est parti.
-- **Scorer rule-based** pour `test_generation` : on écrit le code source + les tests générés dans un tempdir et on lance `pytest test_src.py`. Score = `passed / collected`. Pas de LLM-as-judge dans cette itération.
+- **Deux types de scorers** :
+  - **Rule-based** pour `test_generation` : on écrit le code source + les tests générés dans un tempdir et on lance `pytest test_src.py`. Score = `passed / collected`. Objectif et déterministe.
+  - **LLM-as-judge** pour `code_documentation` : un second appel LLM note la doc sur 4 axes (accuracy, completeness, clarity, usefulness) × 0-5. Score = `mean(axes) / 5`. Le judge est `gemini-2.5-flash` pinné à `temperature=0.0` pour stabilité. Nécessaire dès qu'on mesure un output subjectif (pas d'oracle).
 
 ## Usage
 
@@ -138,6 +144,77 @@ Run complet **195 appels LLM** sur 13 cas × 3 paths × 5 modèles.
 - **Δ MCP − Competent négatif sur ≥ 2 modèles sur 5** → red flag, l'outil n'ajoute plus de valeur par rapport à un utilisateur compétent
 - **Un case individuel à 0.000 sur ≥ 3 modèles** → template ou extracteur cassé
 
+## Matrice `code_documentation` v1
+
+Premier run LLM-as-judge du repo. 78 appels générateur + 78 appels judge = **156 LLM calls** sur 13 cas × 3 paths × 2 modèles (`gemini-2.5-flash` + `gemma-4-31b-it`).
+
+### Rubric LLM-as-judge
+
+Le judge (`gemini-2.5-flash` pinné, `temperature=0.0`) note chaque doc sur **4 axes × 0-5** :
+
+| Axe | 0 | 3 | 5 |
+|---|---|---|---|
+| **accuracy** | APIs inventées, signatures fausses | Mostly correct, 1 misrep mineur | Every claim verifiable contre le code |
+| **completeness** | Surface publique manquante | Main entities documentées, 1 symbole manque | Tous symboles + params + returns + exceptions |
+| **clarity** | Markdown cassé, structure confuse | Lisible mais inégal | Bien organisé, scannable, terminology consistant |
+| **usefulness** | Lecteur doit lire le code | Common case couvert, edge cases manquent | Dev utilise correctement la code depuis la doc seule |
+
+Score final = `mean(axes) / 5` → 0-1.
+
+Prompt du judge : G-Eval style, paragraphe `reasoning` ≤ 60 mots **avant** le JSON. `max_tokens=4000` (le reasoning interne de Gemini 2.5 consomme 1-2k tokens silencieusement).
+
+### Scores moyens par path
+
+| Modèle | MCP | Competent | Raw |
+|---|---|---|---|
+| `gemini-2.5-flash` | 0.985 | **1.000** | **1.000** |
+| `gemma-4-31b-it` | 0.931 | **0.969** | **0.977** |
+| **Global** | **0.958** | **0.985** | **0.988** |
+
+### Δ par modèle
+
+#### Δ MCP − Raw (vs utilisateur naïf)
+
+| Modèle | MCP | Raw | **Δ** |
+|---|---|---|---|
+| `gemini-2.5-flash` | 0.985 | 1.000 | **−0.015** |
+| `gemma-4-31b-it` | 0.931 | 0.977 | **−0.046** |
+
+#### Δ MCP − Competent (vs utilisateur qui sait)
+
+| Modèle | MCP | Competent | **Δ** |
+|---|---|---|---|
+| `gemini-2.5-flash` | 0.985 | 1.000 | **−0.015** |
+| `gemma-4-31b-it` | 0.931 | 0.969 | **−0.038** |
+
+### Lecture — MCP ne bat pas les baselines
+
+**Les deux Δ sont négatifs sur les 2 modèles.** Contrairement à `test_generation` où MCP apportait +0.15 à +0.68 sur Δ MCP−Raw, ici MCP **perd** de 1 à 5 points à tous les coups.
+
+Cause racine identifiée en inspectant un cas qui perd (`08_inheritance` sur gemini-2.5-flash, MCP=0.85 vs raw=1.00) :
+
+- Le template MCP actuel impose un *« Output ONLY the documentation content — no preamble »*. Le modèle obéit littéralement et commence directement par `### class Shape`, sans vue d'ensemble du module.
+- Le judge pénalise cette absence sur l'axe **Clarity** (3/5) et **Usefulness** (4/5) : *« no module-level overview, reader has to figure out intent »*.
+- Le path **raw** n'a pas cette contrainte, donc le modèle écrit naturellement un paragraphe d'intro (*« This module defines an abstract base class Shape... »*), que le judge note 5/5 partout.
+
+La contrainte « no preamble » qui marche pour `test_generation` (où le préambule en prose casse l'import pytest) **ne se transpose pas** à la documentation, où une vue d'ensemble EST une partie utile du livrable. Follow-up : reformuler le contrat de sortie du template documentation sans cette interdiction.
+
+### Autres observations
+
+- **Ceiling effect attendu** : 8/13 cas scorent 1.000 sur les 3 paths × 2 modèles. Les cas simples (arithmetic, class_init, type_hints) sont trop faciles pour différencier. Les 5 cas complexes (state_machine, async_context, decorator_retry, pipeline_compose, lru_memoize) portent le signal.
+- **Judge family-bias confirmé probable** : le judge `gemini-2.5-flash` note gemini-2.5-flash-generated docs à 0.985, gemma-4-31b-it à 0.931. Un écart de +0.054 pour le modèle de la même famille sans qu'il produise objectivement des docs meilleures. Mitigation : lire les **deltas** pas les absolus. Ici les deltas sont comparables (négatifs des deux côtés, magnitude similaire), donc le biais ne change pas la conclusion.
+- **0 errors sur 78 cases** : pipeline robuste, parsing JSON du judge marche, aucun call crashé.
+
+### Seuils de régression
+
+- **MCP avg global < 0.85** → investiguer (v1 tient 0.958)
+- **MCP avg < 0.85 sur un modèle individuel** → régression sur ce modèle (v1 : 0.931 gemma, 0.985 gemini)
+- **0 errors / 78** : si ce nombre monte sur un futur run, soit le judge est cassé, soit la rate limit Gemini a frappé
+
+### Follow-up ouvert : reformuler le template doc
+
+Suite directe de cette matrice v1 : issue séparée à ouvrir pour reformuler [collegue/prompts/templates/tools/documentation/default.yaml](../collegue/prompts/templates/tools/documentation/default.yaml) — retirer *« Output ONLY the documentation content — no preamble »* et autoriser (voire demander) une vue d'ensemble module-level. Attendre qu'une matrice v2 montre Δ MCP − Competent ≥ +0.05 sur au moins 1 modèle avant de considérer le tool documentation comme apportant de la valeur.
+
 ## Format d'un cas
 
 ```yaml
@@ -159,7 +236,7 @@ Contraintes :
 
 ## Scoring — détails
 
-Pour `test_generation` :
+### `test_generation` (rule-based pytest)
 
 1. Extraction du code de test depuis le `response.text` du tool
    - Cherche d'abord un fence ` ```python ... ``` ` contenant `def test_`
@@ -172,6 +249,21 @@ Pour `test_generation` :
    - `collected == 0` → **0.0** (aucun test collectable, syntax error généralement)
    - `collected < min_expected_tests` → `passed/collected × 0.7` (pénalité quantité)
    - Sinon → `passed / collected`
+
+### `code_documentation` (LLM-as-judge)
+
+1. Construit un prompt judge avec 3 blocs : `<code_under_test>`, `<must_document>` (symboles publics attendus), `<generated_documentation>`
+2. Appelle `gemini-2.5-flash` (pinné, `temperature=0.0`, `max_tokens=4000`)
+3. Parse la réponse : regex `\{[^{}]*\}` + `json.loads`, prend le dernier match valide (le judge émet souvent un paragraphe `reasoning` avant le JSON)
+4. Valide que les 4 axes (`accuracy`, `completeness`, `clarity`, `usefulness`) sont des int 0-5
+5. Score :
+   - JSON invalide / axe hors-bornes → **0.0** avec `errors=1`
+   - Doc output vide → **0.0** avec `errors=1`
+   - Sinon → `sum(axes) / 20.0` (normalisation en 0-1)
+
+Pourquoi pas ensemble (3 appels médiane) : coût × 3 pour une réduction de noise ~√3. On préfère re-runner la matrice 3 fois et comparer les moyennes par cellule si le noise floor devient un problème.
+
+Pourquoi pas un judge cross-family : `openai`/`anthropic` demanderaient une clé API + infra de provider supplémentaire. Known limitation ; mitigée en lisant les deltas, pas les absolus.
 
 ## Ajouter un nouveau tool
 

--- a/tests/evals/runner.py
+++ b/tests/evals/runner.py
@@ -374,7 +374,11 @@ async def _run_single_case(
             "stdout_tail": raw_error,
         }
     else:
-        eval_score = entry["score"](case, tool_output)
+        score_fn = entry["score"]
+        if asyncio.iscoroutinefunction(score_fn):
+            eval_score = await score_fn(case, tool_output)
+        else:
+            eval_score = score_fn(case, tool_output)
         score_payload = dataclasses.asdict(eval_score)
 
     record = {

--- a/tests/evals/scorers/code_documentation.py
+++ b/tests/evals/scorers/code_documentation.py
@@ -1,36 +1,239 @@
-"""Stub scorer for ``code_documentation``.
+"""LLM-as-judge scorer for ``code_documentation``.
 
-PR B ships the pipeline plumbing — case files, runner registry entries, and
-this stub that returns a fixed 1.0 so a matrix run end-to-end produces a
-valid report. The **real** LLM-as-judge scorer lands in PR C (#246 tracker),
-which will replace `score` below without changing its signature.
+Unlike ``test_generation``, documentation quality is subjective — you can't
+run it against an oracle like pytest. We score each generated doc on 4 axes
+(accuracy, completeness, clarity, usefulness) using a fixed judge model
+(``gemini-2.5-flash``, temperature 0.0). Design follows G-Eval (arXiv
+2303.16634) : short chain-of-thought before structured scoring, with
+anchor descriptions at 0/3/5 to reduce grader variance.
 
-Keeping the scorer API identical to `test_generation.score` — same
-``EvalScore`` shape — means the runner and report renderer need zero
-schema-aware branching.
+## Rubric
+
+Each axis 0-5 (integers), three anchor descriptions in the judge prompt:
+
+- **Accuracy**     0 = invented APIs / wrong signatures / wrong raises.
+                   3 = mostly correct, one minor misrepresentation.
+                   5 = every claim is verifiable against the code.
+- **Completeness** 0 = entire public surface missing.
+                   3 = main entities documented; at least one is missing.
+                   5 = every public symbol + params + returns + exceptions.
+- **Clarity**      0 = unreadable, broken markdown.
+                   3 = readable but uneven.
+                   5 = well-organised, scannable, consistent terminology.
+- **Usefulness**   0 = reader still has to read the code.
+                   3 = covers common case, skips usage examples / edge notes.
+                   5 = correct use possible from doc alone, including errors.
+
+Final score = mean(axes) / 5 → 0-1, normalised so the runner's report
+renderer (which expects 0-1 floats) works without schema-aware branching.
+
+## Judge model: pinned `gemini-2.5-flash`
+
+Stability (GA, no preview drift), low cost, rate-limit headroom. Self-bias
+against Gemma generators is a known limitation — mitigated by reporting
+**Δ MCP − Competent** rather than absolute scores.
+
+## Fallback policy
+
+Invalid JSON from the judge → ``errors=1, score=0.0``. Silent fallback to
+1.0 would poison the matrix (the whole point of PR B → PR C was to stop
+trusting the stub).
 """
 from __future__ import annotations
 
-from typing import Any, Dict
+import json
+import re
+import time
+from typing import Any, Dict, Optional
+
+from collegue.config import settings
+from collegue.resources.llm.providers import LLMConfig, generate_text
 
 from tests.evals.scorers.test_generation import EvalScore
 
 
-def score(case: Dict[str, Any], doc_output: str) -> EvalScore:
-    """Stub — always returns a clean 1.0.
+JUDGE_MODEL = "gemini-2.5-flash"
+_AXES = ("accuracy", "completeness", "clarity", "usefulness")
 
-    The real scorer (PR C) will run an LLM-as-judge over ``doc_output``
-    with a 4-axis rubric (accuracy, completeness, clarity, usefulness) on
-    0-5 scale and return ``score = mean/5``. For PR B we only need the
-    pipeline to render reports, so we short-circuit.
+_JUDGE_PROMPT_TEMPLATE = """\
+You are evaluating the quality of developer-facing code documentation
+produced by an automated tool. You are strict but fair. Your output is
+machine-parsed.
+
+<code_under_test>
+{code}
+</code_under_test>
+
+<must_document>
+{must_document}
+</must_document>
+
+<generated_documentation>
+{documentation}
+</generated_documentation>
+
+Score the documentation on four axes (0 to 5, integers only):
+
+- accuracy:     0 = describes functionality that does not exist or contradicts
+                    the code (invented APIs, wrong signatures, wrong raises).
+                3 = mostly correct with one minor misrepresentation.
+                5 = every claim is verifiable against the code.
+
+- completeness: 0 = entire public surface is missing (no params, returns, or
+                    exceptions documented).
+                3 = main entities documented, but at least one symbol in
+                    <must_document> OR one raise-site is missing.
+                5 = every public symbol from <must_document>, every parameter,
+                    return value, and raised exception is covered.
+
+- clarity:      0 = unreadable, confusing structure, broken markdown.
+                3 = readable but uneven (mixed terminology, shallow headings).
+                5 = well-organised, scannable, terminology consistent,
+                    appropriate for a working developer.
+
+- usefulness:   0 = reader still has to read the code to use it.
+                3 = covers the common case but omits usage examples or
+                    non-obvious constraints.
+                5 = a developer can use the code correctly from the doc
+                    alone, including edge cases and error handling.
+
+First, write a <= 60-word reasoning paragraph evaluating the documentation
+against all four axes together. Then emit ONLY a JSON object on a single
+line.
+
+Output contract — exactly this shape, no markdown fence, no prose after:
+{{"reasoning": "<= 60 words", "accuracy": 0-5, "completeness": 0-5, "clarity": 0-5, "usefulness": 0-5}}
+"""
+
+
+def _build_judge_prompt(case: Dict[str, Any], doc_output: str) -> str:
+    must_doc = case.get("must_document", [])
+    if isinstance(must_doc, list):
+        must_doc_str = ", ".join(must_doc) if must_doc else "(none listed)"
+    else:
+        must_doc_str = str(must_doc)
+    return _JUDGE_PROMPT_TEMPLATE.format(
+        code=case.get("code", ""),
+        must_document=must_doc_str,
+        documentation=doc_output,
+    )
+
+
+def _extract_json_object(text: str) -> Optional[Dict[str, Any]]:
+    """Find the first ``{...}`` block and json.loads it.
+
+    Tolerant to the judge emitting a reasoning paragraph before the JSON
+    or a trailing newline — we just grep the last well-formed object.
     """
+    if not text:
+        return None
+    # Judge is instructed to emit the JSON at the end; prefer the last match.
+    matches = list(re.finditer(r"\{[^{}]*\}", text, flags=re.DOTALL))
+    for match in reversed(matches):
+        try:
+            return json.loads(match.group(0))
+        except json.JSONDecodeError:
+            continue
+    return None
+
+
+def _axes_from_payload(payload: Dict[str, Any]) -> Optional[Dict[str, int]]:
+    """Validate each axis is an integer 0-5. Return None on any failure."""
+    result: Dict[str, int] = {}
+    for axis in _AXES:
+        value = payload.get(axis)
+        if not isinstance(value, int) or value < 0 or value > 5:
+            # Coerce floats like 4.0 but reject 4.5 or strings.
+            if isinstance(value, float) and value == int(value):
+                value = int(value)
+            else:
+                return None
+        result[axis] = int(value)
+    return result
+
+
+async def _call_judge(prompt: str) -> str:
+    config = LLMConfig(
+        model_name=JUDGE_MODEL,
+        api_key=settings.LLM_API_KEY,
+        # Gemini 2.5 has an internal reasoning phase that consumes output
+        # budget silently (can swallow 1-2k tokens before emitting anything
+        # user-visible). Empirically 400 and 800 truncated the JSON right
+        # after the reasoning paragraph; 4000 lets the judge emit both.
+        max_tokens=4000,
+        temperature=0.0,
+    )
+    response = await generate_text(config, prompt)
+    return response.text or ""
+
+
+async def score(case: Dict[str, Any], doc_output: str) -> EvalScore:
+    """LLM-as-judge score for a generated documentation output.
+
+    Async because the judge makes a Gemini call. The runner detects
+    coroutine scorers and awaits them — sync scorers (like
+    ``test_generation.score``) still work unchanged.
+    """
+    started = time.monotonic()
+    judge_raw = ""
+
+    if not (doc_output or "").strip():
+        # Empty output from the generator — no point judging, score 0.
+        return EvalScore(
+            score=0.0,
+            collected=4,
+            passed=0,
+            failed=4,
+            errors=1,
+            skipped=0,
+            duration_s=time.monotonic() - started,
+            stdout_tail="[empty doc_output — generator returned no content]",
+        )
+
+    prompt = _build_judge_prompt(case, doc_output)
+    try:
+        judge_raw = await _call_judge(prompt)
+    except Exception as exc:  # network / rate-limit / model crash
+        return EvalScore(
+            score=0.0,
+            collected=4,
+            passed=0,
+            failed=4,
+            errors=1,
+            skipped=0,
+            duration_s=time.monotonic() - started,
+            stdout_tail=f"[judge call raised {type(exc).__name__}: {exc}]",
+        )
+
+    payload = _extract_json_object(judge_raw)
+    axes = _axes_from_payload(payload) if payload else None
+    if axes is None:
+        return EvalScore(
+            score=0.0,
+            collected=4,
+            passed=0,
+            failed=4,
+            errors=1,
+            skipped=0,
+            duration_s=time.monotonic() - started,
+            stdout_tail=f"[judge output unparseable]\n{judge_raw[:1000]}",
+        )
+
+    total = sum(axes.values())
+    passed_count = sum(1 for v in axes.values() if v >= 3)
+    reasoning = (payload.get("reasoning") or "")[:200]
+    tail = (
+        f"judge={JUDGE_MODEL} "
+        f"axes={axes} "
+        f"reasoning={reasoning!r}"
+    )
     return EvalScore(
-        score=1.0,
-        collected=4,   # 4 axes (stub convention)
-        passed=4,
-        failed=0,
+        score=round(total / 20.0, 3),  # mean of 4 axes, each 0-5 → total 0-20
+        collected=4,
+        passed=passed_count,
+        failed=4 - passed_count,
         errors=0,
         skipped=0,
-        duration_s=0.0,
-        stdout_tail="[stub scorer — replace in PR C with real LLM-as-judge]",
+        duration_s=round(time.monotonic() - started, 2),
+        stdout_tail=tail,
     )


### PR DESCRIPTION
Closes [#246](https://github.com/VynoDePal/Collegue/issues/246) (PR C du chantier, après #245 et #247).

## Ce que fait cette PR

Remplace le stub scorer de PR B par un **LLM-as-judge réel** sur 4 axes. Lance la **matrice v1** (78 gen + 78 judge = 156 LLM calls). Document les résultats honnêtement.

**Headline** : le pipeline marche. Les numbers sont **sobres** — MCP perd face aux baselines. Analyse ci-dessous.

## Design du judge (evidence-based)

| Décision | Choix | Rationale |
|---|---|---|
| Rubric | 4 axes (accuracy, completeness, clarity, usefulness) | Convergence de la littérature : *Beyond Accuracy* (arxiv 2007.10744) + pratique qodo-cover. Au-delà de 5 axes, le noise domine. |
| Scale | 0-5 integer avec ancrages 0/3/5 dans le prompt | Best alignment humain selon arxiv 2601.03444. Prometheus 2 (arxiv 2405.01535) utilise la même structure, atteint Pearson 0.6-0.7 avec GPT-4. |
| CoT | Paragraphe `reasoning` ≤ 60 mots **avant** le JSON | G-Eval (arxiv 2303.16634) : Spearman 0.514 avec humains quand le judge raisonne d'abord. |
| Judge model | `gemini-2.5-flash` pinné, temperature 0.0, max_tokens 4000 | Seul GA stable dans notre liste (pas les `-preview`). Self-bias contre Gemma mitigé en reportant **deltas**. 4000 tokens parce que Gemini 2.5 a un thinking phase qui consomme 1-2k tokens avant output visible. |
| Aggregation | `mean(axes) / 5.0` non-pondéré | Weighting sans calibration humaine = biais infondé. |
| Fallback | JSON invalide / axe out-of-range → `score=0.0, errors=1` | Silent fallback à 1.0 poisonerait la matrice — c'était le problème du stub en PR B. |

## Changements

### [tests/evals/scorers/code_documentation.py](tests/evals/scorers/code_documentation.py)

Remplace le stub de PR B (30 lignes) par l'impl réelle (~230 lignes). Signature async (`async def score`). Utilise `EvalScore` de test_generation — zéro schema-aware branching dans le runner. Le `stdout_tail` persiste judge model + axes + reasoning pour diffabilité offline.

### [tests/evals/runner.py](tests/evals/runner.py)

1 ligne ajoutée : le runner détecte coroutine scorers via `asyncio.iscoroutinefunction` et les await. Scorers sync (`test_generation.score` via pytest subprocess) continuent de marcher inchangés.

### [docs/llm_evals.md](docs/llm_evals.md)

- Architecture diagram + « Caractéristiques » section : mention des 2 scorer types (rule-based vs LLM-as-judge)
- Nouvelle section **Matrice `code_documentation` v1** : rubric détaillée, chiffres complets, lecture honnête, root-cause analysis
- Section « Scoring — détails » : 2 sous-sections pour les 2 scorers

## Validation avant matrice

### 1. Smoke test du judge sur 3 docs hand-crafted

| Doc de test | Score attendu | Score mesuré |
|---|---|---|
| DELIBERATELY_WRONG (invente une API `compute` qui n'existe pas) | ~0 | **0.0** (all axes=0) |
| DELIBERATELY_BAD (vague, pas de details, *"add does addition"*) | ~0.3-0.4 | **0.4** (accuracy=5, completeness=0, clarity=3, usefulness=0) |
| DELIBERATELY_GOOD (reference complete avec signatures + examples + raises) | ~1.0 | **1.0** (all axes=5) |

Rubric calibrée, pas besoin d'itérer sur le prompt.

### 2. Dry-run 2 cas × 2 modèles = 12 LLM calls

Toutes les 12 succès, pipe end-to-end stable.

## Résultats matrice v1

**Scope** : 13 cas × 3 paths × 2 modèles = 78 gen calls + 78 judge calls = **156 LLM calls**, ~15 min, ~$1.

### Scores moyens par path

| Modèle | MCP | Competent | Raw |
|---|---|---|---|
| gemini-2.5-flash | 0.985 | **1.000** | **1.000** |
| gemma-4-31b-it | 0.931 | **0.969** | **0.977** |
| **Global** | **0.958** | **0.985** | **0.988** |

### Δ par modèle

| Modèle | Δ MCP − Raw | Δ MCP − Competent |
|---|---|---|
| gemini-2.5-flash | **−0.015** | **−0.015** |
| gemma-4-31b-it | **−0.046** | **−0.038** |

**Les deux deltas négatifs sur les deux modèles.** MCP n'apporte aucune valeur mesurable par ce judge.

## Root cause (inspection manuelle)

Exemple : `08_inheritance` sur gemini-2.5-flash, MCP=0.85 vs Raw=1.00.

### MCP output (obéit au template)
```markdown
### class Shape
An abstract base class for geometric shapes.
#### area()
...
```
→ Judge : Clarity=3/5 *"no module-level overview"*

### Raw output (prompt minimal)
```markdown
This document provides an overview and detailed explanation of the Python code
for calculating the areas of various geometric shapes...

## Shape Area Calculation Module
This module defines an abstract base class Shape and concrete implementations...
```
→ Judge : Clarity=5/5

**Le bug** : le template MCP contient *« Output ONLY the documentation content — no preamble »*. Le modèle obéit littéralement. Or pour la doc, **un overview module-level EST une partie utile du livrable** (contrairement aux tests où un préambule casserait pytest).

La contrainte a été portée par erreur depuis `test_generation` où elle est nécessaire.

## Follow-up : [issue #248](https://github.com/VynoDePal/Collegue/issues/248)

Ouvre une issue dédiée pour reformuler le template documentation et re-rouler matrice v2. Cible : Δ MCP − Competent ≥ +0.05 sur ≥ 1 modèle.

## Ce que cette PR clôt vs ce qu'elle laisse ouvert

### Clos
- ✅ Infrastructure eval pour `code_documentation` complète (PR #245 + PR #247 + cette PR)
- ✅ Primitif LLM-as-judge en place, réutilisable pour d'autres tools subjectifs (`refactoring`, futurs)
- ✅ Rubric calibrée sur docs de qualité connue
- ✅ Matrice v1 mesurée honnêtement
- ✅ Root cause du sous-performance de MCP identifiée

### Laissé ouvert (par intention, pas par négligence)
- ⏳ Rendre MCP supérieur aux baselines : dépend de #248
- ⏳ Family-bias du judge gemini vs gemma : documenté, mitigé en lisant deltas
- ⏳ Escalation 5-modèles : décidable après que matrix v2 montre des deltas positifs

## Impact pytest

| Métrique | Avant | Après |
|---|---|---|
| Passed | 571 | **571** |
| Failed | 0 | 0 |

## Test plan

- [x] Smoke judge : 3 docs de qualité connue → scores aligned avec intuition
- [x] Dry run 2 cas × 2 modèles → 12/12 succès
- [x] Matrice complète 13 × 3 × 2 = 78 runs → 0 errors, pipeline stable
- [x] Doc mise à jour avec rubric + numbers + root cause
- [x] Follow-up issue #248 ouverte pour le vrai fix du template
- [x] `pytest tests/` → 571 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)