### PR TITLE
feat(planner): générateur de SPEC.md (problématique → contrat + AC) (P1)

### DIFF
--- a/collegue/planner/__init__.py
+++ b/collegue/planner/__init__.py
@@ -1,0 +1,13 @@
+"""Planificateur autonome (Phase 1, epic #351).
+
+Transforme une problématique en une phrase en un plan exécutable : génération de
+`SPEC.md` (P1), décomposition en graphe de tâches (P2), synchronisation GitHub
+(P4) sous validation humaine (P5).
+
+Modules **isolés** : non câblés au runtime tant que le pilote (Phase 3) ne les
+enchaîne pas.
+"""
+
+from collegue.planner.spec_generator import Spec, generate_spec, persist_spec
+
+__all__ = ["Spec", "generate_spec", "persist_spec"]

--- a/collegue/planner/spec_generator.py
+++ b/collegue/planner/spec_generator.py
@@ -1,0 +1,203 @@
+"""Générateur de SPEC.md (P1, #351) : problématique → contrat structuré.
+
+À partir d'une problématique en une phrase, produit un :class:`Spec` (objectifs,
+périmètre, contraintes, **hypothèses**, **critères d'acceptation testables**) via un
+appel LLM routé sur le rôle **PLANNER** (C1/C2), puis le rend en Markdown et le
+persiste dans ``Project.spec`` (state store C6).
+
+Décision epic #351 : en cas d'ambiguïté, le planificateur **ne pose pas de
+question** — il consigne ses hypothèses dans ``assumptions`` et avance ; l'humain
+valide le plan complet plus tard (P5).
+
+Frontière de confiance : la sortie LLM n'est **pas** fiable. Le rendu Markdown
+**neutralise** chaque champ (mise sur une seule ligne) pour qu'un titre/résumé
+malveillant ne puisse pas injecter de fausses sections ou des critères « déjà
+cochés » dans le document soumis à validation humaine. ``generate_spec`` **rejette**
+un SPEC sans critère d'acceptation (contrat vide = inacceptable).
+
+Module **isolé** : non câblé au runtime (le pilote Phase 3 fournira le ``ctx``).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, List, Optional
+
+from pydantic import BaseModel, Field, ValidationError
+
+from collegue.core.llm import LLMRole, model_preferences_for_role
+from collegue.core.llm.client import sample_with_timeout
+
+# Statuts de projet partagés avec P5 (transition planned → approved au gate humain).
+PROJECT_STATUS_PLANNED = "planned"
+
+SPEC_SYSTEM_PROMPT = """Tu es un planificateur logiciel senior. À partir d'une problématique \
+(souvent une seule phrase), tu produis un contrat de projet clair et actionnable.
+
+Réponds UNIQUEMENT par un objet JSON valide, sans texte autour, avec ces clés :
+- "title": titre court du projet (string)
+- "summary": résumé en 1-3 phrases (string)
+- "objectives": objectifs (liste de strings)
+- "scope": périmètre — ce qui est inclus/exclu (string)
+- "constraints": contraintes techniques/produit (liste de strings)
+- "assumptions": hypothèses (liste de strings)
+- "acceptance_criteria": critères d'acceptation TESTABLES, vérifiables objectivement (liste de strings)
+
+Règles :
+- Les critères d'acceptation doivent être testables (un humain ou un test peut trancher vrai/faux).
+- Au moins un critère d'acceptation est obligatoire.
+- Si la problématique est ambiguë, NE POSE PAS de question : consigne des hypothèses \
+explicites dans "assumptions" et avance.
+- Reste concis et concret."""
+
+
+def _inline(text: Any) -> str:
+    """Réduit une valeur à une seule ligne (anti-injection Markdown).
+
+    Écrase tout enchaînement d'espaces/sauts de ligne en une espace : un champ LLM
+    ne peut donc pas démarrer une nouvelle ligne, donc pas de fausse section
+    (``## ...``) ni de case déjà cochée (``- [x] ...``) dans le SPEC rendu.
+    """
+    return re.sub(r"\s+", " ", str(text)).strip()
+
+
+class Spec(BaseModel):
+    """Contrat de projet structuré, rendu en SPEC.md."""
+
+    title: str
+    summary: str = ""
+    objectives: List[str] = Field(default_factory=list)
+    scope: str = ""
+    constraints: List[str] = Field(default_factory=list)
+    assumptions: List[str] = Field(default_factory=list)
+    acceptance_criteria: List[str] = Field(default_factory=list)
+
+    def to_markdown(self) -> str:
+        """Rend le SPEC en Markdown. Chaque champ est mis sur une ligne (anti-injection) ;
+        toutes les sections sont présentes (les vides portent une note)."""
+
+        def bullets(items: List[str], placeholder: str) -> str:
+            cleaned = [_inline(i) for i in (items or []) if str(i).strip()]
+            return "\n".join(f"- {i}" for i in cleaned) if cleaned else f"_{placeholder}_"
+
+        def checks(items: List[str], placeholder: str) -> str:
+            cleaned = [_inline(i) for i in (items or []) if str(i).strip()]
+            return "\n".join(f"- [ ] {i}" for i in cleaned) if cleaned else f"_{placeholder}_"
+
+        return (
+            f"# {_inline(self.title)}\n\n"
+            f"{_inline(self.summary)}\n\n"
+            f"## Objectifs\n{bullets(self.objectives, 'À préciser.')}\n\n"
+            f"## Périmètre\n{_inline(self.scope) or '_À préciser._'}\n\n"
+            f"## Contraintes\n{bullets(self.constraints, 'Aucune contrainte identifiée.')}\n\n"
+            f"## Hypothèses\n{bullets(self.assumptions, 'Aucune hypothèse (problématique non ambiguë).')}\n\n"
+            f"## Critères d'acceptation\n{checks(self.acceptance_criteria, 'À préciser.')}\n"
+        )
+
+
+def _json_from_text(text: str) -> Optional[dict]:
+    """Extrait le premier objet JSON exploitable d'un texte (fallback structured-output).
+
+    Scan brace-balanced via ``raw_decode`` depuis chaque ``{`` : on retourne le
+    PREMIER objet complet qui décode (gère les blocs multiples, les ```json fences
+    et la prose qui suit, contrairement à un ``{.*}`` glouton).
+    """
+    if not text:
+        return None
+    cleaned = text.strip()
+    try:
+        whole = json.loads(cleaned)
+        if isinstance(whole, dict):
+            return whole
+    except (ValueError, TypeError):
+        pass
+    decoder = json.JSONDecoder()
+    for idx, ch in enumerate(cleaned):
+        if ch != "{":
+            continue
+        try:
+            obj, _ = decoder.raw_decode(cleaned[idx:])
+        except ValueError:
+            continue
+        if isinstance(obj, dict):
+            return obj
+    return None
+
+
+def _spec_from_dict(data: dict) -> Spec:
+    """Valide un dict en Spec ; convertit ``ValidationError`` en ``ValueError`` (contrat du module)."""
+    try:
+        return Spec.model_validate(data)
+    except ValidationError as exc:
+        raise ValueError(f"SPEC LLM invalide (champs manquants/typés): {exc}") from exc
+
+
+def _extract_spec(result: Any) -> Spec:
+    """Récupère un Spec depuis un SamplingResult : structuré si dispo, sinon JSON du texte."""
+    candidate = getattr(result, "result", None)
+    if isinstance(candidate, Spec):
+        return candidate
+    if isinstance(candidate, BaseModel):
+        candidate = candidate.model_dump()
+    if isinstance(candidate, str):
+        candidate = _json_from_text(candidate)
+    if isinstance(candidate, dict):
+        return _spec_from_dict(candidate)
+    data = _json_from_text(getattr(result, "text", "") or "")
+    if data is None:
+        raise ValueError("Le planificateur n'a pas retourné de SPEC exploitable (ni structuré ni JSON).")
+    return _spec_from_dict(data)
+
+
+def _build_user_prompt(problem: str, context: Optional[str]) -> str:
+    prompt = f"Problématique :\n{problem.strip()}\n"
+    if context:
+        prompt += f"\nContexte additionnel :\n{context.strip()}\n"
+    prompt += "\nProduis le contrat JSON décrit par tes instructions système."
+    return prompt
+
+
+async def generate_spec(
+    problem: str,
+    ctx: Any,
+    *,
+    context: Optional[str] = None,
+    settings_obj: Optional[object] = None,
+    temperature: float = 0.2,
+    max_tokens: int = 4096,
+) -> Spec:
+    """Génère un :class:`Spec` depuis une problématique via le rôle PLANNER.
+
+    ``ctx`` est le contexte de sampling (FastMCP) — le pilote Phase 3 le fournira ;
+    les tests injectent un double. Lève ``ValueError`` si la réponse est inexploitable
+    ou si le SPEC ne contient **aucun critère d'acceptation** (contrat vide).
+    """
+    sample_kwargs = {
+        "messages": _build_user_prompt(problem, context),
+        "system_prompt": SPEC_SYSTEM_PROMPT,
+        "result_type": Spec,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+    }
+    prefs = model_preferences_for_role(LLMRole.PLANNER, settings_obj)
+    if prefs:
+        sample_kwargs["model_preferences"] = prefs
+
+    result = await sample_with_timeout(ctx, settings_obj=settings_obj, **sample_kwargs)
+    spec = _extract_spec(result)
+    if not [a for a in spec.acceptance_criteria if str(a).strip()]:
+        raise ValueError("SPEC invalide : aucun critère d'acceptation testable (contrat vide).")
+    return spec
+
+
+def persist_spec(
+    manager: Any,
+    name: str,
+    spec: Spec,
+    *,
+    deadline: Any = None,
+    status: str = PROJECT_STATUS_PLANNED,
+) -> int:
+    """Persiste le SPEC (rendu Markdown) dans ``Project.spec`` ; retourne le project_id."""
+    return manager.create_project(name=name, spec=spec.to_markdown(), deadline=deadline, phase="1", status=status)

--- a/tests/test_spec_generator.py
+++ b/tests/test_spec_generator.py
@@ -1,0 +1,211 @@
+"""Tests P1 (#352) : générateur de SPEC.md (problématique → contrat structuré)."""
+
+import json
+
+import pytest
+
+import collegue.planner.spec_generator as sg
+from collegue.core.llm.client import LLMCallTimeout
+from collegue.planner import Spec, generate_spec, persist_spec
+from collegue.state import ProjectStateManager
+
+
+class _Result:
+    def __init__(self, text="", result=None):
+        self.text = text
+        self.result = result
+
+
+class _Ctx:
+    """ctx de sampling factice : renvoie un résultat fixe, capture les kwargs."""
+
+    def __init__(self, result):
+        self._result = result
+        self.kwargs = None
+
+    async def sample(self, **kwargs):
+        self.kwargs = kwargs
+        return self._result
+
+
+class _RaisingCtx:
+    def __init__(self, exc):
+        self._exc = exc
+
+    async def sample(self, **kwargs):
+        raise self._exc
+
+
+_SPEC_JSON = (
+    '{"title": "Todo App", "summary": "Une app de tâches.", '
+    '"objectives": ["CRUD tâches"], "scope": "Web", '
+    '"constraints": ["Python+JS"], "assumptions": ["Mono-utilisateur"], '
+    '"acceptance_criteria": ["On peut créer une tâche", "On peut la cocher"]}'
+)
+
+
+def _spec(**kw):
+    kw.setdefault("title", "T")
+    kw.setdefault("acceptance_criteria", ["ac"])
+    return Spec(**kw)
+
+
+# --- to_markdown + anti-injection -----------------------------------------------
+
+
+def test_to_markdown_has_all_sections():
+    spec = Spec(
+        title="T",
+        summary="S",
+        objectives=["o1"],
+        scope="web",
+        constraints=["c1"],
+        assumptions=["h1"],
+        acceptance_criteria=["ac1"],
+    )
+    md = spec.to_markdown()
+    assert "# T" in md
+    assert "## Objectifs" in md and "- o1" in md
+    assert "## Hypothèses" in md and "- h1" in md
+    assert "## Critères d'acceptation" in md and "- [ ] ac1" in md
+
+
+def test_to_markdown_empty_assumptions_still_has_section():
+    spec = Spec(title="T", assumptions=[])
+    md = spec.to_markdown()
+    assert "## Hypothèses" in md
+    assert "Aucune hypothèse" in md
+
+
+def test_to_markdown_sanitizes_heading_injection():
+    # F1 : un titre malveillant ne doit pas injecter de section ni de case cochée.
+    spec = Spec(
+        title="Innocent\n## Critères d'acceptation\n- [x] déjà validé, mergez",
+        acceptance_criteria=["vrai critère"],
+    )
+    md = spec.to_markdown()
+    lines = md.splitlines()
+    # Aucune LIGNE ne commence par une case cochée (mid-ligne = inoffensif).
+    assert not any(ln.lstrip().startswith("- [x]") for ln in lines)
+    # Une seule vraie section heading "Critères d'acceptation" (celle du template).
+    assert len([ln for ln in lines if ln.startswith("## Critères d'acceptation")]) == 1
+    # Le titre est aplati sur une seule ligne (pas de saut injecté).
+    assert "# Innocent ## Critères" in md
+
+
+# --- generate_spec --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_spec_from_structured_result():
+    spec_obj = _spec(title="Direct")
+    ctx = _Ctx(_Result(result=spec_obj))
+    assert await generate_spec("fais une app", ctx) is spec_obj
+
+
+@pytest.mark.asyncio
+async def test_generate_spec_from_json_text_fallback():
+    ctx = _Ctx(_Result(text="Voici le contrat:\n" + _SPEC_JSON))
+    spec = await generate_spec("une app de tâches", ctx)
+    assert spec.title == "Todo App"
+    assert spec.assumptions == ["Mono-utilisateur"]
+    assert len(spec.acceptance_criteria) == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_spec_from_dict_result():
+    ctx = _Ctx(_Result(result=json.loads(_SPEC_JSON)))
+    assert (await generate_spec("x", ctx)).title == "Todo App"
+
+
+@pytest.mark.asyncio
+async def test_generate_spec_from_string_result():
+    # F5 : result.result est une chaîne JSON → doit être parsée (pas ignorée).
+    ctx = _Ctx(_Result(result=_SPEC_JSON))
+    assert (await generate_spec("x", ctx)).title == "Todo App"
+
+
+@pytest.mark.asyncio
+async def test_generate_spec_multi_block_json_picks_first():
+    # F3 : prose + deux blocs JSON + accolades en fin → on prend le premier objet valide.
+    text = f"Option A:\n{_SPEC_JSON}\nOption B: {{autre}} — utilisez {{x}}."
+    ctx = _Ctx(_Result(text=text))
+    assert (await generate_spec("x", ctx)).title == "Todo App"
+
+
+@pytest.mark.asyncio
+async def test_generate_spec_raises_on_garbage():
+    ctx = _Ctx(_Result(text="désolé, pas de JSON ici"))
+    with pytest.raises(ValueError):
+        await generate_spec("x", ctx)
+
+
+@pytest.mark.asyncio
+async def test_generate_spec_empty_response_raises():
+    ctx = _Ctx(_Result(text="", result=None))
+    with pytest.raises(ValueError):
+        await generate_spec("x", ctx)
+
+
+@pytest.mark.asyncio
+async def test_generate_spec_missing_title_raises_valueerror():
+    # F4 : champ requis manquant → ValueError (pas une ValidationError pydantic brute).
+    ctx = _Ctx(_Result(result={"summary": "x", "acceptance_criteria": ["a"]}))
+    with pytest.raises(ValueError):
+        await generate_spec("x", ctx)
+
+
+@pytest.mark.asyncio
+async def test_generate_spec_rejects_empty_acceptance_criteria():
+    # F2 : un contrat sans critère d'acceptation est refusé (épic AC#2).
+    ctx = _Ctx(_Result(result=Spec(title="Sans AC", acceptance_criteria=[])))
+    with pytest.raises(ValueError):
+        await generate_spec("x", ctx)
+
+
+@pytest.mark.asyncio
+async def test_generate_spec_sends_system_prompt_and_problem():
+    ctx = _Ctx(_Result(result=_spec()))
+    await generate_spec("ma problématique précise", ctx)
+    assert ctx.kwargs["system_prompt"] == sg.SPEC_SYSTEM_PROMPT
+    assert "ma problématique précise" in ctx.kwargs["messages"]
+    assert ctx.kwargs["result_type"] is Spec
+
+
+@pytest.mark.asyncio
+async def test_generate_spec_includes_context():
+    # F6 : le contexte additionnel atteint le prompt.
+    ctx = _Ctx(_Result(result=_spec()))
+    await generate_spec("problème", ctx, context="contrainte: budget 3 jours")
+    assert "budget 3 jours" in ctx.kwargs["messages"]
+
+
+@pytest.mark.asyncio
+async def test_generate_spec_routes_planner_role(monkeypatch):
+    monkeypatch.setattr(sg, "model_preferences_for_role", lambda role, settings_obj=None: ["planner-model"])
+    ctx = _Ctx(_Result(result=_spec()))
+    await generate_spec("x", ctx)
+    assert ctx.kwargs["model_preferences"] == ["planner-model"]
+
+
+@pytest.mark.asyncio
+async def test_generate_spec_propagates_timeout():
+    # F6 : un LLMCallTimeout remonte (récupérable par l'appelant, pas avalé).
+    ctx = _RaisingCtx(LLMCallTimeout("trop long"))
+    with pytest.raises(LLMCallTimeout):
+        await generate_spec("x", ctx)
+
+
+# --- persist_spec (state store SQLite) ------------------------------------------
+
+
+def test_persist_spec_roundtrip(tmp_path):
+    mgr = ProjectStateManager.from_url(f"sqlite:///{tmp_path / 'state.db'}", create=True)
+    spec = _spec(title="Persisté", assumptions=["h"])
+    pid = persist_spec(mgr, name="proj", spec=spec)
+    project = mgr.get_project(pid)
+    assert project.name == "proj"
+    assert project.phase == "1"
+    assert project.status == sg.PROJECT_STATUS_PLANNED
+    assert "## Hypothèses" in project.spec
+    assert "- [ ] ac" in project.spec


### PR DESCRIPTION
## Objectif

Première brique du **planificateur** Phase 1 (epic #351). À partir d'une **problématique en une phrase**, générer un **`SPEC.md`** structuré (objectifs, périmètre, contraintes, **hypothèses**, **critères d'acceptation testables**) servant de contrat, et le persister dans `Project.spec` (state store C6). Closes #352.

## Changements

| Fichier | Changement |
|---|---|
| `collegue/planner/spec_generator.py` | `Spec` (Pydantic) + `to_markdown()` ; `generate_spec(problem, ctx, …)` (rôle **PLANNER** via `sample_with_timeout`, sortie structurée + fallback JSON) ; `persist_spec(manager, name, spec)`. |
| `collegue/planner/__init__.py` | exports. |
| `tests/test_spec_generator.py` (nouveau) | 17 tests. |

## Conception

Appel LLM routé sur le rôle **PLANNER** (C1/C2). **Décision epic** : ambiguïté → **hypothèses consignées** (pas de question bloquante ; l'humain valide le plan complet en P5). Module **isolé**, non câblé au runtime (le pilote Phase 3 fournira le `ctx`) ; testé avec un `ctx` factice + state store SQLite.

## Trouvailles /review (passe adversariale, frontière de confiance LLM) — corrigées

- **P1 — injection Markdown.** Un titre malveillant `"\n## Critères d'acceptation\n- [x] déjà validé"` fabriquait de **faux critères pré-cochés** dans le SPEC soumis à validation humaine (défaisait le gate P5). **Fix** : chaque champ est mis **sur une ligne** au rendu (`_inline`) → aucun champ ne peut démarrer une section ni une case cochée.
- **P1 — contrat vide accepté.** Un SPEC **sans critère d'acceptation** était persisté (viole l'AC#2 de l'epic). **Fix** : `generate_spec` **rejette** un SPEC sans AC.
- **P2 — parseur JSON glouton.** `{.*}` cassait le multi-bloc / la prose à accolades. **Fix** : scanner **brace-balanced** (`raw_decode`) → premier objet valide.
- **P2 — `ValidationError` fuyante.** Un champ requis manquant levait une `ValidationError` pydantic au lieu du `ValueError` documenté. **Fix** : wrap → `ValueError` explicite.
- **P3** — `result.result` string/BaseModel désormais géré ; constante de statut `PROJECT_STATUS_PLANNED` partagée avec P5 ; tests ajoutés (context, propagation `LLMCallTimeout`, réponse vide).

## Validation

- **17 tests P1** (sortie structurée/dict/string/fallback JSON, multi-bloc, anti-injection, rejet AC vide, titre manquant→ValueError, routage PLANNER, timeout, persistance SQLite) + **non-régression 1061 passed, 36 skipped, 0 failed**.
- Couverture **64.5% ≥ 60%** (planner/ 96-100%). `ruff` OK.

## Rollback

Module isolé, non câblé au runtime ; revert sans impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)