### PR TITLE
fix: use correct ImpactAnalysisRequest fields in architecture→impact delegation builder

### DIFF
--- a/collegue/core/expert_delegation.py
+++ b/collegue/core/expert_delegation.py
@@ -721,11 +721,14 @@ def _build_impact_params_from_architecture(source_tool: str, result: Dict[str, A
         if isinstance(issue, dict):
             modules.extend(issue.get("affected_modules", []))
 
+    issues_summary = "; ".join(i.get("title", "") for i in result.get("issues", []) if isinstance(i, dict))
+
     return {
-        "description": f"Impact des refactorings architecturaux recommandés ({len(modules)} modules)",
-        "change_type": "refactoring",
-        "files_changed": [{"path": m, "change_type": "refactoring"} for m in modules[:10]],
-        "parameters": {"context": "auto-delegated from architecture_analysis"},
+        "change_intent": f"Refactoring architectural recommandé: {issues_summary}"
+        if issues_summary
+        else "Refactoring architectural",
+        "files": [{"path": m, "content": f"# Module impacté: {m}", "language": "python"} for m in modules[:10]]
+        or [{"path": "unknown", "content": "# Aucun module identifié", "language": "python"}],
     }
 
 

--- a/tests/test_delegation_chains.py
+++ b/tests/test_delegation_chains.py
@@ -401,3 +401,35 @@ async def test_real_delegation_engine_evaluation():
     test_task = next(t for t in tasks if t.target_tool == "test_generation")
     assert test_task.params["code"] == refactoring_result["refactored_code"]
     assert test_task.params["test_framework"] == "pytest"
+
+
+@pytest.mark.asyncio
+async def test_architecture_to_impact_delegation_params():
+    """Verify architecture→impact delegation builds valid ImpactAnalysisRequest params."""
+    from collegue.core.expert_delegation import _build_impact_params_from_architecture
+    from collegue.tools.impact_analysis.models import ImpactAnalysisRequest
+
+    # With affected modules
+    params = _build_impact_params_from_architecture(
+        "architecture_analysis",
+        {
+            "issues": [
+                {"severity": "error", "title": "Circular dependency", "affected_modules": ["core/a.py", "core/b.py"]},
+            ],
+        },
+    )
+    req = ImpactAnalysisRequest(**params)
+    assert "Circular dependency" in req.change_intent
+    assert len(req.files) == 2
+    assert req.files[0].path == "core/a.py"
+
+    # Without affected modules (fallback to placeholder)
+    params2 = _build_impact_params_from_architecture(
+        "architecture_analysis",
+        {
+            "issues": [{"title": "Bad pattern"}],
+        },
+    )
+    req2 = ImpactAnalysisRequest(**params2)
+    assert "Bad pattern" in req2.change_intent
+    assert len(req2.files) >= 1

--- a/tests/test_phase3_delegation.py
+++ b/tests/test_phase3_delegation.py
@@ -140,7 +140,8 @@ class TestArchitectureParamsBuilders:
             ]
         }
         params = _build_impact_params_from_architecture("architecture_analysis", result)
-        assert len(params["files_changed"]) == 2
+        assert len(params["files"]) == 2
+        assert "Cycle" in params["change_intent"]
 
 
 class TestPerformanceParamsBuilders:


### PR DESCRIPTION
## Summary

Fixes #308 — The `architecture_analysis → impact_analysis` delegation always failed with a `ValidationError` because `_build_impact_params_from_architecture` built params with wrong field names.

**Wrong params (before):**
```python
{"description": "...", "change_type": "refactoring", "files_changed": [...]}
```

**Correct params (after):**
```python
{"change_intent": "Refactoring architectural: ...", "files": [{"path": "...", "content": "...", "language": "python"}, ...]}
```

`ImpactAnalysisRequest` requires `change_intent` (str, required) and `files` (List[ImpactFile], required).

### Files changed:
- `collegue/core/expert_delegation.py` — fix `_build_impact_params_from_architecture`
- `tests/test_delegation_chains.py` — add test validating the fix
- `tests/test_phase3_delegation.py` — update existing test to match correct field names

## Review & Testing Checklist for Human

- [ ] Run `pytest tests/test_delegation_chains.py tests/test_phase3_delegation.py -v` to verify both tests pass
- [ ] Verify the delegation chain `architecture_analysis → impact_analysis` now succeeds in a real scenario

### Notes

- Discovered by systematically validating all 14 delegation params builders against their target request models
- This was the only builder with invalid field names; the other 13 all produce valid params

Link to Devin session: https://app.devin.ai/sessions/23e3a9004eb44bcfb8c791238af4fab4
Requested by: @VynoDePal