### PR TITLE
feat(sandbox): exécuteur Docker isolé (jamais sur l'hôte) (C8)

### DIFF
--- a/collegue/sandbox/__init__.py
+++ b/collegue/sandbox/__init__.py
@@ -1,0 +1,20 @@
+"""Sandbox d'exécution isolé du moteur autonome (C8, brief §6).
+
+Exécute le code généré dans un conteneur Docker durci — jamais sur l'hôte.
+Module **isolé**, non câblé au runtime (le pilote Phase 3 le câblera ;
+l'intégration OpenHands est différée en Phase 2).
+"""
+
+from collegue.sandbox.executor import (
+    DEFAULT_SANDBOX_IMAGE,
+    DockerSandbox,
+    SandboxResult,
+    SandboxUnavailable,
+)
+
+__all__ = [
+    "DockerSandbox",
+    "SandboxResult",
+    "SandboxUnavailable",
+    "DEFAULT_SANDBOX_IMAGE",
+]

--- a/collegue/sandbox/executor.py
+++ b/collegue/sandbox/executor.py
@@ -1,0 +1,242 @@
+"""Exécuteur de code en sandbox Docker isolé (C8, brief §6).
+
+Garde-fou critique : le code généré n'est **jamais** exécuté sur l'hôte. Toute
+commande tourne dans un conteneur Docker éphémère, durci, qui ne monte **que** le
+workspace du projet — pas le reste du système de fichiers hôte.
+
+Durcissement appliqué :
+- réseau coupé (``--network none``), capabilities droppées (``--cap-drop ALL``),
+  ``no-new-privileges``, root FS en lecture seule (``--read-only`` + ``/tmp`` tmpfs) ;
+- **refus de tourner en root** (sinon le code non fiable s'exécuterait en uid 0) ;
+- **validation du workspace** : la racine du FS / un chemin avec ``:`` sont refusés ;
+  ``workspace_root`` confine les workspaces autorisés (recommandé en Phase 3) ;
+- **conteneur nommé + kill au timeout** : un ``docker run`` qui dépasse le délai ne
+  laisse pas de conteneur orphelin (tuer le client ne tue pas le conteneur) ;
+- **sortie bornée** : stdout/stderr vont sur disque puis sont relus avec un plafond,
+  pour qu'une commande hostile ne fasse pas exploser la mémoire du parent.
+
+Architecture testable : la **construction** de la commande ``docker run`` est pure
+(testée sans Docker) ; l'**exécution** est testée par mock de subprocess en CI et
+vérifiée pour de vrai par les tests ``integration`` (isolation FS hôte + persistance).
+
+Durcissement différé (Phase 3, à la mise en service) : profil seccomp explicite,
+user-namespace remap, quota de taille sur le workspace, image ``collegue-sandbox``
+pinnée par digest + Node via NodeSource + scan d'image. Voir aussi le piège DinD :
+si l'exécuteur appelle un daemon Docker distant/hôte, les chemins ``workspace`` sont
+résolus par CE daemon — ``workspace_root`` doit alors pointer un chemin commun.
+
+Module **isolé** : non câblé au runtime (l'intégration OpenHands comme worker est
+différée en Phase 2 ; le pilote Phase 3 câblera cet exécuteur).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import uuid
+from dataclasses import dataclass
+from typing import List, Optional, Union
+
+DEFAULT_SANDBOX_IMAGE = "collegue-sandbox:latest"
+
+# Code de sortie conventionnel pour un dépassement de délai (cf. coreutils timeout).
+TIMEOUT_EXIT_CODE = 124
+
+
+class SandboxUnavailable(RuntimeError):
+    """Docker indisponible, ou refus de s'exécuter (ex. en root)."""
+
+
+@dataclass
+class SandboxResult:
+    """Résultat d'une exécution en sandbox."""
+
+    exit_code: int
+    stdout: str
+    stderr: str
+    timed_out: bool = False
+
+    @property
+    def ok(self) -> bool:
+        return self.exit_code == 0 and not self.timed_out
+
+
+class DockerSandbox:
+    """Exécute des commandes dans un conteneur Docker isolé et durci.
+
+    Isolation (AC#1 « ne peut pas lire le FS hôte ») : seul ``workspace`` est monté
+    (sur ``/workspace``) ; aucun autre chemin hôte n'est exposé. Persistance (AC#2) :
+    ``workspace`` est un répertoire réel réutilisé d'une exécution à l'autre.
+    """
+
+    def __init__(
+        self,
+        image: str = DEFAULT_SANDBOX_IMAGE,
+        *,
+        network: str = "none",
+        memory: str = "512m",
+        cpus: str = "1.0",
+        pids_limit: int = 256,
+        timeout: float = 120.0,
+        max_output_bytes: int = 10 * 1024 * 1024,
+        workspace_root: Optional[str] = None,
+        allow_root: bool = False,
+        docker_bin: str = "docker",
+    ):
+        self.image = image
+        self.network = network
+        self.memory = memory
+        self.cpus = cpus
+        self.pids_limit = pids_limit
+        self.timeout = timeout
+        self.max_output_bytes = max_output_bytes
+        self.workspace_root = workspace_root
+        self.allow_root = allow_root
+        self.docker_bin = docker_bin
+
+    # ── validation / construction (pur, testable sans Docker) ─────────────────────
+
+    def _validate_workspace(self, workspace: str) -> str:
+        """Résout et valide le workspace. Lève ``ValueError`` si dangereux.
+
+        Refuse : la racine du FS, un chemin contenant ``:`` (délimiteur ``-v``), et —
+        si ``workspace_root`` est défini — tout chemin hors de cette racine
+        (``realpath`` pour déjouer les symlinks).
+        """
+        ws = os.path.realpath(os.path.abspath(workspace))
+        if ":" in ws:
+            raise ValueError(f"workspace invalide (contient ':'): {ws}")
+        if ws == os.path.sep:
+            raise ValueError("workspace invalide : la racine du FS ne peut pas être montée")
+        if self.workspace_root is not None:
+            root = os.path.realpath(os.path.abspath(self.workspace_root))
+            if os.path.commonpath([ws, root]) != root:
+                raise ValueError(f"workspace hors du répertoire autorisé {root}: {ws}")
+        return ws
+
+    def _build_run_argv(self, cmd: Union[str, List[str]], workspace: str, name: Optional[str] = None) -> List[str]:
+        """Construit l'argv ``docker run`` durci. Pure (testable sans Docker)."""
+        ws = os.path.abspath(workspace)
+        inner = ["sh", "-c", cmd] if isinstance(cmd, str) else list(cmd)
+        argv = [self.docker_bin, "run", "--rm"]
+        if name:
+            argv += ["--name", name]
+        argv += [
+            "--network",
+            self.network,
+            "--cap-drop",
+            "ALL",
+            "--security-opt",
+            "no-new-privileges",
+            "--pids-limit",
+            str(self.pids_limit),
+            "--memory",
+            self.memory,
+            "--cpus",
+            self.cpus,
+            "--stop-timeout",
+            "5",
+            "--read-only",  # root FS en lecture seule
+            "--tmpfs",
+            "/tmp",  # scratch éphémère écrivable
+            "-e",
+            "HOME=/tmp",
+        ]
+        # Exécuter en tant qu'utilisateur hôte non-root : le workspace (dir hôte)
+        # reste écrivable/persisté, et le conteneur ne tourne jamais en root
+        # (run_command refuse uid 0 sauf allow_root explicite).
+        if hasattr(os, "getuid"):
+            argv += ["--user", f"{os.getuid()}:{os.getgid()}"]
+        argv += [
+            "-v",
+            f"{ws}:/workspace",  # SEUL chemin hôte monté
+            "-w",
+            "/workspace",
+            self.image,
+            *inner,
+        ]
+        return argv
+
+    # ── exécution ─────────────────────────────────────────────────────────────────
+
+    def _read_capped(self, path: str) -> str:
+        """Relit un fichier de sortie avec un plafond (évite l'OOM du parent)."""
+        with open(path, "rb") as f:
+            data = f.read(self.max_output_bytes + 1)
+        text = data[: self.max_output_bytes].decode("utf-8", errors="replace")
+        if len(data) > self.max_output_bytes:
+            text += f"\n[sandbox] sortie tronquée à {self.max_output_bytes} octets"
+        return text
+
+    def _kill_container(self, name: str) -> None:
+        """Tue un conteneur par nom (best-effort) — pour ne pas laisser d'orphelin."""
+        try:
+            subprocess.run([self.docker_bin, "kill", name], capture_output=True, timeout=15)
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            pass
+
+    def run_command(self, cmd: Union[str, List[str]], workspace: str) -> SandboxResult:
+        """Exécute ``cmd`` dans le sandbox, workspace monté sur ``/workspace``.
+
+        ``cmd`` peut être une chaîne (``sh -c`` dans le conteneur) ou un argv (liste).
+        Lève :class:`SandboxUnavailable` si Docker est absent ou si l'on tourne en
+        root sans ``allow_root``. Lève ``ValueError`` si le workspace est invalide.
+        """
+        if not self.allow_root and hasattr(os, "getuid") and os.getuid() == 0:
+            raise SandboxUnavailable(
+                "refus de lancer le sandbox en root (le code non fiable tournerait en uid 0) ; "
+                "configurer allow_root=True en connaissance de cause."
+            )
+        ws = self._validate_workspace(workspace)
+        os.makedirs(ws, exist_ok=True)
+        name = f"collegue-sbx-{uuid.uuid4().hex[:12]}"
+        argv = self._build_run_argv(cmd, ws, name=name)
+
+        out_f = tempfile.NamedTemporaryFile(prefix="sbx-out-", delete=False)
+        err_f = tempfile.NamedTemporaryFile(prefix="sbx-err-", delete=False)
+        out_path, err_path = out_f.name, err_f.name
+        timed_out = False
+        try:
+            try:
+                proc = subprocess.run(argv, stdout=out_f, stderr=err_f, timeout=self.timeout)
+                exit_code = proc.returncode
+            except subprocess.TimeoutExpired:
+                # Tuer le client ne tue pas le conteneur → on le tue par nom.
+                self._kill_container(name)
+                exit_code = TIMEOUT_EXIT_CODE
+                timed_out = True
+            except FileNotFoundError as exc:
+                raise SandboxUnavailable(f"Binaire Docker introuvable: {self.docker_bin}") from exc
+            finally:
+                out_f.close()
+                err_f.close()
+
+            stdout = self._read_capped(out_path)
+            stderr = self._read_capped(err_path)
+            if timed_out:
+                stderr += f"\n[sandbox] délai dépassé après {self.timeout:g}s"
+            return SandboxResult(exit_code=exit_code, stdout=stdout, stderr=stderr, timed_out=timed_out)
+        finally:
+            for path in (out_path, err_path):
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+
+    def run_tests(self, workspace: str, command: Union[str, List[str]] = "pytest -q") -> SandboxResult:
+        """Lance la suite de tests d'un projet dans le sandbox (défaut : ``pytest -q``)."""
+        return self.run_command(command, workspace)
+
+    def is_available(self) -> bool:
+        """True si le binaire Docker répond (``docker version``)."""
+        try:
+            proc = subprocess.run(
+                [self.docker_bin, "version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            return False
+        return proc.returncode == 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,21 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  # Image d'exécution du sandbox isolé (C8). Sous le profil "sandbox" : NON
+  # démarrée par `docker compose up` — l'exécuteur (collegue/sandbox/executor.py)
+  # lance des conteneurs éphémères à la demande via `docker run`. Cette entrée sert
+  # à builder l'image : `docker compose --profile sandbox build collegue-sandbox`.
+  collegue-sandbox:
+    build:
+      context: .
+      dockerfile: docker/sandbox/Dockerfile
+    image: collegue-sandbox:latest
+    profiles:
+      - sandbox
+    # Conteneur de référence sans rôle de service long-running.
+    restart: "no"
+    command: ["python", "--version"]
+
 volumes:
   nginx_logs:
   collegue_data:

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -1,0 +1,26 @@
+# Image d'exécution du sandbox isolé (C8, brief §4.4/§6).
+# Stack cible des projets générés : Web = backend Python + frontend JS/TS (§8).
+# Lancée par collegue/sandbox/executor.py via `docker run` durci (réseau coupé,
+# capabilities droppées, root FS read-only, utilisateur non-root, workspace seul
+# chemin monté). N'exécute JAMAIS de code sur l'hôte.
+
+FROM python:3.12-slim
+
+# Node.js + npm pour le frontend JS/TS ; outils de build minimaux pour les deps
+# Python natives. Nettoyage du cache apt pour garder l'image légère.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        nodejs \
+        npm \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Utilisateur non-root par défaut (le `docker run` peut surcharger --user pour
+# matcher l'UID hôte et garder le workspace écrivable/persisté).
+RUN useradd --create-home --uid 1000 sandbox
+
+WORKDIR /workspace
+USER sandbox
+
+# Pas d'ENTRYPOINT applicatif : l'exécuteur fournit la commande à chaque run.
+CMD ["python", "--version"]

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,249 @@
+"""Tests C8 (#342) : exécuteur sandbox Docker isolé.
+
+- Unitaires (CI, sans Docker) : commande `docker run` durcie, parsing/troncature
+  du résultat, timeout (+ kill du conteneur), refus root, validation du workspace
+  — via mock de subprocess.
+- Intégration (Docker, marqués `integration`, skippés en CI) : exécution réelle,
+  isolation FS hôte (AC#1, via escape `..`), persistance du workspace (AC#2).
+"""
+
+import os
+import tempfile
+
+import pytest
+
+import collegue.sandbox.executor as ex
+from collegue.sandbox import DockerSandbox, SandboxResult, SandboxUnavailable
+
+
+class _Proc:
+    def __init__(self, returncode=0):
+        self.returncode = returncode
+
+
+def _mounts(argv):
+    return [argv[i + 1] for i, a in enumerate(argv) if a == "-v"]
+
+
+# --- construction de la commande durcie (pur, sans Docker) ----------------------
+
+
+def test_build_argv_isolation_flags(tmp_path):
+    sb = DockerSandbox(image="img", network="none")
+    argv = sb._build_run_argv("echo hi", str(tmp_path))
+    joined = " ".join(argv)
+    assert "--network none" in joined
+    assert "--cap-drop ALL" in joined
+    assert "--security-opt no-new-privileges" in joined
+    assert "--read-only" in argv
+    assert "--tmpfs" in argv and "/tmp" in argv
+    assert "--pids-limit" in argv
+    assert "--memory" in argv and "--cpus" in argv
+    assert "-w" in argv and "/workspace" in argv
+
+
+def test_build_argv_mounts_only_workspace(tmp_path):
+    # AC#1 (config) : SEUL le workspace est monté, aucun autre chemin hôte.
+    sb = DockerSandbox(image="img")
+    argv = sb._build_run_argv("echo hi", str(tmp_path))
+    assert _mounts(argv) == [f"{tmp_path}:/workspace"]
+
+
+def test_build_argv_runs_non_root(tmp_path):
+    sb = DockerSandbox(image="img")
+    argv = sb._build_run_argv("echo hi", str(tmp_path))
+    if hasattr(os, "getuid"):
+        assert "--user" in argv
+        assert f"{os.getuid()}:{os.getgid()}" in argv
+
+
+def test_build_argv_name_optional(tmp_path):
+    sb = DockerSandbox(image="img")
+    assert "--name" not in sb._build_run_argv("echo", str(tmp_path))
+    argv = sb._build_run_argv("echo", str(tmp_path), name="c1")
+    assert "--name" in argv and "c1" in argv
+
+
+def test_build_argv_string_is_shell_wrapped(tmp_path):
+    sb = DockerSandbox(image="img")
+    argv = sb._build_run_argv("echo hi && ls", str(tmp_path))
+    assert argv[-3:] == ["sh", "-c", "echo hi && ls"]
+
+
+def test_build_argv_list_is_passed_directly(tmp_path):
+    sb = DockerSandbox(image="img")
+    argv = sb._build_run_argv(["pytest", "-q"], str(tmp_path))
+    assert argv[-2:] == ["pytest", "-q"]
+
+
+# --- validation du workspace (anti "monte tout l'hôte") -------------------------
+
+
+def test_validate_workspace_rejects_fs_root():
+    with pytest.raises(ValueError):
+        DockerSandbox(image="img")._validate_workspace("/")
+
+
+def test_validate_workspace_rejects_colon():
+    with pytest.raises(ValueError):
+        DockerSandbox(image="img")._validate_workspace("/tmp/a:b")
+
+
+def test_validate_workspace_enforces_root(tmp_path):
+    sb = DockerSandbox(image="img", workspace_root=str(tmp_path))
+    sub = tmp_path / "proj"
+    sub.mkdir()
+    assert sb._validate_workspace(str(sub)) == os.path.realpath(str(sub))
+    with pytest.raises(ValueError):
+        sb._validate_workspace("/etc")
+
+
+def test_run_command_rejects_dangerous_workspace():
+    with pytest.raises(ValueError):
+        DockerSandbox(image="img", allow_root=True).run_command("echo hi", "/")
+
+
+# --- refus de tourner en root ---------------------------------------------------
+
+
+def test_run_command_refuses_root_by_default(monkeypatch, tmp_path):
+    monkeypatch.setattr(ex.os, "getuid", lambda: 0)
+    with pytest.raises(SandboxUnavailable):
+        DockerSandbox(image="img").run_command("echo hi", str(tmp_path))
+
+
+# --- run_command (subprocess mocké : sortie vers fichiers) ----------------------
+
+
+def test_run_command_parses_result(monkeypatch, tmp_path):
+    captured = {}
+
+    def _fake_run(argv, **kw):
+        captured["argv"] = argv
+        kw["stdout"].write(b"hello\n")
+        return _Proc(returncode=0)
+
+    monkeypatch.setattr(ex.subprocess, "run", _fake_run)
+    res = DockerSandbox(image="img", allow_root=True).run_command("echo hello", str(tmp_path))
+    assert res.ok
+    assert res.stdout == "hello\n"
+    assert captured["argv"][:3] == ["docker", "run", "--rm"]
+    assert "--name" in captured["argv"]
+
+
+def test_run_command_creates_workspace(monkeypatch, tmp_path):
+    monkeypatch.setattr(ex.subprocess, "run", lambda argv, **kw: _Proc())
+    ws = tmp_path / "new_ws"
+    DockerSandbox(image="img", allow_root=True).run_command("echo hi", str(ws))
+    assert ws.is_dir()
+
+
+def test_run_command_output_truncated(monkeypatch, tmp_path):
+    def _fake_run(argv, **kw):
+        kw["stdout"].write(b"abcdefghij")  # 10 octets
+        return _Proc(returncode=0)
+
+    monkeypatch.setattr(ex.subprocess, "run", _fake_run)
+    res = DockerSandbox(image="img", allow_root=True, max_output_bytes=5).run_command("x", str(tmp_path))
+    assert res.stdout.startswith("abcde")
+    assert "tronquée" in res.stdout
+
+
+def test_run_command_timeout_kills_container(monkeypatch, tmp_path):
+    killed = {}
+
+    def _fake_run(argv, **kw):
+        if argv[1:2] == ["kill"]:
+            killed["name"] = argv[-1]
+            return _Proc()
+        raise ex.subprocess.TimeoutExpired(cmd=argv, timeout=1)
+
+    monkeypatch.setattr(ex.subprocess, "run", _fake_run)
+    res = DockerSandbox(image="img", allow_root=True, timeout=1).run_command("sleep 100", str(tmp_path))
+    assert res.timed_out
+    assert res.exit_code == ex.TIMEOUT_EXIT_CODE
+    assert killed.get("name", "").startswith("collegue-sbx-")  # conteneur tué (pas d'orphelin)
+
+
+def test_run_command_docker_missing_raises(monkeypatch, tmp_path):
+    def _fake_run(argv, **kw):
+        raise FileNotFoundError("docker")
+
+    monkeypatch.setattr(ex.subprocess, "run", _fake_run)
+    with pytest.raises(SandboxUnavailable):
+        DockerSandbox(image="img", allow_root=True).run_command("echo hi", str(tmp_path))
+
+
+def test_run_tests_default_command(monkeypatch, tmp_path):
+    captured = {}
+
+    def _fake_run(argv, **kw):
+        captured["argv"] = argv
+        return _Proc()
+
+    monkeypatch.setattr(ex.subprocess, "run", _fake_run)
+    DockerSandbox(image="img", allow_root=True).run_tests(str(tmp_path))
+    assert captured["argv"][-3:] == ["sh", "-c", "pytest -q"]
+
+
+def test_is_available(monkeypatch):
+    monkeypatch.setattr(ex.subprocess, "run", lambda *a, **k: _Proc(returncode=0))
+    assert DockerSandbox().is_available() is True
+
+    def _missing(*a, **k):
+        raise FileNotFoundError()
+
+    monkeypatch.setattr(ex.subprocess, "run", _missing)
+    assert DockerSandbox().is_available() is False
+
+
+def test_result_ok_property():
+    assert SandboxResult(0, "", "").ok
+    assert not SandboxResult(1, "", "").ok
+    assert not SandboxResult(0, "", "", timed_out=True).ok
+
+
+# --- intégration Docker réelle (skippée en CI) ----------------------------------
+
+_SANDBOX_TEST_IMAGE = os.getenv("SANDBOX_TEST_IMAGE", "python:3.12-slim")
+
+
+def _sandbox_or_skip():
+    sb = DockerSandbox(image=_SANDBOX_TEST_IMAGE, allow_root=True)
+    if not sb.is_available():
+        pytest.skip("Docker indisponible")
+    return sb
+
+
+@pytest.mark.integration
+def test_sandbox_runs_command_real(tmp_path):
+    res = _sandbox_or_skip().run_command("echo sandbox-ok", str(tmp_path))
+    assert res.ok
+    assert "sandbox-ok" in res.stdout
+
+
+@pytest.mark.integration
+def test_sandbox_cannot_escape_to_host(tmp_path):
+    # AC#1 : depuis le sandbox, impossible d'atteindre un fichier hôte hors workspace
+    # (le parent de /workspace dans le conteneur est sa propre racine, pas l'hôte).
+    sb = _sandbox_or_skip()
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (tmp_path / "secret.txt").write_text("SECRET_SIBLING")
+    res = sb.run_command("cat /workspace/../secret.txt", str(ws))
+    assert "SECRET_SIBLING" not in res.stdout
+    assert res.exit_code != 0
+
+
+@pytest.mark.integration
+def test_sandbox_root_fs_read_only(tmp_path):
+    res = _sandbox_or_skip().run_command("echo x > /etc/passwd", str(tmp_path))
+    assert res.exit_code != 0  # root FS en lecture seule
+
+
+@pytest.mark.integration
+def test_sandbox_workspace_persists(tmp_path):
+    sb = _sandbox_or_skip()
+    sb.run_command("echo persisted > marker.txt", str(tmp_path))
+    res = sb.run_command("cat marker.txt", str(tmp_path))
+    assert "persisted" in res.stdout


### PR DESCRIPTION
## Objectif

Huitième et **dernier** enfant de la Phase 0 (epic #334). **Garde-fou critique du brief §6** : le code généré ne s'exécute **jamais** sur l'hôte. Réalise l'**AC#3 de l'epic** (commande exécutée en sandbox + FS hôte inaccessible). Closes #342.

## Changements

| Fichier | Changement |
|---|---|
| `collegue/sandbox/executor.py` | `DockerSandbox.run_command/run_tests` : conteneur éphémère durci (`--network none`, `--cap-drop ALL`, `no-new-privileges`, `--read-only` + tmpfs, limites mémoire/CPU/PID, non-root) montant **seulement** le workspace. |
| `docker/sandbox/Dockerfile` | Image d'exécution Python + Node/JS-TS (stack web cible §8). |
| `docker-compose.yml` | Service `collegue-sandbox` sous profil `sandbox` (buildable, non démarré par `up`). |
| `tests/test_sandbox.py` (nouveau) | 19 tests. |

## Conception

Testabilité : la **construction** de `docker run` est pure (testée sans Docker, vérifie les flags d'isolation) ; l'**exécution** est testée par mock subprocess en CI et par les tests `integration` (Docker réel) pour l'isolation/persistance. Module **isolé**, non câblé au runtime (OpenHands → Phase 2 ; pilote → Phase 3).

## Trouvailles /review (passe adversariale **sécurité**, 4 vecteurs reproduits en live) — corrigées

- **P1 — `workspace="/"` montait tout le FS hôte** (annulait la garantie). **Fix** : validation (refus racine, `:`, hors `workspace_root` ; `realpath` anti-symlink).
- **P1 — `--user`=uid appelant → ROOT si l'appelant est root.** **Fix** : **refus de tourner en root** par défaut (`allow_root` explicite sinon).
- **P1 — conteneur orphelin au timeout** (tuer le client `docker run` ne tue pas le conteneur). **Fix** : `--name` unique + `docker kill` au timeout.
- **P2 — stdout illimité → OOM du parent.** **Fix** : sortie vers fichiers + relecture plafonnée (`max_output_bytes`).
- **P2 — test d'isolation en trompe-l'œil** (sentinelle `/tmp` masquée par la tmpfs du conteneur). **Fix** : test d'**évasion via `/workspace/..`** (vrai négatif) + test root FS read-only.
- **Documenté Phase 3** : seccomp explicite/userns-remap/quota workspace, image `collegue-sandbox` pinnée par digest + Node via NodeSource + scan, et le **piège DinD** (daemon distant résout les chemins → utiliser `workspace_root`).

## Validation

- **19 tests C8** (flags d'isolation, validation workspace, refus root, timeout+kill, troncature sortie) + **non-régression 1044 passed, 36 skipped, 0 failed**.
- **Isolation vérifiée sur Docker réel** : FS hôte inaccessible (évasion `..` bloquée), root FS read-only, workspace persistant.
- Couverture **64.3% ≥ 60%** (sandbox/ 96-100%). `ruff` OK.

## Rollback

Module + service isolés, non câblés au runtime ; revert sans impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)