### PR TITLE
feat(llm): enum LLMRole + résolution modèle/provider par rôle (C1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,17 @@ LLM_API_KEY="votre_clé_api_gemini"
 # Modèle par défaut: gemini-3-flash-preview
 # LLM_MODEL="gemini-3-flash-preview"
 
+# --- Modèles par rôle (optionnel) ---
+# Permet d'affecter un modèle/provider différent selon le rôle de l'appel LLM.
+# Si non défini, chaque rôle retombe sur LLM_PROVIDER / LLM_MODEL ci-dessus.
+# Rôles : CODER (codeur fort), QA (triage économique), REVIEWER, PLANNER.
+# LLM_MODEL_CODER="<modèle fort pour générer du code>"
+# LLM_PROVIDER_CODER="gemini"
+# LLM_MODEL_QA="<modèle économique pour QA/triage>"
+# LLM_PROVIDER_QA="lmstudio"
+# LLM_MODEL_PLANNER="<modèle pour la planification>"
+# LLM_MODEL_REVIEWER="<modèle pour la revue>"
+
 # --- LM Studio (serveur local compatible OpenAI) ---
 # Pour utiliser un modèle local via LM Studio :
 #   1. Lancer le serveur dans LM Studio (Developer > Start Server)

--- a/collegue/config.py
+++ b/collegue/config.py
@@ -27,6 +27,18 @@ class Settings(BaseSettings):
     # Laisser vide pour utiliser l'URL par défaut du provider.
     LLM_BASE_URL: Optional[str] = None
 
+    # Modèle/provider par rôle (codeur fort, QA économique, planner…).
+    # Optionnels : si non définis, on retombe sur LLM_MODEL / LLM_PROVIDER.
+    # Résolus via collegue.core.llm.resolve_role().
+    LLM_MODEL_CODER: Optional[str] = None
+    LLM_PROVIDER_CODER: Optional[str] = None
+    LLM_MODEL_QA: Optional[str] = None
+    LLM_PROVIDER_QA: Optional[str] = None
+    LLM_MODEL_REVIEWER: Optional[str] = None
+    LLM_PROVIDER_REVIEWER: Optional[str] = None
+    LLM_MODEL_PLANNER: Optional[str] = None
+    LLM_PROVIDER_PLANNER: Optional[str] = None
+
     MAX_TOKENS: int = 8192
     REQUEST_TIMEOUT: int = 60
     ENGINE_INIT_TIMEOUT: float = 10.0

--- a/collegue/core/llm/__init__.py
+++ b/collegue/core/llm/__init__.py
@@ -1,0 +1,5 @@
+"""Couche LLM unifiée de Collègue (rôles, résolution de modèle par rôle)."""
+
+from collegue.core.llm.roles import LLMRole, resolve_role
+
+__all__ = ["LLMRole", "resolve_role"]

--- a/collegue/core/llm/roles.py
+++ b/collegue/core/llm/roles.py
@@ -1,0 +1,54 @@
+"""Rôles LLM et résolution du couple (provider, modèle) par rôle.
+
+Le brief « moteur de dev autonome » (§5) veut des modèles par rôle : un codeur
+fort, un QA/triage économique, un planner, etc. Le multi-provider existe déjà
+(``collegue/config.py``) ; ce module ajoute uniquement le mapping rôle→modèle,
+configurable via ``.env`` (``LLM_MODEL_<ROLE>`` / ``LLM_PROVIDER_<ROLE>``) avec
+fallback sur le couple global ``LLM_PROVIDER`` / ``LLM_MODEL``.
+
+Purement additif : sans config par rôle, ``resolve_role`` renvoie le défaut
+global, donc aucun comportement existant ne change.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional, Tuple
+
+
+class LLMRole(str, Enum):
+    """Rôle fonctionnel d'un appel LLM, qui détermine le modèle utilisé."""
+
+    CODER = "coder"
+    QA = "qa"
+    REVIEWER = "reviewer"
+    PLANNER = "planner"
+    DEFAULT = "default"
+
+
+def resolve_role(role: LLMRole | str = LLMRole.DEFAULT, settings_obj: Optional[object] = None) -> Tuple[str, str]:
+    """Retourne ``(provider, model)`` pour un rôle donné.
+
+    Priorité : config dédiée au rôle (``LLM_PROVIDER_<ROLE>`` / ``LLM_MODEL_<ROLE>``)
+    si présente, sinon fallback sur le couple global ``LLM_PROVIDER`` / ``LLM_MODEL``.
+    Chaque dimension (provider, model) retombe indépendamment sur le défaut.
+
+    Args:
+        role: rôle (``LLMRole`` ou sa valeur str). Inconnu → traité comme DEFAULT.
+        settings_obj: settings à interroger (défaut : le singleton ``settings``).
+    """
+    if settings_obj is None:
+        from collegue.config import settings as settings_obj
+
+    role_value = role.value if isinstance(role, LLMRole) else str(role).lower()
+
+    default_provider = getattr(settings_obj, "LLM_PROVIDER", "gemini")
+    default_model = getattr(settings_obj, "LLM_MODEL", "")
+
+    if role_value == LLMRole.DEFAULT.value:
+        return default_provider, default_model
+
+    suffix = role_value.upper()
+    provider = getattr(settings_obj, f"LLM_PROVIDER_{suffix}", None) or default_provider
+    model = getattr(settings_obj, f"LLM_MODEL_{suffix}", None) or default_model
+    return provider, model

--- a/collegue/core/llm/roles.py
+++ b/collegue/core/llm/roles.py
@@ -32,6 +32,7 @@ def resolve_role(role: LLMRole | str = LLMRole.DEFAULT, settings_obj: Optional[o
     Priorité : config dédiée au rôle (``LLM_PROVIDER_<ROLE>`` / ``LLM_MODEL_<ROLE>``)
     si présente, sinon fallback sur le couple global ``LLM_PROVIDER`` / ``LLM_MODEL``.
     Chaque dimension (provider, model) retombe indépendamment sur le défaut.
+    Une valeur vide (``""``) est traitée comme « non définie » → fallback global.
 
     Args:
         role: rôle (``LLMRole`` ou sa valeur str). Inconnu → traité comme DEFAULT.

--- a/tests/test_llm_roles.py
+++ b/tests/test_llm_roles.py
@@ -1,0 +1,55 @@
+"""Tests de la résolution de modèle/provider par rôle (C1, epic #334)."""
+
+from collegue.config import Settings
+from collegue.core.llm import LLMRole, resolve_role
+
+
+def test_default_role_uses_global_config():
+    s = Settings(LLM_PROVIDER="gemini", LLM_MODEL="gemini-3-flash-preview")
+    assert resolve_role(LLMRole.DEFAULT, s) == ("gemini", "gemini-3-flash-preview")
+
+
+def test_role_without_dedicated_config_falls_back():
+    # Aucun LLM_MODEL_CODER défini → fallback sur le couple global.
+    s = Settings(LLM_PROVIDER="gemini", LLM_MODEL="gemini-3-flash-preview")
+    assert resolve_role(LLMRole.CODER, s) == ("gemini", "gemini-3-flash-preview")
+
+
+def test_role_with_dedicated_model():
+    s = Settings(
+        LLM_PROVIDER="gemini",
+        LLM_MODEL="gemini-3-flash-preview",
+        LLM_MODEL_CODER="gemini-3-pro-preview",
+    )
+    # Le modèle du rôle prime, le provider retombe sur le global.
+    assert resolve_role(LLMRole.CODER, s) == ("gemini", "gemini-3-pro-preview")
+
+
+def test_role_with_dedicated_provider_and_model():
+    s = Settings(
+        LLM_PROVIDER="gemini",
+        LLM_MODEL="gemini-3-flash-preview",
+        LLM_PROVIDER_QA="lmstudio",
+        LLM_MODEL_QA="qwen2.5-coder",
+    )
+    assert resolve_role(LLMRole.QA, s) == ("lmstudio", "qwen2.5-coder")
+
+
+def test_independent_fallback_per_dimension():
+    # Provider du rôle défini mais pas le modèle → modèle retombe sur le global.
+    s = Settings(
+        LLM_PROVIDER="gemini",
+        LLM_MODEL="gemini-3-flash-preview",
+        LLM_PROVIDER_PLANNER="openai",
+    )
+    assert resolve_role(LLMRole.PLANNER, s) == ("openai", "gemini-3-flash-preview")
+
+
+def test_role_accepts_string_value():
+    s = Settings(LLM_PROVIDER="gemini", LLM_MODEL="m", LLM_MODEL_REVIEWER="rev-model")
+    assert resolve_role("reviewer", s) == ("gemini", "rev-model")
+
+
+def test_unknown_role_treated_as_default():
+    s = Settings(LLM_PROVIDER="gemini", LLM_MODEL="m")
+    assert resolve_role("inconnu", s) == ("gemini", "m")

--- a/tests/test_llm_roles.py
+++ b/tests/test_llm_roles.py
@@ -1,22 +1,55 @@
-"""Tests de la résolution de modèle/provider par rôle (C1, epic #334)."""
+"""Tests de la résolution de modèle/provider par rôle (C1, epic #334).
+
+Isolation : on construit les Settings avec ``_env_file=None`` et on purge les
+variables d'environnement par rôle, pour que chaque test contrôle entièrement
+ses entrées (sinon un ``LLM_MODEL_CODER`` ambiant ferait passer/échouer les
+tests de fallback à tort).
+"""
+
+import pytest
 
 from collegue.config import Settings
 from collegue.core.llm import LLMRole, resolve_role
 
+_ROLE_ENV_VARS = [
+    "LLM_MODEL_CODER",
+    "LLM_PROVIDER_CODER",
+    "LLM_MODEL_QA",
+    "LLM_PROVIDER_QA",
+    "LLM_MODEL_REVIEWER",
+    "LLM_PROVIDER_REVIEWER",
+    "LLM_MODEL_PLANNER",
+    "LLM_PROVIDER_PLANNER",
+    "LLM_MODEL",
+    "LLM_PROVIDER",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_role_env(monkeypatch):
+    """Purge l'environnement LLM par rôle pour des tests déterministes."""
+    for var in _ROLE_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def _settings(**kwargs) -> Settings:
+    # _env_file=None : ne pas charger le .env du repo pendant les tests.
+    return Settings(_env_file=None, **kwargs)
+
 
 def test_default_role_uses_global_config():
-    s = Settings(LLM_PROVIDER="gemini", LLM_MODEL="gemini-3-flash-preview")
+    s = _settings(LLM_PROVIDER="gemini", LLM_MODEL="gemini-3-flash-preview")
     assert resolve_role(LLMRole.DEFAULT, s) == ("gemini", "gemini-3-flash-preview")
 
 
 def test_role_without_dedicated_config_falls_back():
     # Aucun LLM_MODEL_CODER défini → fallback sur le couple global.
-    s = Settings(LLM_PROVIDER="gemini", LLM_MODEL="gemini-3-flash-preview")
+    s = _settings(LLM_PROVIDER="gemini", LLM_MODEL="gemini-3-flash-preview")
     assert resolve_role(LLMRole.CODER, s) == ("gemini", "gemini-3-flash-preview")
 
 
 def test_role_with_dedicated_model():
-    s = Settings(
+    s = _settings(
         LLM_PROVIDER="gemini",
         LLM_MODEL="gemini-3-flash-preview",
         LLM_MODEL_CODER="gemini-3-pro-preview",
@@ -26,7 +59,7 @@ def test_role_with_dedicated_model():
 
 
 def test_role_with_dedicated_provider_and_model():
-    s = Settings(
+    s = _settings(
         LLM_PROVIDER="gemini",
         LLM_MODEL="gemini-3-flash-preview",
         LLM_PROVIDER_QA="lmstudio",
@@ -37,7 +70,7 @@ def test_role_with_dedicated_provider_and_model():
 
 def test_independent_fallback_per_dimension():
     # Provider du rôle défini mais pas le modèle → modèle retombe sur le global.
-    s = Settings(
+    s = _settings(
         LLM_PROVIDER="gemini",
         LLM_MODEL="gemini-3-flash-preview",
         LLM_PROVIDER_PLANNER="openai",
@@ -46,10 +79,16 @@ def test_independent_fallback_per_dimension():
 
 
 def test_role_accepts_string_value():
-    s = Settings(LLM_PROVIDER="gemini", LLM_MODEL="m", LLM_MODEL_REVIEWER="rev-model")
+    s = _settings(LLM_PROVIDER="gemini", LLM_MODEL="m", LLM_MODEL_REVIEWER="rev-model")
     assert resolve_role("reviewer", s) == ("gemini", "rev-model")
 
 
 def test_unknown_role_treated_as_default():
-    s = Settings(LLM_PROVIDER="gemini", LLM_MODEL="m")
+    s = _settings(LLM_PROVIDER="gemini", LLM_MODEL="m")
     assert resolve_role("inconnu", s) == ("gemini", "m")
+
+
+def test_empty_string_override_falls_back_to_global():
+    # Une valeur vide est traitée comme « non défini » → fallback global.
+    s = _settings(LLM_PROVIDER="gemini", LLM_MODEL="m", LLM_MODEL_CODER="")
+    assert resolve_role(LLMRole.CODER, s) == ("gemini", "m")


### PR DESCRIPTION
## Objectif

Première brique de la **Phase 0** du moteur de développement autonome (epic #334). Ajoute le mapping **rôle → modèle** : un codeur fort, un QA économique, un planner. Le multi-provider existe déjà ; ceci est **purement additif** (aucun comportement runtime modifié, fallback sur le couple global).

Closes #335.

## Changements

| Fichier | Changement |
|---|---|
| `collegue/core/llm/roles.py` (nouveau) | enum `LLMRole` (CODER/QA/REVIEWER/PLANNER/DEFAULT) + `resolve_role(role) -> (provider, model)` avec fallback **indépendant par dimension** sur `LLM_PROVIDER`/`LLM_MODEL`. |
| `collegue/core/llm/__init__.py` (nouveau) | exports `LLMRole`, `resolve_role`. |
| `collegue/config.py` | champs optionnels `LLM_MODEL_<ROLE>` / `LLM_PROVIDER_<ROLE>`. |
| `.env.example` | section « Modèles par rôle » documentée. |
| `tests/test_llm_roles.py` (nouveau) | 7 tests. |

## Utilisation

```env
# Sans config par rôle → tout retombe sur LLM_MODEL/LLM_PROVIDER (comportement actuel).
LLM_MODEL_CODER="gemini-3-pro-preview"   # codeur fort
LLM_PROVIDER_QA="lmstudio"               # QA local économique
LLM_MODEL_QA="qwen2.5-coder"
```

## Acceptance Criteria (#335)

- ✅ `LLM_MODEL_CODER` / `LLM_PROVIDER_QA` lus depuis `.env`.
- ✅ `resolve_role(CODER)` = config du rôle si définie, sinon couple global (fallback testé).
- ✅ Rôle sans config dédiée → défaut global ; aucun outil existant cassé.
- ✅ `pytest` + `ruff` verts.

## Validation

- **7 nouveaux tests** OK (défaut, fallback, modèle dédié, provider+modèle dédiés, fallback indépendant par dimension, valeur str, rôle inconnu).
- **Non-régression** : `test_lmstudio_provider` + `test_monitoring_metrics` verts (37 tests au total).
- `ruff check` + `ruff format` OK.

## Out of Scope

- Câblage de `role` dans `sample_llm` → **C2 (#336)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)