### PR TITLE
feat(monitoring): capture du modèle utilisé + tarifs OpenAI/Anthropic (C3)

### DIFF
--- a/collegue/core/llm/sampling_handler.py
+++ b/collegue/core/llm/sampling_handler.py
@@ -40,6 +40,7 @@ def _make_handler_class():
                     record_usage(
                         getattr(usage, "prompt_tokens", 0) or 0,
                         getattr(usage, "completion_tokens", 0) or 0,
+                        getattr(response, "model", "") or "",
                     )
                 return response
 

--- a/collegue/monitoring/metrics.py
+++ b/collegue/monitoring/metrics.py
@@ -178,9 +178,7 @@ class MetricsCollector:
                 from collegue.config import settings
 
                 # Providers locaux (LM Studio…) : exécution gratuite → coût nul.
-                if settings.is_local_provider:
-                    return 0.0, 0.0
-                model = settings.LLM_MODEL
+                return cost_per_token(settings.LLM_MODEL, provider=settings.LLM_PROVIDER)
             return cost_per_token(model)
         except Exception:
             return DEFAULT_INPUT_COST_PER_TOKEN, DEFAULT_OUTPUT_COST_PER_TOKEN

--- a/collegue/monitoring/pricing.py
+++ b/collegue/monitoring/pricing.py
@@ -1,22 +1,35 @@
 """Tarifs LLM par modèle pour le calcul de coût du dashboard.
 
 Coûts en USD par token (et non par million), pour pouvoir multiplier
-directement par un nombre de tokens. Source : grille publique Google
-Gemini Developer API (https://ai.google.dev/gemini-api/docs/pricing),
-relevée en mai 2026.
+directement par un nombre de tokens. Sources des grilles publiques (relevées
+2026) : Google Gemini (https://ai.google.dev/gemini-api/docs/pricing),
+OpenAI (https://openai.com/api/pricing/), Anthropic
+(https://www.anthropic.com/pricing).
 
 Les tarifs ``input``/``output`` sont des tarifs standard (tier payant,
 prompts ≤ 200k pour les modèles Pro). Les variantes audio / cache /
 grands prompts ne sont pas distinguées : l'objectif est une estimation
-de coût lisible sur le dashboard, pas une facturation exacte.
+de coût lisible sur le dashboard, pas une facturation exacte. Les providers
+locaux (LM Studio, Ollama, Unsloth) sont gratuits → coût 0, mais uniquement si
+``provider`` est passé à :func:`cost_per_token` (le nom du modèle seul ne suffit
+pas à savoir qu'un modèle tourne en local).
+
+Note (périmètre) : le ``MetricsCollector`` calcule le coût avec un tarif unique
+résolu au démarrage depuis ``settings.LLM_MODEL``/``LLM_PROVIDER``. Le modèle
+réellement utilisé par appel est capturé pour l'``activity_log`` (affichage),
+mais le coût par-modèle-capturé n'est pas encore branché dans ``record_execution``
+(amélioration ultérieure).
 """
 
 from __future__ import annotations
 
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 # (input_usd_per_token, output_usd_per_token)
 _PER_1M = 1_000_000.0
+
+# Providers locaux : exécution sur la machine → coût nul.
+_LOCAL_PROVIDERS = ("lmstudio", "ollama", "unsloth")
 
 # Grille par modèle, exprimée en USD / 1M tokens pour rester lisible,
 # convertie en USD / token plus bas.
@@ -30,6 +43,13 @@ _MODEL_PRICES_PER_1M: Dict[str, Tuple[float, float]] = {
     "gemini-2.5-flash": (0.30, 2.50),
     "gemini-2.5-flash-lite": (0.10, 0.40),
     "gemini-2.5-pro": (1.25, 10.00),
+    # OpenAI GPT-5.x
+    "gpt-5.4": (2.50, 15.00),
+    "gpt-5.4-mini": (0.75, 4.50),
+    # Anthropic Claude 4.x
+    "claude-opus-4": (5.00, 25.00),
+    "claude-sonnet-4": (3.00, 15.00),
+    "claude-haiku-4": (1.00, 5.00),
 }
 
 # Repli quand le modèle configuré n'est pas dans la table : on reprend les
@@ -46,19 +66,26 @@ def _normalize(model: str) -> str:
     return name
 
 
