### PR TITLE
fix: guard delegation builders against empty refactored_code

### DIFF
--- a/collegue/core/expert_delegation.py
+++ b/collegue/core/expert_delegation.py
@@ -511,8 +511,9 @@ def _build_refactoring_params_from_consistency(source_tool: str, result: Dict[st
 
 def _build_documentation_params_from_refactoring(source_tool: str, result: Dict[str, Any]) -> Dict[str, Any]:
     """Construit les paramètres de documentation depuis un résultat de refactoring."""
+    code = result.get("refactored_code", "") or "# No refactored code available"
     return {
-        "code": result.get("refactored_code", ""),
+        "code": code,
         "language": result.get("language", "python"),
         "documentation_type": "auto",
         "parameters": {"context": "auto-delegated from code_refactoring"},
@@ -521,8 +522,9 @@ def _build_documentation_params_from_refactoring(source_tool: str, result: Dict[
 
 def _build_test_params_from_refactoring(source_tool: str, result: Dict[str, Any]) -> Dict[str, Any]:
     """Construit les paramètres de test_generation depuis un résultat de refactoring."""
+    code = result.get("refactored_code", "") or "# No refactored code available"
     return {
-        "code": result.get("refactored_code", ""),
+        "code": code,
         "language": result.get("language", "python"),
         "test_framework": "pytest" if result.get("language", "python") == "python" else "jest",
         "coverage_target": 0.80,
@@ -653,8 +655,9 @@ def _performance_needs_tests(result: Dict[str, Any]) -> bool:
 
 def _build_review_params_from_refactoring(source_tool: str, result: Dict[str, Any]) -> Dict[str, Any]:
     """Construit les paramètres de code review depuis un résultat de refactoring."""
+    code = result.get("refactored_code", "") or "# No refactored code available"
     return {
-        "code": result.get("refactored_code", ""),
+        "code": code,
         "language": result.get("language", "python"),
         "review_standards": ["naming", "complexity", "security", "dry", "solid"],
         "severity_threshold": "warning",

--- a/collegue/core/expert_delegation.py
+++ b/collegue/core/expert_delegation.py
@@ -509,12 +509,20 @@ def _build_refactoring_params_from_consistency(source_tool: str, result: Dict[st
     }
 
 
+def _empty_code_placeholder(language: str) -> str:
+    """Return a language-appropriate placeholder when code is empty."""
+    if language in ("javascript", "typescript"):
+        return "// No refactored code available"
+    return "# No refactored code available"
+
+
 def _build_documentation_params_from_refactoring(source_tool: str, result: Dict[str, Any]) -> Dict[str, Any]:
     """Construit les paramètres de documentation depuis un résultat de refactoring."""
-    code = result.get("refactored_code", "") or "# No refactored code available"
+    lang = result.get("language", "python").lower()
+    code = (result.get("refactored_code", "") or "").strip() or _empty_code_placeholder(lang)
     return {
         "code": code,
-        "language": result.get("language", "python"),
+        "language": lang,
         "documentation_type": "auto",
         "parameters": {"context": "auto-delegated from code_refactoring"},
     }
@@ -522,11 +530,12 @@ def _build_documentation_params_from_refactoring(source_tool: str, result: Dict[
 
 def _build_test_params_from_refactoring(source_tool: str, result: Dict[str, Any]) -> Dict[str, Any]:
     """Construit les paramètres de test_generation depuis un résultat de refactoring."""
-    code = result.get("refactored_code", "") or "# No refactored code available"
+    lang = result.get("language", "python").lower()
+    code = (result.get("refactored_code", "") or "").strip() or _empty_code_placeholder(lang)
     return {
         "code": code,
-        "language": result.get("language", "python"),
-        "test_framework": "pytest" if result.get("language", "python") == "python" else "jest",
+        "language": lang,
+        "test_framework": "pytest" if lang == "python" else "jest",
         "coverage_target": 0.80,
         "parameters": {"context": "auto-delegated from code_refactoring"},
     }
@@ -655,10 +664,11 @@ def _performance_needs_tests(result: Dict[str, Any]) -> bool:
 
 def _build_review_params_from_refactoring(source_tool: str, result: Dict[str, Any]) -> Dict[str, Any]:
     """Construit les paramètres de code review depuis un résultat de refactoring."""
-    code = result.get("refactored_code", "") or "# No refactored code available"
+    lang = result.get("language", "python").lower()
+    code = (result.get("refactored_code", "") or "").strip() or _empty_code_placeholder(lang)
     return {
         "code": code,
-        "language": result.get("language", "python"),
+        "language": lang,
         "review_standards": ["naming", "complexity", "security", "dry", "solid"],
         "severity_threshold": "warning",
         "context": "auto-delegated from code_refactoring — vérifier la qualité du refactoring",

--- a/tests/test_delegation_chains.py
+++ b/tests/test_delegation_chains.py
@@ -403,8 +403,7 @@ async def test_real_delegation_engine_evaluation():
     assert test_task.params["test_framework"] == "pytest"
 
 
-@pytest.mark.asyncio
-async def test_empty_code_delegation_builders():
+def test_empty_code_delegation_builders():
     """Verify delegation builders handle empty refactored_code without crashing."""
     from collegue.core.expert_delegation import (
         _build_documentation_params_from_refactoring,
@@ -415,16 +414,24 @@ async def test_empty_code_delegation_builders():
     from collegue.tools.code_review.models import CodeReviewRequest
     from collegue.tools.test_generation.models import TestGenerationRequest
 
-    empty_result = {"refactored_code": "", "language": "python"}
+    for code_val in ["", "   ", None]:
+        result = {"refactored_code": code_val, "language": "python"}
 
-    params = _build_test_params_from_refactoring("code_refactoring", empty_result)
-    req = TestGenerationRequest(**params)
-    assert len(req.code) >= 1
+        params = _build_test_params_from_refactoring("code_refactoring", result)
+        req = TestGenerationRequest(**params)
+        assert len(req.code) >= 1
 
-    params = _build_review_params_from_refactoring("code_refactoring", empty_result)
-    req = CodeReviewRequest(**params)
-    assert len(req.code) >= 1
+        params = _build_review_params_from_refactoring("code_refactoring", result)
+        req = CodeReviewRequest(**params)
+        assert len(req.code) >= 1
 
-    params = _build_documentation_params_from_refactoring("code_refactoring", empty_result)
-    req = DocumentationRequest(**params)
-    assert len(req.code) >= 1
+        params = _build_documentation_params_from_refactoring("code_refactoring", result)
+        req = DocumentationRequest(**params)
+        assert len(req.code) >= 1
+
+    # JS language uses // comment marker
+    js_result = {"refactored_code": "", "language": "JavaScript"}
+    params = _build_test_params_from_refactoring("code_refactoring", js_result)
+    assert params["code"].startswith("//")
+    assert params["language"] == "javascript"
+    assert params["test_framework"] == "jest"

--- a/tests/test_delegation_chains.py
+++ b/tests/test_delegation_chains.py
@@ -403,7 +403,6 @@ async def test_real_delegation_engine_evaluation():
     assert test_task.params["test_framework"] == "pytest"
 
 
-
 def test_empty_code_delegation_builders():
     """Verify delegation builders handle empty refactored_code without crashing."""
     from collegue.core.expert_delegation import (

--- a/tests/test_delegation_chains.py
+++ b/tests/test_delegation_chains.py
@@ -401,3 +401,30 @@ async def test_real_delegation_engine_evaluation():
     test_task = next(t for t in tasks if t.target_tool == "test_generation")
     assert test_task.params["code"] == refactoring_result["refactored_code"]
     assert test_task.params["test_framework"] == "pytest"
+
+
+@pytest.mark.asyncio
+async def test_empty_code_delegation_builders():
+    """Verify delegation builders handle empty refactored_code without crashing."""
+    from collegue.core.expert_delegation import (
+        _build_documentation_params_from_refactoring,
+        _build_review_params_from_refactoring,
+        _build_test_params_from_refactoring,
+    )
+    from collegue.tools.code_documentation.models import DocumentationRequest
+    from collegue.tools.code_review.models import CodeReviewRequest
+    from collegue.tools.test_generation.models import TestGenerationRequest
+
+    empty_result = {"refactored_code": "", "language": "python"}
+
+    params = _build_test_params_from_refactoring("code_refactoring", empty_result)
+    req = TestGenerationRequest(**params)
+    assert len(req.code) >= 1
+
+    params = _build_review_params_from_refactoring("code_refactoring", empty_result)
+    req = CodeReviewRequest(**params)
+    assert len(req.code) >= 1
+
+    params = _build_documentation_params_from_refactoring("code_refactoring", empty_result)
+    req = DocumentationRequest(**params)
+    assert len(req.code) >= 1


### PR DESCRIPTION
## Summary

Fixes #314 — Three delegation param builders crash with `ValidationError` when the source expert returns empty `refactored_code=""`:
- `_build_test_params_from_refactoring` → `TestGenerationRequest` requires `code.min_length=1`
- `_build_review_params_from_refactoring` → `CodeReviewRequest` requires `code.min_length=1`
- `_build_documentation_params_from_refactoring` → `DocumentationRequest` requires `code.min_length=1`

Fix: use `or "# No refactored code available"` fallback when code is empty/None.

## Review & Testing Checklist for Human

- [ ] Verify the delegation chain `code_refactoring → test_generation` works when refactoring produces no code changes

### Notes

- Discovered by systematically testing all 14 builders with empty inputs
- Same pattern applied to all 3 affected builders for consistency

Link to Devin session: https://app.devin.ai/sessions/23e3a9004eb44bcfb8c791238af4fab4
Requested by: @VynoDePal