### PR TITLE
feat: extend Ruff linting to F + I + B rules and fix all violations

### DIFF
--- a/collegue/app.py
+++ b/collegue/app.py
@@ -1,16 +1,18 @@
 """
 Collègue MCP - Un assistant de développement intelligent inspiré par Junie
 """
-import sys
-import os
-import logging
 import asyncio
+import logging
+import os
+import sys
 import time
+
 from fastmcp.server.lifespan import lifespan
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from fastmcp import FastMCP
+
 from collegue.config import settings
 
 logger = logging.getLogger(__name__)
@@ -212,7 +214,7 @@ async def validate_llm_config():
     except Exception as e:
         error_msg = f"❌ Configuration LLM invalide (Clé API ou modèle '{settings.LLM_MODEL}' incorrect) : {str(e)}"
         logger.error(error_msg)
-        raise ValueError(error_msg)
+        raise ValueError(error_msg) from e
 
 
 _lazy_engine_instance = None
@@ -250,7 +252,6 @@ async def core_lifespan(server):
     }
 
     # Initialisation rapide des composants essentiels
-    parser_init = time.time()
     logger.info(f"✅ CodeParser initialisé en {time.time() - startup_start:.3f}s")
     
     # Initialisation lazy du PromptEngine pour ne pas bloquer le démarrage
@@ -262,9 +263,9 @@ async def core_lifespan(server):
 
     startup_elapsed = time.time() - startup_start
     logger.info(f"✅ Composants initialisés en {startup_elapsed:.2f}s")
-    logger.info(f"   - Parser: disponible")
-    logger.info(f"   - ResourceManager: disponible")
-    logger.info(f"   - PromptEngine: initialisation en cours (lazy)")
+    logger.info("   - Parser: disponible")
+    logger.info("   - ResourceManager: disponible")
+    logger.info("   - PromptEngine: initialisation en cours (lazy)")
     logger.info(f"   - ToolsRegistry: pré-chargé ({len(await tools_registry.get())} outils)")
     
     print(f"✅ Composants initialisés via lifespan context: {list(state.keys())}", file=sys.stderr)
@@ -285,7 +286,7 @@ async def core_lifespan(server):
         logger.debug(f"Erreur lors de la fermeture des connexions K8s: {e}")
         
     try:
-        import psycopg2.pool
+        import psycopg2.pool  # noqa: F401
         # Si un pool global PostgreSQL est utilisé (ex: psycopg2.pool), on le ferme ici
         logger.info("🛑 Connexions PostgreSQL nettoyées.")
     except ImportError:
@@ -294,8 +295,8 @@ async def core_lifespan(server):
 sampling_handler = None
 if settings.LLM_API_KEY:
     try:
-        from openai import AsyncOpenAI
         from fastmcp.client.sampling.handlers.openai import OpenAISamplingHandler
