### PR TITLE
fix: preserve agent metadata in impact_analysis when LLM returns non-JSON

### DIFF
--- a/collegue/tools/impact_analysis/tool.py
+++ b/collegue/tools/impact_analysis/tool.py
@@ -350,6 +350,14 @@ class ImpactAnalysisTool(AgentLoopMixin, BaseTool):
                 except Exception as e:
                     if self.logger:
                         self.logger.warning(f"Erreur parsing insights LLM: {e}")
+                    response = response.model_copy(
+                        update={
+                            "analysis_depth_used": "deep",
+                            "agent_iterations": agent_result.total_iterations,
+                            "agent_best_score": agent_result.best_score,
+                            "agent_converged": agent_result.converged,
+                        }
+                    )
 
             except Exception as e:
                 if self.logger:


### PR DESCRIPTION
## Summary

Fixes a bug where `impact_analysis` in `deep` mode silently drops agent loop metadata (`agent_iterations`, `agent_best_score`, `agent_converged`, `analysis_depth_used`) when the LLM returns non-JSON text that fails `parse_llm_json_response`.

**Before:** On parse failure, the response retained defaults from the sync path: `agent_iterations=0` and `analysis_depth_used="fast"`, even though the agent loop actually executed.

**After:** The inner `except` handler now propagates agent metadata to the response, so downstream consumers (dashboard, monitoring) correctly see `analysis_depth_used="deep"` and the actual iteration count.

**Change:** 8 lines added in the inner `except` block of `_execute_core_logic_async` (tool.py).

Closes #295

## Review & Testing Checklist for Human

- [ ] Verify that when LLM returns valid JSON, behavior is unchanged (the happy path `try` block still applies all fields including `llm_insights` and `semantic_summary`)
- [ ] Verify that when LLM returns non-JSON, `analysis_depth_used` is now `"deep"` instead of `"fast"`, and `agent_iterations > 0`

### Notes

Found during real-condition testing with Gemma 4 26B. The LLM sometimes returns plain text instead of JSON for the deep analysis prompt, triggering this code path.

Link to Devin session: https://app.devin.ai/sessions/23e3a9004eb44bcfb8c791238af4fab4
Requested by: @VynoDePal