### PR TITLE
fix: normalize LLM field aliases in _parse_plan_from_text

### DIFF
--- a/collegue/core/meta_orchestrator.py
+++ b/collegue/core/meta_orchestrator.py
@@ -143,6 +143,23 @@ def _parse_plan_from_text(text: str) -> Optional[OrchestratorPlan]:
     if bracket_start != -1 and bracket_end > bracket_start:
         candidates.append(text[bracket_start : bracket_end + 1])
 
+    def _normalize_step(step: dict) -> dict:
+        """Normalize common LLM field aliases to OrchestratorStep fields."""
+        normalized = dict(step)
+        if "tool" not in normalized:
+            for alias in ("tool_name", "name"):
+                if alias in normalized:
+                    normalized["tool"] = normalized.pop(alias)
+                    break
+        if "reason" not in normalized:
+            for alias in ("description", "rationale"):
+                if alias in normalized:
+                    normalized["reason"] = normalized.pop(alias)
+                    break
+        if "params" not in normalized:
+            normalized["params"] = {}
+        return normalized
+
     for candidate in candidates:
         try:
             data = _json.loads(candidate)
@@ -152,14 +169,16 @@ def _parse_plan_from_text(text: str) -> Optional[OrchestratorPlan]:
         # If data is a dict with "steps", parse directly
         if isinstance(data, dict) and "steps" in data:
             try:
-                return OrchestratorPlan(**data)
+                steps = [_normalize_step(s) if isinstance(s, dict) else s for s in data["steps"]]
+                return OrchestratorPlan(steps=steps)
             except Exception:
                 continue
 
         # If data is a list, treat as steps array
         if isinstance(data, list):
             try:
-                return OrchestratorPlan(steps=data)
+                steps = [_normalize_step(s) if isinstance(s, dict) else s for s in data]
+                return OrchestratorPlan(steps=steps)
             except Exception:
                 continue
 

--- a/tests/test_orchestrator_fixes.py
+++ b/tests/test_orchestrator_fixes.py
@@ -298,3 +298,27 @@ async def test_orchestrator_uses_fallback_parser_when_structured_output_fails():
     # Should have used the fallback parser and executed code_review
     assert "code_review" in response.tools_used
     assert response.confidence > 0
+
+
+def test_parse_plan_normalizes_field_aliases():
+    """Verify _parse_plan_from_text normalizes tool_name/description to tool/reason."""
+    from collegue.core.meta_orchestrator import _parse_plan_from_text
+
+    # tool_name + description (common LLM output)
+    plan = _parse_plan_from_text(
+        '{"steps": [{"tool_name": "code_review", "description": "Review", "params": {"code": "x"}}]}'
+    )
+    assert plan is not None
+    assert plan.steps[0].tool == "code_review"
+    assert plan.steps[0].reason == "Review"
+
+    # name + rationale
+    plan = _parse_plan_from_text('[{"name": "test_generation", "rationale": "Generate tests"}]')
+    assert plan is not None
+    assert plan.steps[0].tool == "test_generation"
+    assert plan.steps[0].params == {}
+
+    # Correct fields still work
+    plan = _parse_plan_from_text('{"steps": [{"tool": "code_review", "reason": "R", "params": {}}]}')
+    assert plan is not None
+    assert plan.steps[0].tool == "code_review"


### PR DESCRIPTION
## Summary

Fixes #316 — The orchestrator's fallback plan parser (`_parse_plan_from_text`) fails silently when the LLM uses common field aliases instead of the exact `OrchestratorStep` field names.

**Model fields:** `tool`, `reason`, `params`  
**Common LLM aliases that now work:**
- `tool_name` → `tool`
- `name` → `tool`  
- `description` → `reason`
- `rationale` → `reason`
- missing `params` → defaults to `{}`

This is especially important for Gemma 4 26B which doesn't support structured output and frequently generates `tool_name`/`description` in its JSON plans.

## Review & Testing Checklist for Human

- [ ] Run the orchestrator with Gemma 4 26B and verify plans are parsed correctly
- [ ] Verify existing tests still pass: `pytest tests/test_orchestrator_fixes.py -v`

### Notes

- Normalization is applied per-step before model construction
- Original field names (`tool`, `reason`) still work unchanged
- Added 3 test cases covering aliases, missing params, and correct fields

Link to Devin session: https://app.devin.ai/sessions/23e3a9004eb44bcfb8c791238af4fab4
Requested by: @VynoDePal