### PR TITLE
feat(llm): ajoute le provider Unsloth AI (serveur local compatible OpenAI)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@
 
 # LLM Configuration
 # ----------------
-# Fournisseur LLM : gemini (défaut), openai, anthropic, lmstudio
+# Fournisseur LLM : gemini (défaut), openai, anthropic, lmstudio, unsloth
 # LLM_PROVIDER="gemini"
 # Configuration de clé API Google Gemini ( à modifier si besoin )
 # Obtenez votre clé sur https://aistudio.google.com/apikey
@@ -26,6 +26,15 @@ LLM_API_KEY="votre_clé_api_gemini"
 # LLM_BASE_URL="http://localhost:1234/v1"   # défaut si non défini
 # Depuis un conteneur Docker, viser l'hôte :
 # LLM_BASE_URL="http://host.docker.internal:1234/v1"
+
+# --- Unsloth AI (serveur local compatible OpenAI) ---
+# Pour utiliser un modèle local via Unsloth :
+#   1. Lancer le serveur Unsloth (expose /v1 sur le port 8888 par défaut)
+#   2. Décommenter les lignes ci-dessous (clé API requise par Unsloth)
+# LLM_PROVIDER="unsloth"
+# LLM_MODEL="<nom-du-modèle-chargé>"
+# LLM_API_KEY="sk-unsloth-..."             # créée dans Settings > API
+# LLM_BASE_URL="http://localhost:8888/v1"  # défaut si non défini
 
 # Variables d'environnement pour Keycloak (Docker)
 # KEYCLOAK_ADMIN=admin

--- a/collegue/app.py
+++ b/collegue/app.py
@@ -193,11 +193,12 @@ async def validate_llm_config():
     - ``gemini`` (défaut) — utilise ``google-genai``
     - ``openai`` — utilise ``openai``
     - ``anthropic`` — utilise ``anthropic``
-    - ``lmstudio`` — serveur local compatible OpenAI (clé non requise)
+    - ``lmstudio`` / ``unsloth`` / ``ollama`` — serveur local compatible OpenAI
     """
     provider = getattr(settings, "LLM_PROVIDER", "gemini").lower()
 
-    # Les providers locaux (LM Studio) n'exigent pas de clé API.
+    # Les providers locaux exigent une clé API seulement si l'utilisateur en a
+    # configuré une (Unsloth en attend une, LM Studio/Ollama l'ignorent).
     if not settings.LLM_API_KEY and not settings.is_local_provider:
         error_msg = "❌ Configuration LLM manquante : LLM_API_KEY n'est pas définie."
         logger.error(error_msg)
@@ -205,15 +206,16 @@ async def validate_llm_config():
 
     logger.info(f"🔍 Validation du modèle LLM '{settings.LLM_MODEL}' (provider={provider}) en cours...")
     try:
-        if provider == "lmstudio":
+        if settings.is_local_provider:
             import openai
 
             base_url = settings.llm_base_url
-            # LM Studio ignore la clé ; on en fournit une factice si absente.
-            client = openai.OpenAI(api_key=settings.LLM_API_KEY or "lm-studio", base_url=base_url)
+            # Clé : celle fournie (requise par Unsloth) sinon une factice
+            # (LM Studio / Ollama l'ignorent mais le SDK OpenAI en exige une).
+            client = openai.OpenAI(api_key=settings.LLM_API_KEY or "local", base_url=base_url)
 
             def check_connection():
-                # Teste juste la connexion au serveur local et liste les modèles.
+                # Teste la connexion au serveur local et liste les modèles.
                 return list(client.models.list())
 
             models = await asyncio.to_thread(check_connection)
@@ -221,12 +223,12 @@ async def validate_llm_config():
             if settings.LLM_MODEL in available:
                 model_display = settings.LLM_MODEL
             elif available:
-                # Modèle non listé (ou nom différent) : on n'échoue pas, le
-                # serveur peut charger le modèle à la demande.
+                # Modèle non listé : on n'échoue pas, le serveur peut le charger
+                # à la demande.
                 model_display = f"{settings.LLM_MODEL} (modèles chargés: {', '.join(available[:3])})"
             else:
-                model_display = f"{settings.LLM_MODEL} (aucun modèle chargé dans LM Studio)"
-            logger.info(f"✅ Connexion LM Studio OK ({base_url}). {model_display}")
+                model_display = f"{settings.LLM_MODEL} (aucun modèle chargé)"
+            logger.info(f"✅ Connexion {provider} OK ({base_url}). {model_display}")
             return True
 
         elif provider == "gemini":
@@ -383,13 +385,14 @@ if settings.LLM_API_KEY or settings.is_local_provider:
 
         provider = settings.LLM_PROVIDER.lower()
         # URL de base selon le provider : Gemini par défaut, ou l'endpoint
-        # compatible OpenAI du provider (LM Studio / OpenAI / base_url custom).
+        # compatible OpenAI du provider (LM Studio / Unsloth / OpenAI / custom).
         if provider in ("gemini", ""):
             base_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
         else:
             base_url = settings.llm_base_url  # None pour OpenAI cloud → défaut SDK
-        # LM Studio ignore la clé : on en fournit une factice si absente.
-        api_key = settings.LLM_API_KEY or ("lm-studio" if settings.is_local_provider else None)
+        # Clé fournie si présente (requise par Unsloth) ; factice pour les locaux
+        # qui l'ignorent (LM Studio / Ollama), car le SDK OpenAI en exige une.
+        api_key = settings.LLM_API_KEY or ("local" if settings.is_local_provider else None)
 
         openai_client = AsyncOpenAI(api_key=api_key, base_url=base_url)
         sampling_handler = UsageTrackingSamplingHandler(

--- a/collegue/app.py
+++ b/collegue/app.py
@@ -197,8 +197,8 @@ async def validate_llm_config():
     """
     provider = getattr(settings, "LLM_PROVIDER", "gemini").lower()
 
