### PR TITLE
feat: add AgentLoopMixin — infrastructure de boucle agentique pour les tools

### DIFF
--- a/collegue/tools/agent_loop.py
+++ b/collegue/tools/agent_loop.py
@@ -1,0 +1,320 @@
+"""
+Agent Loop — Mixin pour transformer les tools one-shot en agents itératifs.
+
+Ce mixin ajoute une boucle perception-action aux tools qui utilisent un LLM :
+  Prompt → LLM → Validation → [échec?] → Feedback → Re-prompt → ... → Output
+
+Chaque tool qui adopte ce mixin implémente ses propres critères de validation
+et de qualité via les méthodes abstraites validate_output(), assess_quality()
+et build_feedback().
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger("agent_loop")
+
+
+class AgentLoopConfig(BaseModel):
+    """Configuration de la boucle agentique."""
+
+    max_iterations: int = Field(
+        default=3,
+        ge=1,
+        le=10,
+        description="Nombre maximum d'itérations (1 = one-shot classique)",
+    )
+    improvement_threshold: float = Field(
+        default=0.1,
+        ge=0.0,
+        le=1.0,
+        description="Amélioration minimale attendue entre itérations",
+    )
+    abort_on_regression: bool = Field(
+        default=True,
+        description="Arrêter si la qualité régresse entre deux itérations",
+    )
+    initial_temperature: float = Field(
+        default=0.7,
+        ge=0.0,
+        le=2.0,
+        description="Température initiale du LLM (décroît à chaque itération)",
+    )
+    temperature_decay: float = Field(
+        default=0.15,
+        ge=0.0,
+        le=0.5,
+        description="Réduction de température par itération",
+    )
+    min_temperature: float = Field(
+        default=0.2,
+        ge=0.0,
+        le=1.0,
+        description="Température minimale (plancher)",
+    )
+
+
+class AgentIteration(BaseModel):
+    """Résultat d'une itération de la boucle agentique."""
+
+    iteration: int = Field(..., description="Numéro de l'itération (1-indexed)")
+    validation_passed: bool = Field(..., description="True si la validation a réussi")
+    validation_errors: List[str] = Field(
+        default_factory=list,
+        description="Erreurs de validation détectées",
+    )
+    quality_score: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description="Score de qualité de l'output (0.0-1.0)",
+    )
+    temperature_used: float = Field(
+        default=0.7,
+        description="Température LLM utilisée pour cette itération",
+    )
+    feedback_sent: Optional[str] = Field(
+        default=None,
+        description="Feedback envoyé au LLM pour la prochaine itération",
+    )
+
+
+class AgentLoopResult(BaseModel):
+    """Résultat complet de la boucle agentique."""
+
+    best_output: str = Field(..., description="Meilleur output produit")
+    iterations: List[AgentIteration] = Field(
+        default_factory=list,
+        description="Historique de toutes les itérations",
+    )
+    total_iterations: int = Field(
+        default=1,
+        description="Nombre total d'itérations effectuées",
+    )
+    best_score: float = Field(
+        default=0.0,
+        description="Meilleur score de qualité atteint",
+    )
+    converged: bool = Field(
+        default=False,
+        description="True si la boucle a convergé (validation réussie)",
+    )
+    errors_fixed: List[str] = Field(
+        default_factory=list,
+        description="Erreurs corrigées au cours des itérations",
+    )
+
+
+class AgentLoopMixin:
+    """Mixin qui ajoute le comportement agentique à un BaseTool.
+
+    Pour utiliser ce mixin, un tool doit :
+    1. Hériter de AgentLoopMixin en plus de BaseTool
+    2. Définir un attribut agent_config (ou utiliser le défaut)
+    3. Implémenter validate_agent_output(), assess_agent_quality(), build_agent_feedback()
+    4. Appeler self.agent_execute() dans _execute_core_logic_async()
+    """
+
+    agent_config: AgentLoopConfig = AgentLoopConfig()
+
+    async def agent_execute(
+        self,
+        initial_prompt: str,
+        system_prompt: str,
+        ctx: Any,
+        context: Optional[Dict[str, Any]] = None,
+        max_tokens: int = 2000,
+    ) -> AgentLoopResult:
+        """Boucle agentique : prompt → LLM → validate → feedback → re-prompt.
+
+        Args:
+            initial_prompt: Le prompt initial à envoyer au LLM.
+            system_prompt: Le system prompt (rôle du LLM).
+            ctx: Le contexte FastMCP (pour ctx.sample, ctx.info, etc.).
+            context: Dictionnaire de contexte passé aux méthodes de validation.
+            max_tokens: Nombre maximum de tokens pour la réponse LLM.
+
+        Returns:
+            AgentLoopResult avec le meilleur output et l'historique des itérations.
+        """
+        context = context or {}
+        iterations: List[AgentIteration] = []
+        best_output = ""
+        best_score = -1.0
+        current_prompt = initial_prompt
+        errors_fixed: List[str] = []
+        previous_errors: List[str] = []
+
+        config = self.agent_config
+
+        for i in range(config.max_iterations):
+            temperature = max(
+                config.min_temperature,
+                config.initial_temperature - i * config.temperature_decay,
+            )
+
+            if ctx:
+                await ctx.report_progress(progress=i, total=config.max_iterations)
+                if config.max_iterations > 1:
+                    await ctx.info(f"🔄 Itération {i + 1}/{config.max_iterations} (température: {temperature:.2f})")
+
+            # 1. Appel LLM
+            try:
+                result = await ctx.sample(
+                    messages=current_prompt,
+                    system_prompt=system_prompt,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                )
+                raw_output = result.text or ""
+            except Exception as e:
+                logger.error(f"Erreur LLM à l'itération {i + 1}: {e}")
+                iteration = AgentIteration(
+                    iteration=i + 1,
+                    validation_passed=False,
+                    validation_errors=[f"Erreur LLM: {e}"],
+                    quality_score=0.0,
+                    temperature_used=temperature,
+                )
+                iterations.append(iteration)
+                break
+
+            # 2. Validation
+            errors = await self.validate_agent_output(raw_output, context)
+
+            # 3. Évaluation de la qualité
+            quality = await self.assess_agent_quality(raw_output, context)
+            quality = max(0.0, min(1.0, quality))
+
+            iteration = AgentIteration(
+                iteration=i + 1,
+                validation_passed=len(errors) == 0,
+                validation_errors=errors,
+                quality_score=quality,
+                temperature_used=temperature,
+            )
+
+            # 4. Tracking des erreurs corrigées
+            if i > 0 and previous_errors:
+                fixed = [e for e in previous_errors if e not in errors]
+                errors_fixed.extend(fixed)
+
+            previous_errors = errors[:]
+
+            # 5. Tracking du meilleur résultat
+            if quality > best_score:
+                best_score = quality
+                best_output = raw_output
+            elif config.abort_on_regression and i > 0:
+                if ctx:
+                    await ctx.info(
+                        f"⚠️ Qualité en régression ({quality:.2f} < {best_score:.2f}), "
+                        f"arrêt et retour du meilleur résultat."
+                    )
+                iterations.append(iteration)
+                break
+
+            # 6. Succès → sortir
+            success_threshold = 1.0 - config.improvement_threshold
+            if len(errors) == 0 and quality >= success_threshold:
+                if ctx and config.max_iterations > 1:
+                    await ctx.info(f"✅ Validation réussie à l'itération {i + 1} (score: {quality:.2f})")
+                iterations.append(iteration)
+                break
+
+            # 7. Construire le feedback pour la prochaine itération
+            if i < config.max_iterations - 1:
+                feedback = await self.build_agent_feedback(raw_output, errors, quality, context)
+                iteration.feedback_sent = feedback
+                current_prompt = (
+                    f"{initial_prompt}\n\n"
+                    f"## FEEDBACK DE L'ITÉRATION {i + 1}\n"
+                    f"Score de qualité: {quality:.2f}/1.0\n\n"
+                    f"{feedback}\n\n"
+                    f"Corrige les problèmes ci-dessus et régénère ta réponse."
+                )
+                if ctx:
+                    await ctx.info(f"📝 {len(errors)} erreur(s) détectée(s), envoi du feedback pour correction...")
+
+            iterations.append(iteration)
+
+        # Progression finale
+        if ctx:
+            await ctx.report_progress(
+                progress=config.max_iterations,
+                total=config.max_iterations,
+            )
+
+        converged = any(it.validation_passed for it in iterations)
+
+        return AgentLoopResult(
+            best_output=best_output,
+            iterations=iterations,
+            total_iterations=len(iterations),
+            best_score=best_score,
+            converged=converged,
+            errors_fixed=errors_fixed,
+        )
+
+    # --- Méthodes abstraites à implémenter par chaque tool ---
+
+    async def validate_agent_output(self, output: str, context: Dict[str, Any]) -> List[str]:
+        """Valide l'output du LLM. Retourne une liste d'erreurs (vide = succès).
+
+        À implémenter par chaque tool. Exemples de validations :
+        - Vérification syntaxique (AST parse)
+        - Vérification de couverture (nombre de tests, éléments documentés)
+        - Vérification de format (JSON valide, markdown correct)
+
+        Args:
+            output: La réponse brute du LLM.
+            context: Dictionnaire avec les données contextuelles du tool.
+
+        Returns:
+            Liste d'erreurs. Liste vide = validation réussie.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} doit implémenter validate_agent_output()")
+
+    async def assess_agent_quality(self, output: str, context: Dict[str, Any]) -> float:
+        """Évalue la qualité de l'output. Retourne un score 0.0-1.0.
+
+        À implémenter par chaque tool. Le score doit refléter :
+        - 0.0 : output inutilisable
+        - 0.5 : output utilisable mais avec des défauts
+        - 1.0 : output parfait
+
+        Args:
+            output: La réponse brute du LLM.
+            context: Dictionnaire avec les données contextuelles du tool.
+
+        Returns:
+            Score de qualité entre 0.0 et 1.0.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} doit implémenter assess_agent_quality()")
+
+    async def build_agent_feedback(
+        self,
+        output: str,
+        errors: List[str],
+        quality: float,
+        context: Dict[str, Any],
+    ) -> str:
+        """Construit un feedback pour corriger l'output à la prochaine itération.
+
+        À implémenter par chaque tool. Le feedback doit être :
+        - Spécifique (quelles erreurs corriger)
+        - Actionnable (comment les corriger)
+        - Concis (pas de répétition du prompt initial)
+
+        Args:
+            output: La réponse brute du LLM.
+            errors: Les erreurs de validation détectées.
+            quality: Le score de qualité.
+            context: Dictionnaire avec les données contextuelles du tool.
+
+        Returns:
+            Texte de feedback à ajouter au prompt pour la prochaine itération.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} doit implémenter build_agent_feedback()")

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1,0 +1,441 @@
+"""Tests pour AgentLoopMixin — boucle agentique des tools."""
+
+import pytest
+
+from collegue.tools.agent_loop import (
+    AgentIteration,
+    AgentLoopConfig,
+    AgentLoopMixin,
+    AgentLoopResult,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers — fake ctx & concrete agents for testing
+# ---------------------------------------------------------------------------
+
+
+class FakeCtx:
+    """Simule le contexte FastMCP pour les tests."""
+
+    def __init__(self, responses=None):
+        self.responses = list(responses or ["default response"])
+        self._call_index = 0
+        self.infos = []
+        self.progress = []
+
+    async def sample(self, messages=None, system_prompt=None, temperature=0.7, max_tokens=2000, **kwargs):
+        text = self.responses[min(self._call_index, len(self.responses) - 1)]
+        self._call_index += 1
+
+        class FakeResult:
+            pass
+
+        r = FakeResult()
+        r.text = text
+        return r
+
+    async def info(self, msg):
+        self.infos.append(msg)
+
+    async def report_progress(self, progress, total):
+        self.progress.append((progress, total))
+
+
+class AlwaysValidAgent(AgentLoopMixin):
+    """Agent qui valide toujours au premier coup."""
+
+    async def validate_agent_output(self, output, context):
+        return []
+
+    async def assess_agent_quality(self, output, context):
+        return 1.0
+
+    async def build_agent_feedback(self, output, errors, quality, context):
+        return "N/A"
+
+
+class FailsThenSucceedsAgent(AgentLoopMixin):
+    """Agent qui échoue à la première itération puis réussit à la seconde."""
+
+    def __init__(self):
+        self.agent_config = AgentLoopConfig(max_iterations=3)
+        self._call_count = 0
+
+    async def validate_agent_output(self, output, context):
+        self._call_count += 1
+        if self._call_count == 1:
+            return ["Syntaxe invalide: ligne 5: unexpected indent"]
+        return []
+
+    async def assess_agent_quality(self, output, context):
+        if self._call_count <= 1:
+            return 0.3
+        return 0.9
+
+    async def build_agent_feedback(self, output, errors, quality, context):
+        return f"Erreurs détectées: {'; '.join(errors)}. Corrige la syntaxe."
+
+
+class AlwaysFailsAgent(AgentLoopMixin):
+    """Agent qui échoue systématiquement (pour tester max_iterations)."""
+
+    def __init__(self):
+        self.agent_config = AgentLoopConfig(max_iterations=3)
+
+    async def validate_agent_output(self, output, context):
+        return ["Erreur persistante"]
+
+    async def assess_agent_quality(self, output, context):
+        return 0.2
+
+    async def build_agent_feedback(self, output, errors, quality, context):
+        return "Toujours en erreur."
+
+
+class RegressingAgent(AgentLoopMixin):
+    """Agent dont la qualité régresse entre itérations."""
+
+    def __init__(self):
+        self.agent_config = AgentLoopConfig(max_iterations=3, abort_on_regression=True)
+        self._call_count = 0
+
+    async def validate_agent_output(self, output, context):
+        return ["Erreur"]
+
+    async def assess_agent_quality(self, output, context):
+        self._call_count += 1
+        if self._call_count == 1:
+            return 0.6
+        return 0.3  # régression
+
+    async def build_agent_feedback(self, output, errors, quality, context):
+        return "Feedback"
+
+
+class KeywordAgent(AgentLoopMixin):
+    """Agent qui vérifie la présence d'un mot-clé dans la réponse."""
+
+    def __init__(self, keyword="python"):
+        self.agent_config = AgentLoopConfig(max_iterations=3)
+        self.keyword = keyword
+
+    async def validate_agent_output(self, output, context):
+        if self.keyword not in output.lower():
+            return [f"Le mot '{self.keyword}' n'apparaît pas dans la réponse"]
+        return []
+
+    async def assess_agent_quality(self, output, context):
+        return 1.0 if self.keyword in output.lower() else 0.3
+
+    async def build_agent_feedback(self, output, errors, quality, context):
+        return f"Ta réponse doit mentionner '{self.keyword}'. Erreurs: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# Tests des modèles Pydantic
+# ---------------------------------------------------------------------------
+
+
+class TestAgentLoopConfig:
+    def test_defaults(self):
+        config = AgentLoopConfig()
+        assert config.max_iterations == 3
+        assert config.improvement_threshold == 0.1
+        assert config.abort_on_regression is True
+        assert config.initial_temperature == 0.7
+        assert config.temperature_decay == 0.15
+        assert config.min_temperature == 0.2
+
+    def test_custom_config(self):
+        config = AgentLoopConfig(max_iterations=5, abort_on_regression=False)
+        assert config.max_iterations == 5
+        assert config.abort_on_regression is False
+
+    def test_validation_bounds(self):
+        with pytest.raises(Exception):
+            AgentLoopConfig(max_iterations=0)
+        with pytest.raises(Exception):
+            AgentLoopConfig(max_iterations=11)
+
+
+class TestAgentIteration:
+    def test_creation(self):
+        it = AgentIteration(
+            iteration=1,
+            validation_passed=True,
+            quality_score=0.95,
+        )
+        assert it.iteration == 1
+        assert it.validation_passed is True
+        assert it.validation_errors == []
+        assert it.quality_score == 0.95
+        assert it.feedback_sent is None
+
+
+class TestAgentLoopResult:
+    def test_creation(self):
+        result = AgentLoopResult(
+            best_output="code refactoré",
+            total_iterations=2,
+            best_score=0.9,
+            converged=True,
+        )
+        assert result.best_output == "code refactoré"
+        assert result.total_iterations == 2
+        assert result.converged is True
+
+
+# ---------------------------------------------------------------------------
+# Tests de la boucle agentique
+# ---------------------------------------------------------------------------
+
+
+class TestAgentLoopMixin:
+    @pytest.mark.asyncio
+    async def test_success_first_iteration(self):
+        """La boucle sort en 1 itération si validation réussie."""
+        agent = AlwaysValidAgent()
+        ctx = FakeCtx(responses=["print('hello')"])
+
+        result = await agent.agent_execute(
+            initial_prompt="Refactorise ce code",
+            system_prompt="Tu es un expert Python",
+            ctx=ctx,
+        )
+
+        assert result.total_iterations == 1
+        assert result.converged is True
+        assert result.best_score == 1.0
+        assert result.best_output == "print('hello')"
+
+    @pytest.mark.asyncio
+    async def test_success_second_iteration(self):
+        """La boucle corrige après feedback et réussit en 2 itérations."""
+        agent = FailsThenSucceedsAgent()
+        ctx = FakeCtx(responses=["bad code", "good code"])
+
+        result = await agent.agent_execute(
+            initial_prompt="Refactorise ce code",
+            system_prompt="Tu es un expert Python",
+            ctx=ctx,
+        )
+
+        assert result.total_iterations == 2
+        assert result.converged is True
+        assert result.best_score == 0.9
+        assert result.best_output == "good code"
+        assert len(result.errors_fixed) > 0
+
+    @pytest.mark.asyncio
+    async def test_max_iterations_reached(self):
+        """La boucle s'arrête après max_iterations et retourne le meilleur."""
+        agent = AlwaysFailsAgent()
+        agent.agent_config = AgentLoopConfig(max_iterations=3, abort_on_regression=False)
+        ctx = FakeCtx(responses=["bad1", "bad2", "bad3"])
+
+        result = await agent.agent_execute(
+            initial_prompt="Refactorise",
+            system_prompt="Expert",
+            ctx=ctx,
+        )
+
+        assert result.total_iterations == 3
+        assert result.converged is False
+        assert result.best_output in ("bad1", "bad2", "bad3")
+
+    @pytest.mark.asyncio
+    async def test_abort_on_regression(self):
+        """La boucle s'arrête si la qualité régresse."""
+        agent = RegressingAgent()
+        ctx = FakeCtx(responses=["output1", "output2_worse", "output3"])
+
+        result = await agent.agent_execute(
+            initial_prompt="Refactorise",
+            system_prompt="Expert",
+            ctx=ctx,
+        )
+
+        assert result.total_iterations == 2
+        assert result.best_score == 0.6
+        assert result.best_output == "output1"
+
+    @pytest.mark.asyncio
+    async def test_temperature_decreases(self):
+        """La température diminue à chaque itération."""
+        agent = AlwaysFailsAgent()
+        agent.agent_config = AgentLoopConfig(
+            max_iterations=3,
+            initial_temperature=0.7,
+            temperature_decay=0.15,
+            min_temperature=0.2,
+            abort_on_regression=False,
+        )
+        ctx = FakeCtx(responses=["a", "b", "c"])
+
+        result = await agent.agent_execute(
+            initial_prompt="test",
+            system_prompt="test",
+            ctx=ctx,
+        )
+
+        temps = [it.temperature_used for it in result.iterations]
+        assert temps[0] == pytest.approx(0.7)
+        assert temps[1] == pytest.approx(0.55)
+        assert temps[2] == pytest.approx(0.4)
+
+    @pytest.mark.asyncio
+    async def test_temperature_min_floor(self):
+        """La température ne descend pas en dessous du minimum."""
+        agent = AlwaysFailsAgent()
+        agent.agent_config = AgentLoopConfig(
+            max_iterations=3,
+            initial_temperature=0.4,
+            temperature_decay=0.15,
+            min_temperature=0.2,
+            abort_on_regression=False,
+        )
+        ctx = FakeCtx(responses=["a", "b", "c"])
+
+        result = await agent.agent_execute(
+            initial_prompt="test",
+            system_prompt="test",
+            ctx=ctx,
+        )
+
+        temps = [it.temperature_used for it in result.iterations]
+        assert temps[0] == pytest.approx(0.4)
+        assert temps[1] == pytest.approx(0.25)
+        assert temps[2] == pytest.approx(0.2)  # plancher
+
+    @pytest.mark.asyncio
+    async def test_one_shot_mode(self):
+        """max_iterations=1 se comporte comme un one-shot classique."""
+        agent = AlwaysFailsAgent()
+        agent.agent_config = AgentLoopConfig(max_iterations=1)
+        ctx = FakeCtx(responses=["output"])
+
+        result = await agent.agent_execute(
+            initial_prompt="test",
+            system_prompt="test",
+            ctx=ctx,
+        )
+
+        assert result.total_iterations == 1
+        assert len(result.iterations) == 1
+
+    @pytest.mark.asyncio
+    async def test_keyword_agent_corrects(self):
+        """L'agent à mot-clé corrige après feedback."""
+        agent = KeywordAgent(keyword="python")
+        ctx = FakeCtx(
+            responses=[
+                "Java is a great language",
+                "Python is a great language",
+            ]
+        )
+
+        result = await agent.agent_execute(
+            initial_prompt="Décris un langage",
+            system_prompt="Expert",
+            ctx=ctx,
+        )
+
+        assert result.converged is True
+        assert result.best_output == "Python is a great language"
+        assert result.total_iterations == 2
+
+    @pytest.mark.asyncio
+    async def test_context_passed_through(self):
+        """Le contexte est correctement passé aux méthodes de validation."""
+        received_context = {}
+
+        class ContextCapture(AgentLoopMixin):
+            async def validate_agent_output(self, output, context):
+                received_context.update(context)
+                return []
+
+            async def assess_agent_quality(self, output, context):
+                return 1.0
+
+            async def build_agent_feedback(self, output, errors, quality, context):
+                return ""
+
+        agent = ContextCapture()
+        ctx = FakeCtx(responses=["output"])
+
+        await agent.agent_execute(
+            initial_prompt="test",
+            system_prompt="test",
+            ctx=ctx,
+            context={"language": "python", "original_code": "x = 1"},
+        )
+
+        assert received_context["language"] == "python"
+        assert received_context["original_code"] == "x = 1"
+
+    @pytest.mark.asyncio
+    async def test_progress_reported(self):
+        """La progression est reportée via ctx.report_progress()."""
+        agent = AlwaysValidAgent()
+        ctx = FakeCtx(responses=["output"])
+
+        await agent.agent_execute(
+            initial_prompt="test",
+            system_prompt="test",
+            ctx=ctx,
+        )
+
+        assert len(ctx.progress) >= 2  # au moins start + end
+
+    @pytest.mark.asyncio
+    async def test_feedback_in_iterations(self):
+        """Le feedback est enregistré dans l'historique des itérations."""
+        agent = FailsThenSucceedsAgent()
+        ctx = FakeCtx(responses=["bad", "good"])
+
+        result = await agent.agent_execute(
+            initial_prompt="test",
+            system_prompt="test",
+            ctx=ctx,
+        )
+
+        assert result.iterations[0].feedback_sent is not None
+        assert "Syntaxe invalide" in result.iterations[0].feedback_sent
+
+    @pytest.mark.asyncio
+    async def test_not_implemented_errors(self):
+        """Les méthodes abstraites lèvent NotImplementedError."""
+        agent = AgentLoopMixin()
+        with pytest.raises(NotImplementedError):
+            await agent.validate_agent_output("output", {})
+        with pytest.raises(NotImplementedError):
+            await agent.assess_agent_quality("output", {})
+        with pytest.raises(NotImplementedError):
+            await agent.build_agent_feedback("output", [], 0.5, {})
+
+    @pytest.mark.asyncio
+    async def test_llm_error_handling(self):
+        """La boucle gère les erreurs LLM sans crash."""
+
+        class ErrorCtx:
+            async def sample(self, **kwargs):
+                raise ConnectionError("LLM unavailable")
+
+            async def info(self, msg):
+                pass
+
+            async def report_progress(self, progress, total):
+                pass
+
+        agent = AlwaysValidAgent()
+        ctx = ErrorCtx()
+
+        result = await agent.agent_execute(
+            initial_prompt="test",
+            system_prompt="test",
+            ctx=ctx,
+        )
+
+        assert result.total_iterations == 1
+        assert result.converged is False
+        assert "Erreur LLM" in result.iterations[0].validation_errors[0]


