### PR TITLE
feat(monitoring): budget dur $/tokens + auto-pause (C4)

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -56,6 +56,31 @@ class Settings(BaseSettings):
     LLM_RATE_LIMIT_PER_MINUTE: int = 15
     LLM_RATE_LIMIT_PER_DAY: int = 500
 
+    # --- Budget DUR global (coût $ / tokens) + auto-pause (garde-fou brief §6) ---
+    # Plafond DUR sur la dépense cumulée, distinct du rate limiter (fréquence) et
+    # des quotas per-session (collegue.tools.quotas). Quand le coût cumulé atteint
+    # MAX_COST_USD, ou le total de tokens atteint MAX_TOKENS_BUDGET, les appels LLM
+    # sont stoppés (auto-pause) — protège contre une boucle LLM emballée.
+    # 0 (ou non défini) = plafond désactivé (opt-in ; défaut = aucun changement).
+    # Portée : compteur cumulé du process serveur (le moteur autonome = 1 process ;
+    # le dashboard est un lecteur séparé). En multi-worker, le cap est par-worker.
+    # Providers locaux (LM Studio/Ollama/Unsloth) : coût = 0 → MAX_COST_USD inerte,
+    # seul MAX_TOKENS_BUDGET les protège.
+    MAX_COST_USD: float = 0.0
+    MAX_TOKENS_BUDGET: int = 0
+    # Action quand le budget est atteint : "pause" (défaut) = refuse les appels
+    # LLM et attend une intervention humaine (relever le plafond / réinitialiser
+    # les métriques) ; "warn" = journalise seulement sans bloquer.
+    BUDGET_EXHAUSTED_ACTION: str = "pause"
+
+    @field_validator("BUDGET_EXHAUSTED_ACTION", mode="before")
+    @classmethod
+    def _normalize_budget_action(cls, v):
+        if not v:
+            return "pause"
+        action = str(v).strip().lower()
+        return action if action in ("pause", "warn") else "pause"
+
     SUPPORTED_LANGUAGES: List[str] = ["python", "javascript", "typescript", "php"]
 
     OAUTH_ENABLED: bool = False

--- a/collegue/core/llm/sampling_handler.py
+++ b/collegue/core/llm/sampling_handler.py
@@ -10,6 +10,10 @@ importable et testable. Deux différences avec ``OpenAISamplingHandler`` :
    modèles OpenAI connus (``ChatModel``) et ignorerait silencieusement un modèle
    Gemini/local passé en préférence → le routage par rôle serait un no-op. Ici,
    toute préférence explicite non vide prime, sinon le modèle par défaut.
+3. **Garde budget dur (C4)** : avant chaque appel, ``enforce_budget()`` vérifie
+   le plafond $/tokens cumulé. C'est le chokepoint universel (tous les
+   ``ctx.sample()`` passent ici) → une boucle LLM emballée est stoppée (auto-pause)
+   au lieu de brûler tout le budget. No-op si les plafonds sont désactivés.
 
 ``build_sampling_handler`` est tolérant : il retourne ``None`` si ``fastmcp`` /
 ``openai`` ne sont pas disponibles, pour ne pas casser le démarrage.
@@ -34,6 +38,12 @@ def _make_handler_class():
             inner = self.client.chat.completions.create
 
             async def _create(*a, **kw):
+                # Garde budget dur (C4) : stoppe l'appel AVANT toute dépense si le
+                # plafond $/tokens cumulé est atteint. Chokepoint universel — tous
+                # les ctx.sample() transitent ici. No-op si plafonds désactivés.
+                from collegue.monitoring.metrics import enforce_budget
+
+                enforce_budget()
                 response = await inner(*a, **kw)
                 usage = getattr(response, "usage", None)
                 if usage is not None:

--- a/collegue/monitoring/activity_log.py
+++ b/collegue/monitoring/activity_log.py
@@ -141,6 +141,24 @@ class ActivityLog:
             }
         )
 