+        from openai import AsyncOpenAI
         llm_api_key = settings.LLM_API_KEY
         gemini_client = AsyncOpenAI(
             api_key=llm_api_key,
@@ -318,14 +319,14 @@ app = FastMCP(
     sampling_handler_behavior="fallback",
 )
 
+from fastmcp.server.middleware.caching import (
+	CallToolSettings,
+	ResponseCachingMiddleware,
+)
 from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
 from fastmcp.server.middleware.logging import StructuredLoggingMiddleware
-from fastmcp.server.middleware.timing import TimingMiddleware
 from fastmcp.server.middleware.rate_limiting import RateLimitingMiddleware
-from fastmcp.server.middleware.caching import (
-    ResponseCachingMiddleware,
-    CallToolSettings,
-)
+from fastmcp.server.middleware.timing import TimingMiddleware
 
 app.add_middleware(ErrorHandlingMiddleware(
     include_traceback=settings.DEBUG,
@@ -357,8 +358,8 @@ logger.info(
 )
 
 from collegue.core import register_core
-from collegue.tools import register_tools
 from collegue.resources import register_resources
+from collegue.tools import register_tools
 
 register_core(app)
 register_tools(app)

--- a/collegue/autonomous/watchdog.py
+++ b/collegue/autonomous/watchdog.py
@@ -16,12 +16,12 @@ from typing import List, Optional, Tuple
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
+from collegue.autonomous.config_registry import UserConfig, get_config_registry
+from collegue.autonomous.context_pack import ContextPackBuilder
 from collegue.config import settings
 from collegue.resources.llm.providers import LLMConfig, generate_text
-from collegue.tools.sentry_monitor import SentryMonitorTool, SentryRequest
 from collegue.tools.github_ops import GitHubOpsTool, GitHubRequest
-from collegue.autonomous.config_registry import get_config_registry, UserConfig
-from collegue.autonomous.context_pack import ContextPackBuilder, ContextPack
+from collegue.tools.sentry_monitor import SentryMonitorTool, SentryRequest
 
 try:
     from fastmcp.server.dependencies import get_http_headers
@@ -63,7 +63,6 @@ def _fuzzy_find_match(search: str, content: str, threshold: float = 0.6) -> Tupl
 
     best_match = None
     best_score = 0.0
-    best_start = -1
 
 
     for i in range(len(content_lines) - search_len + 1):
@@ -75,7 +74,6 @@ def _fuzzy_find_match(search: str, content: str, threshold: float = 0.6) -> Tupl
 
         if ratio > best_score:
             best_score = ratio
-            best_start = i
             best_match = window_text
 
 
@@ -89,7 +87,6 @@ def _fuzzy_find_match(search: str, content: str, threshold: float = 0.6) -> Tupl
             ratio = difflib.SequenceMatcher(None, normalized_search, normalized_window).ratio()
             if ratio > best_score:
                 best_score = ratio
-                best_start = i
                 best_match = window_text
 
     if best_score >= threshold:
@@ -349,7 +346,6 @@ class AutoFixer:
                     web_config,
                     f"Trouve des solutions pour cette erreur Python:\n{error_type}: {error_message}"
                 )
-                web_response = web_response_obj.text
                 web_citations = [
                     annotation.get("url_citation", {}) 
                     for annotation in web_response_obj.annotations 
@@ -501,7 +497,7 @@ Réponds UNIQUEMENT avec le JSON valide, sans markdown ni explication."""
 
 
         patched_content = original_content
-        for search_found, replace, match_type in patch_operations:
+        for search_found, replace, _match_type in patch_operations:
             patched_content = patched_content.replace(search_found, replace, 1)
 
         patches_applied = len(patch_operations)

--- a/collegue/client/mcp_client.py
+++ b/collegue/client/mcp_client.py
@@ -1,12 +1,10 @@
 """
 Client Python pour interagir avec le serveur Collègue MCP
 """
+import logging
 import os
 import sys
-import json
-import asyncio
-from typing import Dict, List, Any, Optional, Union
-import logging
+from typing import Any, Dict, List
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/collegue/config.py
+++ b/collegue/config.py
@@ -1,10 +1,11 @@
 """
 Configuration - Paramètres de configuration pour le MCP Collègue
 """
-from pydantic_settings import BaseSettings
-from pydantic import field_validator, model_validator, AnyHttpUrl
-from typing import Optional, List, Union, Any
 import logging
+from typing import List, Optional, Union
+
+from pydantic import field_validator, model_validator
+from pydantic_settings import BaseSettings
 
 logger = logging.getLogger(__name__)
 

--- a/collegue/core/auth.py
+++ b/collegue/core/auth.py
@@ -5,7 +5,8 @@ Centralise les fonctions d'authentification et de résolution de tokens
 pour éviter la duplication entre sentry_monitor.py et github_ops.py.
 """
 import os
-from typing import Optional, Dict, Any
+from typing import Optional
+
 from .security_logger import security_logger
 
 

--- a/collegue/core/file_security.py
+++ b/collegue/core/file_security.py
@@ -4,8 +4,8 @@ Utilitaires de lecture de fichiers sécurisés.
 Ce module fournit des fonctions pour lire des fichiers en toute sécurité,
 protégées contre les attaques TOCTOU, les symlinks et les traversées de chemin.
 """
-import os
 import fcntl
+import os
 from typing import Optional
 
 
@@ -51,7 +51,7 @@ def safe_read_file(filepath: str, max_size: int, base_dir: Optional[str] = None)
         fd = os.open(filepath, os.O_RDONLY | os.O_NOFOLLOW)
     except OSError as e:
         if e.errno == 40:  # ELOOP - trop de niveaux de liens symboliques
-            raise FileSecurityError(f'Symlink detected and blocked: {filepath}')
+            raise FileSecurityError(f'Symlink detected and blocked: {filepath}') from e
         raise
     
     try:
@@ -121,7 +121,7 @@ def safe_getsize(filepath: str, base_dir: Optional[str] = None) -> int:
         fd = os.open(filepath, os.O_RDONLY | os.O_NOFOLLOW)
     except OSError as e:
         if e.errno == 40:
-            raise FileSecurityError(f'Symlink detected and blocked: {filepath}')
+            raise FileSecurityError(f'Symlink detected and blocked: {filepath}') from e
         raise
     
     try:

--- a/collegue/core/header_security.py
+++ b/collegue/core/header_security.py
@@ -4,7 +4,6 @@ HTTP Header Security Utilities
 Provides functions to sanitize HTTP headers and prevent injection attacks.
 """
 import re
-from typing import Optional
 
 
 class HeaderSecurityError(Exception):

--- a/collegue/core/memory_manager.py
+++ b/collegue/core/memory_manager.py
@@ -5,14 +5,13 @@ Fournit des utilitaires pour surveiller et nettoyer la mémoire,
 prévenant les fuites sur les sessions longues.
 """
 import gc
-import weakref
 import logging
 import threading
 import time
-from typing import Any, Dict, Optional, Callable, List, Iterator, Tuple
-from dataclasses import dataclass
+import weakref
 from collections import deque
-
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
 
 # Lock pour le singleton MemoryManager
 _memory_manager_lock = threading.Lock()

--- a/collegue/core/meta_orchestrator.py
+++ b/collegue/core/meta_orchestrator.py
@@ -10,13 +10,14 @@ when the handler is invoked outside of a proper lifespan context (tests,
 ad-hoc scripts).
 """
 
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional
+
 from pydantic import BaseModel, Field
 
 from .tools_registry import ToolsRegistry
 
 try:
-    from fastmcp import FastMCP, Context
+    from fastmcp import Context, FastMCP
 except ImportError:
     FastMCP = Any
     Context = Any
@@ -96,8 +97,8 @@ def register_meta_orchestrator(app: FastMCP):
         Orchestrateur intelligent utilisant une approche Plan -> Exécute -> Synthétise.
         Plus robuste pour les tâches complexes et évite les erreurs de protocole natif.
         """
-        import time
         import json
+        import time
 
         start_time = time.time()
         await ctx.info(

--- a/collegue/core/middleware_llm_rate_limit.py
+++ b/collegue/core/middleware_llm_rate_limit.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from typing import Any, Optional
+from typing import Optional
 
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 

--- a/collegue/core/parser.py
+++ b/collegue/core/parser.py
@@ -3,7 +3,8 @@ Code Parser - Analyse syntaxique du code pour différents langages
 """
 import ast
 import re
-from typing import Dict, List, Any, Optional, Tuple
+from typing import Any, Dict, List
+
 
 class CodeParser:
     def __init__(self):
@@ -784,7 +785,7 @@ class CodeParser:
                 params = []
                 defaults = [None] * (len(node.args.args) - len(node.args.defaults)) + list(node.args.defaults)
 
-                for arg, default in zip(node.args.args, defaults):
+                for arg, default in zip(node.args.args, defaults, strict=False):
                     param_info = {
                         "name": arg.arg,
                         "type": None,
@@ -851,7 +852,7 @@ class CodeParser:
                         params = []
                         defaults = [None] * (len(child.args.args) - len(child.args.defaults)) + list(child.args.defaults)
 
-                        for i, (arg, default) in enumerate(zip(child.args.args, defaults)):
+                        for i, (arg, default) in enumerate(zip(child.args.args, defaults, strict=False)):
                             if i == 0 and arg.arg == 'self':
                                 continue
 

--- a/collegue/core/resource_manager.py
+++ b/collegue/core/resource_manager.py
@@ -1,8 +1,8 @@
 """
 Resource Manager - Gestionnaire centralisé des ressources pour Collègue MCP
 """
-from typing import Dict, Any, Optional, List
 import logging
+from typing import Any, Dict, List, Optional
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/collegue/core/security_logger.py
+++ b/collegue/core/security_logger.py
@@ -4,10 +4,10 @@ Security Logger - Journalisation des événements de sécurité
 Ce module fournit des fonctions de logging dédiées aux événements de sécurité
 pour faciliter la détection et l'investigation d'incidents.
 """
-import logging
 import json
+import logging
 from datetime import datetime, timezone
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 
 class SecurityLogger:

--- a/collegue/core/shared.py
+++ b/collegue/core/shared.py
@@ -4,16 +4,15 @@ Shared utilities for Collegue tools.
 This module contains common models and functions used across multiple tools
 to avoid duplication and ensure consistency.
 """
-import json
 import asyncio
 import concurrent.futures
+import json
+import re
 from pathlib import Path
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, List, Optional
 
 import yaml
 from pydantic import BaseModel, Field
-
-import re
 
 from . import validators as _validators
 

--- a/collegue/core/tool_llm_manager.py
+++ b/collegue/core/tool_llm_manager.py
@@ -1,10 +1,12 @@
 """
 ToolLLMManager - Gestionnaire centralisé des appels LLM pour tous les outils
 """
-from typing import Optional, List, Dict, Tuple, Any
-from collegue.config import Settings, settings as global_settings
-from collegue.resources.llm.providers import LLMConfig, generate_text
 import asyncio
+from typing import Any, Dict, List, Optional, Tuple
+
+from collegue.config import Settings
+from collegue.config import settings as global_settings
+from collegue.resources.llm.providers import LLMConfig, generate_text
 
 
 class ToolLLMManager:

--- a/collegue/health_server.py
+++ b/collegue/health_server.py
@@ -1,10 +1,9 @@
 
-from fastapi import FastAPI
-import uvicorn
-
 import sys
-import os
 from pathlib import Path
+
+import uvicorn
+from fastapi import FastAPI
 
 parent_dir = str(Path(__file__).parent.parent.absolute())
 sys.path.insert(0, parent_dir)

--- a/collegue/parsing/__init__.py
+++ b/collegue/parsing/__init__.py
@@ -1,19 +1,20 @@
 from .base import (
-    Import,
-    Declaration,
-    ParseResult,
     BaseParser,
+    Declaration,
+    Import,
+    ParseResult,
 )
 from .javascript import JSParser
 from .python import PythonParser
 from .utils import (
     detect_language,
-    parse_file,
-    resolve_relative_import,
-    resolve_module_to_file,
-    get_unused_imports,
     get_unused_declarations,
+    get_unused_imports,
+    parse_file,
+    resolve_module_to_file,
+    resolve_relative_import,
 )
+
 __all__ = [
     'Import',
     'Declaration', 

--- a/collegue/parsing/base.py
+++ b/collegue/parsing/base.py
@@ -1,7 +1,9 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import List, Dict, Any, Optional, Tuple, Set
 from enum import Enum
+from typing import Dict, List, Optional, Tuple
+
+
 class ImportType(Enum):
     IMPORT = "import"
     FROM_IMPORT = "from_import"

--- a/collegue/parsing/javascript.py
+++ b/collegue/parsing/javascript.py
@@ -1,9 +1,9 @@
 import re
-from typing import List, Dict, Any, Optional, Tuple
-from .base import (
-    Import, Declaration, ParseResult, BaseParser,
-    ImportType, DeclarationType
-)
+from typing import Dict, List, Optional, Tuple
+
+from .base import BaseParser, Declaration, DeclarationType, Import, ImportType
+
+
 class JSParser(BaseParser):
     RESERVED_KEYWORDS = {
         'break', 'case', 'catch', 'class', 'const', 'continue', 'debugger', 'default',
@@ -21,7 +21,7 @@ class JSParser(BaseParser):
         'Parameters', 'ReturnType', 'InstanceType', 'ThisParameterType', 'OmitThisParameter',
         'ThisType', 'Uppercase', 'Lowercase', 'Capitalize', 'Uncapitalize',
         'Promise', 'Map', 'Set', 'WeakMap', 'WeakSet', 'Date', 'RegExp', 'Error',
-        'Function', 'String', 'Number', 'Boolean', 'Object', 'Array', 'console',
+        'Function', 'String', 'Number', 'Boolean', 'Object', 'console',
         'window', 'document', 'process', 'Buffer', 'Math', 'JSON',
     }
     def __init__(self, content: str, filename: Optional[str] = None):

--- a/collegue/parsing/python.py
+++ b/collegue/parsing/python.py
@@ -1,10 +1,10 @@
 import ast
 import re
-from typing import List, Dict, Any, Optional, Tuple
-from .base import (
-    Import, Declaration, ParseResult, BaseParser,
-    ImportType, DeclarationType
-)
+from typing import Dict, List, Optional, Tuple
+
+from .base import BaseParser, Declaration, DeclarationType, Import, ImportType, ParseResult
+
+
 class PythonParser(BaseParser):
     def __init__(self, content: str, filename: Optional[str] = None):
         super().__init__(content, filename)
@@ -18,7 +18,7 @@ class PythonParser(BaseParser):
         try:
             self._tree = ast.parse(self.content)
             self._ast_valid = True
-        except SyntaxError as e:
+        except SyntaxError:
             self._tree = None
             self._ast_valid = False
     def find_imports(self) -> List[Import]:

--- a/collegue/parsing/utils.py
+++ b/collegue/parsing/utils.py
@@ -1,6 +1,7 @@
 import os
-from typing import Optional, Dict, List, Tuple
-from .base import ParseResult, Import
+from typing import Dict, List, Optional
+
+from .base import Import, ParseResult
 from .javascript import JSParser
 from .python import PythonParser
 
@@ -152,7 +153,7 @@ def get_unused_declarations(parse_result: ParseResult) -> List[str]:
     used_names = set(name for _, name in parse_result.identifiers)
 
     unused = []
-    for name, decl in parse_result.declarations.items():
+    for name, _decl in parse_result.declarations.items():
         if name not in used_names:
             unused.append(name)
 

--- a/collegue/prompts/__init__.py
+++ b/collegue/prompts/__init__.py
@@ -1,9 +1,8 @@
 """
 Prompts - Système de prompts personnalisés
 """
-import os
 import logging
-
+import os
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/collegue/prompts/engine/__init__.py
+++ b/collegue/prompts/engine/__init__.py
@@ -1,14 +1,7 @@
 """
 Engine - Module du moteur de prompts personnalisés
 """
-from .models import (
-    PromptTemplate, 
-    PromptCategory, 
-    PromptExecution, 
-    PromptLibrary,
-    PromptVariable,
-    PromptVariableType
-)
+from .models import PromptCategory, PromptExecution, PromptLibrary, PromptTemplate, PromptVariable, PromptVariableType
 from .prompt_engine import PromptEngine
 
 __all__ = [

--- a/collegue/prompts/engine/enhanced_prompt_engine.py
+++ b/collegue/prompts/engine/enhanced_prompt_engine.py
@@ -5,7 +5,7 @@ import datetime
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from .models import PromptVariable
 from .optimizer import LanguageOptimizer

--- a/collegue/prompts/engine/models.py
+++ b/collegue/prompts/engine/models.py
@@ -1,11 +1,12 @@
 """
 Models - Modèles de données pour le système de prompts personnalisés
 """
-from pydantic import BaseModel, Field
-from typing import Dict, List, Optional, Any, Union
-from enum import Enum
 import datetime
 import uuid
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
 
 
 class PromptVariableType(str, Enum):

--- a/collegue/prompts/engine/optimizer.py
+++ b/collegue/prompts/engine/optimizer.py
@@ -1,8 +1,8 @@
 """
 Optimiseur de prompts par langage de programmation
 """
-from typing import Dict, List, Any, Optional
 import logging
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/collegue/prompts/engine/prompt_engine.py
+++ b/collegue/prompts/engine/prompt_engine.py
@@ -1,15 +1,14 @@
 """
 Prompt Engine - Moteur de gestion des prompts personnalisés
 """
-import json
-import os
-import logging
-from typing import Dict, List, Optional, Any, Union
 import datetime
+import json
+import logging
+import os
 from pathlib import Path
+from typing import Any, Dict, List, Optional
 
-from .models import PromptTemplate, PromptCategory, PromptExecution, PromptLibrary, PromptVariable
-
+from .models import PromptCategory, PromptExecution, PromptLibrary, PromptTemplate, PromptVariable
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/collegue/prompts/engine/versioning.py
+++ b/collegue/prompts/engine/versioning.py
@@ -2,13 +2,13 @@
 Système de versioning des prompts avec gestion des versions et performances
 """
 import json
-import os
-from datetime import datetime
-from typing import Dict, List, Optional, Any
-from pathlib import Path
-import uuid
-from dataclasses import dataclass, asdict
 import logging
+import os
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/collegue/prompts/templates/__init__.py
+++ b/collegue/prompts/templates/__init__.py
@@ -4,7 +4,8 @@ Templates Module - Gestion des templates YAML pour les outils MCP
 
 import os
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
+
 
 def get_template_path(tool_name: str, version: str = "default") -> Optional[Path]:
     """

--- a/collegue/prompts/versions/__init__.py
+++ b/collegue/prompts/versions/__init__.py
@@ -5,7 +5,8 @@ Versions Module - Gestion du versioning des prompts et métriques
 import json
 import os
 from pathlib import Path
-from typing import Dict, List, Optional, Any
+from typing import Any, Dict, List, Optional
+
 
 def get_versions_file() -> Path:
     """

--- a/collegue/resources/__init__.py
+++ b/collegue/resources/__init__.py
@@ -1,10 +1,9 @@
 """
 Resources - Ressources de référence pour les langages et frameworks
 """
-import os
 import logging
+import os
 import sys
-
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/collegue/resources/javascript/__init__.py
+++ b/collegue/resources/javascript/__init__.py
@@ -2,9 +2,10 @@
 Ressources JavaScript - Module pour les références et la documentation JavaScript
 """
 
-from .standard_library import register_stdlib
-from .frameworks import register_frameworks
 from .best_practices import register_best_practices
+from .frameworks import register_frameworks
+from .standard_library import register_stdlib
+
 
 def register(app, app_state):
     """Enregistre les ressources JavaScript dans l'application FastMCP."""

--- a/collegue/resources/javascript/best_practices.py
+++ b/collegue/resources/javascript/best_practices.py
@@ -1,10 +1,11 @@
 """
 Best Practices JavaScript - Ressources pour les bonnes pratiques en JavaScript
 """
-from pydantic import BaseModel
-from typing import Dict, List, Optional, Any
-
 import json
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
+
 
 class JavaScriptBestPractice(BaseModel):
     """Modèle pour une bonne pratique JavaScript."""

--- a/collegue/resources/javascript/frameworks.py
+++ b/collegue/resources/javascript/frameworks.py
@@ -1,10 +1,11 @@
 """
 Frameworks JavaScript - Ressources pour les frameworks JavaScript populaires
 """
-from pydantic import BaseModel
-from typing import Dict, List, Optional, Any
-
 import json
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
+
 
 class JavaScriptFrameworkReference(BaseModel):
     """Modèle pour une référence de framework JavaScript."""

--- a/collegue/resources/javascript/standard_library.py
+++ b/collegue/resources/javascript/standard_library.py
@@ -1,10 +1,11 @@
 """
 Standard Library JavaScript - Ressources pour les fonctionnalités standard de JavaScript
 """
-from pydantic import BaseModel
-from typing import Dict, List, Optional, Any
 import json
-import os
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
+
 
 class JavaScriptAPIReference(BaseModel):
     """Modèle pour une référence d'API JavaScript."""

--- a/collegue/resources/llm/__init__.py
+++ b/collegue/resources/llm/__init__.py
@@ -2,9 +2,10 @@
 Module LLM - Intégration et configuration des modèles de langage
 """
 
-from .providers import register_providers
-from .prompts import register_prompts
 from .optimization import register_optimization
+from .prompts import register_prompts
+from .providers import register_providers
+
 
 def register(app, app_state):
     """Enregistre les ressources LLM dans l'application FastMCP."""

--- a/collegue/resources/llm/optimization.py
+++ b/collegue/resources/llm/optimization.py
@@ -1,12 +1,12 @@
 """
 Optimization LLM - Optimisation des prompts pour les différents modèles de langage
 """
-from pydantic import BaseModel
-from typing import Dict, List, Optional, Any
 import json
-import os
 import logging
 from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/collegue/resources/llm/prompts.py
+++ b/collegue/resources/llm/prompts.py
@@ -1,12 +1,11 @@
 """
 Prompts LLM - Gestion des prompts pour les différents modèles de langage
 """
-from pydantic import BaseModel
-from typing import Dict, List, Optional, Any
 import json
-import os
 import logging
-from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/collegue/resources/llm/providers.py
+++ b/collegue/resources/llm/providers.py
@@ -1,10 +1,11 @@
 """
 Providers LLM - Intégration avec Google Gemini uniquement
 """
-from pydantic import BaseModel
-from typing import Dict, List, Optional, Any
 import json
 import logging
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -45,7 +46,7 @@ def _extract_google_citations(response) -> List[Dict[str, Any]]:
 	metadata = candidate.grounding_metadata
 	chunks = getattr(metadata, 'grounding_chunks', None) or []
 	
-	for i, chunk in enumerate(chunks):
+	for _i, chunk in enumerate(chunks):
 		if hasattr(chunk, 'web') and chunk.web:
 			annotations.append({
 				'type': 'url_citation',

--- a/collegue/resources/php/__init__.py
+++ b/collegue/resources/php/__init__.py
@@ -17,9 +17,9 @@ def register(app: FastMCP, app_state: dict):
 		app: L'application FastMCP
 		app_state: L'état de l'application
 	"""
-	from .standard_library import register_stdlib
-	from .frameworks import register_frameworks
 	from .best_practices import register_best_practices
+	from .frameworks import register_frameworks
+	from .standard_library import register_stdlib
 
 	register_stdlib(app, app_state)
 	register_frameworks(app, app_state)

--- a/collegue/resources/php/best_practices.py
+++ b/collegue/resources/php/best_practices.py
@@ -1,9 +1,10 @@
 """
 Best Practices PHP - Ressources pour les bonnes pratiques en PHP moderne
 """
-from pydantic import BaseModel
-from typing import Dict, List, Optional, Any
 import json
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
 
 
 class PHPBestPractice(BaseModel):

--- a/collegue/resources/php/frameworks.py
+++ b/collegue/resources/php/frameworks.py
@@ -1,10 +1,10 @@
 """
 Frameworks PHP - Ressources pour les frameworks PHP populaires
 """
-from pydantic import BaseModel
-from typing import Dict, List, Optional, Any
-
 import json
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
 
 
 class PHPFrameworkReference(BaseModel):

--- a/collegue/resources/php/standard_library.py
+++ b/collegue/resources/php/standard_library.py
@@ -1,10 +1,10 @@
 """
 Standard Library PHP - Ressources pour les fonctions et extensions natives PHP
 """
-from pydantic import BaseModel
-from typing import Dict, List, Optional, Any
 import json
-import os
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
 
 
 class PHPModuleReference(BaseModel):

--- a/collegue/resources/python/__init__.py
+++ b/collegue/resources/python/__init__.py
@@ -2,9 +2,10 @@
 Ressources Python - Module pour les références et la documentation Python
 """
 
-from .standard_library import register_stdlib
-from .frameworks import register_frameworks
 from .best_practices import register_best_practices
+from .frameworks import register_frameworks
+from .standard_library import register_stdlib
+
 
 def register(app, app_state):
     """Enregistre les ressources Python dans l'application FastMCP."""

--- a/collegue/resources/python/best_practices.py
+++ b/collegue/resources/python/best_practices.py
@@ -1,9 +1,11 @@
 """
 Best Practices Python - Ressources pour les bonnes pratiques en Python
 """
-from pydantic import BaseModel
-from typing import Dict, List, Optional, Any
 import json
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
+
 
 class PythonBestPractice(BaseModel):
     """Modèle pour une bonne pratique Python."""

--- a/collegue/resources/python/frameworks.py
+++ b/collegue/resources/python/frameworks.py
@@ -1,10 +1,11 @@
 """
 Frameworks Python - Ressources pour les frameworks Python populaires
 """
-from pydantic import BaseModel
-from typing import Dict, List, Optional, Any
-
 import json
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
+
 
 class PythonFrameworkReference(BaseModel):
     """Modèle pour une référence de framework Python."""

--- a/collegue/resources/python/standard_library.py
+++ b/collegue/resources/python/standard_library.py
@@ -1,10 +1,11 @@
 """
 Standard Library Python - Ressources pour la bibliothèque standard Python
 """
-from pydantic import BaseModel
-from typing import Dict, List, Optional, Any
 import json
-import os
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
 
 class PythonModuleReference(BaseModel):
     """Modèle pour une référence de module Python."""

--- a/collegue/resources/skills.py
+++ b/collegue/resources/skills.py
@@ -163,7 +163,7 @@ def _register_skills_fallback(app: Any, app_state: dict):
         skill_md = skill_path / "SKILL.md"
         
         @app.resource(uri=f"collegue://skills/{skill_name}")
-        def get_skill():
+        def get_skill(skill_md=skill_md):
             try:
                 with open(skill_md, 'r', encoding='utf-8') as f:
                     return f.read()

--- a/collegue/resources/typescript/__init__.py
+++ b/collegue/resources/typescript/__init__.py
@@ -21,9 +21,7 @@ def register(app: FastMCP, app_state: dict):
         app: L'application FastMCP
         app_state: L'état de l'application
     """
-    from . import types
-    from . import frameworks
-    from . import best_practices
+    from . import best_practices, frameworks, types
     
     types.register(app, app_state)
     frameworks.register(app, app_state)

--- a/collegue/resources/typescript/best_practices.py
+++ b/collegue/resources/typescript/best_practices.py
@@ -3,9 +3,9 @@ Ressources pour les bonnes pratiques TypeScript.
 
 Ce module fournit des recommandations et bonnes pratiques pour le développement TypeScript.
 """
-from fastmcp import FastMCP
-from typing import Dict, Any, List
 import json
+
+from fastmcp import FastMCP
 
 GENERAL_BEST_PRACTICES = {
     "strict_null_checks": {

--- a/collegue/resources/typescript/frameworks.py
+++ b/collegue/resources/typescript/frameworks.py
@@ -3,9 +3,9 @@ Ressources pour les frameworks TypeScript.
 
 Ce module fournit des informations sur les frameworks et bibliothèques populaires pour TypeScript.
 """
-from fastmcp import FastMCP
-from typing import Dict, Any, List
 import json
+
+from fastmcp import FastMCP
 
 FRONTEND_FRAMEWORKS = {
     "Angular": {

--- a/collegue/resources/typescript/types.py
+++ b/collegue/resources/typescript/types.py
@@ -3,9 +3,9 @@ Ressources pour les types et interfaces TypeScript.
 
 Ce module fournit des informations sur les types et interfaces standard de TypeScript.
 """
-from fastmcp import FastMCP
-from typing import Dict, Any, List
 import json
+
+from fastmcp import FastMCP
 
 PRIMITIVE_TYPES = {
     "string": {

--- a/collegue/tools/__init__.py
+++ b/collegue/tools/__init__.py
@@ -1,14 +1,14 @@
 """
 Tools Package - Enregistrement direct des outils avec FastMCP
 """
-import os
-import sys
 import importlib
 import inspect
-from typing import Dict, List, Type, Any
+import os
+import sys
+from typing import Any, Dict, List, Type
 
 try:
-    from fastmcp import FastMCP, Context
+    from fastmcp import Context, FastMCP
 except ImportError:
     FastMCP = Any
     Context = Any
@@ -50,7 +50,7 @@ def _discover_tools() -> List[Type[BaseTool]]:
             try:
                 module = importlib.import_module(f'collegue.tools.{module_name}')
                 
-                for name, obj in inspect.getmembers(module):
+                for _name, obj in inspect.getmembers(module):
                     if (inspect.isclass(obj) and
                         issubclass(obj, BaseTool) and
                         obj != BaseTool and
@@ -71,7 +71,7 @@ def _discover_tools() -> List[Type[BaseTool]]:
                     package_module = importlib.import_module(f'collegue.tools.{item}')
                     
                     # Chercher les classes BaseTool dans le package
-                    for name, obj in inspect.getmembers(package_module):
+                    for _name, obj in inspect.getmembers(package_module):
                         if (inspect.isclass(obj) and
                             issubclass(obj, BaseTool) and
                             obj != BaseTool and

--- a/collegue/tools/analyzers/__init__.py
+++ b/collegue/tools/analyzers/__init__.py
@@ -4,7 +4,8 @@ Base Analyzer for Repo Consistency Check.
 Provides common functionality for language-specific analyzers.
 """
 from abc import ABC, abstractmethod
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional
+
 from ..base import ToolError
 
 

--- a/collegue/tools/analyzers/base.py
+++ b/collegue/tools/analyzers/base.py
@@ -4,7 +4,8 @@ Base Analyzer for Repo Consistency Check.
 Provides common functionality for language-specific analyzers.
 """
 from abc import ABC, abstractmethod
-from typing import List, Dict, Any
+from typing import Any, Dict, List
+
 from ..base import ToolError
 
 

--- a/collegue/tools/analyzers/javascript.py
+++ b/collegue/tools/analyzers/javascript.py
@@ -7,8 +7,9 @@ Analyzes JS/TS code for:
 """
 import re
 from typing import List
-from .base import BaseAnalyzer
+
 from ...core.shared import ConsistencyIssue
+from .base import BaseAnalyzer
 
 
 class JavaScriptAnalyzer(BaseAnalyzer):
@@ -40,7 +41,7 @@ class JavaScriptAnalyzer(BaseAnalyzer):
 						if name and re.match(r'^\w+$', name):
 							imports[name] = (i, match.group(0))
 
-		for name, (line, import_stmt) in imports.items():
+		for name, (line, _import_stmt) in imports.items():
 			pattern = rf'\b{re.escape(name)}\b'
 			matches = list(re.finditer(pattern, code))
 

--- a/collegue/tools/analyzers/php.py
+++ b/collegue/tools/analyzers/php.py
@@ -4,9 +4,11 @@ PHP Analyzer for Repo Consistency Check.
 Détecte les imports (use) et variables inutilisés dans le code PHP.
 """
 import re
-from typing import List, Dict, Any
-from .base import BaseAnalyzer, AnalyzerError
+from typing import List
+
 from ...core.shared import ConsistencyIssue
+from .base import BaseAnalyzer
+
 
 class PHPAnalyzer(BaseAnalyzer):
     def analyze_unused_imports(self, code: str, filepath: str) -> List[ConsistencyIssue]:
@@ -115,7 +117,7 @@ class PHPAnalyzer(BaseAnalyzer):
                     line=data['line'],
                     message=f"Variable locale inutilisée: {name}",
                     confidence=70, # Regex moins fiable que AST
-                    suggested_fix=f"Supprimer la variable ou l'utiliser",
+                    suggested_fix="Supprimer la variable ou l'utiliser",
                     engine="php-regex-analyzer"
                 ))
                 
@@ -151,7 +153,7 @@ class PHPAnalyzer(BaseAnalyzer):
                     line=method['line'],
                     message=f"Méthode privée non utilisée: {method['name']}",
                     confidence=80,
-                    suggested_fix=f"Supprimer la méthode si elle n'est pas utilisée via call_user_func",
+                    suggested_fix="Supprimer la méthode si elle n'est pas utilisée via call_user_func",
                     engine="php-regex-analyzer"
                 ))
                 

--- a/collegue/tools/analyzers/python.py
+++ b/collegue/tools/analyzers/python.py
@@ -9,8 +9,9 @@ Analyzes Python code for:
 import ast
 import re
 from typing import List
-from .base import BaseAnalyzer
+
 from ...core.shared import ConsistencyIssue
+from .base import BaseAnalyzer
 
 
 class PythonAnalyzer(BaseAnalyzer):

--- a/collegue/tools/base.py
+++ b/collegue/tools/base.py
@@ -4,24 +4,26 @@ Base Tool - Classe de base pour tous les outils du projet Collègue
 Le timing, logging, error handling et caching sont gérés par les
 middleware FastMCP natifs configurés dans app.py.
 """
+import asyncio
+import logging
 import os
 import time
-import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Type, Union
+
 from pydantic import BaseModel, ValidationError
 from pydantic_core import PydanticUndefined
-import asyncio
+
 from ..core.security_logger import security_logger
-from .rate_limiter import (
-    get_rate_limiter_manager,
-    RateLimitExceeded,
-    RateLimitConfig,
-)
 from .quotas import (
-    get_global_quota_manager,
     QuotaExceeded,
     QuotaManager,
+    get_global_quota_manager,
+)
+from .rate_limiter import (
+    RateLimitConfig,
+    RateLimitExceeded,
+    get_rate_limiter_manager,
 )
 
 
@@ -161,7 +163,7 @@ class BaseTool(ABC):
             manager.check_rate_limit(self.tool_name)
         except RateLimitExceeded as e:
             self.logger.warning(f"Rate limit exceeded for {self.tool_name}: {e}")
-            raise ToolRateLimitError(str(e))
+            raise ToolRateLimitError(str(e)) from e
     
     def cleanup(self, force_gc: bool = False) -> None:
         """
@@ -254,7 +256,7 @@ class BaseTool(ABC):
                     
         except QuotaExceeded as e:
             self.logger.warning(f"Quota exceeded for {self.tool_name}: {e}")
-            raise ToolQuotaError(str(e))
+            raise ToolQuotaError(str(e)) from e
     
     def _record_llm_tokens(self, tokens: int, **kwargs):
         """Enregistre l'utilisation de tokens LLM."""
@@ -263,7 +265,7 @@ class BaseTool(ABC):
                 self._quota_manager.record_llm_tokens(tokens)
             except QuotaExceeded as e:
                 self.logger.warning(f"LLM token quota exceeded: {e}")
-                raise ToolQuotaError(str(e))
+                raise ToolQuotaError(str(e)) from e
     
     def _check_execution_time(self, **kwargs) -> float:
         """
@@ -282,7 +284,7 @@ class BaseTool(ABC):
             return self._quota_manager.check_execution_time()
         except QuotaExceeded as e:
             self.logger.warning(f"Execution time quota exceeded: {e}")
-            raise ToolQuotaError(str(e))
+            raise ToolQuotaError(str(e)) from e
 
     async def prepare_prompt(self, request: BaseModel, template_name: Optional[str] = None) -> str:
         """Resolve a prompt for ``request`` via the template + A/B infrastructure.
@@ -474,7 +476,7 @@ class BaseTool(ABC):
             return True
 
         except ValidationError as e:
-            raise ToolValidationError(f"Validation de la requête échouée: {e}")
+            raise ToolValidationError(f"Validation de la requête échouée: {e}") from e
 
     def normalize_request(self, request: Union[BaseModel, Dict[str, Any]]) -> BaseModel:
         """
@@ -508,7 +510,7 @@ class BaseTool(ABC):
                 )
 
         except ValidationError as e:
-            raise ToolValidationError(f"Normalisation de la requête échouée: {e}")
+            raise ToolValidationError(f"Normalisation de la requête échouée: {e}") from e
 
     @abstractmethod
     def _execute_core_logic(self, request: BaseModel, **kwargs) -> BaseModel:

--- a/collegue/tools/clients/__init__.py
+++ b/collegue/tools/clients/__init__.py
@@ -7,11 +7,11 @@ Provides reusable HTTP clients with standardized:
 - Error handling and response parsing
 - Request/response logging
 """
-from .base import APIClient, APIResponse, APIError
-from .sentry import SentryClient
+from .base import APIClient, APIError, APIResponse
+from .github import GitHubClient
 from .kubernetes import KubernetesClient
 from .postgres import PostgresClient
-from .github import GitHubClient
+from .sentry import SentryClient
 
 __all__ = [
     'APIClient',

--- a/collegue/tools/clients/base.py
+++ b/collegue/tools/clients/base.py
@@ -3,12 +3,13 @@ Base API client with retry logic and standardized error handling.
 
 Provides a foundation for all external API clients in the tools package.
 """
-import time
 import logging
+import time
 from abc import ABC
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Callable, TypeVar, Generic
 from enum import Enum
+from typing import Any, Callable, Dict, Optional, TypeVar
+
 from ...core.header_security import sanitize_header_value
 from ...core.security_logger import security_logger
 
@@ -53,7 +54,7 @@ class APIError(Exception):
 T = TypeVar('T')
 
 
-class APIClient(ABC):
+class APIClient(ABC):  # noqa: B024
 
 	def __init__(
 		self,

--- a/collegue/tools/clients/github.py
+++ b/collegue/tools/clients/github.py
@@ -100,7 +100,7 @@ class GitHubClient(APIClient):
 		except ToolExecutionError:
 			raise
 		except Exception as e:
-			raise ToolExecutionError(f"Erreur API GitHub: {e}")
+			raise ToolExecutionError(f"Erreur API GitHub: {e}") from e
 
 	def _api_get(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> Any:
 		return self._request_json('GET', endpoint, params=params)

--- a/collegue/tools/clients/kubernetes.py
+++ b/collegue/tools/clients/kubernetes.py
@@ -5,6 +5,7 @@ Provides a client for common Kubernetes operations with kubectl-like interface.
 Includes protection against command injection attacks.
 """
 from typing import List, Optional
+
 from .base import APIResponse
 
 

--- a/collegue/tools/clients/postgres.py
+++ b/collegue/tools/clients/postgres.py
@@ -6,8 +6,8 @@ Provides read-only access to PostgreSQL databases with safe query execution.
 import os
 from typing import Optional
 
-from .base import APIResponse, APIError
 from ...core.auth import resolve_postgres_url
+from .base import APIError, APIResponse
 
 
 class PostgresClient:
@@ -42,11 +42,11 @@ class PostgresClient:
         self._driver = None
 
         try:
-            import psycopg2
+            import psycopg2  # noqa: F401
             self._driver = 'psycopg2'
         except ImportError:
             try:
-                import asyncpg
+                import asyncpg  # noqa: F401
                 self._driver = 'asyncpg'
             except ImportError:
                 self._driver = None
@@ -70,7 +70,7 @@ class PostgresClient:
 
     def _get_connection(self):
         if self._driver == 'psycopg2':
-            import psycopg2
+            import psycopg2  # noqa: F401
             return psycopg2.connect(self.connection_string)
         else:
             raise APIError("No PostgreSQL driver available. Install psycopg2 or asyncpg.")
@@ -251,7 +251,7 @@ class PostgresClient:
                     if cur.description:
                         columns = [desc[0] for desc in cur.description]
                         rows = cur.fetchall()
-                        data = [dict(zip(columns, row)) for row in rows]
+                        data = [dict(zip(columns, row, strict=False)) for row in rows]
                     else:
                         data = []
 

--- a/collegue/tools/clients/sentry.py
+++ b/collegue/tools/clients/sentry.py
@@ -6,7 +6,8 @@ Provides access to Sentry API for listing projects, issues, and releases.
 import os
 import re
 from typing import Dict, Optional
-from .base import APIClient, APIResponse, APIError
+
+from .base import APIClient, APIError, APIResponse
 
 
 class SentryClient(APIClient):

--- a/collegue/tools/code_documentation/__init__.py
+++ b/collegue/tools/code_documentation/__init__.py
@@ -10,9 +10,9 @@ Ce module a été refactorisé pour respecter l'architecture modulaire:
 Usage:
     from collegue.tools.code_documentation import DocumentationTool, DocumentationRequest, DocumentationResponse
 """
-from .tool import DocumentationTool
-from .models import DocumentationRequest, DocumentationResponse
 from .engine import DocumentationEngine
+from .models import DocumentationRequest, DocumentationResponse
+from .tool import DocumentationTool
 
 __all__ = [
     'DocumentationTool',

--- a/collegue/tools/code_documentation/engine.py
+++ b/collegue/tools/code_documentation/engine.py
@@ -4,8 +4,9 @@ Moteur d'analyse et de génération de documentation.
 Contient la logique métier pure : analyse d'éléments de code, formatage,
 calcul de couverture, génération de suggestions.
 """
-from typing import List, Dict, Any, Optional
-from .config import STYLE_INSTRUCTIONS, FORMAT_INSTRUCTIONS, LANGUAGE_INSTRUCTIONS
+from typing import Any, Dict, List
+
+from .config import FORMAT_INSTRUCTIONS, LANGUAGE_INSTRUCTIONS, STYLE_INSTRUCTIONS
 
 
 class DocumentationEngine:
@@ -182,17 +183,17 @@ class DocumentationEngine:
         """Construit le prompt pour le LLM."""
         prompt_parts = [
             f"Génère une documentation pour le code {language} suivant",
-            f"",
+            "",
             f"Style: {STYLE_INSTRUCTIONS.get(style, STYLE_INSTRUCTIONS['standard'])}",
             f"Format: {FORMAT_INSTRUCTIONS.get(format_type, FORMAT_INSTRUCTIONS['markdown'])}",
-            f""
+            ""
         ]
         
         prompt_parts.extend([
             f"```{language}",
             code,
-            f"```",
-            f""
+            "```",
+            ""
         ])
         
         if elements:

--- a/collegue/tools/code_documentation/models.py
+++ b/collegue/tools/code_documentation/models.py
@@ -1,7 +1,8 @@
 """
 Modèles Pydantic pour l'outil Code Documentation.
 """
-from typing import Optional, Dict, Any, List
+from typing import Dict, List, Optional
+
 from pydantic import BaseModel, Field
 
 

--- a/collegue/tools/code_documentation/tool.py
+++ b/collegue/tools/code_documentation/tool.py
@@ -8,12 +8,13 @@ Refactorisé: Le fichier original faisait 668 lignes, maintenant ~180 lignes.
 """
 
 import time
-from typing import List, Dict, Any
-from ..base import BaseTool, ToolError
+from typing import Any, Dict, List
+
 from ...core.shared import run_async_from_sync
-from .models import DocumentationRequest, DocumentationResponse
+from ..base import BaseTool, ToolError
+from .config import FORMAT_DESCRIPTIONS, STYLE_DESCRIPTIONS
 from .engine import DocumentationEngine
-from .config import STYLE_DESCRIPTIONS, FORMAT_DESCRIPTIONS
+from .models import DocumentationRequest, DocumentationResponse
 
 
 class DocumentationTool(BaseTool):

--- a/collegue/tools/dependency_guard/__init__.py
+++ b/collegue/tools/dependency_guard/__init__.py
@@ -10,8 +10,8 @@ Ce module a été refactorisé pour respecter l'architecture modulaire:
 Usage:
     from collegue.tools.dependency_guard import DependencyGuardTool
 """
-from .tool import DependencyGuardTool
 from .models import DependencyGuardRequest, DependencyGuardResponse, DependencyIssue
+from .tool import DependencyGuardTool
 
 __all__ = [
     'DependencyGuardTool',

--- a/collegue/tools/dependency_guard/engine.py
+++ b/collegue/tools/dependency_guard/engine.py
@@ -4,19 +4,15 @@ Moteur d'analyse des dépendances pour l'outil Dependency Guard.
 Contient la logique métier pure : parsing des fichiers, vérification
 d'existence, détection de vulnérabilités.
 """
-import re
 import json
-import urllib.request
+import re
 import urllib.error
 import urllib.parse
-from typing import List, Dict, Any, Optional
-from concurrent.futures import ThreadPoolExecutor
-from .config import (
-    REGISTRY_URLS, OSV_BATCH_URL, OSV_VULN_URL,
-    OSV_CHUNK_SIZE, LANGUAGE_ECOSYSTEM
-)
-from .models import DependencyIssue
+import urllib.request
+from typing import Any, Dict, List
+
 from ..base import ToolValidationError
+from .config import OSV_BATCH_URL, OSV_CHUNK_SIZE, OSV_VULN_URL, REGISTRY_URLS
 
 
 class DependencyAnalysisEngine:
@@ -50,7 +46,7 @@ class DependencyAnalysisEngine:
             for name, version in all_deps.items():
                 dependencies.append({'name': name, 'version': version})
         except json.JSONDecodeError as e:
-            raise ToolValidationError(f"Erreur de parsing JSON: {e}")
+            raise ToolValidationError(f"Erreur de parsing JSON: {e}") from e
         return dependencies
     
     def parse_package_lock(self, content: str) -> List[Dict[str, str]]:
@@ -66,7 +62,7 @@ class DependencyAnalysisEngine:
                 version = info if isinstance(info, str) else info.get('version', '*')
                 deps.append({'name': name, 'version': version})
         except json.JSONDecodeError as e:
-            raise ToolValidationError(f"Erreur de parsing package-lock.json: {e}")
+            raise ToolValidationError(f"Erreur de parsing package-lock.json: {e}") from e
         return deps
     
     def parse_pyproject_toml(self, content: str) -> List[Dict[str, str]]:
@@ -105,7 +101,7 @@ class DependencyAnalysisEngine:
                     continue
                 dependencies.append({'name': name, 'version': version})
         except json.JSONDecodeError as e:
-            raise ToolValidationError(f"Erreur de parsing composer.json: {e}")
+            raise ToolValidationError(f"Erreur de parsing composer.json: {e}") from e
         return dependencies
     
     def parse_composer_lock(self, content: str) -> List[Dict[str, str]]:
@@ -116,7 +112,7 @@ class DependencyAnalysisEngine:
             for pkg in data.get('packages', []) + data.get('packages-dev', []):
                 dependencies.append({'name': pkg.get('name'), 'version': pkg.get('version')})
         except json.JSONDecodeError as e:
-            raise ToolValidationError(f"Erreur de parsing composer.lock: {e}")
+            raise ToolValidationError(f"Erreur de parsing composer.lock: {e}") from e
         return dependencies
     
     def detect_content_type(self, content: str, language: str) -> str:
@@ -257,7 +253,7 @@ class DependencyAnalysisEngine:
         queries = []
         dep_map = {}
         
-        for i, dep in enumerate(deps):
+        for _i, dep in enumerate(deps):
             name = dep['name']
             version = self.extract_version(dep.get('version', '*'))
             if not version or version == '*':

--- a/collegue/tools/dependency_guard/models.py
+++ b/collegue/tools/dependency_guard/models.py
@@ -1,7 +1,8 @@
 """
 Modèles Pydantic pour l'outil Dependency Guard.
 """
-from typing import Optional, List
+from typing import List, Optional
+
 from pydantic import BaseModel, Field, field_validator
 
 

--- a/collegue/tools/dependency_guard/tool.py
+++ b/collegue/tools/dependency_guard/tool.py
@@ -11,14 +11,14 @@ Cet outil vérifie la validité et la sécurité des dépendances d'un projet:
 Refactorisé: Le fichier original faisait 834 lignes, maintenant ~200 lignes.
 """
 
-from typing import List, Dict, Any
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Dict, List
 
-from ..base import BaseTool, ToolValidationError
 from ...core.shared import aggregate_severities
-from .models import DependencyGuardRequest, DependencyGuardResponse, DependencyIssue
+from ..base import BaseTool, ToolValidationError
+from .config import DEPRECATED_PACKAGES, KNOWN_MALICIOUS_PACKAGES, LANGUAGE_ECOSYSTEM
 from .engine import DependencyAnalysisEngine
-from .config import KNOWN_MALICIOUS_PACKAGES, DEPRECATED_PACKAGES, LANGUAGE_ECOSYSTEM
+from .models import DependencyGuardRequest, DependencyGuardResponse, DependencyIssue
 
 
 class DependencyGuardTool(BaseTool):

--- a/collegue/tools/github_commands/__init__.py
+++ b/collegue/tools/github_commands/__init__.py
@@ -9,13 +9,13 @@ Organizes GitHub API operations by domain:
 - FileCommands: File content operations
 """
 from ..clients import GitHubClient
-from .repos import RepoCommands, RepoInfo
-from .prs import PRCommands, PRInfo, FileChange, Comment
-from .issues import IssueCommands, IssueInfo
 from .branches import BranchCommands, BranchInfo, CommitInfo
 from .files import FileCommands
-from .workflows import WorkflowCommands, WorkflowRun
+from .issues import IssueCommands, IssueInfo
+from .prs import Comment, FileChange, PRCommands, PRInfo
+from .repos import RepoCommands, RepoInfo
 from .search import SearchCommands, SearchResult
+from .workflows import WorkflowCommands, WorkflowRun
 
 __all__ = [
     'GitHubClient',

--- a/collegue/tools/github_commands/branches.py
+++ b/collegue/tools/github_commands/branches.py
@@ -3,10 +3,12 @@ Branch Commands for GitHub Operations.
 
 Handles branch listing, creation, and commit operations.
 """
-from typing import Optional, List
+from typing import List, Optional
+
 from pydantic import BaseModel
-from ..clients import GitHubClient
+
 from ..base import ToolExecutionError
+from ..clients import GitHubClient
 
 
 class BranchInfo(BaseModel):
@@ -55,8 +57,8 @@ class BranchCommands(GitHubClient):
 		try:
 			resp = self._api_get(f"/repos/{owner}/{repo}/git/ref/heads/{branch}")
 			return resp['object']['sha']
-		except ToolExecutionError:
-			raise ToolExecutionError(f"Source branch '{branch}' not found")
+		except ToolExecutionError as e:
+			raise ToolExecutionError(f"Source branch '{branch}' not found") from e
 
 	def create_branch(self, owner: str, repo: str, branch: str,
 					  from_branch: Optional[str] = None) -> BranchInfo:

--- a/collegue/tools/github_commands/files.py
+++ b/collegue/tools/github_commands/files.py
@@ -4,9 +4,10 @@ File Commands for GitHub Operations.
 Handles file content operations (read/update).
 """
 import base64
-from typing import Optional, Dict, Any
-from ..clients import GitHubClient
+from typing import Any, Dict, Optional
+
 from ..base import ToolExecutionError
+from ..clients import GitHubClient
 
 
 class FileCommands(GitHubClient):

--- a/collegue/tools/github_commands/issues.py
+++ b/collegue/tools/github_commands/issues.py
@@ -3,8 +3,10 @@ Issue Commands for GitHub Operations.
 
 Handles issue listing, details, and creation.
 """
-from typing import Optional, List
+from typing import List, Optional
+
 from pydantic import BaseModel
+
 from ..clients import GitHubClient
 
 

--- a/collegue/tools/github_commands/prs.py
+++ b/collegue/tools/github_commands/prs.py
@@ -3,8 +3,10 @@ Pull Request Commands for GitHub Operations.
 
 Handles PR listing, details, files, comments, and creation.
 """
-from typing import Optional, List
+from typing import List, Optional
+
 from pydantic import BaseModel
+
 from ..clients import GitHubClient
 
 

--- a/collegue/tools/github_commands/repos.py
+++ b/collegue/tools/github_commands/repos.py
@@ -3,8 +3,10 @@ Repository Commands for GitHub Operations.
 
 Handles repository listing and details.
 """
-from typing import Optional, List
+from typing import List, Optional
+
 from pydantic import BaseModel
+
 from ..clients import GitHubClient
 
 

--- a/collegue/tools/github_commands/search.py
+++ b/collegue/tools/github_commands/search.py
@@ -3,8 +3,10 @@ Search Commands for GitHub Operations.
 
 Handles code search on GitHub.
 """
-from typing import Optional, List
+from typing import List, Optional
+
 from pydantic import BaseModel
+
 from ..clients import GitHubClient
 
 

--- a/collegue/tools/github_commands/workflows.py
+++ b/collegue/tools/github_commands/workflows.py
@@ -3,8 +3,10 @@ Workflow Commands for GitHub Operations.
 
 Handles GitHub Actions workflow runs.
 """
-from typing import Optional, List
+from typing import List, Optional
+
 from pydantic import BaseModel
+
 from ..clients import GitHubClient
 
 

--- a/collegue/tools/github_ops.py
+++ b/collegue/tools/github_ops.py
@@ -5,8 +5,11 @@ Permet à Collègue d'interagir avec GitHub sans changer de fenêtre.
 """
 
 from typing import List, Optional
+
 from pydantic import BaseModel, Field, field_validator
+
 from ..core.auth import register_config_with_github, resolve_token
+from ..core.shared import validate_github_command
 from .base import BaseTool, ToolExecutionError
 from .github_commands.branches import BranchCommands, BranchInfo, CommitInfo
 from .github_commands.files import FileCommands
@@ -15,7 +18,6 @@ from .github_commands.prs import Comment, FileChange, PRCommands, PRInfo
 from .github_commands.repos import RepoCommands, RepoInfo
 from .github_commands.search import SearchCommands, SearchResult
 from .github_commands.workflows import WorkflowCommands, WorkflowRun
-from ..core.shared import validate_github_command
 
 
 class GitHubRequest(BaseModel):
@@ -391,7 +393,7 @@ class GitHubOpsTool(BaseTool):
                 raise ToolExecutionError(
                     "owner, repo, path, message, content requis pour update_file"
                 )
-            result = files_cmd.update_file(
+            files_cmd.update_file(
                 request.owner,
                 request.repo,
                 request.path,

--- a/collegue/tools/iac_guardrails_scan/__init__.py
+++ b/collegue/tools/iac_guardrails_scan/__init__.py
@@ -10,15 +10,15 @@ Ce module a été refactorisé pour respecter l'architecture modulaire:
 Usage:
     from collegue.tools.iac_guardrails_scan import IacGuardrailsScanTool
 """
-from .tool import IacGuardrailsScanTool
 from .models import (
+    CustomPolicy,
+    IacFinding,
     IacGuardrailsRequest,
     IacGuardrailsResponse,
-    IacFinding,
-    CustomPolicy,
+    LLMSecurityInsight,
     RemediationAction,
-    LLMSecurityInsight
 )
+from .tool import IacGuardrailsScanTool
 
 __all__ = [
     'IacGuardrailsScanTool',

--- a/collegue/tools/iac_guardrails_scan/engine.py
+++ b/collegue/tools/iac_guardrails_scan/engine.py
@@ -4,12 +4,10 @@ Moteur d'analyse pour l'outil IaC Guardrails Scan.
 Contient la logique métier pure, séparée de l'orchestration du Tool.
 """
 import re
-import yaml
-import json
-from typing import List, Tuple, Optional, Dict, Any
-from ...core.shared import aggregate_severities, parse_llm_json_response
-from .models import IacFinding, IacGuardrailsRequest, FileInput
-from .config import SEVERITY_WEIGHTS, RISK_THRESHOLDS
+from typing import Dict, List, Tuple
+
+from .config import SEVERITY_WEIGHTS
+from .models import IacFinding
 
 
 class IacAnalysisEngine:
@@ -131,7 +129,7 @@ class IacAnalysisEngine:
         has_user_instruction = False
         last_user_is_root = True
 
-        for i, line in enumerate(lines, 1):
+        for _i, line in enumerate(lines, 1):
             line_stripped = line.strip()
             if line_stripped.startswith('USER '):
                 has_user_instruction = True

--- a/collegue/tools/iac_guardrails_scan/models.py
+++ b/collegue/tools/iac_guardrails_scan/models.py
@@ -1,8 +1,10 @@
 """
 Modèles Pydantic pour l'outil IaC Guardrails Scan.
 """
-from typing import Optional, Dict, Any, List
+from typing import Any, Dict, List, Optional
+
 from pydantic import BaseModel, Field, field_validator
+
 from ...core.shared import FileInput, validate_fast_deep
 
 

--- a/collegue/tools/iac_guardrails_scan/tool.py
+++ b/collegue/tools/iac_guardrails_scan/tool.py
@@ -11,26 +11,25 @@ Refactorisé: Le fichier original faisait 956 lignes, maintenant ~200 lignes.
 La logique métier a été déplacée dans engine.py, les modèles dans models.py.
 """
 
-from typing import List, Dict, Any, Optional
 import asyncio
-import json
+from typing import Any, Dict, List
 
+from ...core.shared import aggregate_severities, load_rules
 from ..base import BaseTool
-from ...core.shared import load_rules, aggregate_severities
-from .models import (
-    IacGuardrailsRequest,
-    IacGuardrailsResponse,
-    IacFinding,
-    RemediationAction,
-    LLMSecurityInsight,
-    FileInput,
-    CustomPolicy,
-)
-from .engine import IacAnalysisEngine
-from .config import DEEP_ANALYSIS_PROMPT_TEMPLATE, FALLBACK_PROMPT_TEMPLATE
+from ..scanners.dockerfile import DockerfileScanner
 from ..scanners.kubernetes import KubernetesScanner
 from ..scanners.terraform import TerraformScanner
-from ..scanners.dockerfile import DockerfileScanner
+from .config import DEEP_ANALYSIS_PROMPT_TEMPLATE
+from .engine import IacAnalysisEngine
+from .models import (
+    CustomPolicy,
+    FileInput,
+    IacFinding,
+    IacGuardrailsRequest,
+    IacGuardrailsResponse,
+    LLMSecurityInsight,
+    RemediationAction,
+)
 
 
 class IacGuardrailsScanTool(BaseTool):
@@ -163,6 +162,7 @@ class IacGuardrailsScanTool(BaseTool):
     ) -> List[IacFinding]:
         """Applique les policies personnalisées sur un fichier."""
         import re
+
         import yaml
 
         findings = []

--- a/collegue/tools/impact_analysis/__init__.py
+++ b/collegue/tools/impact_analysis/__init__.py
@@ -10,12 +10,18 @@ Ce module a été refactorisé pour respecter l'architecture modulaire:
 Usage:
     from collegue.tools.impact_analysis import ImpactAnalysisTool, ImpactAnalysisRequest, ImpactAnalysisResponse
 """
-from .tool import ImpactAnalysisTool
 from .engine import ImpactAnalysisEngine
 from .models import (
-    ImpactAnalysisRequest, ImpactAnalysisResponse,
-    ImpactedFile, RiskNote, SearchQuery, TestRecommendation, FollowupAction, LLMInsight
+    FollowupAction,
+    ImpactAnalysisRequest,
+    ImpactAnalysisResponse,
+    ImpactedFile,
+    LLMInsight,
+    RiskNote,
+    SearchQuery,
+    TestRecommendation,
 )
+from .tool import ImpactAnalysisTool
 
 __all__ = [
     'ImpactAnalysisTool',

--- a/collegue/tools/impact_analysis/engine.py
+++ b/collegue/tools/impact_analysis/engine.py
@@ -4,12 +4,15 @@ Moteur d'analyse d'impact pour l'outil Impact Analysis.
 Contient la logique métier pure : extraction d'identifiants, analyse de fichiers,
 détection de risques, génération de recommandations.
 """
-import re
 import ast
-from typing import List, Dict, Any, Optional, Set, Tuple
+import re
+from typing import Dict, List, Optional, Set
+
 from .config import (
-    IDENTIFIER_PATTERNS, RISK_PATTERNS, RISK_CATEGORIES,
-    CONFIDENCE_THRESHOLDS, TEST_FILE_EXTENSIONS, TEST_COMMANDS
+    IDENTIFIER_PATTERNS,
+    RISK_CATEGORIES,
+    RISK_PATTERNS,
+    TEST_FILE_EXTENSIONS,
 )
 
 

--- a/collegue/tools/impact_analysis/models.py
+++ b/collegue/tools/impact_analysis/models.py
@@ -2,9 +2,11 @@
 Modèles Pydantic pour l'outil Impact Analysis.
 """
 
-from typing import Optional, List
+from typing import List, Optional
+
 from pydantic import BaseModel, Field, field_validator
-from ...core.shared import validate_fast_deep, validate_confidence_mode
+
+from ...core.shared import validate_confidence_mode, validate_fast_deep
 
 
 class ImpactFile(BaseModel):

--- a/collegue/tools/impact_analysis/tool.py
+++ b/collegue/tools/impact_analysis/tool.py
@@ -10,21 +10,22 @@ Cet outil analyse l'impact potentiel d'un changement de code avant son implémen
 Refactorisé: Le fichier original faisait 680 lignes, maintenant ~200 lignes.
 """
 
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List
+
+from ...core.shared import parse_llm_json_response
 from ..base import BaseTool, ToolValidationError
-from ...core.shared import run_async_from_sync, parse_llm_json_response
+from .config import CONFIDENCE_THRESHOLDS
+from .engine import ImpactAnalysisEngine
 from .models import (
+    FollowupAction,
     ImpactAnalysisRequest,
     ImpactAnalysisResponse,
     ImpactedFile,
+    LLMInsight,
     RiskNote,
     SearchQuery,
     TestRecommendation,
-    FollowupAction,
-    LLMInsight,
 )
-from .engine import ImpactAnalysisEngine
-from .config import CONFIDENCE_THRESHOLDS
 
 
 class ImpactAnalysisTool(BaseTool):
@@ -146,10 +147,10 @@ class ImpactAnalysisTool(BaseTool):
     ) -> str:
         """Construit le prompt pour l'analyse deep avec LLM."""
         prompt_parts = [
-            f"Analyse en profondeur l'impact du changement suivant:",
-            f"",
+            "Analyse en profondeur l'impact du changement suivant:",
+            "",
             f"Intent: {request.change_intent}",
-            f"",
+            "",
             f"Fichiers impactés ({len(impacted_files)}):",
         ]
 
@@ -157,20 +158,20 @@ class ImpactAnalysisTool(BaseTool):
             prompt_parts.append(f"  - {f['path']} ({f.get('impact_type', 'unknown')})")
 
         if risk_notes:
-            prompt_parts.extend([f"", f"Risques identifiés:"])
+            prompt_parts.extend(["", "Risques identifiés:"])
             for r in risk_notes[:5]:
                 prompt_parts.append(f"  - [{r['category']}] {r['note']}")
 
         prompt_parts.extend(
             [
-                f"",
-                f"Fournis une analyse structurée au format JSON:",
-                f"{{",
-                f'  "semantic_summary": "Résumé sémantique du changement",',
-                f'  "insights": [',
-                f'    {{"category": "semantic|architectural|business", "insight": "...", "confidence": "high|medium|low"}}',
-                f"  ]",
-                f"}}",
+                "",
+                "Fournis une analyse structurée au format JSON:",
+                "{",
+                '  "semantic_summary": "Résumé sémantique du changement",',
+                '  "insights": [',
+                '    {"category": "semantic|architectural|business", "insight": "...", "confidence": "high|medium|low"}',
+                "  ]",
+                "}",
             ]
         )
 
@@ -180,7 +181,6 @@ class ImpactAnalysisTool(BaseTool):
         self, request: ImpactAnalysisRequest, **kwargs
     ) -> ImpactAnalysisResponse:
         """Exécute l'analyse d'impact (synchrone)."""
-        ctx = kwargs.get("ctx")
 
         # 1. Extraire les identifiants
         identifiers = self._engine.extract_identifiers(request.change_intent)

--- a/collegue/tools/kubernetes_ops.py
+++ b/collegue/tools/kubernetes_ops.py
@@ -4,32 +4,30 @@ Kubernetes Operations Tool - Gestion et inspection des clusters Kubernetes
 Permet à Collègue de lister les pods, lire les logs et décrire les ressources.
 """
 
-import logging
-import os
-import json
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional
+
 from pydantic import BaseModel, Field, field_validator
-from .base import BaseTool, ToolExecutionError
+
 from ..core.shared import validate_k8s_command
+from .base import BaseTool, ToolExecutionError
 from .clients import KubernetesClient
 from .transformers import (
-    transform_pods,
-    transform_pod_detail,
-    transform_deployments,
-    transform_deployment,
-    transform_services,
-    transform_namespaces,
-    transform_events,
-    transform_nodes,
-    transform_node,
     transform_configmaps,
+    transform_deployment,
+    transform_deployments,
+    transform_events,
+    transform_namespaces,
+    transform_node,
+    transform_nodes,
+    transform_pod_detail,
+    transform_pods,
     transform_secrets,
-    _format_age,
+    transform_services,
 )
 
 try:
-    from kubernetes import client, config
-    from kubernetes.client.rest import ApiException
+    from kubernetes import client, config  # noqa: F401
+    from kubernetes.client.rest import ApiException  # noqa: F401
 
     HAS_K8S = True
 except ImportError:
@@ -277,7 +275,7 @@ class KubernetesOpsTool(BaseTool):
                 except config.ConfigException:
                     config.load_kube_config(context=context)
         except Exception as e:
-            raise ToolExecutionError(f"Erreur de configuration Kubernetes: {e}")
+            raise ToolExecutionError(f"Erreur de configuration Kubernetes: {e}") from e
 
     def _get_kubernetes_client(self, request: KubernetesRequest) -> KubernetesClient:
         return KubernetesClient(

--- a/collegue/tools/postgres_db.py
+++ b/collegue/tools/postgres_db.py
@@ -4,18 +4,19 @@ PostgreSQL Database Tool - Inspection et requêtes de bases de données PostgreS
 Permet à Collègue d'inspecter le schéma, vérifier les données et debugger les requêtes SQL.
 """
 
-import logging
 import re
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional
+
 from pydantic import BaseModel, Field, field_validator
-from .base import BaseTool, ToolExecutionError
+
 from ..core.shared import validate_postgres_command
+from .base import BaseTool, ToolExecutionError
 from .clients import PostgresClient
 
 try:
-    import psycopg2
-    from psycopg2 import sql
-    from psycopg2.extras import RealDictCursor
+    import psycopg2  # noqa: F401
+    from psycopg2 import sql  # noqa: F401
+    from psycopg2.extras import RealDictCursor  # noqa: F401
 
     HAS_PSYCOPG2 = True
 except ImportError:

--- a/collegue/tools/quotas.py
+++ b/collegue/tools/quotas.py
@@ -7,13 +7,13 @@ Gère les limites globales pour:
 - Nombre de fichiers par requête
 - Temps d'exécution des tools
 """
-import os
-import time
-import threading
-from typing import Dict, Optional, Any, List
-from dataclasses import dataclass, field
-from enum import Enum
 import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List, Optional
 
 
 class QuotaExceeded(Exception):

--- a/collegue/tools/rate_limiter.py
+++ b/collegue/tools/rate_limiter.py
@@ -6,13 +6,13 @@ Implémente plusieurs algorithmes de rate limiting:
 - Fixed Window: Simple et efficace
 - Sliding Window Log: Précis mais plus coûteux en mémoire
 """
-import time
-import threading
-from abc import ABC, abstractmethod
-from typing import Dict, Optional, Tuple, Any
-from dataclasses import dataclass, field
-from enum import Enum
 import logging
+import threading
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Optional, Tuple
 
 
 class RateLimitExceeded(Exception):

--- a/collegue/tools/refactoring/__init__.py
+++ b/collegue/tools/refactoring/__init__.py
@@ -10,9 +10,9 @@ Ce module a été refactorisé pour respecter l'architecture modulaire:
 Usage:
     from collegue.tools.refactoring import RefactoringTool, RefactoringRequest, RefactoringResponse
 """
-from .tool import RefactoringTool
-from .models import RefactoringRequest, RefactoringResponse, LLMRefactoringResult
 from .engine import RefactoringEngine
+from .models import LLMRefactoringResult, RefactoringRequest, RefactoringResponse
+from .tool import RefactoringTool
 
 __all__ = [
     'RefactoringTool',

--- a/collegue/tools/refactoring/engine.py
+++ b/collegue/tools/refactoring/engine.py
@@ -4,10 +4,11 @@ Moteur d'analyse et de refactoring pour l'outil Refactoring.
 Contient la logique métier pure : analyse de métriques, validation syntaxique,
 extraction de code, calcul des améliorations.
 """
-import re
 import ast
 import json
-from typing import Dict, Any, List, Tuple
+import re
+from typing import Any, Dict, List, Tuple
+
 from .config import COMMENT_PATTERNS, COMPLEXITY_INDICATORS, REFACTORING_TYPES
 
 

--- a/collegue/tools/refactoring/models.py
+++ b/collegue/tools/refactoring/models.py
@@ -1,7 +1,8 @@
 """
 Modèles Pydantic pour l'outil Refactoring.
 """
-from typing import Optional, Dict, Any, List
+from typing import Any, Dict, List, Optional
+
 from pydantic import BaseModel, Field
 
 

--- a/collegue/tools/refactoring/tool.py
+++ b/collegue/tools/refactoring/tool.py
@@ -12,12 +12,13 @@ Cet outil refactorise et améliore le code selon différents types de transforma
 Refactorisé: Le fichier original faisait 687 lignes, maintenant ~200 lignes.
 """
 
-from typing import List, Dict, Any, Optional
-from ..base import BaseTool, ToolError
+from typing import Any, Dict, List
+
 from ...core.shared import run_async_from_sync
-from .models import RefactoringRequest, RefactoringResponse, LLMRefactoringResult
+from ..base import BaseTool, ToolError
+from .config import REFACTORING_LANGUAGE_INSTRUCTIONS
 from .engine import RefactoringEngine
-from .config import REFACTORING_TYPES, REFACTORING_LANGUAGE_INSTRUCTIONS
+from .models import LLMRefactoringResult, RefactoringRequest, RefactoringResponse
 
 
 class RefactoringTool(BaseTool):
@@ -163,12 +164,12 @@ class RefactoringTool(BaseTool):
         prompt_parts = [
             f"Effectue un refactoring de type '{refactoring_type}'",
             f"Description: {refactoring_desc}",
-            f"IMPORTANT: Préserve exactement le comportement du code original",
+            "IMPORTANT: Préserve exactement le comportement du code original",
             f"Langage: {language}",
-            f"",
+            "",
         ]
 
-        prompt_parts.extend([f"```{language}", code, f"```", f""])
+        prompt_parts.extend([f"```{language}", code, "```", ""])
 
         lang_instructions = REFACTORING_LANGUAGE_INSTRUCTIONS.get(language.lower(), {})
         if refactoring_type in lang_instructions:

--- a/collegue/tools/repo_consistency_check/__init__.py
+++ b/collegue/tools/repo_consistency_check/__init__.py
@@ -10,8 +10,8 @@ Ce module a été refactorisé pour respecter l'architecture modulaire:
 Usage:
     from collegue.tools.repo_consistency_check import RepoConsistencyCheckTool
 """
-from .tool import RepoConsistencyCheckTool
 from .models import ConsistencyCheckRequest, ConsistencyCheckResponse, LLMInsight, SuggestedAction
+from .tool import RepoConsistencyCheckTool
 
 __all__ = [
     'RepoConsistencyCheckTool',

--- a/collegue/tools/repo_consistency_check/engine.py
+++ b/collegue/tools/repo_consistency_check/engine.py
@@ -4,12 +4,13 @@ Moteur d'analyse de cohérence pour le Repo Consistency Check.
 Contient la logique métier pure : détection de duplication, analyse de symboles,
 calcul de scores, etc.
 """
-import re
 import ast
 import hashlib
-from typing import List, Dict, Any, Tuple, Set
+import re
+from typing import Dict, List, Set, Tuple
+
 from ...core.shared import ConsistencyIssue, detect_language_from_extension
-from .config import BUILTINS, REFACTORING_WEIGHTS, REFACTORING_THRESHOLDS, DUPLICATION_MIN_LINES
+from .config import BUILTINS, DUPLICATION_MIN_LINES, REFACTORING_THRESHOLDS, REFACTORING_WEIGHTS
 
 
 class ConsistencyAnalysisEngine:

--- a/collegue/tools/repo_consistency_check/models.py
+++ b/collegue/tools/repo_consistency_check/models.py
@@ -2,8 +2,10 @@
 Modèles Pydantic pour l'outil Repo Consistency Check.
 """
 
-from typing import Optional, List, Dict, Any
+from typing import Any, Dict, List, Optional
+
 from pydantic import BaseModel, Field, field_validator
+
 from ...core.shared import validate_fast_deep
 
 

--- a/collegue/tools/repo_consistency_check/tool.py
+++ b/collegue/tools/repo_consistency_check/tool.py
@@ -13,22 +13,21 @@ Refactorisé: Le fichier original faisait 813 lignes, maintenant ~180 lignes.
 """
 
 import asyncio
-import json
-from typing import List, Dict, Any, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
-from ..base import BaseTool
 from ...core.shared import aggregate_severities, parse_llm_json_response
+from ..analyzers.javascript import JavaScriptAnalyzer
+from ..analyzers.php import PHPAnalyzer
+from ..analyzers.python import PythonAnalyzer
+from ..base import BaseTool
+from .config import ALL_CHECKS
+from .engine import ConsistencyAnalysisEngine
 from .models import (
     ConsistencyCheckRequest,
     ConsistencyCheckResponse,
     LLMInsight,
     SuggestedAction,
 )
-from .engine import ConsistencyAnalysisEngine
-from .config import ALL_CHECKS, SEVERITY_MAP
-from ..analyzers.python import PythonAnalyzer
-from ..analyzers.javascript import JavaScriptAnalyzer
-from ..analyzers.php import PHPAnalyzer
 
 
 class RepoConsistencyCheckTool(BaseTool):
@@ -230,7 +229,7 @@ Réponds UNIQUEMENT avec le JSON, sans markdown ni explication."""
     ) -> Optional[Dict[str, Any]]:
         """Exécute le refactoring automatique si activé."""
         try:
-            from ..refactoring import RefactoringTool, RefactoringRequest
+            from ..refactoring import RefactoringRequest, RefactoringTool
 
             if not suggested_actions:
                 return None

--- a/collegue/tools/scanners/__init__.py
+++ b/collegue/tools/scanners/__init__.py
@@ -4,7 +4,8 @@ Base Scanner for IaC Guardrails.
 Provides common functionality for IaC-specific scanners.
 """
 from abc import ABC, abstractmethod
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional
+
 from ..base import ToolError
 
 

--- a/collegue/tools/scanners/dockerfile.py
+++ b/collegue/tools/scanners/dockerfile.py
@@ -4,7 +4,8 @@ Dockerfile Scanner for IaC Guardrails.
 Scans Dockerfiles for security issues.
 """
 import re
-from typing import List, Dict, Any
+from typing import List
+
 from . import BaseScanner, IacFinding
 
 
@@ -71,7 +72,7 @@ class DockerfileScanner(BaseScanner):
 		has_user = False
 		runs_as_root = True
 
-		for i, line in enumerate(lines, 1):
+		for _i, line in enumerate(lines, 1):
 			if re.match(r'^USER\s+', line, re.IGNORECASE):
 				has_user = True
 				user_match = re.match(r'^USER\s+(\S+)', line, re.IGNORECASE)

--- a/collegue/tools/scanners/kubernetes.py
+++ b/collegue/tools/scanners/kubernetes.py
@@ -3,8 +3,8 @@ Kubernetes Scanner for IaC Guardrails.
 
 Scans Kubernetes YAML manifests for security issues.
 """
-import re
-from typing import List, Dict, Any
+from typing import Dict, List
+
 from . import BaseScanner, IacFinding
 
 

--- a/collegue/tools/scanners/terraform.py
+++ b/collegue/tools/scanners/terraform.py
@@ -4,7 +4,8 @@ Terraform Scanner for IaC Guardrails.
 Scans Terraform HCL files for security issues.
 """
 import re
-from typing import List, Dict, Any
+from typing import List
+
 from . import BaseScanner, IacFinding
 
 

--- a/collegue/tools/secret_scan/__init__.py
+++ b/collegue/tools/secret_scan/__init__.py
@@ -10,8 +10,8 @@ Ce module a été refactorisé pour respecter l'architecture modulaire:
 Usage:
     from collegue.tools.secret_scan import SecretScanTool
 """
+from .models import SecretFinding, SecretScanRequest, SecretScanResponse
 from .tool import SecretScanTool
-from .models import SecretScanRequest, SecretScanResponse, SecretFinding
 
 __all__ = [
     'SecretScanTool',

--- a/collegue/tools/secret_scan/engine.py
+++ b/collegue/tools/secret_scan/engine.py
@@ -4,13 +4,14 @@ Moteur de détection des secrets pour l'outil Secret Scan.
 Contient la logique métier pure pour la détection, le masquage
 et la gestion des secrets.
 """
+import fnmatch
 import os
 import re
-import fnmatch
 from typing import List, Optional, Tuple
+
+from ...core.file_security import FileSecurityError, safe_read_file
+from .config import DEFAULT_EXCLUDES, DEFAULT_EXTENSIONS, SECRET_PATTERNS, SECRET_RECOMMENDATIONS, SEVERITY_LEVELS
 from .models import SecretFinding
-from .config import SECRET_PATTERNS, SEVERITY_LEVELS, SECRET_RECOMMENDATIONS, DEFAULT_EXTENSIONS, DEFAULT_EXCLUDES
-from ...core.file_security import safe_read_file, FileSecurityError
 
 
 class SecretDetectionEngine:

--- a/collegue/tools/secret_scan/models.py
+++ b/collegue/tools/secret_scan/models.py
@@ -2,7 +2,8 @@
 Modèles Pydantic pour l'outil Secret Scan.
 """
 
-from typing import Optional, List
+from typing import List, Optional
+
 from pydantic import BaseModel, Field, field_validator
 
 

--- a/collegue/tools/secret_scan/tool.py
+++ b/collegue/tools/secret_scan/tool.py
@@ -13,11 +13,12 @@ La logique métier a été déplacée dans engine.py, les modèles dans models.p
 """
 
 import os
-from typing import List, Dict, Any, Optional
-from ..base import BaseTool, ToolValidationError
+from typing import Any, Dict, List
+
 from ...core.shared import aggregate_severities
-from .models import SecretScanRequest, SecretScanResponse, SecretFinding
+from ..base import BaseTool, ToolValidationError
 from .engine import SecretDetectionEngine
+from .models import SecretFinding, SecretScanRequest, SecretScanResponse
 
 
 class SecretScanTool(BaseTool):

--- a/collegue/tools/sentry_monitor.py
+++ b/collegue/tools/sentry_monitor.py
@@ -4,25 +4,25 @@ Sentry Monitor Tool - Récupération des erreurs et monitoring depuis Sentry
 Permet à Collègue de récupérer les stacktraces réelles et prioriser le refactoring.
 """
 
-import logging
-import os
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional
+
 from pydantic import BaseModel, Field, field_validator
-from .base import BaseTool, ToolExecutionError
+
+from ..core.auth import register_config_with_github, resolve_org, resolve_token
 from ..core.shared import validate_sentry_command
+from .base import BaseTool, ToolExecutionError
 from .clients import SentryClient
 from .transformers import (
-    transform_projects,
-    transform_project,
-    transform_issues,
     transform_issue,
-    transform_sentry_events,
+    transform_issues,
+    transform_project,
+    transform_project_stats,
+    transform_projects,
     transform_releases,
     transform_repos,
+    transform_sentry_events,
     transform_tags,
-    transform_project_stats,
 )
-from ..core.auth import resolve_token, resolve_org, register_config_with_github
 
 try:
     from fastmcp.server.dependencies import get_http_headers
@@ -30,14 +30,14 @@ except Exception:
     get_http_headers = None
 
 try:
-    import requests
+    import requests  # noqa: F401
 
     HAS_REQUESTS = True
 except ImportError:
     HAS_REQUESTS = False
 
 try:
-    from collegue.autonomous.config_registry import get_config_registry
+    from collegue.autonomous.config_registry import get_config_registry  # noqa: F401
 
     HAS_CONFIG_REGISTRY = True
 except ImportError:
@@ -263,13 +263,12 @@ class SentryMonitorTool(BaseTool):
     def _parse_sentryclirc(self, content: str) -> ConfigInfo:
         """Parse un contenu style INI (.sentryclirc)."""
         import configparser
-        import io
 
         config = configparser.ConfigParser()
         try:
             config.read_string(content)
         except configparser.Error as e:
-            raise ToolExecutionError(f"Erreur de parsing .sentryclirc: {e}")
+            raise ToolExecutionError(f"Erreur de parsing .sentryclirc: {e}") from e
 
         info = ConfigInfo()
 
@@ -504,9 +503,6 @@ class SentryMonitorTool(BaseTool):
                     response.error_message or "Failed to get project stats"
                 )
             stats_data = response.data or {}
-            # Extract stats from response
-            total_events = stats_data.get("total", 0)
-            unresolved = stats_data.get("unresolved", 0)
             stats = transform_project_stats(stats_data, request.project)
             return SentryResponse(
                 success=True,

--- a/collegue/tools/test_generation/__init__.py
+++ b/collegue/tools/test_generation/__init__.py
@@ -10,9 +10,9 @@ Ce module a été refactorisé pour respecter l'architecture modulaire:
 Usage:
     from collegue.tools.test_generation import TestGenerationTool, TestGenerationRequest, TestGenerationResponse
 """
-from .tool import TestGenerationTool
-from .models import TestGenerationRequest, TestGenerationResponse, LLMTestGenerationResult
 from .engine import TestGenerationEngine
+from .models import LLMTestGenerationResult, TestGenerationRequest, TestGenerationResponse
+from .tool import TestGenerationTool
 
 __all__ = [
     'TestGenerationTool',

--- a/collegue/tools/test_generation/engine.py
+++ b/collegue/tools/test_generation/engine.py
@@ -4,10 +4,11 @@ Moteur d'analyse et de génération de tests.
 Contient la logique métier pure : analyse de code, extraction d'éléments,
 gestion des templates, génération de fallback.
 """
-import re
 import ast
-from typing import List, Dict, Any, Optional, Tuple
-from .config import TEST_FRAMEWORKS, DEFAULT_FRAMEWORKS, IMPORT_TEMPLATES, TEST_TEMPLATES, LANGUAGE_TEST_INSTRUCTIONS
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from .config import DEFAULT_FRAMEWORKS, IMPORT_TEMPLATES, LANGUAGE_TEST_INSTRUCTIONS, TEST_FRAMEWORKS
 
 
 class TestGenerationEngine:
@@ -285,15 +286,15 @@ class TestGenerationEngine:
         """Construit le prompt pour le LLM."""
         prompt_parts = [
             f"Génère des tests unitaires pour le code {language} suivant.",
-            f"",
+            "",
             f"Framework de test: {framework}",
             f"Cible de couverture: {coverage_target:.0%}",
             f"Inclure des mocks: {'oui' if include_mocks else 'non'}",
-            f"",
+            "",
             f"```{language}",
             code,
-            f"```",
-            f"",
+            "```",
+            "",
         ]
         
         if elements:

--- a/collegue/tools/test_generation/models.py
+++ b/collegue/tools/test_generation/models.py
@@ -1,7 +1,8 @@
 """
 Modèles Pydantic pour l'outil Test Generation.
 """
-from typing import Optional, Dict, Any, List
+from typing import Dict, List, Optional
+
 from pydantic import BaseModel, Field, field_validator
 
 

--- a/collegue/tools/test_generation/tool.py
+++ b/collegue/tools/test_generation/tool.py
@@ -8,17 +8,15 @@ Refactorisé: Le fichier original faisait 767 lignes, maintenant ~200 lignes.
 """
 
 import time
-from typing import List, Dict, Any, Optional
-import pathlib
+from typing import Any, Dict, List
 
-from ..base import BaseTool, ToolError, ToolValidationError
 from ...core.shared import run_async_from_sync
+from ..base import BaseTool, ToolValidationError
+from .engine import TestGenerationEngine
 from .models import (
     TestGenerationRequest,
     TestGenerationResponse,
-    LLMTestGenerationResult,
 )
-from .engine import TestGenerationEngine
 
 
 class TestGenerationTool(BaseTool):

--- a/collegue/tools/transformers/__init__.py
+++ b/collegue/tools/transformers/__init__.py
@@ -3,44 +3,52 @@ Transformers Package - Fonctions de transformation des données.
 
 Transforme les données brutes des APIs en modèles Pydantic typés.
 """
-from .kubernetes import (
-	transform_pods,
-	transform_pod_detail,
-	transform_deployments,
-	transform_deployment,
-	transform_services,
-	transform_namespaces,
-	transform_events,
-	transform_nodes,
-	transform_node,
-	transform_configmaps,
-	transform_secrets,
-	_format_age,
-)
-from .sentry import (
-	transform_projects,
-	transform_project,
-	transform_issues,
-	transform_issue,
-	transform_events as transform_sentry_events,
-	transform_releases,
-	transform_repos as transform_sentry_repos,
-	transform_tags,
-	transform_project_stats,
+from .github import (
+	transform_branch,
+	transform_branches,
+	transform_pr,
+	transform_pr_comments,
+	transform_pr_files,
+	transform_prs,
+	transform_repo,
+	transform_repos,
+	transform_search_results,
+	transform_workflow_runs,
 )
 from .github import (
-	transform_repos,
-	transform_repo,
-	transform_prs,
-	transform_pr,
-	transform_pr_files,
-	transform_pr_comments,
-	transform_issues as transform_github_issues,
 	transform_issue as transform_github_issue,
-	transform_branches,
-	transform_branch,
-	transform_workflow_runs,
-	transform_search_results,
+)
+from .github import (
+	transform_issues as transform_github_issues,
+)
+from .kubernetes import (
+	_format_age,
+	transform_configmaps,
+	transform_deployment,
+	transform_deployments,
+	transform_events,
+	transform_namespaces,
+	transform_node,
+	transform_nodes,
+	transform_pod_detail,
+	transform_pods,
+	transform_secrets,
+	transform_services,
+)
+from .sentry import (
+	transform_events as transform_sentry_events,
+)
+from .sentry import (
+	transform_issue,
+	transform_issues,
+	transform_project,
+	transform_project_stats,
+	transform_projects,
+	transform_releases,
+	transform_tags,
+)
+from .sentry import (
+	transform_repos as transform_sentry_repos,
 )
 
 __all__ = [

--- a/collegue/tools/transformers/github.py
+++ b/collegue/tools/transformers/github.py
@@ -3,13 +3,20 @@ GitHub Transformers - Fonctions de transformation des données GitHub.
 
 Transforme les données brutes de l'API GitHub en modèles Pydantic typés.
 """
-from typing import Any, Dict, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List
+
 from ...core.shared import normalize_keys
 
 if TYPE_CHECKING:
 	from ..github_commands import (
-		RepoInfo, PRInfo, IssueInfo, BranchInfo,
-		FileChange, Comment, WorkflowRun, SearchResult
+		BranchInfo,
+		Comment,
+		FileChange,
+		IssueInfo,
+		PRInfo,
+		RepoInfo,
+		SearchResult,
+		WorkflowRun,
 	)
 
 

--- a/collegue/tools/transformers/kubernetes.py
+++ b/collegue/tools/transformers/kubernetes.py
@@ -4,15 +4,21 @@ Kubernetes Transformers - Fonctions de transformation des données Kubernetes.
 Transforme les données brutes de l'API Kubernetes en modèles Pydantic typés.
 """
 from datetime import datetime, timezone
-from typing import Any, Dict, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from ...core.shared import normalize_keys
 
 if TYPE_CHECKING:
 	from ..kubernetes_ops import (
-		PodInfo, PodDetail, ContainerStatus, DeploymentInfo,
-		ServiceInfo, NamespaceInfo, EventInfo, NodeInfo,
-		ConfigMapInfo, SecretInfo
+		ConfigMapInfo,
+		DeploymentInfo,
+		EventInfo,
+		NamespaceInfo,
+		NodeInfo,
+		PodDetail,
+		PodInfo,
+		SecretInfo,
+		ServiceInfo,
 	)
 
 
@@ -81,7 +87,7 @@ def transform_pods(pods_data: List[Dict[str, Any]]) -> List['PodInfo']:
 
 def transform_pod_detail(pod_data: Dict[str, Any]) -> 'PodDetail':
 	"""Transform raw pod data into PodDetail object."""
-	from ..kubernetes_ops import PodDetail, ContainerStatus
+	from ..kubernetes_ops import ContainerStatus, PodDetail
 	pod_data = normalize_keys(pod_data) or {}
 	metadata = pod_data.get('metadata', {})
 	spec = pod_data.get('spec', {})
@@ -292,7 +298,7 @@ def transform_nodes(nodes_data: List[Dict[str, Any]]) -> List['NodeInfo']:
 
 		# Extract roles
 		roles = []
-		for label, value in metadata.get('labels', {}).items():
+		for label, _value in metadata.get('labels', {}).items():
 			if label.startswith("node-role.kubernetes.io/"):
 				roles.append(label.split("/")[1])
 
@@ -327,7 +333,7 @@ def transform_node(node_data: Dict[str, Any]) -> 'NodeInfo':
 	status = node_data.get('status', {})
 
 	roles = []
-	for label, value in metadata.get('labels', {}).items():
+	for label, _value in metadata.get('labels', {}).items():
 		if label.startswith("node-role.kubernetes.io/"):
 			roles.append(label.split("/")[1])
 

--- a/collegue/tools/transformers/sentry.py
+++ b/collegue/tools/transformers/sentry.py
@@ -3,15 +3,12 @@ Sentry Transformers - Fonctions de transformation des données Sentry.
 
 Transforme les données brutes de l'API Sentry en modèles Pydantic typés.
 """
-from typing import Any, Dict, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from ...core.shared import normalize_keys
 
 if TYPE_CHECKING:
-	from ..sentry_monitor import (
-		ProjectInfo, IssueInfo, EventInfo, ReleaseInfo,
-		RepoInfo, TagDistribution, ProjectStats
-	)
+	from ..sentry_monitor import EventInfo, IssueInfo, ProjectInfo, ProjectStats, ReleaseInfo, RepoInfo, TagDistribution
 
 def transform_projects(projects_data: List[Dict[str, Any]]) -> List['ProjectInfo']:
 	from ..sentry_monitor import ProjectInfo

--- a/collegue/tools/utils/test_generators_adapter.py
+++ b/collegue/tools/utils/test_generators_adapter.py
@@ -4,7 +4,7 @@ Test Templates - Fonctions simples de génération de tests.
 Ce module fournit des fonctions directes pour générer des templates de tests
 sans architecture OO complexe.
 """
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 
 def _generate_test_case(name: str, description: str = "") -> str:
@@ -376,7 +376,7 @@ def generate_phpunit_tests(code: str, functions: List[Dict[str, Any]],
         func_name = func.get("name", "unknown")
         test_name = f"test_{func_name}".replace(" ", "_")
         lines.extend([
-            f"    /** @test */",
+            "    /** @test */",
             f"    public function {test_name}()",
             "    {",
             "        // TODO: Implement test",
@@ -389,7 +389,7 @@ def generate_phpunit_tests(code: str, functions: List[Dict[str, Any]],
     for cls in classes:
         class_name = cls.get("name", "Unknown")
         lines.extend([
-            f"    /** @test */",
+            "    /** @test */",
             f"    public function {class_name.lower()}_initialization()",
             "    {",
             "        // TODO: Implement test",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,12 @@ line-length = 120
 target-version = "py312"
 
 [tool.ruff.lint]
-# Narrow initial rule set: only real bugs (undefined names, duplicate
-# definitions). Style rules (unused imports, f-string-no-placeholder, etc.)
-# will be enabled in follow-up PRs once the codebase is cleaned up.
-select = ["F811", "F821", "F822", "F823"]
+select = [
+    "F",     # Pyflakes — all error detection rules
+    "I",     # isort — import sorting
+    "B",     # flake8-bugbear — common bug patterns
+]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["F811", "F821", "F822", "F823"]
+"tests/**" = ["F", "B"]
+"collegue/**/__init__.py" = ["F401"]  # Re-exports in __init__.py are intentional

--- a/tests/evals/runner.py
+++ b/tests/evals/runner.py
@@ -48,11 +48,9 @@ from collegue.config import settings
 from collegue.resources.llm.providers import LLMConfig, generate_text
 from collegue.tools.code_documentation import DocumentationRequest, DocumentationTool
 from collegue.tools.test_generation import TestGenerationRequest, TestGenerationTool
-
 from tests.evals.eval_context import EvalContext
 from tests.evals.scorers import code_documentation as doc_scorer
 from tests.evals.scorers import test_generation as tg_scorer
-
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CASES_ROOT = Path(__file__).parent / "cases"

--- a/tests/evals/scorers/code_documentation.py
+++ b/tests/evals/scorers/code_documentation.py
@@ -48,9 +48,7 @@ from typing import Any, Dict, Optional
 
 from collegue.config import settings
 from collegue.resources.llm.providers import LLMConfig, generate_text
-
 from tests.evals.scorers.test_generation import EvalScore
-
 
 JUDGE_MODEL = "gemini-2.5-flash"
 _AXES = ("accuracy", "completeness", "clarity", "usefulness")

--- a/tests/evals/scorers/test_generation.py
+++ b/tests/evals/scorers/test_generation.py
@@ -14,7 +14,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict
 
-
 _SUMMARY_RE = re.compile(
     r"(?P<count>\d+)\s+(?P<outcome>passed|failed|error[s]?|skipped)",
     re.IGNORECASE,

--- a/tests/prompts/engine/test_models.py
+++ b/tests/prompts/engine/test_models.py
@@ -6,12 +6,12 @@ import uuid
 from datetime import datetime
 
 from collegue.prompts.engine.models import (
-    PromptVariable,
-    PromptVariableType,
-    PromptTemplate,
     PromptCategory,
     PromptExecution,
-    PromptLibrary
+    PromptLibrary,
+    PromptTemplate,
+    PromptVariable,
+    PromptVariableType,
 )
 
 

--- a/tests/prompts/engine/test_prompt_engine.py
+++ b/tests/prompts/engine/test_prompt_engine.py
@@ -1,21 +1,21 @@
 """
 Tests unitaires pour le moteur de prompts personnalisés
 """
-import unittest
-import os
 import json
-import tempfile
+import os
 import shutil
-from unittest.mock import patch, MagicMock
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
 
-from collegue.prompts.engine.prompt_engine import PromptEngine
 from collegue.prompts.engine.models import (
-    PromptTemplate, 
     PromptCategory,
+    PromptExecution,
+    PromptTemplate,
     PromptVariable,
     PromptVariableType,
-    PromptExecution
 )
+from collegue.prompts.engine.prompt_engine import PromptEngine
 
 
 class TestPromptEngine(unittest.TestCase):

--- a/tests/prompts/interface/test_api.py
+++ b/tests/prompts/interface/test_api.py
@@ -8,24 +8,19 @@ pytest.skip(
 	allow_module_level=True,
 )
 
-import unittest
 import json
-import tempfile
-import shutil
 import os
-from unittest.mock import patch, MagicMock
+import shutil
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
 
-from fastapi.testclient import TestClient
+from collegue.prompts.interface.api import get_prompt_engine, register_prompt_interface
 from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from collegue.prompts.engine import PromptEngine
-from collegue.prompts.interface.api import register_prompt_interface, get_prompt_engine
-from collegue.prompts.engine.models import (
-    PromptTemplate, 
-    PromptCategory,
-    PromptVariable,
-    PromptVariableType
-)
+from collegue.prompts.engine.models import PromptCategory, PromptTemplate, PromptVariable, PromptVariableType
 
 
 class TestPromptAPI(unittest.TestCase):

--- a/tests/prompts/interface/test_web.py
+++ b/tests/prompts/interface/test_web.py
@@ -8,24 +8,19 @@ pytest.skip(
 	allow_module_level=True,
 )
 
-import unittest
 import json
-import tempfile
-import shutil
 import os
-from unittest.mock import patch, MagicMock
+import shutil
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
 
-from fastapi.testclient import TestClient
+from collegue.prompts.interface.web import register_web_interface
 from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from collegue.prompts.engine import PromptEngine
-from collegue.prompts.interface.web import register_web_interface
-from collegue.prompts.engine.models import (
-    PromptTemplate, 
-    PromptCategory,
-    PromptVariable,
-    PromptVariableType
-)
+from collegue.prompts.engine.models import PromptCategory, PromptTemplate, PromptVariable, PromptVariableType
 
 
 class TestPromptWebInterface(unittest.TestCase):

--- a/tests/stress/real_cases/fixtures/python/dead_code.py
+++ b/tests/stress/real_cases/fixtures/python/dead_code.py
@@ -1,6 +1,6 @@
 """Module with unused imports and dead code for repo_consistency_check testing."""
-import os  # unused
 import json  # unused
+import os  # unused
 from collections import OrderedDict  # unused
 
 ACTIVE_COUNT = 0

--- a/tests/stress/real_cases/scenarios/secret_scan.py
+++ b/tests/stress/real_cases/scenarios/secret_scan.py
@@ -1,7 +1,7 @@
 """Real-world scenarios for secret_scan."""
 from __future__ import annotations
 
-from tests.stress.real_cases import fixture, findings_of, tool_content
+from tests.stress.real_cases import findings_of, fixture, tool_content
 
 TOOL_NAME = "secret_scan"
 

--- a/tests/stress/run_injection_audit.py
+++ b/tests/stress/run_injection_audit.py
@@ -16,7 +16,6 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 from runner import MCPSession, run_case  # noqa: E402
 
-
 # Surface-level leak heuristics. Not exhaustive — they cover the classic cases:
 # system-prompt leakage, verbatim key echoes, and explicit acknowledgement
 # phrases that a compliant LLM emits when it has followed a jailbreak.

--- a/tests/stress/run_real_cases.py
+++ b/tests/stress/run_real_cases.py
@@ -23,6 +23,7 @@ sys.path.insert(0, str(_HERE.parent.parent))   # repo root → enables `tests.st
 sys.path.insert(0, str(_HERE))                  # stress dir → enables `runner`
 
 from runner import MCPSession, run_case  # noqa: E402
+
 from tests.stress.real_cases import is_error_response, is_quota_inconclusive, response_text  # noqa: E402
 
 SCENARIO_MODULES = [

--- a/tests/stress/runner.py
+++ b/tests/stress/runner.py
@@ -10,7 +10,7 @@ import os
 import subprocess
 import time
 import uuid
-from dataclasses import dataclass, field, asdict
+from dataclasses import asdict, dataclass, field
 from typing import Any
 
 import httpx

--- a/tests/test_architecture_fixes.py
+++ b/tests/test_architecture_fixes.py
@@ -1,11 +1,13 @@
-import pytest
 import asyncio
-from unittest.mock import patch, MagicMock
 from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
 from pydantic import BaseModel
 
 from collegue.tools.base import BaseTool
 from collegue.tools.github_ops import GitHubOpsTool, GitHubRequest, GitHubResponse
+
 
 class DummyPromptEngine:
     pass

--- a/tests/test_base_tool_rate_limits.py
+++ b/tests/test_base_tool_rate_limits.py
@@ -3,20 +3,21 @@ Tests d'intégration pour rate limiting et quotas dans BaseTool.
 """
 import pytest
 from pydantic import BaseModel
+
 from collegue.tools.base import (
     BaseTool,
-    ToolRateLimitError,
     ToolQuotaError,
+    ToolRateLimitError,
     ToolValidationError,
-)
-from collegue.tools.rate_limiter import (
-    get_rate_limiter_manager,
-    reset_rate_limiter_manager,
-    RateLimitConfig,
 )
 from collegue.tools.quotas import (
     get_global_quota_manager,
     reset_global_quota_manager,
+)
+from collegue.tools.rate_limiter import (
+    RateLimitConfig,
+    get_rate_limiter_manager,
+    reset_rate_limiter_manager,
 )
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,19 +1,19 @@
 """
 Tests du client Python pour Collègue MCP
 """
+import asyncio
 import os
 import sys
 import unittest
-import asyncio
 from types import SimpleNamespace
-from unittest.mock import patch, MagicMock, AsyncMock
-
+from unittest.mock import AsyncMock, MagicMock, patch
 
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, parent_dir)
 
 
 from collegue.client import CollegueClient
+
 
 class TestCollegueClient(unittest.TestCase):
     """Tests unitaires pour le client Python Collègue MCP."""

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -3,12 +3,13 @@ Tests unitaires pour les clients du package collegue.tools.clients
 
 Ces tests utilisent des mocks pour tester les clients sans faire d'appels réels aux APIs.
 """
-import sys
 import os
+import sys
+
 sys.path.insert(0, '/home/kevyn-odjo/Documents/Collegue')
 
-from unittest.mock import Mock, patch, MagicMock
 import json
+from unittest.mock import MagicMock, Mock, patch
 
 print("=" * 80)
 print("TESTS UNITAIRES - CLIENTS")
@@ -22,7 +23,7 @@ print("TEST 1: SENTRY CLIENT")
 print("=" * 80)
 
 try:
-    from collegue.tools.clients import SentryClient, APIError
+    from collegue.tools.clients import APIError, SentryClient
     
     # Test 1.1: Initialisation
     print("\n1.1 Test initialisation SentryClient...")
@@ -195,7 +196,7 @@ print("TEST 2: KUBERNETES CLIENT")
 print("=" * 80)
 
 try:
-    from collegue.tools.clients import KubernetesClient, APIError
+    from collegue.tools.clients import APIError, KubernetesClient
     
     # Test 2.1: Initialisation avec kubectl
     print("\n2.1 Test initialisation KubernetesClient (mode kubectl)...")
@@ -490,7 +491,7 @@ print("TEST 3: POSTGRES CLIENT")
 print("=" * 80)
 
 try:
-    from collegue.tools.clients import PostgresClient, APIError
+    from collegue.tools.clients import APIError, PostgresClient
     
     # Test 3.1: Initialisation avec connection_string
     print("\n3.1 Test initialisation PostgresClient (avec connection_string)...")

--- a/tests/test_code_documentation.py
+++ b/tests/test_code_documentation.py
@@ -1,14 +1,15 @@
 """
 Tests unitaires pour l'outil Code Documentation refactorisé.
 """
-import pytest
 from unittest.mock import MagicMock
 
+import pytest
+
 from collegue.tools.code_documentation import (
-    DocumentationTool,
+    DocumentationEngine,
     DocumentationRequest,
     DocumentationResponse,
-    DocumentationEngine
+    DocumentationTool,
 )
 
 

--- a/tests/test_core_components.py
+++ b/tests/test_core_components.py
@@ -7,18 +7,18 @@ Architecture actuelle:
 - Les tools sont enregistrés via register_tools(app) sans app_state.
 - L'orchestration utilise le meta_orchestrator FastMCP natif.
 """
-import sys
 import os
+import sys
 import unittest
 from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from collegue.core import CodeParser
-from collegue.core import register_core
-from collegue.tools import register_tools, _discover_tools
-from collegue.config import Settings
 from fastmcp import FastMCP
+
+from collegue.config import Settings
+from collegue.core import CodeParser, register_core
+from collegue.tools import _discover_tools, register_tools
 
 
 class TestCoreRegistration(unittest.TestCase):
@@ -96,7 +96,7 @@ class TestToolExecution(unittest.TestCase):
 
     def test_refactoring_tool_local_fallback(self):
         """Le RefactoringTool fonctionne en mode local (sans LLM)."""
-        from collegue.tools.refactoring import RefactoringTool, RefactoringRequest
+        from collegue.tools.refactoring import RefactoringRequest, RefactoringTool
 
         tool = RefactoringTool({})
         request = RefactoringRequest(
@@ -109,7 +109,7 @@ class TestToolExecution(unittest.TestCase):
 
     def test_secret_scan_tool(self):
         """Le SecretScanTool détecte les secrets."""
-        from collegue.tools.secret_scan import SecretScanTool, SecretScanRequest
+        from collegue.tools.secret_scan import SecretScanRequest, SecretScanTool
 
         tool = SecretScanTool({})
         request = SecretScanRequest(

--- a/tests/test_dependency_guard.py
+++ b/tests/test_dependency_guard.py
@@ -1,15 +1,12 @@
 """
 Tests unitaires pour l'outil Dependency Guard refactorisé.
 """
-import pytest
-from unittest.mock import MagicMock, patch
 import json
+from unittest.mock import MagicMock, patch
 
-from collegue.tools.dependency_guard import (
-    DependencyGuardTool,
-    DependencyGuardRequest,
-    DependencyIssue
-)
+import pytest
+
+from collegue.tools.dependency_guard import DependencyGuardRequest, DependencyGuardTool, DependencyIssue
 from collegue.tools.dependency_guard.engine import DependencyAnalysisEngine
 
 

--- a/tests/test_docker_compose_config.py
+++ b/tests/test_docker_compose_config.py
@@ -2,9 +2,10 @@
 Tests unitaires pour la configuration Docker Compose.
 Vérifie que le kc-provisioner est désactivé et que le healthcheck est correct.
 """
+import os
+
 import pytest
 import yaml
-import os
 
 
 class TestDockerComposeConfig:

--- a/tests/test_documentation_fixes.py
+++ b/tests/test_documentation_fixes.py
@@ -1,6 +1,9 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
-from unittest.mock import MagicMock, AsyncMock, patch
-from collegue.tools.code_documentation import DocumentationTool, DocumentationRequest
+
+from collegue.tools.code_documentation import DocumentationRequest, DocumentationTool
+
 
 @pytest.mark.asyncio
 async def test_documentation_tool_success():

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -8,18 +8,18 @@ pytest.skip(
 	allow_module_level=True,
 )
 
+import asyncio
+import json
 import os
 import sys
-import json
-import asyncio
-from typing import Dict, Any
-
+from typing import Any, Dict
 
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, parent_dir)
 
 
 from fastmcp import Client
+
 
 def safe_json_print(obj):
     """Affiche un objet de manière sécurisée, même s'il n'est pas JSON sérialisable."""

--- a/tests/test_enhanced_prompt_system.py
+++ b/tests/test_enhanced_prompt_system.py
@@ -1,22 +1,21 @@
 """
 Tests unitaires pour le système de prompts amélioré
 """
-import sys
-import unittest
 import asyncio
-import tempfile
-import shutil
 import os
-from unittest.mock import Mock, patch
+import shutil
+import sys
+import tempfile
+import unittest
 from pathlib import Path
-
+from unittest.mock import Mock, patch
 
 parent_dir = str(Path(__file__).parent.parent.absolute())
 sys.path.insert(0, parent_dir)
 
-from collegue.prompts.engine.versioning import PromptVersionManager
-from collegue.prompts.engine.optimizer import LanguageOptimizer
 from collegue.prompts.engine.enhanced_prompt_engine import EnhancedPromptEngine
+from collegue.prompts.engine.optimizer import LanguageOptimizer
+from collegue.prompts.engine.versioning import PromptVersionManager
 
 
 class TestPromptVersionManager(unittest.TestCase):

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -2,12 +2,13 @@
 Tests unitaires pour le script entrypoint.sh
 Vérifie que les deux services démarrent correctement.
 """
-import pytest
+import os
+import signal
 import subprocess
 import time
+
+import pytest
 import requests
-import signal
-import os
 
 
 class TestEntrypoint:
@@ -34,8 +35,8 @@ class TestHealthServer:
     @pytest.fixture(scope="module")
     def health_server(self):
         """Démarre le health server pour les tests."""
-        import subprocess
         import os
+        import subprocess
         
         health_server_path = os.path.join(os.path.dirname(__file__), '..', 'collegue', 'health_server.py')
         proc = subprocess.Popen(['python3', health_server_path], 

--- a/tests/test_env_validation.py
+++ b/tests/test_env_validation.py
@@ -1,6 +1,8 @@
 import pytest
 from pydantic import ValidationError
+
 from collegue.config import Settings
+
 
 def test_sentry_dsn_validation():
     # Valid DSN

--- a/tests/test_fault_tolerance.py
+++ b/tests/test_fault_tolerance.py
@@ -1,9 +1,11 @@
-import pytest
 import asyncio
-from unittest.mock import AsyncMock, patch, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
 
 from collegue.tools.base import BaseTool, ToolExecutionError
-from pydantic import BaseModel
+
 
 class DummyRequest(BaseModel):
     code: str

--- a/tests/test_file_security.py
+++ b/tests/test_file_security.py
@@ -1,12 +1,14 @@
 """
 Tests unitaires pour les utilitaires de sécurité fichier.
 """
-import pytest
+import fcntl
 import os
 import tempfile
-import fcntl
-from unittest.mock import patch, MagicMock
-from collegue.core.file_security import safe_read_file, safe_getsize, FileSecurityError
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from collegue.core.file_security import FileSecurityError, safe_getsize, safe_read_file
 
 
 class TestFileSecurity:

--- a/tests/test_header_security.py
+++ b/tests/test_header_security.py
@@ -2,11 +2,12 @@
 Tests for HTTP Header Security utilities
 """
 import pytest
+
 from collegue.core.header_security import (
-    sanitize_header_value,
+    HeaderSecurityError,
     sanitize_header_name,
+    sanitize_header_value,
     validate_url_safe_string,
-    HeaderSecurityError
 )
 
 

--- a/tests/test_iac_guardrails_scan.py
+++ b/tests/test_iac_guardrails_scan.py
@@ -1,17 +1,13 @@
 """
 Tests unitaires pour l'outil IaC Guardrails Scan refactorisé.
 """
-import pytest
 from unittest.mock import MagicMock, patch
 
-from collegue.tools.iac_guardrails_scan import (
-    IacGuardrailsScanTool,
-    IacGuardrailsRequest,
-    IacFinding,
-    CustomPolicy
-)
-from collegue.tools.iac_guardrails_scan.engine import IacAnalysisEngine
+import pytest
+
 from collegue.core.shared import FileInput
+from collegue.tools.iac_guardrails_scan import CustomPolicy, IacFinding, IacGuardrailsRequest, IacGuardrailsScanTool
+from collegue.tools.iac_guardrails_scan.engine import IacAnalysisEngine
 
 
 class TestIacAnalysisEngine:

--- a/tests/test_impact_analysis.py
+++ b/tests/test_impact_analysis.py
@@ -1,19 +1,20 @@
 """
 Tests unitaires pour l'outil Impact Analysis refactorisé.
 """
-import pytest
 from unittest.mock import MagicMock
 
+import pytest
+
+from collegue.core.shared import FileInput
 from collegue.tools.impact_analysis import (
-    ImpactAnalysisTool,
+    ImpactAnalysisEngine,
     ImpactAnalysisRequest,
     ImpactAnalysisResponse,
+    ImpactAnalysisTool,
     ImpactedFile,
     RiskNote,
-    ImpactAnalysisEngine
 )
 from collegue.tools.impact_analysis.models import ImpactFile
-from collegue.core.shared import FileInput
 
 
 class TestImpactAnalysisEngine:

--- a/tests/test_javascript_resources.py
+++ b/tests/test_javascript_resources.py
@@ -1,28 +1,28 @@
 """
 Tests unitaires pour les ressources JavaScript
 """
+import os
+import sys
 import unittest
 from unittest.mock import MagicMock, patch
-import sys
-import os
-from fastapi.testclient import TestClient
-from fastapi import FastAPI
 
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from collegue.resources.javascript.standard_library import (
-    get_api_reference, get_all_apis,
-    JavaScriptAPIReference
+from collegue.resources.javascript.best_practices import (
+    JavaScriptBestPractice,
+    get_all_best_practices,
+    get_best_practice,
 )
 from collegue.resources.javascript.frameworks import (
-    get_framework_reference, get_all_frameworks,
-    JavaScriptFrameworkReference
+    JavaScriptFrameworkReference,
+    get_all_frameworks,
+    get_framework_reference,
 )
-from collegue.resources.javascript.best_practices import (
-    get_best_practice, get_all_best_practices,
-    JavaScriptBestPractice
-)
+from collegue.resources.javascript.standard_library import JavaScriptAPIReference, get_all_apis, get_api_reference
+
 
 class TestJavaScriptStandardLibrary(unittest.TestCase):
     """Tests pour le module standard_library des ressources JavaScript."""
@@ -94,9 +94,9 @@ class TestJavaScriptResourcesEndpoints(unittest.TestCase):
         self.app_state = {"resource_manager": MagicMock()}
 
 
-        from collegue.resources.javascript.standard_library import register_stdlib
-        from collegue.resources.javascript.frameworks import register_frameworks
         from collegue.resources.javascript.best_practices import register_best_practices
+        from collegue.resources.javascript.frameworks import register_frameworks
+        from collegue.resources.javascript.standard_library import register_stdlib
 
         register_stdlib(self.app, self.app_state)
         register_frameworks(self.app, self.app_state)

--- a/tests/test_kubernetes_injection.py
+++ b/tests/test_kubernetes_injection.py
@@ -1,5 +1,7 @@
 import pytest
+
 from collegue.tools.clients.kubernetes import KubernetesClient
+
 
 def test_kubernetes_client_command_injection():
     client = KubernetesClient()

--- a/tests/test_kubernetes_ops_fixes.py
+++ b/tests/test_kubernetes_ops_fixes.py
@@ -1,7 +1,10 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
-from collegue.tools.kubernetes_ops import KubernetesOpsTool, KubernetesRequest
+
 from collegue.tools.clients.base import APIResponse
+from collegue.tools.kubernetes_ops import KubernetesOpsTool, KubernetesRequest
+
 
 @pytest.fixture
 def mock_k8s_client():

--- a/tests/test_kubernetes_security.py
+++ b/tests/test_kubernetes_security.py
@@ -1,8 +1,10 @@
 """
 Tests de sécurité pour KubernetesClient - Protection contre command injection.
 """
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
+
 from collegue.tools.clients.kubernetes import KubernetesClient, KubernetesSecurityError
 
 

--- a/tests/test_llm_helpers.py
+++ b/tests/test_llm_helpers.py
@@ -3,12 +3,13 @@ Tests unitaires pour les LLM Helpers du package collegue.tools.llm_helpers
 
 Ces tests utilisent des mocks pour tester les builders et formatters sans faire d'appels réels aux LLMs.
 """
-import sys
 import os
+import sys
+
 sys.path.insert(0, '/home/kevyn-odjo/Documents/Collegue')
 
-from unittest.mock import Mock, patch, MagicMock
 import json
+from unittest.mock import MagicMock, Mock, patch
 
 print("=" * 80)
 print("TESTS UNITAIRES - LLM HELPERS")
@@ -22,7 +23,11 @@ print("TEST 1: LLM REQUEST BUILDER")
 print("=" * 80)
 
 try:
-    from collegue.tools.llm_helpers.builders import LLMRequestBuilder, DocumentationRequestBuilder, RefactoringRequestBuilder
+    from collegue.tools.llm_helpers.builders import (
+        DocumentationRequestBuilder,
+        LLMRequestBuilder,
+        RefactoringRequestBuilder,
+    )
     
     # Test 1.1: Initialisation LLMRequestBuilder
     print("\n1.1 Test initialisation LLMRequestBuilder...")
@@ -217,7 +222,13 @@ print("TEST 3: TEST GENERATORS")
 print("=" * 80)
 
 try:
-    from collegue.tools.test_generators import TestGenerator, PytestGenerator, JestGenerator, MochaGenerator, UnittestGenerator
+    from collegue.tools.test_generators import (
+        JestGenerator,
+        MochaGenerator,
+        PytestGenerator,
+        TestGenerator,
+        UnittestGenerator,
+    )
     
     # Test 3.1: TestGenerator de base
     print("\n3.1 Test TestGenerator de base...")
@@ -321,12 +332,7 @@ print("TEST 4: VALIDATEURS SHARED")
 print("=" * 80)
 
 try:
-    from collegue.tools.shared import (
-        validate_fast_deep, 
-        detect_language_from_extension,
-        FileInput,
-        SeverityLevel
-    )
+    from collegue.tools.shared import FileInput, SeverityLevel, detect_language_from_extension, validate_fast_deep
     
     # Test 4.1: validate_fast_deep
     print("\n4.1 Test validate_fast_deep...")

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -3,13 +3,14 @@ Tests d'intégration pour les LLM Models et Optimisations
 
 Ces tests valident l'utilisation des modèles Gemini et les techniques d'optimisation de prompts.
 """
-import sys
 import os
+import sys
+
 sys.path.insert(0, '/home/kevyn-odjo/Documents/Collegue')
 
-from unittest.mock import Mock, patch, MagicMock
 import json
 import time
+from unittest.mock import MagicMock, Mock, patch
 
 print("=" * 80)
 print("TESTS D'INTÉGRATION - LLM MODELS & OPTIMIZATIONS")

--- a/tests/test_llm_optimization.py
+++ b/tests/test_llm_optimization.py
@@ -1,21 +1,24 @@
 """
 Tests unitaires pour le module optimization des ressources LLM
 """
+import os
+import sys
 import unittest
 from unittest.mock import MagicMock, patch
-import sys
-import os
-from fastapi.testclient import TestClient
-from fastapi import FastAPI
 
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from collegue.resources.llm.optimization import (
-    OptimizationStrategy, PromptOptimization,
-    get_optimization, get_all_optimizations,
-    optimize_prompt
+    OptimizationStrategy,
+    PromptOptimization,
+    get_all_optimizations,
+    get_optimization,
+    optimize_prompt,
 )
+
 
 class TestLLMOptimization(unittest.TestCase):
     """Tests pour le module optimization des ressources LLM."""

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -8,22 +8,27 @@ pytest.skip(
 	allow_module_level=True,
 )
 
+import asyncio
+import os
+import sys
 import unittest
 from unittest.mock import MagicMock, patch
-import sys
-import os
-import asyncio
-from fastapi.testclient import TestClient
-from fastapi import FastAPI
 
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from collegue.resources.llm.providers import (
-    initialize_llm_client, generate_text,
-    get_default_model_config, get_available_models,
-    LLMConfig, LLMProvider, LLMResponse
+    LLMConfig,
+    LLMProvider,
+    LLMResponse,
+    generate_text,
+    get_available_models,
+    get_default_model_config,
+    initialize_llm_client,
 )
+
 
 class TestLLMProviders(unittest.TestCase):
     """Tests pour le module providers des ressources LLM."""

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -11,19 +11,17 @@ pytest.skip(
 	allow_module_level=True,
 )
 
-import os
-import sys
 import json
 import logging
+import os
+import sys
 from pathlib import Path
-from typing import Dict, Any, Optional
-
+from typing import Any, Dict, Optional
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from collegue.config import Settings
 from collegue.core.tool_llm_manager import ToolLLMManager
-
 
 logging.basicConfig(
     level=logging.INFO,

--- a/tests/test_mcp_connection.py
+++ b/tests/test_mcp_connection.py
@@ -8,12 +8,12 @@ correctement généré côté serveur lors de l'initialisation, mais la transmis
 dans les requêtes suivantes ne fonctionne pas correctement. Ce problème est mentionné comme
 "Partiellement résolu" et nécessite une correction au niveau du serveur.
 """
-import requests
 import json
 import re
 from typing import Optional
 
 import pytest
+import requests
 
 pytest.skip(
     "Test d’intégration (nécessite un serveur MCP local) – non déterministe en CI",

--- a/tests/test_mcp_init_timeout.py
+++ b/tests/test_mcp_init_timeout.py
@@ -1,10 +1,11 @@
 """
 Tests unitaires pour le LazyPromptEngine et le fix du timeout d'initialisation.
 """
-import pytest
 import asyncio
 import time
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
 
 from collegue.app import LazyPromptEngine
 
@@ -176,8 +177,9 @@ class TestBaseToolIntegration:
     @pytest.mark.asyncio
     async def test_execute_async_awaits_lazy_engine(self):
         """Test que execute_async attend le LazyPromptEngine."""
-        from collegue.tools.base import BaseTool
         from pydantic import BaseModel
+
+        from collegue.tools.base import BaseTool
         
         class DummyRequest(BaseModel):
             code: str
@@ -222,8 +224,9 @@ class TestBaseToolIntegration:
     @pytest.mark.asyncio
     async def test_execute_async_handles_none_engine(self):
         """Test que execute_async gère un engine None (fallback)."""
-        from collegue.tools.base import BaseTool
         from pydantic import BaseModel
+
+        from collegue.tools.base import BaseTool
         
         class DummyRequest(BaseModel):
             code: str

--- a/tests/test_mcp_session.py
+++ b/tests/test_mcp_session.py
@@ -2,13 +2,12 @@
 """
 Script de test avancé pour MCP transport http avec gestion de session
 """
-import requests
 import json
 import re
 from typing import Optional
 
-
 import pytest
+import requests
 
 pytest.skip(
 	"Test d’intégration (docker/serveur MCP requis) – non déterministe en CI",

--- a/tests/test_memory_leak_fixes.py
+++ b/tests/test_memory_leak_fixes.py
@@ -3,14 +3,15 @@ Tests pour les corrections de fuites mémoire (issue #141).
 """
 import gc
 from unittest.mock import Mock, patch
+
 from pydantic import BaseModel
 
 from collegue.core.memory_manager import (
-    MemoryManager,
     LimitedSizeHistory,
+    MemoryManager,
     TTLCache,
-    get_memory_manager,
     cleanup_all,
+    get_memory_manager,
 )
 from collegue.tools.base import BaseTool
 

--- a/tests/test_nginx_config.py
+++ b/tests/test_nginx_config.py
@@ -1,9 +1,10 @@
 """
 Tests unitaires pour la configuration nginx
 """
-import pytest
-import re
 import os
+import re
+
+import pytest
 
 
 class TestNginxConfig:

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -5,10 +5,9 @@ L'authentification JWT est configurée directement dans app.py
 via FastMCP(auth=JWTVerifier(...)). Les tests de OAuthManager
 ont été supprimés car la classe n'existe plus.
 """
-import unittest
-import sys
 import os
-
+import sys
+import unittest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -8,17 +8,17 @@ pytest.skip(
 	allow_module_level=True,
 )
 
-import sys
-import os
-import unittest
 import asyncio
+import os
+import sys
+import unittest
 from pathlib import Path
-
 
 parent_dir = str(Path(__file__).parent.parent.absolute())
 sys.path.insert(0, parent_dir)
 
 from collegue.core.orchestrator import ToolOrchestrator
+
 
 class TestToolOrchestrator(unittest.TestCase):
     """Tests unitaires pour la classe ToolOrchestrator"""

--- a/tests/test_orchestrator_fixes.py
+++ b/tests/test_orchestrator_fixes.py
@@ -1,10 +1,17 @@
-import pytest
-import sys
 import json
-from unittest.mock import MagicMock, AsyncMock, patch
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from collegue.core.meta_orchestrator import register_meta_orchestrator, OrchestratorRequest, OrchestratorPlan, OrchestratorStep
+import pytest
+
 import collegue.core.meta_orchestrator as mo
+from collegue.core.meta_orchestrator import (
+    OrchestratorPlan,
+    OrchestratorRequest,
+    OrchestratorStep,
+    register_meta_orchestrator,
+)
+
 
 class MockContext:
     def __init__(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,16 +1,16 @@
 """
 Tests unitaires pour le CodeParser
 """
-import sys
 import os
+import sys
 import unittest
 from pathlib import Path
-
 
 parent_dir = str(Path(__file__).parent.parent.absolute())
 sys.path.insert(0, parent_dir)
 
 from collegue.core.parser import CodeParser
+
 
 class TestCodeParser(unittest.TestCase):
     """Tests unitaires pour la classe CodeParser"""

--- a/tests/test_postgres_client_generated.py
+++ b/tests/test_postgres_client_generated.py
@@ -5,14 +5,15 @@ Couverture cible: 0.9
 Framework: pytest
 Mocks: unittest.mock
 """
-import pytest
 import os
 import re
-from unittest.mock import MagicMock, patch
 from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 # Assuming the module is named postgres_client.py
-from collegue.tools.clients.postgres import PostgresClient, APIResponse, APIError
+from collegue.tools.clients.postgres import APIError, APIResponse, PostgresClient
 
 
 @pytest.fixture

--- a/tests/test_postgres_db_fixes.py
+++ b/tests/test_postgres_db_fixes.py
@@ -1,7 +1,10 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
-from collegue.tools.postgres_db import PostgresDBTool, PostgresRequest
+
 from collegue.tools.clients.base import APIResponse
+from collegue.tools.postgres_db import PostgresDBTool, PostgresRequest
+
 
 @pytest.fixture
 def mock_postgres_client():

--- a/tests/test_python_resources.py
+++ b/tests/test_python_resources.py
@@ -1,28 +1,20 @@
 """
 Tests unitaires pour les ressources Python
 """
+import os
+import sys
 import unittest
 from unittest.mock import MagicMock, patch
-import sys
-import os
-from fastapi.testclient import TestClient
-from fastapi import FastAPI
 
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from collegue.resources.python.standard_library import (
-    get_module_reference, get_all_modules,
-    PythonModuleReference
-)
-from collegue.resources.python.frameworks import (
-    get_framework_reference, get_all_frameworks,
-    PythonFrameworkReference
-)
-from collegue.resources.python.best_practices import (
-    get_best_practice, get_all_best_practices,
-    PythonBestPractice
-)
+from collegue.resources.python.best_practices import PythonBestPractice, get_all_best_practices, get_best_practice
+from collegue.resources.python.frameworks import PythonFrameworkReference, get_all_frameworks, get_framework_reference
+from collegue.resources.python.standard_library import PythonModuleReference, get_all_modules, get_module_reference
+
 
 class TestPythonStandardLibrary(unittest.TestCase):
     """Tests pour le module standard_library des ressources Python."""
@@ -88,9 +80,9 @@ class TestPythonResourcesEndpoints(unittest.TestCase):
         self.app_state = {"resource_manager": MagicMock()}
 
 
-        from collegue.resources.python.standard_library import register_stdlib
-        from collegue.resources.python.frameworks import register_frameworks
         from collegue.resources.python.best_practices import register_best_practices
+        from collegue.resources.python.frameworks import register_frameworks
+        from collegue.resources.python.standard_library import register_stdlib
 
         register_stdlib(self.app, self.app_state)
         register_frameworks(self.app, self.app_state)

--- a/tests/test_quotas.py
+++ b/tests/test_quotas.py
@@ -2,20 +2,22 @@
 Tests unitaires pour le système de quotas.
 """
 import os
-import time
-import pytest
 import tempfile
+import time
 from unittest.mock import patch
+
+import pytest
+
 from collegue.tools.quotas import (
-    QuotaManager,
     GlobalQuotaManager,
     QuotaConfig,
     QuotaExceeded,
+    QuotaManager,
     QuotaType,
     ResourceUsage,
+    check_all_quotas,
     get_global_quota_manager,
     reset_global_quota_manager,
-    check_all_quotas,
 )
 
 

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,18 +1,20 @@
 """
 Tests unitaires pour le système de rate limiting.
 """
-import pytest
-import time
 import threading
+import time
+
+import pytest
+
 from collegue.tools.rate_limiter import (
-    TokenBucketLimiter,
     FixedWindowLimiter,
-    SlidingWindowLimiter,
-    RateLimiterManager,
     RateLimitConfig,
-    RateLimitStrategy,
-    RateLimitExceeded,
     RateLimiterFactory,
+    RateLimiterManager,
+    RateLimitExceeded,
+    RateLimitStrategy,
+    SlidingWindowLimiter,
+    TokenBucketLimiter,
     get_rate_limiter_manager,
     reset_rate_limiter_manager,
 )

--- a/tests/test_rate_limiting_issue_199.py
+++ b/tests/test_rate_limiting_issue_199.py
@@ -3,16 +3,17 @@ Tests pour les corrections de l'issue #199 - Problèmes résiduels rate limiting
 """
 import pytest
 from pydantic import BaseModel
+
 from collegue.tools.base import BaseTool, ToolValidationError
-from collegue.tools.rate_limiter import (
-    get_rate_limiter_manager,
-    reset_rate_limiter_manager,
-    RateLimitConfig,
-    RateLimitStrategy,
-)
 from collegue.tools.quotas import (
     get_global_quota_manager,
     reset_global_quota_manager,
+)
+from collegue.tools.rate_limiter import (
+    RateLimitConfig,
+    RateLimitStrategy,
+    get_rate_limiter_manager,
+    reset_rate_limiter_manager,
 )
 
 

--- a/tests/test_refactoring.py
+++ b/tests/test_refactoring.py
@@ -1,15 +1,11 @@
 """
 Tests unitaires pour l'outil Refactoring refactorisé.
 """
-import pytest
-from unittest.mock import MagicMock, patch, AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from collegue.tools.refactoring import (
-    RefactoringTool,
-    RefactoringRequest,
-    RefactoringResponse,
-    RefactoringEngine
-)
+import pytest
+
+from collegue.tools.refactoring import RefactoringEngine, RefactoringRequest, RefactoringResponse, RefactoringTool
 
 
 class TestRefactoringEngine:

--- a/tests/test_refactoring_prompt_templates.py
+++ b/tests/test_refactoring_prompt_templates.py
@@ -23,7 +23,6 @@ import pytest
 from collegue.prompts.engine.enhanced_prompt_engine import EnhancedPromptEngine
 from collegue.tools.refactoring.tool import RefactoringTool
 
-
 TEMPLATES_DIR = Path("collegue/prompts/templates/tools")
 
 

--- a/tests/test_repo_consistency_check.py
+++ b/tests/test_repo_consistency_check.py
@@ -1,17 +1,18 @@
 """
 Tests unitaires pour l'outil Repo Consistency Check refactorisé.
 """
-import pytest
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from collegue.core.shared import ConsistencyIssue, FileInput
 from collegue.tools.repo_consistency_check import (
-    RepoConsistencyCheckTool,
     ConsistencyCheckRequest,
-    ConsistencyCheckResponse
+    ConsistencyCheckResponse,
+    RepoConsistencyCheckTool,
 )
 from collegue.tools.repo_consistency_check.engine import ConsistencyAnalysisEngine
 from collegue.tools.repo_consistency_check.models import ConsistencyFile
-from collegue.core.shared import FileInput, ConsistencyIssue
 
 
 class TestConsistencyAnalysisEngine:

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -1,15 +1,15 @@
 """
 Tests unitaires pour le gestionnaire de ressources
 """
+import os
+import sys
 import unittest
 from unittest.mock import MagicMock, patch
-import sys
-import os
-
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from collegue.core.resource_manager import ResourceManager
+
 
 class TestResourceManager(unittest.TestCase):
     """Tests pour la classe ResourceManager."""

--- a/tests/test_secret_scan.py
+++ b/tests/test_secret_scan.py
@@ -1,14 +1,11 @@
 """
 Tests unitaires pour l'outil Secret Scan refactorisé.
 """
-import pytest
 from unittest.mock import MagicMock
 
-from collegue.tools.secret_scan import (
-    SecretScanTool,
-    SecretScanRequest,
-    SecretFinding
-)
+import pytest
+
+from collegue.tools.secret_scan import SecretFinding, SecretScanRequest, SecretScanTool
 from collegue.tools.secret_scan.engine import SecretDetectionEngine
 
 

--- a/tests/test_security_fixes_regression.py
+++ b/tests/test_security_fixes_regression.py
@@ -82,11 +82,11 @@ def test_sentry_dsn_invalid_string_still_rejected(monkeypatch):
 
 import collegue.core.meta_orchestrator as mo  # noqa: E402
 from collegue.core.meta_orchestrator import (  # noqa: E402
+    MAX_ORCHESTRATION_STEPS,
+    MAX_QUERY_CHARS,
     OrchestratorPlan,
     OrchestratorRequest,
     OrchestratorStep,
-    MAX_ORCHESTRATION_STEPS,
-    MAX_QUERY_CHARS,
     register_meta_orchestrator,
 )
 
@@ -299,7 +299,6 @@ def test_custom_regex_policy_caps_are_exposed():
 # ---------------------------------------------------------------------------
 
 from collegue.tools.scanners.kubernetes import KubernetesScanner  # noqa: E402
-
 
 DEPLOYMENT_PRIVILEGED = """\
 apiVersion: apps/v1

--- a/tests/test_security_logger.py
+++ b/tests/test_security_logger.py
@@ -1,10 +1,12 @@
 """
 Tests unitaires pour le SecurityLogger
 """
-import pytest
 import json
 import logging
 from unittest.mock import MagicMock, patch
+
+import pytest
+
 from collegue.core.security_logger import SecurityLogger, security_logger
 
 

--- a/tests/test_security_stdlib.py
+++ b/tests/test_security_stdlib.py
@@ -3,14 +3,15 @@ Tests unitaires pour les outils de sécurité utilisant les modules Python stdli
 
 Ces tests valident l'intégration avec les modules de la bibliothèque standard Python.
 """
-import sys
 import os
+import sys
+
 sys.path.insert(0, '/home/kevyn-odjo/Documents/Collegue')
 
-from unittest.mock import Mock, patch, MagicMock, mock_open
-import tempfile
-import shutil
 import json
+import shutil
+import tempfile
+from unittest.mock import MagicMock, Mock, mock_open, patch
 
 print("=" * 80)
 print("TESTS UNITAIRES - SÉCURITÉ + PYTHON STDLIB")
@@ -24,10 +25,11 @@ print("TEST 1: SECRET SCAN + Python stdlib")
 print("=" * 80)
 
 try:
-    from collegue.tools.secret_scan import SecretScanTool, SecretScanRequest
-    import re
     import base64
     import hashlib
+    import re
+
+    from collegue.tools.secret_scan import SecretScanRequest, SecretScanTool
     
     # Test 1.1: Détection avec regex (module re)
     print("\n1.1 Test détection avec regex (module re)...")
@@ -99,10 +101,11 @@ print("TEST 2: DEPENDENCY GUARD + Python stdlib")
 print("=" * 80)
 
 try:
-    from collegue.tools.dependency_guard import DependencyGuardTool, DependencyGuardRequest
-    import urllib.request
-    import urllib.parse
     import json
+    import urllib.parse
+    import urllib.request
+
+    from collegue.tools.dependency_guard import DependencyGuardRequest, DependencyGuardTool
     
     # Test 2.1: Parsing requirements.txt (module os, re)
     print("\n2.1 Test parsing requirements.txt...")
@@ -192,9 +195,11 @@ print("TEST 3: IAC GUARDRAINS + Python stdlib")
 print("=" * 80)
 
 try:
-    from collegue.tools.iac_guardrails_scan import IacGuardrailsScanTool, IacGuardrailsRequest
-    import yaml
     import json
+
+    import yaml
+
+    from collegue.tools.iac_guardrails_scan import IacGuardrailsRequest, IacGuardrailsScanTool
     
     # Test 3.1: Parsing YAML (module yaml)
     print("\n3.1 Test parsing YAML (module yaml)...")
@@ -279,9 +284,10 @@ print("TEST 4: REPO CONSISTENCY CHECK + Python stdlib")
 print("=" * 80)
 
 try:
-    from collegue.tools.repo_consistency_check import RepoConsistencyCheckTool, ConsistencyCheckRequest
     import ast
     import os
+
+    from collegue.tools.repo_consistency_check import ConsistencyCheckRequest, RepoConsistencyCheckTool
     
     # Test 4.1: Parsing AST Python (module ast)
     print("\n4.1 Test parsing AST Python...")
@@ -371,8 +377,9 @@ print("TEST 5: IMPACT ANALYSIS + Python stdlib")
 print("=" * 80)
 
 try:
-    from collegue.tools.impact_analysis import ImpactAnalysisTool, ImpactAnalysisRequest
     import re
+
+    from collegue.tools.impact_analysis import ImpactAnalysisRequest, ImpactAnalysisTool
     
     # Test 5.1: Analyse d'impact avec regex (module re)
     print("\n5.1 Test analyse d'impact (module re)...")

--- a/tests/test_sentry_monitor_fixes.py
+++ b/tests/test_sentry_monitor_fixes.py
@@ -1,7 +1,10 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
-from collegue.tools.sentry_monitor import SentryMonitorTool, SentryRequest
+
 from collegue.tools.clients.base import APIResponse
+from collegue.tools.sentry_monitor import SentryMonitorTool, SentryRequest
+
 
 @pytest.fixture
 def mock_sentry_client():

--- a/tests/test_sentry_security.py
+++ b/tests/test_sentry_security.py
@@ -1,7 +1,10 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
-from collegue.tools.clients.sentry import SentryClient
+
 from collegue.tools.clients.base import APIError
+from collegue.tools.clients.sentry import SentryClient
+
 
 class TestSentrySecurity:
     

--- a/tests/test_test_generation.py
+++ b/tests/test_test_generation.py
@@ -1,14 +1,15 @@
 """
 Tests unitaires pour l'outil Test Generation refactorisé.
 """
-import pytest
 from unittest.mock import MagicMock
 
+import pytest
+
 from collegue.tools.test_generation import (
-    TestGenerationTool,
+    TestGenerationEngine,
     TestGenerationRequest,
     TestGenerationResponse,
-    TestGenerationEngine
+    TestGenerationTool,
 )
 
 

--- a/tests/test_test_generation_fixes.py
+++ b/tests/test_test_generation_fixes.py
@@ -1,6 +1,9 @@
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
-from unittest.mock import MagicMock, AsyncMock
-from collegue.tools.test_generation import TestGenerationTool, TestGenerationRequest, TestGenerationResponse
+
+from collegue.tools.test_generation import TestGenerationRequest, TestGenerationResponse, TestGenerationTool
+
 
 @pytest.mark.asyncio
 async def test_test_generation_success():

--- a/tests/test_tool_prompt_wiring.py
+++ b/tests/test_tool_prompt_wiring.py
@@ -24,7 +24,6 @@ import pytest
 from collegue.tools.code_documentation import DocumentationRequest, DocumentationTool
 from collegue.tools.test_generation import TestGenerationRequest, TestGenerationTool
 
-
 # ---------------------------------------------------------------------------
 # Shared fakes
 # ---------------------------------------------------------------------------

--- a/tests/test_transformers_kubernetes.py
+++ b/tests/test_transformers_kubernetes.py
@@ -2,21 +2,23 @@
 Tests pour le module transformers/kubernetes.py
 """
 import sys
+
 sys.path.insert(0, '/home/kevyn-odjo/Documents/Collegue')
 
-from collegue.tools.transformers.kubernetes import (
-    transform_pods,
-    transform_pod_detail,
-    transform_deployments,
-    transform_services,
-    transform_namespaces,
-    transform_events,
-    transform_nodes,
-    transform_configmaps,
-    transform_secrets,
-    _format_age,
-)
 from datetime import datetime, timezone
+
+from collegue.tools.transformers.kubernetes import (
+    _format_age,
+    transform_configmaps,
+    transform_deployments,
+    transform_events,
+    transform_namespaces,
+    transform_nodes,
+    transform_pod_detail,
+    transform_pods,
+    transform_secrets,
+    transform_services,
+)
 
 
 class TestFormatAge:

--- a/tests/test_transformers_sentry.py
+++ b/tests/test_transformers_sentry.py
@@ -2,18 +2,19 @@
 Tests pour le module transformers/sentry.py
 """
 import sys
+
 sys.path.insert(0, '/home/kevyn-odjo/Documents/Collegue')
 
 from collegue.tools.transformers.sentry import (
-    transform_projects,
-    transform_project,
-    transform_issues,
-    transform_issue,
     transform_events,
+    transform_issue,
+    transform_issues,
+    transform_project,
+    transform_project_stats,
+    transform_projects,
     transform_releases,
     transform_repos,
     transform_tags,
-    transform_project_stats,
 )
 
 

--- a/tests/test_typescript_modern.py
+++ b/tests/test_typescript_modern.py
@@ -3,12 +3,13 @@ Tests unitaires pour les outils TypeScript/JavaScript avec les types et patterns
 
 Ces tests valident l'utilisation des types TypeScript, patterns modernes et bonnes pratiques.
 """
-import sys
 import os
+import sys
+
 sys.path.insert(0, '/home/kevyn-odjo/Documents/Collegue')
 
-from unittest.mock import Mock, patch, MagicMock
 import json
+from unittest.mock import MagicMock, Mock, patch
 
 print("=" * 80)
 print("TESTS UNITAIRES - TYPESCRIPT/JAVASCRIPT MODERNES")
@@ -72,7 +73,7 @@ print("TEST 2: PATTERNS MODERNES JS/TS")
 print("=" * 80)
 
 try:
-    from collegue.tools.repo_consistency_check import RepoConsistencyCheckTool, ConsistencyCheckRequest
+    from collegue.tools.repo_consistency_check import ConsistencyCheckRequest, RepoConsistencyCheckTool
     
     # Test 2.1: Détection var vs const/let
     print("\n2.1 Test détection var vs const/let...")
@@ -295,7 +296,7 @@ print("TEST 4: MODERNISATION DE CODE")
 print("=" * 80)
 
 try:
-    from collegue.tools.refactoring import RefactoringTool, RefactoringRequest
+    from collegue.tools.refactoring import RefactoringRequest, RefactoringTool
     
     # Test 4.1: Moderniser var en const/let
     print("\n4.1 Test modernisation var → const/let...")

--- a/tests/test_typescript_parser.py
+++ b/tests/test_typescript_parser.py
@@ -2,15 +2,15 @@
 """
 Test du parser TypeScript
 """
-import sys
-import os
 import json
+import os
+import sys
 from pathlib import Path
-
 
 sys.path.append(str(Path(__file__).parent.parent))
 
 from collegue.core.parser import CodeParser
+
 
 def main():
     """Test du parser TypeScript avec un fichier d'exemple"""

--- a/tests/test_watchdog_e2e.py
+++ b/tests/test_watchdog_e2e.py
@@ -30,15 +30,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from collegue.autonomous import watchdog as watchdog_mod
-from collegue.autonomous.watchdog import AutoFixer
 from collegue.autonomous.config_registry import UserConfigRegistry
+from collegue.autonomous.watchdog import AutoFixer
+from collegue.tools.github_ops import GitHubResponse, PRInfo
 from collegue.tools.sentry_monitor import (
     EventInfo,
     IssueInfo,
     SentryResponse,
 )
-from collegue.tools.github_ops import GitHubResponse, PRInfo
-
 
 FIXTURES = Path(__file__).parent / "fixtures" / "watchdog"
 

--- a/tests/test_watchdog_integration.py
+++ b/tests/test_watchdog_integration.py
@@ -1,11 +1,14 @@
-import pytest
 import asyncio
-from unittest.mock import AsyncMock, patch, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from collegue.autonomous.watchdog import AutoFixer
-from collegue.tools.sentry_monitor import SentryResponse, ProjectInfo, IssueInfo, RepoInfo as SentryRepoInfo, EventInfo
-from collegue.tools.github_ops import GitHubResponse, PRInfo
 from collegue.tools.github_commands.search import SearchResult
+from collegue.tools.github_ops import GitHubResponse, PRInfo
+from collegue.tools.sentry_monitor import EventInfo, IssueInfo, ProjectInfo, SentryResponse
+from collegue.tools.sentry_monitor import RepoInfo as SentryRepoInfo
+
 
 @pytest.fixture
 def mock_sentry():


### PR DESCRIPTION
## Summary

Étend la configuration Ruff de 4 règles spécifiques (F811-F823) à 3 familles complètes :
- **F** (Pyflakes) — détection d'erreurs logiques, imports inutilisés, variables inutilisées
- **I** (isort) — tri automatique des imports
- **B** (flake8-bugbear) — patterns de bugs courants

Toutes les violations existantes (541+) ont été corrigées :
- Auto-fix : tri des imports (127), f-strings sans placeholder (32), boucles avec variable inutilisée (11)
- Manuel : variables inutilisées (8), `raise` sans `from` dans `except` (17), closure variable binding (1)
- `noqa` : imports de vérification de disponibilité (`try: import X; HAS_X = True`), `APIClient(ABC)` sans méthode abstraite

## Review & Testing Checklist for Human

- [ ] Vérifier que les imports supprimés par F401 ne sont pas des re-exports intentionnels (les `__init__.py` sont exemptés)
- [ ] Vérifier que les `noqa: F401` sur les imports de disponibilité (psycopg2, kubernetes, requests, asyncpg) sont justifiés
- [ ] Vérifier que les `from e` ajoutés ne modifient pas le comportement des handlers d'erreurs
- [ ] Exécuter la suite de tests complète

```bash
ruff check collegue
PYTHONPATH=. pytest tests/ --maxfail=5
```

### Notes

Closes #253

121 fichiers modifiés, mais les changements sont mécaniques (auto-fix) ou ciblés (raise from, variable cleanup). Les tests passent à 100%.

Link to Devin session: https://app.devin.ai/sessions/23e3a9004eb44bcfb8c791238af4fab4
Requested by: @VynoDePal
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vynodepal/collegue/pull/261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->