### PR TITLE
fix: add fallback JSON parser for orchestrator plan when structured output fails

### DIFF
--- a/collegue/core/meta_orchestrator.py
+++ b/collegue/core/meta_orchestrator.py
@@ -112,6 +112,60 @@ class _OrchestratorSynthesisAgent(AgentLoopMixin):
 _synthesis_agent = _OrchestratorSynthesisAgent()
 
 
+def _parse_plan_from_text(text: str) -> Optional[OrchestratorPlan]:
+    """Extract an OrchestratorPlan from free-form LLM text.
+
+    Models that do not support native structured output (e.g. Gemma 4 26B)
+    typically embed a JSON object inside a fenced code block or inline.
+    This helper tries several extraction strategies before giving up.
+    """
+    import json as _json
+    import re as _re
+
+    if not text or not text.strip():
+        return None
+
+    # Strategy 1: extract from fenced code block (```json ... ```)
+    fence_match = _re.search(r"```(?:json)?\s*\n?(.*?)```", text, _re.DOTALL)
+    candidates = []
+    if fence_match:
+        candidates.append(fence_match.group(1).strip())
+
+    # Strategy 2: find the outermost { ... } that looks like JSON
+    brace_start = text.find("{")
+    brace_end = text.rfind("}")
+    if brace_start != -1 and brace_end > brace_start:
+        candidates.append(text[brace_start : brace_end + 1])
+
+    # Strategy 3: find the outermost [ ... ] (array of steps)
+    bracket_start = text.find("[")
+    bracket_end = text.rfind("]")
+    if bracket_start != -1 and bracket_end > bracket_start:
+        candidates.append(text[bracket_start : bracket_end + 1])
+
+    for candidate in candidates:
+        try:
+            data = _json.loads(candidate)
+        except (_json.JSONDecodeError, ValueError):
+            continue
+
+        # If data is a dict with "steps", parse directly
+        if isinstance(data, dict) and "steps" in data:
+            try:
+                return OrchestratorPlan(**data)
+            except Exception:
+                continue
+
+        # If data is a list, treat as steps array
+        if isinstance(data, list):
+            try:
+                return OrchestratorPlan(steps=data)
+            except Exception:
+                continue
+
+    return None
+
+
 def register_meta_orchestrator(app: FastMCP):
 
     @app.tool(
@@ -247,10 +301,20 @@ RÈGLES :
                 steps = plan_result.result.steps
                 await ctx.info(f"Plan généré: {len(steps)} étapes")
             else:
-                # Fallback texte si le modèle ne supporte pas structured output
+                # Fallback: parse JSON from the LLM text response when the
+                # model does not support native structured output (e.g.
+                # Gemma 4 26B returns plain text with embedded JSON).
                 await ctx.warning("Structured output non supporté, fallback parsing manuel")
-                # ... (code parsing simplifié si besoin, mais on suppose un modèle capable ici)
-                raise ValueError("Le modèle n'a pas retourné un plan structuré")
+                raw_text = getattr(plan_result, "text", "") or ""
+                parsed_plan = _parse_plan_from_text(raw_text)
+                if parsed_plan and parsed_plan.steps:
+                    steps = parsed_plan.steps
+                    await ctx.info(f"Plan extrait du texte: {len(steps)} étapes")
+                else:
+                    raise ValueError(
+                        "Le modèle n'a pas retourné un plan structuré "
+                        "et le texte ne contient pas de JSON exploitable"
+                    )
 
         except Exception as e:
             await ctx.error(f"Echec planification: {e}")

--- a/collegue/core/meta_orchestrator.py
+++ b/collegue/core/meta_orchestrator.py
@@ -312,8 +312,7 @@ RÈGLES :
                     await ctx.info(f"Plan extrait du texte: {len(steps)} étapes")
                 else:
                     raise ValueError(
-                        "Le modèle n'a pas retourné un plan structuré "
-                        "et le texte ne contient pas de JSON exploitable"
+                        "Le modèle n'a pas retourné un plan structuré et le texte ne contient pas de JSON exploitable"
                     )
 
         except Exception as e:

--- a/tests/test_orchestrator_fixes.py
+++ b/tests/test_orchestrator_fixes.py
@@ -165,3 +165,136 @@ async def test_orchestrator_enriches_params_from_context():
     assert captured_params.get("file_path") == "main.py"
     # Verify LLM param was NOT overridden
     assert captured_params.get("code") == "def foo(): pass"
+
+
+def test_parse_plan_from_text_fenced_json():
+    """Fallback parser extracts plan from fenced JSON code block."""
+    from collegue.core.meta_orchestrator import _parse_plan_from_text
+
+    text = """Here is my plan:
+
+```json
+{
+  "steps": [
+    {"tool": "code_review", "reason": "Check quality", "params": {"code": "x=1"}}
+  ]
+}
+```
+"""
+    plan = _parse_plan_from_text(text)
+    assert plan is not None
+    assert len(plan.steps) == 1
+    assert plan.steps[0].tool == "code_review"
+
+
+def test_parse_plan_from_text_inline_json():
+    """Fallback parser extracts plan from inline JSON (no fences)."""
+    from collegue.core.meta_orchestrator import _parse_plan_from_text
+
+    text = 'I will use code_review. {"steps": [{"tool": "code_review", "reason": "Review", "params": {"code": "y=2"}}]}'
+    plan = _parse_plan_from_text(text)
+    assert plan is not None
+    assert len(plan.steps) == 1
+    assert plan.steps[0].tool == "code_review"
+
+
+def test_parse_plan_from_text_steps_array():
+    """Fallback parser extracts plan from a bare JSON array of steps."""
+    from collegue.core.meta_orchestrator import _parse_plan_from_text
+
+    text = '[{"tool": "code_review", "reason": "Review", "params": {"code": "z=3"}}]'
+    plan = _parse_plan_from_text(text)
+    assert plan is not None
+    assert len(plan.steps) == 1
+
+
+def test_parse_plan_from_text_empty():
+    """Fallback parser returns None for empty/nonsense text."""
+    from collegue.core.meta_orchestrator import _parse_plan_from_text
+
+    assert _parse_plan_from_text("") is None
+    assert _parse_plan_from_text("no json here at all") is None
+    assert _parse_plan_from_text(None) is None
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_uses_fallback_parser_when_structured_output_fails():
+    """Orchestrator parses plan from LLM text when result_type returns None."""
+    app = MagicMock()
+    register_meta_orchestrator(app)
+
+    tool_decorator = app.tool.return_value
+    smart_orchestrator_func = tool_decorator.call_args[0][0]
+
+    captured_params = {}
+
+    class RecordingModel:
+        def __init__(self, **kwargs):
+            captured_params.update(kwargs)
+
+    class RecordingTool:
+        def __init__(self, config=None):
+            pass
+
+        def get_request_model(self):
+            return RecordingModel
+
+        async def execute_async(self, req, **kwargs):
+            class Result:
+                def model_dump(self):
+                    return {"status": "ok"}
+
+            return Result()
+
+        def cleanup(self):
+            pass
+
+    mock_tools_cache = {
+        "code_review": {
+            "class": lambda x=None: RecordingTool(),
+            "description": "Code review",
+            "prompt_desc": "code_review: Reviews code quality",
+            "schema": {},
+        }
+    }
+
+    mock_ctx = MockContext()
+    mock_ctx.lifespan_context = {"tools_registry": mock_tools_cache}
+
+    call_count = [0]
+
+    async def mock_sample(*args, **kwargs):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            # Planning: return text (not structured) with embedded JSON
+            class TextResult:
+                result = None  # Structured output failed
+                text = (
+                    "Here is the plan:\n"
+                    "```json\n"
+                    '{"steps": [{"tool": "code_review", "reason": "Review code",'
+                    ' "params": {"code": "def foo(): pass"}}]}\n'
+                    "```"
+                )
+
+            return TextResult()
+        else:
+
+            class SynthResult:
+                text = "Review complete"
+                result = None
+
+            return SynthResult()
+
+    mock_ctx.sample = mock_sample
+
+    request = OrchestratorRequest(
+        query="Review this code",
+        context={"language": "python"},
+    )
+
+    response = await smart_orchestrator_func(request, mock_ctx)
+
+    # Should have used the fallback parser and executed code_review
+    assert "code_review" in response.tools_used
+    assert response.confidence > 0


### PR DESCRIPTION
## Summary

Fixes #304 — The `smart_orchestrator` fails silently when the LLM model (e.g. Gemma 4 26B) doesn't return a native structured `OrchestratorPlan` object. Instead of parsing the JSON from the text response, it raised `ValueError` and returned `confidence=0.0` with `tools_used=[]`.

**Root Cause:** The `else` branch in the planning step had a placeholder comment (`# ... code parsing simplifié si besoin`) that just raised `ValueError`, making the orchestrator unusable with models that don't support native structured output.

**Fix:** Added `_parse_plan_from_text()` function that tries 3 extraction strategies:
1. Fenced code block (`` ```json ... ``` ``)
2. Outermost `{ ... }` (inline JSON object with `steps` key)
3. Outermost `[ ... ]` (bare array of steps)

This allows the orchestrator to work with Gemma 4 26B and similar models that embed JSON in their text response.

## Review & Testing Checklist for Human

- [ ] Verify the fallback parser handles edge cases: nested JSON, malformed fences, mixed content
- [ ] Test with a real Gemma 4 26B call to confirm the orchestrator now executes tools instead of returning confidence=0
- [ ] Check that structured output models (e.g. GPT-4) still use the native path (no regression)

### Notes

- Discovered during Deep Testing Phase 3, test `test_smart_orchestrator_e2e` with real Gemma 4 26B API calls
- 5 new tests added covering fenced JSON, inline JSON, bare array, empty text, and full orchestrator flow with fallback
- All existing tests continue to pass

Link to Devin session: https://app.devin.ai/sessions/23e3a9004eb44bcfb8c791238af4fab4
Requested by: @VynoDePal