-    # Les providers locaux exigent une clé API seulement si l'utilisateur en a
-    # configuré une (Unsloth en attend une, LM Studio/Ollama l'ignorent).
+    # Les providers locaux n'exigent pas de clé côté Collègue (Unsloth la vérifie
+    # lui-même à la connexion ci-dessous).
     if not settings.LLM_API_KEY and not settings.is_local_provider:
         error_msg = "❌ Configuration LLM manquante : LLM_API_KEY n'est pas définie."
         logger.error(error_msg)
@@ -210,12 +210,10 @@ async def validate_llm_config():
             import openai
 
             base_url = settings.llm_base_url
-            # Clé : celle fournie (requise par Unsloth) sinon une factice
-            # (LM Studio / Ollama l'ignorent mais le SDK OpenAI en exige une).
+            # Clé factice si absente : le SDK OpenAI en exige une, les locaux l'ignorent.
             client = openai.OpenAI(api_key=settings.LLM_API_KEY or "local", base_url=base_url)
 
             def check_connection():
-                # Teste la connexion au serveur local et liste les modèles.
                 return list(client.models.list())
 
             models = await asyncio.to_thread(check_connection)
@@ -223,8 +221,7 @@ async def validate_llm_config():
             if settings.LLM_MODEL in available:
                 model_display = settings.LLM_MODEL
             elif available:
-                # Modèle non listé : on n'échoue pas, le serveur peut le charger
-                # à la demande.
+                # Modèle non listé : ne pas échouer, le serveur peut le charger à la demande.
                 model_display = f"{settings.LLM_MODEL} (modèles chargés: {', '.join(available[:3])})"
             else:
                 model_display = f"{settings.LLM_MODEL} (aucun modèle chargé)"
@@ -384,14 +381,12 @@ if settings.LLM_API_KEY or settings.is_local_provider:
                 self.client.chat.completions.create = _create
 
         provider = settings.LLM_PROVIDER.lower()
-        # URL de base selon le provider : Gemini par défaut, ou l'endpoint
-        # compatible OpenAI du provider (LM Studio / Unsloth / OpenAI / custom).
+        # Gemini par défaut ; sinon l'endpoint OpenAI-compatible du provider.
         if provider in ("gemini", ""):
             base_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
         else:
             base_url = settings.llm_base_url  # None pour OpenAI cloud → défaut SDK
-        # Clé fournie si présente (requise par Unsloth) ; factice pour les locaux
-        # qui l'ignorent (LM Studio / Ollama), car le SDK OpenAI en exige une.
+        # Clé factice pour les locaux qui l'ignorent (le SDK OpenAI en exige une).
         api_key = settings.LLM_API_KEY or ("local" if settings.is_local_provider else None)
 
         openai_client = AsyncOpenAI(api_key=api_key, base_url=base_url)

--- a/collegue/config.py
+++ b/collegue/config.py
@@ -100,11 +100,9 @@ class Settings(BaseSettings):
     def llm_api_key(self) -> Optional[str]:
         return self.LLM_API_KEY
 
-    # Providers locaux compatibles OpenAI (serveur sur la machine, coût nul).
-    # La clé API peut être requise (unsloth) ou non (lmstudio, ollama).
+    # Providers locaux compatibles OpenAI (coût nul ; clé requise pour unsloth).
     LOCAL_PROVIDERS: ClassVar[tuple] = ("lmstudio", "ollama", "unsloth")
 