+    def log_budget_event(
+        self,
+        limit_type: str,
+        current: float,
+        limit: float,
+        action: str,
+    ) -> None:
+        """Trace une auto-pause budget (plafond $ / tokens atteint)."""
+        self._append(
+            {
+                "type": "budget_exhausted",
+                "limit_type": limit_type,
+                "current": round(current, 6),
+                "limit": limit,
+                "action": action,
+            }
+        )
+
     # ── read ─────────────────────────────────────────────────────────────
 
     def read_events(

--- a/collegue/monitoring/metrics.py
+++ b/collegue/monitoring/metrics.py
@@ -10,6 +10,7 @@ Tracks per-expert:
 
 import json
 import logging
+import math
 import threading
 import time
 from collections import defaultdict
@@ -136,6 +137,16 @@ class MetricsSummary:
             "experts_count": len(self.experts),
             "experts": self.experts,
         }
+
+
+@dataclass
+class BudgetStatus:
+    """Résultat d'une vérification de budget dur (C4)."""
+
+    exceeded: bool
+    limit_type: str  # "cost" | "tokens"
+    current: float
+    limit: float
 
 
 class MetricsCollector:
@@ -310,6 +321,56 @@ class MetricsCollector:
                 experts=experts_data,
             )
 
+    # ── budget dur (C4) ──────────────────────────────────────────────────────
+
+    def _cumulative_totals(self) -> tuple[float, int]:
+        """(coût cumulé USD, tokens cumulés) sur tous les experts."""
+        with self._lock:
+            total_cost = sum(m.total_cost for m in self._experts.values())
+            total_tokens = sum(m.total_input_tokens + m.total_output_tokens for m in self._experts.values())
+        return total_cost, total_tokens
+
+    def would_exceed_budget(
+        self,
+        max_cost_usd: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+    ) -> Optional[BudgetStatus]:
+        """Retourne un :class:`BudgetStatus` si le budget dur est atteint, sinon ``None``.
+
+        Les plafonds sont résolus depuis ``settings`` (``MAX_COST_USD`` /
+        ``MAX_TOKENS_BUDGET``) s'ils ne sont pas fournis. Un plafond ``<= 0``
+        (ou non défini) est désactivé. La comparaison est ``>=`` : on bloque
+        l'appel suivant dès que la limite est atteinte.
+
+        Granularité (limitation connue, C4) : le coût cumulé est mis à jour à la
+        **fin de chaque exécution d'outil** (``record_execution``), pas par appel
+        LLM. Le dépassement est donc détecté entre outils — ce qui borne le
+        runaway « sur des heures » visé par le brief §6. À l'intérieur d'un seul
+        ``agent_execute``, le surcoût est borné par ``max_iterations`` (≤10) ×
+        ``max_tokens``. Un cap par-appel serait un raffinement ultérieur.
+
+        Providers locaux (LM Studio/Ollama/Unsloth) : coût toujours 0 → le cap
+        ``MAX_COST_USD`` est inerte ; seul ``MAX_TOKENS_BUDGET`` les protège.
+        """
+        if max_cost_usd is None or max_tokens is None:
+            try:
+                from collegue.config import settings
+
+                if max_cost_usd is None:
+                    max_cost_usd = settings.MAX_COST_USD
+                if max_tokens is None:
+                    max_tokens = settings.MAX_TOKENS_BUDGET
+            except Exception:
+                pass
+        total_cost, total_tokens = self._cumulative_totals()
+        # Fail-safe : un coût non fini (NaN/inf — ex. metrics.json corrompu) ne
+        # doit pas aveugler le cap (NaN >= x est False), on le traite en dépassement.
+        if max_cost_usd and max_cost_usd > 0 and (not math.isfinite(total_cost) or total_cost >= max_cost_usd):
+            return BudgetStatus(True, "cost", total_cost, float(max_cost_usd))
+        if max_tokens and max_tokens > 0 and total_tokens >= max_tokens:
+            return BudgetStatus(True, "tokens", float(total_tokens), float(max_tokens))
+        return None
+
     # ── disk persistence ───────────────────────────────────────────────────
 
     def _persist_path(self) -> Path:
