### PR TITLE
fix: enable cross-expert memory sharing in get_context_for()

### DIFF
--- a/collegue/core/project_memory.py
+++ b/collegue/core/project_memory.py
@@ -224,13 +224,16 @@ class ProjectMemory:
         """Construit un contexte mémoire pour un expert donné.
 
         Retourne un dict prêt à être injecté dans le prompt LLM.
-        Sélectionne par type d'entrée (tri par timestamp) pour ne pas
-        évincer les project_profile/fix_applied de score 0.
+        Les entrées pattern_learned, issue_found et fix_applied sont partagées
+        entre tous les experts (pas de filtre expert) car la délégation
+        inter-experts exige que chaque expert ait accès aux découvertes des
+        autres. Seul expert_result reste spécifique à l'expert.
         """
-        # Chercher par type pour éviter que le tri par score évince les entrées à score 0
-        patterns_entries = self.recall(expert=expert, entry_type="pattern_learned", language=language, limit=5)
-        issues_entries = self.recall(expert=expert, entry_type="issue_found", language=language, limit=5)
-        fixes_entries = self.recall(expert=expert, entry_type="fix_applied", language=language, limit=3)
+        # Ne PAS filtrer par expert pour les types cross-expert : un code_refactoring
+        # doit voir les issue_found d'un code_review pour savoir quoi corriger.
+        patterns_entries = self.recall(entry_type="pattern_learned", language=language, limit=5)
+        issues_entries = self.recall(entry_type="issue_found", language=language, limit=5)
+        fixes_entries = self.recall(entry_type="fix_applied", language=language, limit=3)
         profile_entries = self.recall(entry_type="project_profile", language=language, limit=3)
 
         entries = patterns_entries + issues_entries + fixes_entries + profile_entries


### PR DESCRIPTION
## Summary

Fixes a critical bug in `ProjectMemory.get_context_for()` where cross-expert memory sharing was completely non-functional. The method filtered `pattern_learned`, `issue_found`, and `fix_applied` entries by `expert=expert`, meaning each expert could only see its own entries.

**Before:** `get_context_for("code_refactoring")` returns `{}` even when `code_review` has stored critical issues.

**After:** `get_context_for("code_refactoring")` returns all `issue_found`, `pattern_learned`, and `fix_applied` entries from ANY expert, enabling the delegation system to pass context along the chain.

**Change:** Removed `expert=expert` filter from 3 `recall()` calls in `get_context_for()`. Only `project_profile` (already unfiltered) remains unchanged.

**Impact on delegation chains:**
```
code_review stores: issue_found("SQL injection in get_user()")
  → code_refactoring recalls: known_issues=[{"title": "SQL injection..."}]  ← now works
```

Closes #298

## Review & Testing Checklist for Human

- [ ] Verify that `get_context_for()` now returns entries from other experts (test with the reproduction code in issue #298)
- [ ] Check that `_recall_from_memory()` in `agent_loop.py` still uses `get_context_for(tool_name)` correctly — the expert param is still accepted for potential future expert-specific filtering

### Notes

Found during deep multi-agent testing with Gemma 4 26B. All 864 existing tests pass with this change.

Link to Devin session: https://app.devin.ai/sessions/23e3a9004eb44bcfb8c791238af4fab4
Requested by: @VynoDePal