### PR TITLE
fix: use 0.80 instead of 80 for coverage_target in delegation builders

### DIFF
--- a/collegue/core/expert_delegation.py
+++ b/collegue/core/expert_delegation.py
@@ -525,7 +525,7 @@ def _build_test_params_from_refactoring(source_tool: str, result: Dict[str, Any]
         "code": result.get("refactored_code", ""),
         "language": result.get("language", "python"),
         "test_framework": "pytest" if result.get("language", "python") == "python" else "jest",
-        "coverage_target": 80,
+        "coverage_target": 0.80,
         "parameters": {"context": "auto-delegated from code_refactoring"},
     }
 
@@ -548,7 +548,7 @@ def _build_test_params_from_impact(source_tool: str, result: Dict[str, Any]) -> 
         "code": code_summary,
         "language": "python",
         "test_framework": "pytest",
-        "coverage_target": 80,
+        "coverage_target": 0.80,
         "parameters": {"context": "auto-delegated from impact_analysis"},
     }
 
@@ -777,7 +777,7 @@ def _build_test_params_from_performance(source_tool: str, result: Dict[str, Any]
         "code": summary,
         "language": result.get("language", "python"),
         "test_framework": "pytest" if result.get("language", "python") == "python" else "jest",
-        "coverage_target": 80,
+        "coverage_target": 0.80,
         "parameters": {"context": "auto-delegated from performance_analysis"},
     }
 

--- a/tests/test_expert_delegation.py
+++ b/tests/test_expert_delegation.py
@@ -22,6 +22,9 @@ from collegue.core.expert_delegation import (
     DelegationRule,
     DelegationTask,
     ExpertDelegationEngine,
+    _build_test_params_from_impact,
+    _build_test_params_from_performance,
+    _build_test_params_from_refactoring,
     _consistency_needs_refactoring,
     _iac_needs_remediation,
     _impact_has_iac_files,
@@ -29,6 +32,7 @@ from collegue.core.expert_delegation import (
     _refactoring_has_changes,
     create_default_delegation_engine,
 )
+from collegue.tools.test_generation.models import TestGenerationRequest
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -570,13 +574,6 @@ class TestDelegationParamsValidation:
 
     def test_coverage_target_is_float_between_0_and_1(self):
         """coverage_target must be 0.0-1.0, not 0-100 (regression test for #300)."""
-        from collegue.core.expert_delegation import (
-            _build_test_params_from_refactoring,
-            _build_test_params_from_impact,
-            _build_test_params_from_performance,
-        )
-        from collegue.tools.test_generation.models import TestGenerationRequest
-
         # Test from refactoring
         params = _build_test_params_from_refactoring(
             "code_refactoring", {"refactored_code": "def foo(): pass", "language": "python"}

--- a/tests/test_expert_delegation.py
+++ b/tests/test_expert_delegation.py
@@ -582,16 +582,12 @@ class TestDelegationParamsValidation:
         TestGenerationRequest(**params)  # Should not raise
 
         # Test from impact
-        params = _build_test_params_from_impact(
-            "impact_analysis", {"impacted_files": [], "risk_notes": []}
-        )
+        params = _build_test_params_from_impact("impact_analysis", {"impacted_files": [], "risk_notes": []})
         assert 0.0 <= params["coverage_target"] <= 1.0
         TestGenerationRequest(**params)  # Should not raise
 
         # Test from performance
-        params = _build_test_params_from_performance(
-            "performance_analysis", {"optimizations": ["use a set"]}
-        )
+        params = _build_test_params_from_performance("performance_analysis", {"optimizations": ["use a set"]})
         assert 0.0 <= params["coverage_target"] <= 1.0
         TestGenerationRequest(**params)  # Should not raise
 

--- a/tests/test_expert_delegation.py
+++ b/tests/test_expert_delegation.py
@@ -565,6 +565,45 @@ class TestDelegationChainIntegration:
 # ---------------------------------------------------------------------------
 
 
+class TestDelegationParamsValidation:
+    """Validate that delegation builders produce valid tool params."""
+
+    def test_coverage_target_is_float_between_0_and_1(self):
+        """coverage_target must be 0.0-1.0, not 0-100 (regression test for #300)."""
+        from collegue.core.expert_delegation import (
+            _build_test_params_from_refactoring,
+            _build_test_params_from_impact,
+            _build_test_params_from_performance,
+        )
+        from collegue.tools.test_generation.models import TestGenerationRequest
+
+        # Test from refactoring
+        params = _build_test_params_from_refactoring(
+            "code_refactoring", {"refactored_code": "def foo(): pass", "language": "python"}
+        )
+        assert 0.0 <= params["coverage_target"] <= 1.0
+        TestGenerationRequest(**params)  # Should not raise
+
+        # Test from impact
+        params = _build_test_params_from_impact(
+            "impact_analysis", {"impacted_files": [], "risk_notes": []}
+        )
+        assert 0.0 <= params["coverage_target"] <= 1.0
+        TestGenerationRequest(**params)  # Should not raise
+
+        # Test from performance
+        params = _build_test_params_from_performance(
+            "performance_analysis", {"optimizations": ["use a set"]}
+        )
+        assert 0.0 <= params["coverage_target"] <= 1.0
+        TestGenerationRequest(**params)  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
 def _max_depth_in_results(results: List[DelegationResult]) -> int:
     if not results:
         return 0


### PR DESCRIPTION
## Summary

Fixes #300. The delegation parameter builders pass `coverage_target: 80` (integer percentage) to `TestGenerationRequest`, which validates `coverage_target` with `le=1.0` (expects a float between 0.0 and 1.0). This causes all delegation chains that trigger `test_generation` to fail with a Pydantic ValidationError.

**Fix**: Replace `"coverage_target": 80` with `"coverage_target": 0.80` in all 3 builder functions:
- `_build_test_params_from_refactoring` (line 528)
- `_build_test_params_from_impact` (line 551)
- `_build_test_params_from_performance` (line 780)

**Regression test added** in `tests/test_expert_delegation.py::TestDelegationParamsValidation` that validates the generated params produce a valid `TestGenerationRequest` without raising.

## Review & Testing Checklist for Human

- [ ] Verify that delegation chains `performance_analysis → test_generation` now execute without ValidationError
- [ ] Run `pytest tests/test_expert_delegation.py -k TestDelegationParamsValidation` to confirm regression test passes

### Notes

Discovered during deep phase 2 testing with real Gemma 4 26B calls. The error manifests when `performance_analysis` detects optimizations and delegates to `test_generation`.

Link to Devin session: https://app.devin.ai/sessions/23e3a9004eb44bcfb8c791238af4fab4
Requested by: @VynoDePal