@@ -384,3 +445,56 @@ def get_metrics_collector() -> MetricsCollector:
             if _metrics_collector is None:
                 _metrics_collector = MetricsCollector()
     return _metrics_collector
+
+
+def enforce_budget(
+    collector: Optional[MetricsCollector] = None,
+    settings_obj: Optional[Any] = None,
+) -> None:
+    """Garde budget dur (C4) : lève ``BudgetExceeded`` si le plafond $/tokens est atteint.
+
+    Appelée avant chaque appel LLM (au plus tôt). Comportement piloté par
+    ``BUDGET_EXHAUSTED_ACTION`` : ``"pause"`` (défaut) trace l'événement et lève
+    ``BudgetExceeded`` (les appels LLM s'arrêtent jusqu'à intervention humaine) ;
+    ``"warn"`` journalise sans bloquer. Plafonds à 0/non définis → no-op.
+
+    ``collector``/``settings_obj`` sont injectables pour les tests ; par défaut on
+    utilise le singleton et la configuration globale.
+    """
+    from collegue.tools.quotas import BudgetExceeded
+
+    if settings_obj is None:
+        try:
+            from collegue.config import settings as settings_obj
+        except Exception:
+            settings_obj = None
+
+    max_cost = getattr(settings_obj, "MAX_COST_USD", None)
+    max_tokens = getattr(settings_obj, "MAX_TOKENS_BUDGET", None)
+    action = str(getattr(settings_obj, "BUDGET_EXHAUSTED_ACTION", "pause") or "pause").strip().lower()
+
+    collector = collector or get_metrics_collector()
+    status = collector.would_exceed_budget(max_cost_usd=max_cost, max_tokens=max_tokens)
+    if status is None:
+        return
+
+    msg = f"Budget dur atteint ({status.limit_type}): {status.current:.4f} >= {status.limit:.4f}"
+
+    # Trace (journal d'activité pour le dashboard ; tolérant aux pannes).
+    try:
+        from collegue.monitoring.activity_log import get_activity_log
+
+        get_activity_log().log_budget_event(
+            limit_type=status.limit_type,
+            current=status.current,
+            limit=status.limit,
+            action=action,
+        )
+    except Exception:
+        pass
+
+    if action == "warn":
+        logger.warning("%s — action=warn, appels LLM non bloqués.", msg)
+        return
+    logger.error("%s — auto-pause des appels LLM (intervention humaine requise).", msg)
+    raise BudgetExceeded(status.limit_type, status.current, status.limit)

--- a/collegue/tools/quotas.py
+++ b/collegue/tools/quotas.py
@@ -30,6 +30,33 @@ class QuotaExceeded(Exception):
         super().__init__(message)
 
 
+class BudgetExceeded(BaseException):
+    """Plafond budget DUR atteint (coût $ ou tokens cumulés) → auto-pause des appels LLM.
+
+    Distinct de :class:`QuotaExceeded` (quotas per-session) : porte sur la dépense
+    cumulée globale (toutes sessions) et déclenche l'arrêt des appels LLM jusqu'à
+    intervention humaine (relever le plafond ou réinitialiser les métriques).
+
+    **Hérite de ``BaseException`` (pas ``Exception``) à dessein.** L'auto-pause est
+    un signal d'arrêt dur, au même titre que ``KeyboardInterrupt`` : les chemins
+    LLM (agent_loop, méta-orchestrateur, tools) enveloppent ``ctx.sample()`` dans
+    des ``except Exception`` génériques qui, sinon, dégraderaient le dépassement en
+    simple « erreur LLM » d'itération — la pause serait illusoire et la boucle
+    emballée continuerait. En héritant de ``BaseException``, le signal traverse ces
+    handlers et remonte jusqu'au sommet (intervention humaine requise). Les blocs
+    ``finally`` s'exécutent toujours, donc le nettoyage des ressources est préservé.
+    """
+
+    def __init__(self, budget_type: str, current: float, limit: float):
+        self.budget_type = budget_type
+        self.current = current
+        self.limit = limit
+        super().__init__(
+            f"Budget '{budget_type}' atteint: {current:.4f}/{limit:.4f} — "
+            "appels LLM en pause (intervention humaine requise)."
+        )
+
+
 class QuotaType(Enum):
     """Types de quotas disponibles."""
 

