### PR TITLE
fix: fallback to template tests when LLM output has no extractable code block

### DIFF
--- a/collegue/tools/code_documentation/tool.py
+++ b/collegue/tools/code_documentation/tool.py
@@ -359,6 +359,10 @@ class DocumentationTool(AgentLoopMixin, BaseTool):
                 success=bool(generated_docs),
             )
 
+            if not generated_docs:
+                self.logger.warning("Agent loop produced no extractable docs, using fallback")
+                return self._generate_fallback_response(request, code_elements)
+
             formatted_docs = self._engine.format_documentation(
                 generated_docs, request.doc_format or "markdown", request.language
             )

--- a/collegue/tools/test_generation/tool.py
+++ b/collegue/tools/test_generation/tool.py
@@ -312,6 +312,10 @@ class TestGenerationTool(AgentLoopMixin, BaseTool):
                     success=bool(test_code),
                 )
 
+                if not test_code:
+                    self.logger.warning("LLM produced no extractable test code, using fallback")
+                    return self._generate_fallback_response(request, framework, elements)
+
                 # Compter les tests générés
                 test_count = test_code.count("def test_") + test_code.count("@Test")
 
@@ -383,6 +387,10 @@ class TestGenerationTool(AgentLoopMixin, BaseTool):
                 tokens_used=len(test_code) // 4,
                 success=bool(test_code),
             )
+
+            if not test_code:
+                self.logger.warning("Agent loop produced no extractable test code, using fallback")
+                return self._generate_fallback_response(request, framework, elements)
 
             test_count = test_code.count("def test_") + test_code.count("@Test")
             estimated_coverage = self._engine.estimate_coverage(elements, test_count)

--- a/tests/test_test_generation.py
+++ b/tests/test_test_generation.py
@@ -220,6 +220,77 @@ class TestTestGenerationRequest:
             TestGenerationRequest(code="def hello(): pass", language="python", coverage_target=1.5)
 
 
+class TestTestGenerationFallback:
+    """Tests for fallback when LLM returns no extractable code."""
+
+    @pytest.mark.asyncio
+    async def test_async_fallback_on_empty_code_block(self):
+        """Agent loop output with no code block triggers fallback response."""
+        from unittest.mock import AsyncMock
+
+        from collegue.tools.agent_loop import AgentIteration, AgentLoopResult
+
+        tool = TestGenerationTool({})
+        req = TestGenerationRequest(
+            code="def hello():\n    return 'world'",
+            language="python",
+            coverage_target=0.80,
+        )
+
+        mock_ctx = AsyncMock()
+
+        # Fake agent_execute that returns text without a code block
+        agent_result = AgentLoopResult(
+            iterations=[
+                AgentIteration(
+                    iteration=1,
+                    validation_passed=False,
+                    validation_errors=["No code found"],
+                    quality_score=0.0,
+                    temperature_used=0.5,
+                    output="No code here",
+                )
+            ],
+            best_output="No code fences at all, just plain text",
+            best_score=0.0,
+            total_iterations=1,
+            converged=False,
+        )
+        tool.agent_execute = AsyncMock(return_value=agent_result)
+        tool.prepare_prompt = AsyncMock(return_value="prompt")
+
+        result = await tool.execute_async(req, ctx=mock_ctx)
+        result_dict = result.model_dump()
+
+        # Should have fallen back to template-based generation
+        assert result_dict["test_code"], "test_code should not be empty after fallback"
+        assert "def test_" in result_dict["test_code"], "Fallback should generate test functions"
+
+    def test_sync_fallback_on_empty_code_block(self):
+        """Sync LLM output with no code block triggers fallback response."""
+        from unittest.mock import AsyncMock
+
+        tool = TestGenerationTool({})
+        req = TestGenerationRequest(
+            code="def greet(name):\n    return f'Hello {name}'",
+            language="python",
+            coverage_target=0.80,
+        )
+
+        mock_ctx = MagicMock()
+
+        class FakeSampleResult:
+            text = "I cannot generate proper tests for this code."
+
+        mock_ctx.sample = AsyncMock(return_value=FakeSampleResult())
+
+        result = tool.execute(req, ctx=mock_ctx)
+        result_dict = result.model_dump()
+
+        # Should have fallen back to template-based generation
+        assert result_dict["test_code"], "test_code should not be empty after fallback"
+
+
 class TestTestGenerationResponse:
     """Tests pour le modèle TestGenerationResponse."""
 


### PR DESCRIPTION
## Summary

Fixes #306 — The `test_generation` and `code_documentation` tools returned empty output (`test_code=""` / `documentation=""`) when the LLM response (e.g. from Gemma 4 26B) didn't contain a valid fenced code block.

**Root Cause:** After the agent loop completes, `_extract_test_code_block()` / `_strip_outer_fence()` returns an empty string if the LLM output has no code fences. The tool then returned this empty string instead of falling back to the template-based generator.

**Fix:** Added an empty check after code block extraction in both sync and async paths. When empty, falls back to `_generate_fallback_response()` which produces template-based tests/docs.

### Files changed:
- `collegue/tools/test_generation/tool.py` — fallback in both `_execute_core_logic` and `_execute_core_logic_async`
- `collegue/tools/code_documentation/tool.py` — fallback in `_execute_core_logic_async`
- `tests/test_test_generation.py` — 2 new tests for async and sync fallback paths

## Review & Testing Checklist for Human

- [ ] Verify the fallback tests produce non-empty output (run `pytest tests/test_test_generation.py::TestTestGenerationFallback -v`)
- [ ] Test with real Gemma 4 26B to confirm fallback triggers when LLM returns prose instead of code blocks

### Notes

- Discovered during Deep Testing Phase 3, test `test_test_generation_with_coverage_target` with real Gemma 4 26B API calls
- The `code_documentation` tool had the same pattern and was fixed proactively

Link to Devin session: https://app.devin.ai/sessions/23e3a9004eb44bcfb8c791238af4fab4
Requested by: @VynoDePal