-def cost_per_token(model: str) -> Tuple[float, float]:
+def cost_per_token(model: str, provider: Optional[str] = None) -> Tuple[float, float]:
     """Retourne ``(input_usd_per_token, output_usd_per_token)`` pour un modèle.
 
-    Tente une correspondance exacte, puis par préfixe (``gemini-3.5-flash-05-2026``
-    → ``gemini-3.5-flash``), et retombe sur un tarif par défaut sinon.
+    Si ``provider`` est un provider local (LM Studio/Ollama/Unsloth), le coût est
+    nul. Sinon : correspondance exacte sur le modèle, puis par préfixe
+    (``gemini-3.5-flash-05-2026`` → ``gemini-3.5-flash``), puis tarif par défaut.
     """
+    if provider and provider.strip().lower() in _LOCAL_PROVIDERS:
+        return 0.0, 0.0
     key = _normalize(model)
     prices = _MODEL_PRICES_PER_1M.get(key)
     if prices is None:
-        # Correspondance par préfixe pour absorber les suffixes de version/date.
-        for known, known_prices in _MODEL_PRICES_PER_1M.items():
-            if key.startswith(known):
-                prices = known_prices
+        # Correspondance par préfixe pour absorber les suffixes de version/date
+        # (``gpt-5.4-mini-2026-01`` → ``gpt-5.4-mini``). On teste les clés de la
+        # plus longue à la plus courte et seulement sur une frontière ``-``, pour
+        # éviter qu'une clé courte (``gpt-5.4``) ne masque une plus spécifique
+        # (``gpt-5.4-mini``) et surfacture.
+        for known in sorted(_MODEL_PRICES_PER_1M, key=len, reverse=True):
+            if key == known or key.startswith(known + "-"):
+                prices = _MODEL_PRICES_PER_1M[known]
                 break
     if prices is None:
         prices = _DEFAULT_PER_1M

--- a/collegue/monitoring/sampling_usage.py
+++ b/collegue/monitoring/sampling_usage.py
@@ -12,25 +12,32 @@ from __future__ import annotations
 import contextvars
 from typing import Optional, Tuple
 
-# (prompt_tokens, completion_tokens) du dernier appel LLM dans cette task, ou None.
-_last_usage: contextvars.ContextVar[Optional[Tuple[int, int]]] = contextvars.ContextVar(
+# (prompt_tokens, completion_tokens, model) du dernier appel LLM dans cette task,
+# ou None. Le modèle est celui réellement renvoyé par le provider.
+_last_usage: contextvars.ContextVar[Optional[Tuple[int, int, str]]] = contextvars.ContextVar(
     "collegue_last_sampling_usage", default=None
 )
 
 
-def record_usage(prompt_tokens: int, completion_tokens: int) -> None:
+def record_usage(prompt_tokens: int, completion_tokens: int, model: str = "") -> None:
     """Cumule les tokens réels d'un appel LLM (appelé par le handler).
 
-    On accumule plutôt qu'on n'écrase : un seul ``ctx.sample()`` peut déclencher
-    plusieurs appels LLM (boucle d'outils / structured output), et l'appelant ne
-    consomme la valeur qu'une fois via :func:`take_usage`.
+    On accumule les tokens plutôt qu'on n'écrase : un seul ``ctx.sample()`` peut
+    déclencher plusieurs appels LLM (boucle d'outils / structured output), et
+    l'appelant ne consomme la valeur qu'une fois via :func:`take_usage`. Le
+    modèle conservé est le dernier non vide rencontré.
     """
-    prev = _last_usage.get() or (0, 0)
-    _last_usage.set((prev[0] + int(prompt_tokens or 0), prev[1] + int(completion_tokens or 0)))
+    prev_p, prev_c, prev_m = _last_usage.get() or (0, 0, "")
+    model = model or prev_m
+    _last_usage.set((prev_p + int(prompt_tokens or 0), prev_c + int(completion_tokens or 0), model))
 
 
-def take_usage() -> Optional[Tuple[int, int]]:
-    """Récupère et remet à zéro les tokens cumulés (None si aucun appel suivi)."""
+def take_usage() -> Optional[Tuple[int, int, str]]:
+    """Récupère et remet à zéro l'usage cumulé.
+
+    Retourne ``(prompt_tokens, completion_tokens, model)`` ou ``None`` si aucun
+    appel n'a été suivi dans cette task.
+    """
     usage = _last_usage.get()
     _last_usage.set(None)
     return usage

--- a/collegue/tools/agent_loop.py
+++ b/collegue/tools/agent_loop.py
@@ -193,6 +193,7 @@ class AgentLoopMixin:
                 # Tokens : vrais tokens du provider si le handler les a captés
                 # (via ContextVar), sinon estimation ~4 caractères/token.
                 # BaseTool.execute_async les relit pour les métriques de coût.
+                used_model = ""
                 try:
                     from collegue.monitoring.sampling_usage import take_usage
 
@@ -200,7 +201,7 @@ class AgentLoopMixin:
                 except Exception:
                     real = None
                 if real is not None:
-                    est_input_tokens, est_output_tokens = real
+                    est_input_tokens, est_output_tokens, used_model = real
                 else:
                     est_input_tokens = (len(current_prompt) + len(system_prompt or "")) // 4
                     est_output_tokens = len(raw_output) // 4
@@ -220,6 +221,7 @@ class AgentLoopMixin:
                         input_tokens=est_input_tokens,
                         output_tokens=est_output_tokens,
                         iteration=i + 1,
+                        model=used_model,
                     )
                 except Exception:
                     pass

