### PR TITLE
fix: enforce MAX_ENTRIES_PER_EXPERT during store() not just prune()

### DIFF
--- a/collegue/core/project_memory.py
+++ b/collegue/core/project_memory.py
@@ -157,8 +157,9 @@ class ProjectMemory:
             self._entries.append(entry)
             self._dirty = True
 
-            # Pruning si nécessaire
-            if len(self._entries) > self._max_total:
+            # Pruning si nécessaire (global ou per-expert)
+            expert_count = sum(1 for e in self._entries if e.expert == expert)
+            if len(self._entries) > self._max_total or expert_count > MAX_ENTRIES_PER_EXPERT:
                 self._prune_locked()
 
         if auto_save:

--- a/tests/test_project_memory.py
+++ b/tests/test_project_memory.py
@@ -298,6 +298,24 @@ class TestProjectMemoryPrune:
 
         assert len(memory) <= 5
 
+    def test_per_expert_limit_enforced_during_store(self, tmp_path):
+        """Store triggers pruning when a single expert exceeds MAX_ENTRIES_PER_EXPERT."""
+        from collegue.core.project_memory import MAX_ENTRIES_PER_EXPERT
+
+        memory = ProjectMemory(memory_dir=str(tmp_path / "mem"))
+
+        for i in range(MAX_ENTRIES_PER_EXPERT + 50):
+            memory.store(
+                expert="same_expert",
+                entry_type="issue_found",
+                category="a",
+                title=f"Item {i}",
+                data={"i": i},
+                auto_save=False,
+            )
+
+        assert len(memory) <= MAX_ENTRIES_PER_EXPERT
+
 
 class TestProjectMemoryContext:
     def test_get_context_for_empty(self, memory):


### PR DESCRIPTION
## Summary

`ProjectMemory.store()` only triggers pruning when total entries exceed `MAX_TOTAL_ENTRIES` (2000). The per-expert limit `MAX_ENTRIES_PER_EXPERT` (200) was only enforced inside `_prune_locked()`, which meant a single expert could accumulate far beyond 200 entries without triggering the per-expert cleanup.

**Before**: Single expert stores 500 entries → all 500 kept (pruning only triggers at 2000 total)
**After**: Single expert stores 500 entries → pruned to 200 after each threshold crossing

### Changes
- `store()` now checks per-expert count after each insert and triggers `_prune_locked()` when it exceeds `MAX_ENTRIES_PER_EXPERT`
- Added `test_per_expert_limit_enforced_during_store` test

Found during Phase 9e deep testing with Gemma 4 26B.

## Review & Testing Checklist for Human
- [ ] Verify that existing tests still pass (`pytest tests/test_project_memory.py`)
- [ ] Check that the per-expert count check in `store()` doesn't cause performance regression with many stores (the `sum()` call is O(n) per store)

### Notes
- The per-expert count uses `sum(1 for e in self._entries if e.expert == expert)` which is O(n) — acceptable for up to 2000 entries but could be optimized with a counter dict if needed in the future

Link to Devin session: https://app.devin.ai/sessions/23e3a9004eb44bcfb8c791238af4fab4
Requested by: @VynoDePal