### PR TITLE
fix: force MetricsCollector reload from disk on each dashboard refresh

### DIFF
--- a/collegue/dashboard/data.py
+++ b/collegue/dashboard/data.py
@@ -16,11 +16,16 @@ logger = logging.getLogger(__name__)
 
 
 def get_metrics_data() -> Dict[str, Any]:
-    """Get metrics from the MetricsCollector singleton (disk-backed)."""
+    """Get metrics from the MetricsCollector singleton (disk-backed).
+
+    Forces a reload from disk so the dashboard (separate process)
+    always sees the latest data written by the MCP server.
+    """
     try:
         from collegue.monitoring.metrics import get_metrics_collector
 
         collector = get_metrics_collector()
+        collector.reload_from_disk()
         summary = collector.get_summary()
         all_metrics = collector.get_all_metrics()
 
@@ -48,12 +53,14 @@ def get_dashboard_data() -> Dict[str, Any]:
         health = engine.build_project_health(entries_raw)
         recommendations = engine.build_recommendations(entries_raw, limit=10)
 
-        # Metrics from collector (disk-backed)
+        # Metrics from collector (disk-backed, force reload)
         metrics_data: Dict[str, Any] = {}
         try:
             from collegue.monitoring.metrics import get_metrics_collector
 
-            metrics_data = get_metrics_collector().get_summary().to_dict()
+            collector = get_metrics_collector()
+            collector.reload_from_disk()
+            metrics_data = collector.get_summary().to_dict()
         except Exception:
             pass
 

--- a/collegue/monitoring/metrics.py
+++ b/collegue/monitoring/metrics.py
@@ -326,6 +326,12 @@ class MetricsCollector:
         except (OSError, json.JSONDecodeError) as exc:
             logger.debug("metrics load error: %s", exc)
 
+    def reload_from_disk(self) -> None:
+        """Re-read metrics from disk (useful for dashboard in separate process)."""
+        with self._lock:
+            self._experts.clear()
+            self._load_from_disk()
+
     def reset(self) -> None:
         """Reset all metrics."""
         with self._lock:


### PR DESCRIPTION
## Summary

Fixes a bug where the Streamlit dashboard's Metriques tab always showed zeros even after running experts. The root cause: `MetricsCollector` is a singleton that only loads from disk once (at initialization). When the dashboard process starts before any expert runs, the singleton is initialized empty and never re-reads the disk file.

**Fix**: Added `reload_from_disk()` method to `MetricsCollector` and called it in `get_metrics_data()` and `get_dashboard_data()` so the dashboard always reads the latest metrics from disk on each page refresh.

## Review & Testing Checklist for Human

- [ ] Start the dashboard, run an expert test, and verify the Metriques tab shows execution count >= 1 and latency > 0
- [ ] Verify auto-refresh continues to update metrics after additional expert runs

### Notes

Bug found during end-to-end testing of PR #328 (real-time dashboard). The Activite LLM and Memoire tabs worked correctly because they read directly from `activity.jsonl` file, but the Metriques tab relied on the singleton's in-memory state which was stale.

Link to Devin session: https://app.devin.ai/sessions/23e3a9004eb44bcfb8c791238af4fab4
Requested by: @VynoDePal