--- a/tests/test_budget_guard.py
+++ b/tests/test_budget_guard.py
@@ -1,0 +1,254 @@
+"""Tests C4 (#338) : budget DUR global ($/tokens) + auto-pause.
+
+Couvre :
+- `MetricsCollector.would_exceed_budget()` (sous plafond, dépassement coût/tokens, désactivé) ;
+- `enforce_budget()` (pause = lève + trace, warn = ne bloque pas, désactivé = no-op) ;
+- l'exception `BudgetExceeded` et la normalisation de `BUDGET_EXHAUSTED_ACTION`.
+"""
+
+import pytest
+
+from collegue.monitoring.metrics import MetricsCollector, enforce_budget
+from collegue.tools.quotas import BudgetExceeded
+
+
+@pytest.fixture
+def collector(monkeypatch):
+    """MetricsCollector isolé du disque, 1 USD/token in & out (coût == tokens)."""
+    monkeypatch.setattr(MetricsCollector, "_load_from_disk", lambda self: None)
+    monkeypatch.setattr(MetricsCollector, "_save_to_disk", lambda self: None)
+    return MetricsCollector(input_cost_per_token=1.0, output_cost_per_token=1.0)
+
+
+def _spend(collector, input_tokens=0, output_tokens=0):
+    collector.record_execution(
+        expert_name="e",
+        duration_ms=1.0,
+        success=True,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
+
+
+class _FakeSettings:
+    def __init__(self, cost=0.0, tokens=0, action="pause"):
+        self.MAX_COST_USD = cost
+        self.MAX_TOKENS_BUDGET = tokens
+        self.BUDGET_EXHAUSTED_ACTION = action
+
+
+@pytest.fixture
+def fake_activity_log(monkeypatch):
+    """Capture les appels log_budget_event pour vérifier le traçage."""
+    events = []
+
+    class _Log:
+        def log_budget_event(self, **kwargs):
+            events.append(kwargs)
+
+    monkeypatch.setattr("collegue.monitoring.activity_log.get_activity_log", lambda: _Log())
+    return events
+
+
+# --- would_exceed_budget --------------------------------------------------------
+
+
+def test_under_cost_budget_returns_none(collector):
+    _spend(collector, input_tokens=5)  # coût = 5.0
+    assert collector.would_exceed_budget(max_cost_usd=10.0, max_tokens=0) is None
+
+
+def test_cost_budget_exceeded(collector):
+    _spend(collector, input_tokens=12)  # coût = 12.0
+    status = collector.would_exceed_budget(max_cost_usd=10.0, max_tokens=0)
+    assert status is not None and status.exceeded
+    assert status.limit_type == "cost"
+    assert status.current == pytest.approx(12.0)
+    assert status.limit == pytest.approx(10.0)
+
+
+def test_cost_budget_exact_boundary_blocks(collector):
+    # Comparaison >= : atteindre la limite bloque l'appel suivant.
+    _spend(collector, input_tokens=10)  # coût = 10.0
+    assert collector.would_exceed_budget(max_cost_usd=10.0, max_tokens=0) is not None
+
+
+def test_under_token_budget_returns_none(collector):
+    _spend(collector, input_tokens=40, output_tokens=40)  # 80 tokens
+    assert collector.would_exceed_budget(max_cost_usd=0, max_tokens=100) is None
+
+
+def test_token_budget_exceeded(collector):
+    _spend(collector, input_tokens=100, output_tokens=50)  # 150 tokens
+    status = collector.would_exceed_budget(max_cost_usd=0, max_tokens=100)
+    assert status is not None and status.limit_type == "tokens"
+    assert status.current == pytest.approx(150.0)
+    assert status.limit == pytest.approx(100.0)
+
+
+def test_disabled_never_blocks(collector):
+    _spend(collector, input_tokens=10_000, output_tokens=10_000)
+    assert collector.would_exceed_budget(max_cost_usd=0, max_tokens=0) is None
+
+
+def test_cost_checked_before_tokens(collector):
+    # Les deux plafonds dépassés → c'est le coût qui est signalé en premier.
+    _spend(collector, input_tokens=200)  # coût 200, tokens 200
+    status = collector.would_exceed_budget(max_cost_usd=10.0, max_tokens=10)
+    assert status.limit_type == "cost"
+
+
+# --- enforce_budget -------------------------------------------------------------
+
+
+def test_enforce_under_budget_does_not_raise(collector, fake_activity_log):
+    _spend(collector, input_tokens=5)
+    enforce_budget(collector=collector, settings_obj=_FakeSettings(cost=100.0, action="pause"))
+    assert fake_activity_log == []
+
+
+def test_enforce_pause_raises_and_traces_cost(collector, fake_activity_log):
+    _spend(collector, input_tokens=20)
+    with pytest.raises(BudgetExceeded) as exc:
+        enforce_budget(collector=collector, settings_obj=_FakeSettings(cost=10.0, action="pause"))
+    assert exc.value.budget_type == "cost"
+    # L'événement est tracé (AC : "l'événement est tracé").
+    assert len(fake_activity_log) == 1
+    assert fake_activity_log[0]["limit_type"] == "cost"
+
+
+def test_enforce_pause_raises_on_tokens(collector, fake_activity_log):
+    _spend(collector, input_tokens=100, output_tokens=100)  # 200 tokens
+    with pytest.raises(BudgetExceeded) as exc:
+        enforce_budget(collector=collector, settings_obj=_FakeSettings(tokens=150, action="pause"))
+    assert exc.value.budget_type == "tokens"
+
+
+def test_enforce_warn_does_not_raise_but_traces(collector, fake_activity_log):
+    _spend(collector, input_tokens=20)
+    # action=warn : journalise (et trace) mais ne bloque pas.
+    enforce_budget(collector=collector, settings_obj=_FakeSettings(cost=10.0, action="warn"))
+    assert len(fake_activity_log) == 1
+    assert fake_activity_log[0]["action"] == "warn"
+
+
+def test_enforce_disabled_is_noop(collector, fake_activity_log):
+    _spend(collector, input_tokens=10_000)
+    enforce_budget(collector=collector, settings_obj=_FakeSettings(cost=0.0, tokens=0, action="pause"))
+    assert fake_activity_log == []
+
+
+# --- BudgetExceeded -------------------------------------------------------------
+
+
+def test_budget_exceeded_carries_fields():
+    exc = BudgetExceeded("cost", 12.5, 10.0)
+    assert exc.budget_type == "cost"
+    assert exc.current == 12.5
+    assert exc.limit == 10.0
+    assert "pause" in str(exc).lower()
+
+
+def test_budget_exceeded_is_baseexception_not_exception():
+    # L'auto-pause est un signal d'arrêt dur : hériter de BaseException garantit
+    # qu'aucun `except Exception` générique (agent_loop, orchestrateur, tools) ne
+    # l'avale en simple « erreur LLM » — sinon la pause serait illusoire.
+    assert issubclass(BudgetExceeded, BaseException)
+    assert not issubclass(BudgetExceeded, Exception)
+
+
+def test_budget_exceeded_traverses_generic_except():
+    # Régression du bug "pause illusoire" : un `except Exception` ne doit PAS
+    # attraper BudgetExceeded (il doit remonter jusqu'au sommet).
+    caught_by_generic = False
+    propagated = False
+    try:
+        try:
+            raise BudgetExceeded("cost", 1.0, 0.5)
+        except Exception:
+            caught_by_generic = True
+    except BudgetExceeded:
+        propagated = True
+    assert caught_by_generic is False
+    assert propagated is True
+
+
+# --- fail-safe coût non fini (NaN/inf) ------------------------------------------
+
+
+def test_nan_cost_does_not_blind_cap(collector):
+    # NaN >= cap est False → sans fail-safe, un coût corrompu aveuglerait le cap.
+    _spend(collector, input_tokens=1)
+    collector._experts["e"].total_cost = float("nan")
+    status = collector.would_exceed_budget(max_cost_usd=10.0, max_tokens=0)
+    assert status is not None and status.limit_type == "cost"
+
+
+def test_inf_cost_trips_cap(collector):
+    _spend(collector, input_tokens=1)
+    collector._experts["e"].total_cost = float("inf")
+    status = collector.would_exceed_budget(max_cost_usd=10.0, max_tokens=0)
+    assert status is not None and status.limit_type == "cost"
+
+
+# --- traçage disque réel (log_budget_event) -------------------------------------
+
+
+def test_log_budget_event_writes_valid_jsonl(tmp_path):
+    from collegue.monitoring.activity_log import ActivityLog
+
+    log = ActivityLog(base_dir=tmp_path)
+    log.log_budget_event(limit_type="cost", current=12.3456789, limit=10.0, action="pause")
+    events = log.read_events(event_type="budget_exhausted")
+    assert len(events) == 1
+    assert events[0]["limit_type"] == "cost"
+    assert events[0]["action"] == "pause"
+    assert events[0]["limit"] == 10.0
+
+
+# --- câblage handler : enforce_budget AVANT l'appel LLM -------------------------
+
+
+@pytest.mark.asyncio
+async def test_handler_enforces_budget_before_llm_call(monkeypatch):
+    """Le chokepoint universel (_create) appelle enforce_budget AVANT inner().
+
+    Sans ce test, la ligne qui rend la feature réelle (sampling_handler._create)
+    serait du code mort : un refactor pourrait la supprimer en gardant la CI verte.
+    """
+    pytest.importorskip("fastmcp")
+    pytest.importorskip("openai")
+    import collegue.monitoring.metrics as metrics_mod
+    from collegue.core.llm.sampling_handler import build_sampling_handler
+
+    calls = []
+
+    def _fake_enforce(*a, **k):
+        calls.append("enforce")
+        raise BudgetExceeded("cost", 1.0, 0.5)
+
+    # _create importe enforce_budget en lazy depuis ce module → patch pris en compte.
+    monkeypatch.setattr(metrics_mod, "enforce_budget", _fake_enforce)
+
+    handler = build_sampling_handler(default_model="m", api_key="x", base_url=None)
+    assert handler is not None
+
+    # Appeler le create enveloppé : enforce lève AVANT tout appel réseau (inner).
+    # Si BudgetExceeded remonte, c'est qu'enforce a court-circuité avant inner.
+    with pytest.raises(BudgetExceeded):
+        await handler.client.chat.completions.create(model="m", messages=[])
+    assert calls == ["enforce"]
+
+
+# --- normalisation BUDGET_EXHAUSTED_ACTION --------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [("pause", "pause"), ("warn", "warn"), ("PAUSE", "pause"), ("WARN", "warn"), ("garbage", "pause"), ("", "pause")],
+)
+def test_budget_action_normalized(raw, expected):
+    from collegue.config import Settings
+
+    s = Settings(_env_file=None, BUDGET_EXHAUSTED_ACTION=raw)
+    assert s.BUDGET_EXHAUSTED_ACTION == expected


