### PR TITLE
fix: count all activated experts in build_chain_report, not just successful

### DIFF
--- a/collegue/core/expert_delegation.py
+++ b/collegue/core/expert_delegation.py
@@ -402,8 +402,7 @@ class ExpertDelegationEngine:
         def _count_experts(res_list: List[DelegationResult]) -> int:
             count = 0
             for r in res_list:
-                if r.success:
-                    count += 1
+                count += 1
                 count += _count_experts(r.sub_delegations)
             return count
 

--- a/tests/test_expert_delegation.py
+++ b/tests/test_expert_delegation.py
@@ -377,6 +377,28 @@ class TestExpertDelegationEngine:
         assert report.total_time == pytest.approx(3.5)
         assert report.chain_completed is True
 
+    def test_build_chain_report_counts_failed_experts(self):
+        """total_experts_activated must count all activated experts, not just successful ones."""
+        engine = ExpertDelegationEngine()
+        results = [
+            DelegationResult(
+                source_tool="review",
+                target_tool="refactoring",
+                success=True,
+                result={"ok": True},
+                execution_time=1.0,
+            ),
+            DelegationResult(
+                source_tool="refactoring",
+                target_tool="tests",
+                success=False,
+                error="timeout",
+                execution_time=0.5,
+            ),
+        ]
+        report = engine.build_chain_report("review", results)
+        assert report.total_experts_activated == 2
+
     def test_get_rules_for_tool(self):
         engine = ExpertDelegationEngine()
         engine.register_rule(


### PR DESCRIPTION
## Summary

`build_chain_report()` → `_count_experts()` only counted `DelegationResult` entries with `success=True`, making `total_experts_activated` misleadingly low. Failed delegations were silently excluded even though the expert was actually activated and attempted.

**Before**: `total_experts_activated=1` for 2 results (1 success, 1 failure)
**After**: `total_experts_activated=2` (counts all activated experts regardless of outcome)

### Changes
- Removed `if r.success` guard in `_count_experts()` — all results now count
- Added `test_build_chain_report_counts_failed_experts` test

Found during Phase 9g deep testing.

## Review & Testing Checklist for Human
- [ ] Verify that `total_experts_activated` semantics match your expectation (all activated vs only successful)
- [ ] Run `pytest tests/test_expert_delegation.py -v` to confirm all tests pass

### Notes
- This changes the semantics of `total_experts_activated` from "successfully completed" to "attempted" — which matches the field name better

Link to Devin session: https://app.devin.ai/sessions/23e3a9004eb44bcfb8c791238af4fab4
Requested by: @VynoDePal