--- a/tests/test_pricing_capture.py
+++ b/tests/test_pricing_capture.py
@@ -1,0 +1,107 @@
+"""Tests C3 (#337) : tarifs multi-provider + capture du modèle utilisé."""
+
+from collegue.monitoring.pricing import cost_per_token
+from collegue.monitoring.sampling_usage import record_usage, take_usage
+
+_PER_1M = 1_000_000.0
+
+
+# --- tarifs multi-provider ------------------------------------------------------
+
+
+def test_openai_pricing():
+    cin, cout = cost_per_token("gpt-5.4")
+    assert abs(cin - 2.50 / _PER_1M) < 1e-12
+    assert abs(cout - 15.00 / _PER_1M) < 1e-12
+
+
+def test_openai_mini_pricing():
+    cin, cout = cost_per_token("gpt-5.4-mini")
+    assert abs(cin - 0.75 / _PER_1M) < 1e-12
+    assert abs(cout - 4.50 / _PER_1M) < 1e-12
+
+
+def test_anthropic_pricing_prefix_match():
+    # Préfixe : claude-opus-4-8 → claude-opus-4.
+    cin, cout = cost_per_token("claude-opus-4-8")
+    assert abs(cin - 5.00 / _PER_1M) < 1e-12
+    assert abs(cout - 25.00 / _PER_1M) < 1e-12
+
+
+def test_mini_with_date_suffix_not_shadowed_by_base():
+    # Régression F1 : gpt-5.4-mini-<date> ne doit PAS être facturé au tarif
+    # gpt-5.4 (la clé la plus spécifique gagne).
+    cin, cout = cost_per_token("gpt-5.4-mini-2026-01")
+    assert abs(cin - 0.75 / _PER_1M) < 1e-12
+    assert abs(cout - 4.50 / _PER_1M) < 1e-12
+
+
+def test_base_model_with_date_suffix_matches_base():
+    cin, cout = cost_per_token("gpt-5.4-2026-01")
+    assert abs(cin - 2.50 / _PER_1M) < 1e-12
+
+
+def test_prefix_requires_separator_boundary():
+    # "gpt-5.4x" ne doit pas matcher "gpt-5.4" (pas de frontière) → défaut.
+    cin, cout = cost_per_token("gpt-5.4xyz")
+    assert abs(cin - 0.15 / _PER_1M) < 1e-12
+
+
+def test_gemini_still_priced():
+    cin, cout = cost_per_token("gemini-3.5-flash")
+    assert abs(cin - 1.50 / _PER_1M) < 1e-12
+
+
+def test_local_provider_is_free():
+    for provider in ("lmstudio", "ollama", "unsloth"):
+        assert cost_per_token("any-model", provider=provider) == (0.0, 0.0)
+
+
+def test_local_provider_case_insensitive():
+    assert cost_per_token("x", provider="LMStudio") == (0.0, 0.0)
+
+
+def test_unknown_model_falls_back():
+    cin, cout = cost_per_token("modele-inexistant-xyz")
+    assert abs(cin - 0.15 / _PER_1M) < 1e-12
+    assert abs(cout - 0.60 / _PER_1M) < 1e-12
+
+
+def test_remote_provider_does_not_zero_cost():
+    # Un provider non local n'annule pas le coût.
+    cin, _ = cost_per_token("gpt-5.4", provider="openai")
+    assert cin > 0
+
+
+# --- capture du modèle dans l'usage --------------------------------------------
+
+
+def test_usage_captures_model():
+    take_usage()  # purge
+    record_usage(100, 50, "gemini-3.5-flash")
+    usage = take_usage()
+    assert usage == (100, 50, "gemini-3.5-flash")
+
+
+def test_usage_accumulates_tokens_keeps_model():
+    take_usage()  # purge
+    record_usage(10, 5, "gpt-5.4")
+    record_usage(20, 10, "")  # 2e appel sans modèle → garde le précédent
+    assert take_usage() == (30, 15, "gpt-5.4")
+
+
+def test_take_usage_resets():
+    take_usage()
+    record_usage(1, 1, "m")
+    assert take_usage() is not None
+    assert take_usage() is None
+
+
+def test_mixed_model_loop_keeps_last_model_sums_tokens():
+    # Comportement documenté : dans une boucle multi-modèles, les tokens sont
+    # sommés et le dernier modèle non vide est conservé (l'usage alimente
+    # l'activity_log, pas le coût par-modèle).
+    take_usage()
+    record_usage(10, 5, "model-a")
+    record_usage(20, 10, "model-b")
+    assert take_usage() == (30, 15, "model-b")


