### PR TITLE
fix: enrich orchestrator tool params with context data as fallback

### DIFF
--- a/collegue/core/meta_orchestrator.py
+++ b/collegue/core/meta_orchestrator.py
@@ -315,8 +315,18 @@ RÈGLES :
                 tool_instance = tool_class({})  # Nouvelle instance propre
                 req_model = tool_instance.get_request_model()
 
+                # Enrich params with context data as fallback values.
+                # The LLM often omits required fields (e.g. 'language') that
+                # are available in request.context. We inject them as defaults
+                # so validation succeeds without overriding explicit LLM choices.
+                enriched_params = dict(params)
+                if request.context:
+                    for key, value in request.context.items():
+                        if key not in enriched_params:
+                            enriched_params[key] = value
+
                 # Validation Pydantic
-                req_obj = req_model(**params)
+                req_obj = req_model(**enriched_params)
 
                 # Exécution avec injection correcte des dépendances
                 result = await tool_instance.execute_async(req_obj, **tool_kwargs)

--- a/tests/test_orchestrator_fixes.py
+++ b/tests/test_orchestrator_fixes.py
@@ -88,3 +88,77 @@ async def test_orchestrator_planning_and_execution():
 
     assert mock_ctx.sample.call_count == 2
     mock_ctx.info.assert_any_call("Phase 1: Planification...")
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_enriches_params_from_context():
+    """When the LLM plan omits required fields, context data fills them in."""
+    app = MagicMock()
+    register_meta_orchestrator(app)
+
+    tool_decorator = app.tool.return_value
+    smart_orchestrator_func = tool_decorator.call_args[0][0]
+
+    # Tool that records received params
+    captured_params = {}
+
+    class RecordingModel:
+        def __init__(self, **kwargs):
+            captured_params.update(kwargs)
+
+    class RecordingTool:
+        def __init__(self, config=None):
+            pass
+
+        def get_request_model(self):
+            return RecordingModel
+
+        async def execute_async(self, req, **kwargs):
+            class Result:
+                def model_dump(self):
+                    return {"status": "success"}
+            return Result()
+
+        def cleanup(self):
+            pass
+
+    mock_tools_cache = {
+        "code_review": {
+            "class": lambda x=None: RecordingTool(),
+            "description": "Code review",
+            "prompt_desc": "code_review: Reviews code quality",
+            "schema": {},
+        }
+    }
+
+    mock_ctx = MockContext()
+    mock_ctx.lifespan_context = {"tools_registry": mock_tools_cache}
+
+    # LLM generates plan with only "code" param, omitting "language"
+    plan_response = MagicMock()
+    plan_response.result = OrchestratorPlan(
+        steps=[OrchestratorStep(
+            tool="code_review",
+            reason="Review code quality",
+            params={"code": "def foo(): pass"},
+        )]
+    )
+
+    synth_response = MagicMock()
+    synth_response.text = "Code review done"
+
+    mock_ctx.sample.side_effect = [plan_response, synth_response]
+
+    # User provides context with language info
+    request = OrchestratorRequest(
+        query="Review this code",
+        context={"language": "python", "file_path": "main.py"},
+    )
+
+    response = await smart_orchestrator_func(request, mock_ctx)
+
+    # Verify context values were injected as fallback
+    assert captured_params.get("language") == "python"
+    assert captured_params.get("file_path") == "main.py"
+    # Verify LLM param was NOT overridden
+    assert captured_params.get("code") == "def foo(): pass"

--- a/tests/test_orchestrator_fixes.py
+++ b/tests/test_orchestrator_fixes.py
@@ -117,6 +117,7 @@ async def test_orchestrator_enriches_params_from_context():
             class Result:
                 def model_dump(self):
                     return {"status": "success"}
+
             return Result()
 
         def cleanup(self):
@@ -137,11 +138,13 @@ async def test_orchestrator_enriches_params_from_context():
     # LLM generates plan with only "code" param, omitting "language"
     plan_response = MagicMock()
     plan_response.result = OrchestratorPlan(
-        steps=[OrchestratorStep(
-            tool="code_review",
-            reason="Review code quality",
-            params={"code": "def foo(): pass"},
-        )]
+        steps=[
+            OrchestratorStep(
+                tool="code_review",
+                reason="Review code quality",
+                params={"code": "def foo(): pass"},
+            )
+        ]
     )
 
     synth_response = MagicMock()


### PR DESCRIPTION
## Summary

Fixes #302. When `smart_orchestrator` executes its plan, the LLM often generates tool params that omit required fields (e.g. `language` for `CodeReviewRequest`). These fields are available in `request.context` but weren't being injected.

**Fix**: Before Pydantic validation, merge `request.context` keys as fallback values into the LLM-generated params. Context values only fill in missing keys — they never override explicit LLM choices.

**Before**: `req_model(**params)` → fails if LLM omits required field\n**After**: `req_model(**enriched_params)` → context fills gaps, LLM params preserved

## Review & Testing Checklist for Human

- [ ] Verify that orchestrator now successfully executes steps when context contains missing required fields\n- [ ] Run `pytest tests/test_orchestrator_fixes.py` to confirm both tests pass\n- [ ] Check that LLM-provided params are NOT overridden by context (test verifies this)

### Notes

Discovered during deep phase 2 testing with real Gemma 4 26B calls. The orchestrator correctly plans 2 steps (code_review → code_refactoring) but both fail because the LLM puts `code` in params without `language`.

Link to Devin session: https://app.devin.ai/sessions/23e3a9004eb44bcfb8c791238af4fab4
Requested by: @VynoDePal