### PR TITLE
fix: resolve Devin Review bugs in ExpertDelegation engine

### DIFF
--- a/collegue/core/expert_delegation.py
+++ b/collegue/core/expert_delegation.py
@@ -384,35 +384,56 @@ class ExpertDelegationEngine:
         """Retourne l'historique de la chaîne en cours."""
         return list(self._chain_history)
 
-    def build_chain_report(self, source_tool: str) -> DelegationChainReport:
-        """Construit un rapport de la chaîne de délégation."""
+    def build_chain_report(
+        self,
+        source_tool: str,
+        results: Optional[List[DelegationResult]] = None,
+    ) -> DelegationChainReport:
+        """Construit un rapport de la chaîne de délégation.
 
-        def _count_experts(results: List[DelegationResult]) -> int:
+        Args:
+            source_tool: Nom du tool initiateur.
+            results: Résultats de la chaîne (top-level). Si fourni, le rapport
+                est construit à partir de ces résultats plutôt que de l'historique
+                interne partagé, ce qui le rend safe pour les appels concurrents.
+        """
+        chain_results = results if results is not None else self._chain_history
+
+        def _count_experts(res_list: List[DelegationResult]) -> int:
             count = 0
-            for r in results:
+            for r in res_list:
                 if r.success:
                     count += 1
                 count += _count_experts(r.sub_delegations)
             return count
 
-        def _max_depth(results: List[DelegationResult]) -> int:
-            if not results:
+        def _max_depth(res_list: List[DelegationResult]) -> int:
+            if not res_list:
                 return 0
             return max(
-                max(r.depth for r in results),
-                max((_max_depth(r.sub_delegations) for r in results), default=0),
+                max(r.depth for r in res_list),
+                max((_max_depth(r.sub_delegations) for r in res_list), default=0),
             )
 
-        total_time = sum(r.execution_time for r in self._chain_history)
-        all_completed = all(r.success or r.error is not None for r in self._chain_history)
+        total_time = sum(r.execution_time for r in chain_results)
+
+        abort_reason: Optional[str] = None
+        chain_completed = True
+        for r in chain_results:
+            if not r.success and r.error:
+                if "Profondeur maximale" in r.error or "Timeout" in r.error:
+                    chain_completed = False
+                    abort_reason = r.error
+                    break
 
         return DelegationChainReport(
             source_tool=source_tool,
-            total_experts_activated=_count_experts(self._chain_history),
-            max_depth_reached=_max_depth(self._chain_history),
-            results=list(self._chain_history),
+            total_experts_activated=_count_experts(chain_results),
+            max_depth_reached=_max_depth(chain_results),
+            results=list(chain_results),
             total_time=total_time,
-            chain_completed=all_completed,
+            chain_completed=chain_completed,
+            abort_reason=abort_reason,
         )
 
     def get_rules_for_tool(self, tool_name: str) -> List[DelegationRule]:

--- a/collegue/core/meta_orchestrator.py
+++ b/collegue/core/meta_orchestrator.py
@@ -331,14 +331,13 @@ RÈGLES :
                 step_delegations = []
                 if delegation_engine and isinstance(res_dict, dict):
                     try:
-                        delegation_engine.clear_history()
                         tasks = await delegation_engine.evaluate_delegations(tool_name, res_dict)
                         if tasks:
                             await ctx.info(f"🔗 {len(tasks)} délégation(s) déclenchée(s) par {tool_name}")
                             del_results = await delegation_engine.execute_delegation_chain(
                                 tasks, available_tools, ctx=ctx, tool_kwargs=tool_kwargs
                             )
-                            report = delegation_engine.build_chain_report(tool_name)
+                            report = delegation_engine.build_chain_report(tool_name, results=del_results)
                             step_delegations = [r.model_dump() for r in del_results]
                             total_experts_via_delegation += report.total_experts_activated
                             all_delegation_chains.append(report.model_dump())

--- a/tests/test_delegation_chains.py
+++ b/tests/test_delegation_chains.py
@@ -130,8 +130,8 @@ class TestDelegationChainsUnit:
         assert all(s.success for s in sub)
 
         # Rapport
-        report = engine.build_chain_report("repo_consistency_check")
-        assert report.total_experts_activated >= 3
+        report = engine.build_chain_report("repo_consistency_check", results=results)
+        assert report.total_experts_activated == 3
         assert report.chain_completed is True
 
     @pytest.mark.asyncio
@@ -301,6 +301,7 @@ class TestDelegationChainsUnit:
 
 
 @skip_no_key
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_real_delegation_consistency_to_refactoring():
     """Test réel: consistency détecte un problème → refactoring se déclenche via délégation."""