-    # URL de base par défaut pour chaque provider local (endpoint /v1).
     LOCAL_DEFAULT_BASE_URLS: ClassVar[dict] = {
         "lmstudio": "http://localhost:1234/v1",
         "ollama": "http://localhost:11434/v1",

--- a/collegue/config.py
+++ b/collegue/config.py
@@ -100,8 +100,16 @@ class Settings(BaseSettings):
     def llm_api_key(self) -> Optional[str]:
         return self.LLM_API_KEY
 
-    # Providers locaux compatibles OpenAI (pas de clé requise, coût nul).
-    LOCAL_PROVIDERS: ClassVar[tuple] = ("lmstudio", "ollama")
+    # Providers locaux compatibles OpenAI (serveur sur la machine, coût nul).
+    # La clé API peut être requise (unsloth) ou non (lmstudio, ollama).
+    LOCAL_PROVIDERS: ClassVar[tuple] = ("lmstudio", "ollama", "unsloth")
+
+    # URL de base par défaut pour chaque provider local (endpoint /v1).
+    LOCAL_DEFAULT_BASE_URLS: ClassVar[dict] = {
+        "lmstudio": "http://localhost:1234/v1",
+        "ollama": "http://localhost:11434/v1",
+        "unsloth": "http://localhost:8888/v1",
+    }
 
     @property
     def is_local_provider(self) -> bool:
@@ -112,16 +120,11 @@ class Settings(BaseSettings):
         """URL de base effective pour les clients compatibles OpenAI.
 
         LLM_BASE_URL prime ; sinon, valeur par défaut connue pour le provider
-        local (LM Studio écoute sur http://localhost:1234/v1 par défaut).
+        local (ex. LM Studio :1234, Unsloth :8888).
         """
         if self.LLM_BASE_URL:
             return self.LLM_BASE_URL
-        provider = self.LLM_PROVIDER.lower()
-        if provider == "lmstudio":
-            return "http://localhost:1234/v1"
-        if provider == "ollama":
-            return "http://localhost:11434/v1"
-        return None
+        return self.LOCAL_DEFAULT_BASE_URLS.get(self.LLM_PROVIDER.lower())
 
 
 settings = Settings()

--- a/tests/test_lmstudio_provider.py
+++ b/tests/test_lmstudio_provider.py
@@ -1,4 +1,4 @@
-"""Tests de la configuration du provider local LM Studio (compatible OpenAI)."""
+"""Tests des providers locaux compatibles OpenAI (LM Studio, Unsloth)."""
 
 from collegue.config import Settings
 from collegue.monitoring.metrics import MetricsCollector
@@ -11,9 +11,24 @@ def test_lmstudio_is_local_provider():
     assert Settings(LLM_PROVIDER="gemini").is_local_provider is False
 
 
+def test_unsloth_is_local_provider():
+    s = Settings(LLM_PROVIDER="unsloth", LLM_API_KEY="sk-unsloth-xxx")
+    assert s.is_local_provider is True
+
+
 def test_lmstudio_default_base_url():
     s = Settings(LLM_PROVIDER="lmstudio")
     assert s.llm_base_url == "http://localhost:1234/v1"
+
+
+def test_unsloth_default_base_url():
+    s = Settings(LLM_PROVIDER="unsloth")
+    assert s.llm_base_url == "http://localhost:8888/v1"
+
+
+def test_unsloth_explicit_base_url_overrides_default():
+    s = Settings(LLM_PROVIDER="unsloth", LLM_BASE_URL="http://localhost:8000/v1")
+    assert s.llm_base_url == "http://localhost:8000/v1"
 
 
 def test_explicit_base_url_overrides_default():


### PR DESCRIPTION
## Objectif

Permettre de tester Collègue avec **Unsloth AI**, qui expose une API compatible OpenAI (`/v1`) en local, **authentifiée par clé** (`Authorization: Bearer sk-unsloth-…`, port `8888` par défaut). Comme pour LM Studio (PR #332), l'accent est mis sur le **test de connexion** au démarrage.

## Changements

| Fichier | Changement |
|---|---|
| **config.py** | `unsloth` ajouté aux `LOCAL_PROVIDERS` ; nouvelle table `LOCAL_DEFAULT_BASE_URLS` centralisant les URL par défaut (lmstudio `:1234`, ollama `:11434`, **unsloth `:8888`**). |
| **app.py – `validate_llm_config()`** | La branche locale est **généralisée** (`is_local_provider`) pour couvrir lmstudio/unsloth/ollama via le même chemin OpenAI : test de connexion par `GET /v1/models`. La **clé fournie est transmise** (requise par Unsloth) ; clé factice pour les locaux qui l'ignorent. |
| **app.py – sampling handler** | Idem : clé réelle si présente, factice sinon. |
| **metrics.py** | Coût nul conservé pour tous les providers locaux. |
| **.env.example** | Section Unsloth documentée. |
| **tests** | `is_local_provider` + URL par défaut/override pour Unsloth. |

## Utilisation

```env
LLM_PROVIDER="unsloth"
LLM_MODEL="<nom-du-modèle-chargé>"
LLM_API_KEY="sk-unsloth-..."
# LLM_BASE_URL="http://localhost:8888/v1"   # optionnel (défaut)
```

## Validation (contre une instance Unsloth réelle, `localhost:8888`)

- ✅ Connexion + `/v1/models` avec **clé valide** → `validate_llm_config()` = `True`
- ✅ **Clé invalide** → échec propre `ValueError` (HTTP 401 « Invalid or expired API key ») — l'auth est bien vérifiée
- ✅ `is_local_provider` / URL par défaut `:8888` corrects
- ✅ **9 tests** OK (`tests/test_lmstudio_provider.py`), ruff check + format OK

> Note : l'inférence de bout en bout nécessite un modèle chargé côté Unsloth (`POST /inference/load`) ; sans modèle, le serveur renvoie « No model loaded » — la connexion/auth, elle, est validée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)