### PR DESCRIPTION
## Objectif

Troisième brique de la Phase 0 (epic #334). Capture le **modèle réellement utilisé** par appel LLM (pour l'`activity_log`) et étend la grille tarifaire à **OpenAI / Anthropic**, avec **providers locaux = 0**. Closes #337.

## Changements

| Fichier | Changement |
|---|---|
| `collegue/monitoring/sampling_usage.py` | Le ContextVar porte `(prompt, completion, model)` ; `record_usage(..., model)` capture le modèle réel, `take_usage()` le rend (3-tuple). |
| `collegue/core/llm/sampling_handler.py` | transmet `response.model` à `record_usage`. |
| `collegue/tools/agent_loop.py` | `log_llm_call(model=…)` → le modèle réel apparaît dans `activity.jsonl`. |
| `collegue/monitoring/pricing.py` | tarifs `gpt-5.4`/`-mini`, `claude-opus/sonnet/haiku-4` ; `cost_per_token(model, provider=None)` → `(0,0)` pour les locaux. |
| `collegue/monitoring/metrics.py` | `_resolve_model_pricing` passe le provider. |
| `tests/test_pricing_capture.py` (nouveau) | 15 tests. |

## Bug financier corrigé (passe adversariale /review)

Le matching par préfixe **shadowait** les variantes : `gpt-5.4-mini-<date>` était facturé au tarif `gpt-5.4` (**3,3× trop cher**), car `gpt-5.4` précédait `gpt-5.4-mini` dans le dict et `startswith` n'avait pas de frontière. **Corrigé** : on teste les clés de la plus longue à la plus courte, uniquement sur frontière `-`. 3 tests de régression (`gpt-5.4-mini-2026-01` → 0.75/4.50, frontière `gpt-5.4xyz` → défaut).

## Périmètre (documenté honnêtement)

Le **coût des métriques reste au tarif global** (`settings.LLM_MODEL`, résolu au démarrage). Le modèle capturé alimente l'**affichage** (`activity_log`), pas encore le coût par-appel dans `record_execution` — c'est une amélioration ultérieure (threading `model`+`provider` jusqu'au calcul de coût, gestion multi-modèle). Documenté dans `pricing.py`.

## Validation

- **15 tests C3** (tarifs OpenAI/Anthropic/Gemini, locaux=0, anti-shadowing, capture/accumulation modèle) + **non-régression 78 tests verts**.
- `ruff check` + `ruff format` OK.
- `take_usage` 2→3-tuple : seul consommateur `agent_loop` adapté (vérifié, pas d'autre site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)