### PR DESCRIPTION
## Objectif

Quatrième brique de la Phase 0 (epic #334) et **garde-fou critique du brief §6**. Plafond **DUR** sur la dépense cumulée (coût `$` / tokens) avec **auto-pause** : protège contre une boucle LLM emballée qui brûlerait tout le budget. Distinct du rate limiter (fréquence) et des quotas per-session. **Désactivé par défaut** (`0` = opt-in, aucun changement de comportement existant). Closes #338.

## Changements

| Fichier | Changement |
|---|---|
| `collegue/config.py` | `MAX_COST_USD`, `MAX_TOKENS_BUDGET`, `BUDGET_EXHAUSTED_ACTION` (`pause`\|`warn`) + validateur de normalisation. |
| `collegue/tools/quotas.py` | `BudgetExceeded(BaseException)` — signal d'arrêt **dur**. |
| `collegue/monitoring/metrics.py` | `MetricsCollector.would_exceed_budget()` (cumul tous experts, fail-safe NaN/inf) + `enforce_budget()` (trace + lève, ou warn). |
| `collegue/monitoring/activity_log.py` | `log_budget_event()` (traçage dashboard). |
| `collegue/core/llm/sampling_handler.py` | `enforce_budget()` au **chokepoint universel** (`_create`), avant tout appel LLM. |
| `tests/test_budget_guard.py` (nouveau) | 25 tests. |

## Conception

Le câblage se fait en **un seul point** : le handler de sampling (`_create`), par lequel transitent **tous** les `ctx.sample()` (6 sites d'appel). Quand le coût/tokens cumulé atteint le plafond, l'appel est refusé **avant** dépense, l'événement est tracé, et `BudgetExceeded` remonte jusqu'au sommet (intervention humaine).

## Trouvailles /review (passe adversariale, contexte frais) — corrigées

- **#1 (P0) — pause illusoire.** Les chemins LLM enveloppent `ctx.sample()` dans des `except Exception` génériques (agent_loop, orchestrateur) qui dégradaient le dépassement en simple « erreur LLM » d'itération → la boucle emballée continuait. **Fix** : `BudgetExceeded` hérite de `BaseException` (comme `KeyboardInterrupt`) → traverse ces handlers d'un coup, sur les 6 sites. 2 tests de régression verrouillent la propagation.
- **#3 (P2) — NaN aveugle le cap.** `NaN >= cap` vaut `False` → un `metrics.json` corrompu rendait la garde inerte. **Fix** : fail-safe `math.isfinite` (coût non fini = dépassement).
- **#5/#6 — câblage non testé.** Le seul endroit qui rend la feature réelle (`_create`) n'avait aucun test. **Fix** : test prouvant qu'`enforce_budget` s'exécute **avant** l'appel LLM, + test du traçage JSONL réel.

## Limitations documentées (assumées, pas cachées)

- **Granularité par-outil** : le coût est flushé en fin d'exécution d'outil ; le dépassement est détecté **entre** outils (borne le runaway « sur des heures » du brief). Un seul `agent_execute` est borné par `max_iterations` (≤10) × `max_tokens`.
- **Providers locaux** (LM Studio/Ollama/Unsloth) : coût = 0 → `MAX_COST_USD` inerte, seul `MAX_TOKENS_BUDGET` protège.
- **Scope par-process** : compteur du process serveur (le moteur autonome = 1 process ; conforme à l'archi métriques existante).

## Validation

- **25 tests C4** (math du cap, branches pause/warn/désactivé, `BaseException`, NaN/inf, trace JSONL, câblage handler) + **non-régression 981 passed, 36 skipped, 0 failed**.
- `ruff check` + `ruff format` OK.

## Rollback

Piloté par config : `MAX_COST_USD=0` + `MAX_TOKENS_BUDGET=0` désactive la garde sans revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)