### PR TITLE
fix: use stat.S_ISREG instead of os.path.isfile(fd) in file_security.py

### DIFF
--- a/collegue/core/file_security.py
+++ b/collegue/core/file_security.py
@@ -6,6 +6,7 @@ protégées contre les attaques TOCTOU, les symlinks et les traversées de chemi
 """
 import os
 import fcntl
+import stat
 from typing import Optional
 
 
@@ -58,8 +59,8 @@ def safe_read_file(filepath: str, max_size: int, base_dir: Optional[str] = None)
         # Vérifier les stats via le file descriptor (pas de race condition)
         stat_info = os.fstat(fd)
         
-        # Vérifier que c'est un fichier régulier
-        if not os.path.isfile(fd):
+        # Vérifier que c'est un fichier régulier via le file descriptor
+        if not stat.S_ISREG(stat_info.st_mode):
             raise FileSecurityError(f'Not a regular file: {filepath}')
         
         # Vérifier la taille via le file descriptor (TOCTOU-safe)
@@ -127,7 +128,7 @@ def safe_getsize(filepath: str, base_dir: Optional[str] = None) -> int:
     try:
         stat_info = os.fstat(fd)
         
-        if not os.path.isfile(fd):
+        if not stat.S_ISREG(stat_info.st_mode):
             raise FileSecurityError(f'Not a regular file: {filepath}')
         
         return stat_info.st_size


### PR DESCRIPTION
## Summary

`os.path.isfile(fd)` dans `safe_read_file()` et `safe_getsize()` reçoit un **file descriptor** (int) au lieu d'un chemin (str). Quand `os.path.isfile()` reçoit un entier, il le traite comme un chemin littéral (ex: cherche un fichier nommé "3"), ce qui retourne presque toujours `False`.

Remplacé par `stat.S_ISREG(stat_info.st_mode)` qui vérifie correctement le mode du fichier à partir du résultat de `os.fstat()` déjà obtenu.

## Review & Testing Checklist for Human

- [ ] Vérifier que `safe_read_file()` lit correctement les fichiers réguliers (le test `test_safe_read_file_success` passe)
- [ ] Vérifier que les non-fichiers (répertoires, devices, fifos) sont bien rejetés (le test `test_safe_read_file_not_regular_file` passe)
- [ ] Vérifier que `safe_getsize()` retourne la bonne taille pour les fichiers réguliers

```bash
PYTHONPATH=. pytest tests/test_file_security.py -v
```

### Notes

Closes #251

Les 7 tests existants passent. Le fix est minimal : ajout de `import stat` et remplacement de `os.path.isfile(fd)` par `stat.S_ISREG(stat_info.st_mode)` aux lignes 62-63 et 130-131.

Link to Devin session: https://app.devin.ai/sessions/23e3a9004eb44bcfb8c791238af4fab4
Requested by: @VynoDePal
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vynodepal/collegue/pull/260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->