@@ -363,6 +364,7 @@ class OldClass:
 
 
 @skip_no_key
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_real_delegation_engine_evaluation():
     """Test réel: évaluation des règles de délégation avec des résultats réalistes."""

--- a/tests/test_expert_delegation.py
+++ b/tests/test_expert_delegation.py
@@ -11,10 +11,8 @@ Couvre :
 - Règles par défaut
 """
 
-import asyncio
 import time
 from typing import Any, Dict, List
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -94,22 +92,10 @@ def make_tool_registry(tools: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
     """Crée un registre de tools factice."""
     registry = {}
     for name, response_data in tools.items():
-        tool = FakeTool(name, response_data)
         registry[name] = {
-            "class": lambda resp=response_data: FakeTool(name, resp),
+            "class": _make_fake_tool_class(response_data),
             "description": f"Fake {name}",
         }
-        # Fix: capture the response data properly
-        registry[name]["class"] = type(
-            f"Fake{name}",
-            (),
-            {
-                "__init__": lambda self, config=None, resp=response_data: setattr(self, "_resp", resp),
-                "get_request_model": lambda self: FakeRequestModel,
-                "execute_async": lambda self, req, **kw: asyncio.coroutine(lambda: FakeResponse(self._resp))(),
-                "cleanup": lambda self: None,
-            },
-        )
     return registry
 
 
@@ -556,8 +542,8 @@ class TestDelegationChainIntegration:
         # Sub-delegations: refactoring → doc + tests
         assert len(results[0].sub_delegations) == 2
 
-        report = engine.build_chain_report("repo_consistency_check")
-        assert report.total_experts_activated >= 1
+        report = engine.build_chain_report("repo_consistency_check", results=results)
+        assert report.total_experts_activated == 3
 
     @pytest.mark.asyncio
     async def test_no_delegation_when_conditions_not_met(self):


### PR DESCRIPTION
## Summary

Fixes all bugs identified by Devin Review and Copilot on PR #281.

### Bug fixes

1. **Double-counting of experts in `build_chain_report`** — `_count_experts` was called on the flat `_chain_history` which contains all results (parent + child), but it also recursed into each result's `sub_delegations`, counting children twice. Fix: `build_chain_report` now accepts an optional `results` parameter (the top-level results from `execute_delegation_chain`). When passed, `_count_experts` correctly recurses through `sub_delegations` from top-level results only, giving accurate counts (e.g. 3 instead of 5 for a consistency→refactoring→doc+tests chain).

2. **Shared mutable `_chain_history` race condition** — The `ExpertDelegationEngine` stores delegation history in `self._chain_history`, mutated across `await` points. When shared as a singleton via `lifespan_context`, concurrent requests would interleave `clear_history()`, `append()`, and `build_chain_report()` calls. Fix: `build_chain_report` now accepts results directly as a parameter, and `meta_orchestrator.py` passes `del_results` instead of relying on shared instance state. Removed the `clear_history()` call from meta_orchestrator.

3. **`chain_completed` incorrectly `True` for abnormal terminations** — `build_chain_report` marked `chain_completed=True` whenever an error was present (including timeout/depth-max), contradicting the field's doc and leaving `abort_reason` unused. Fix: now detects timeout and depth-max errors specifically, sets `chain_completed=False` and populates `abort_reason`.

4. **Deprecated `asyncio.coroutine` in test helper** — `make_tool_registry` used `asyncio.coroutine(lambda: ...)()` which is deprecated since Python 3.8 and removed in 3.12+. Replaced with the existing `_make_fake_tool_class` helper. Cleaned up unused imports (`asyncio`, `unittest.mock`).

5. **Real LLM tests not marked `@pytest.mark.integration`** — Two test functions in `test_delegation_chains.py` that make real Gemini API calls were not marked with `@pytest.mark.integration`, meaning they would run in CI when a key is present. Added the marker so they are excluded by default (`-m 'not integration'`).

## Review & Testing Checklist for Human

- [ ] Run `pytest tests/test_expert_delegation.py tests/test_delegation_chains.py -v` and verify all 45 unit tests pass
- [ ] Verify the full test suite still passes: `pytest -x`
- [ ] Check that `build_chain_report(source, results=del_results)` returns `total_experts_activated == 3` (not 5) for a consistency→refactoring→doc+tests chain

### Notes

- Backward compatibility preserved: `build_chain_report(source_tool)` without `results` param still works using `_chain_history` (for any existing callers)
- `_chain_history`, `clear_history()`, `get_chain_history()` are kept for backward compatibility but the recommended path is to pass `results` directly

Link to Devin session: https://app.devin.ai/sessions/c4a516bee47c4904a13429ca5042b863
Requested by: @VynoDePal