### PR DESCRIPTION
## Summary

Introduit un mixin `AgentLoopMixin` réutilisable (`collegue/tools/agent_loop.py`) qui transforme les tools one-shot LLM en **agents itératifs** avec une boucle perception-action :

```
Prompt → LLM → Validation → [échec?] → Feedback → Re-prompt → ... → Output
```

### Composants ajoutés

| Classe | Rôle |
|--------|------|
| `AgentLoopConfig` | Configuration (max_iterations, température décroissante, abort on regression) |
| `AgentIteration` | Tracking par itération (erreurs, score qualité, feedback envoyé) |
| `AgentLoopResult` | Résultat final (meilleur output, convergence, erreurs corrigées) |
| `AgentLoopMixin` | Boucle agentique `agent_execute()` avec 3 hooks abstraits |

### Hooks abstraits à implémenter par chaque tool

```python
async def validate_agent_output(output, context) -> list[str]  # erreurs
async def assess_agent_quality(output, context) -> float        # 0.0-1.0
async def build_agent_feedback(output, errors, quality, context) -> str
```

### Caractéristiques
- Température LLM décroissante (0.7 → 0.55 → 0.4 par défaut)
- Abort automatique si la qualité régresse entre itérations
- Tracking du meilleur résultat (retourné même si max iterations atteint)
- Progression reportée via `ctx.report_progress()`
- Gestion des erreurs LLM sans crash

### 18 tests unitaires couvrant :
- Succès en 1 itération
- Correction après feedback (2 itérations)
- Max iterations atteint
- Abort on regression
- Température décroissante + plancher
- Mode one-shot (max_iterations=1)
- Passage de contexte
- Gestion erreurs LLM

Closes #267

## Review & Testing Checklist for Human

- [ ] Vérifier que `AgentLoopMixin` n'introduit aucune dépendance sur un LLM spécifique (il utilise `ctx.sample()` de FastMCP)
- [ ] Vérifier que les 18 tests passent : `PYTHONPATH=. pytest tests/test_agent_loop.py -v`
- [ ] Vérifier que ce mixin est bien opt-in (aucun tool existant n'est modifié dans cette PR)

### Notes

Ce mixin est le prérequis pour les issues #268-#274 qui transformeront chaque tool LLM en agent itératif. Aucun tool existant n'est modifié dans cette PR — c'est de l'infrastructure pure.

Link to Devin session: https://app.devin.ai/sessions/23e3a9004eb44bcfb8c791238af4fab4
Requested by: @VynoDePal
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vynodepal/collegue/pull/275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->