### PR TITLE
feat(planner): décomposition SPEC → graphe de tâches (P2)

### DIFF
--- a/collegue/planner/__init__.py
+++ b/collegue/planner/__init__.py
@@ -8,6 +8,7 @@ Modules **isolés** : non câblés au runtime tant que le pilote (Phase 3) ne le
 enchaîne pas.
 """
 
+from collegue.planner.decomposer import decompose
 from collegue.planner.spec_generator import Spec, generate_spec, persist_spec
 
-__all__ = ["Spec", "generate_spec", "persist_spec"]
+__all__ = ["Spec", "generate_spec", "persist_spec", "decompose"]

--- a/collegue/planner/_parsing.py
+++ b/collegue/planner/_parsing.py
@@ -1,0 +1,40 @@
+"""Utilitaires de parsing partagés par le planificateur (P1/P2).
+
+Source unique pour extraire un objet JSON d'une sortie LLM (souvent entourée de
+prose ou de blocs ```json). Évite la duplication entre ``spec_generator`` et
+``decomposer`` (deux implémentations divergeraient).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+
+def json_from_text(text: str) -> Optional[dict]:
+    """Extrait le premier objet JSON exploitable d'un texte (fallback structured-output).
+
+    Scan brace-balanced via ``raw_decode`` depuis chaque ``{`` : on retourne le
+    PREMIER objet complet qui décode (gère les blocs multiples, les ```json fences
+    et la prose qui suit, contrairement à un ``{.*}`` glouton).
+    """
+    if not text:
+        return None
+    cleaned = text.strip()
+    try:
+        whole = json.loads(cleaned)
+        if isinstance(whole, dict):
+            return whole
+    except (ValueError, TypeError):
+        pass
+    decoder = json.JSONDecoder()
+    for idx, ch in enumerate(cleaned):
+        if ch != "{":
+            continue
+        try:
+            obj, _ = decoder.raw_decode(cleaned[idx:])
+        except ValueError:
+            continue
+        if isinstance(obj, dict):
+            return obj
+    return None

--- a/collegue/planner/decomposer.py
+++ b/collegue/planner/decomposer.py
@@ -1,0 +1,178 @@
+"""Décomposition d'un SPEC en graphe de tâches (P2, #353).
+
+Transforme le `SPEC.md` (P1) en tâches exécutables (titre, critère d'acceptation,
+dépendances), valide le graphe (dépendances dans les bornes, **acyclique**) et les
+persiste dans le state store (C6/C7) en résolvant les dépendances (référencées par
+**index** côté LLM) en vrais IDs de tâches. Journalise le découpage (Decision).
+
+Frontière de confiance LLM : on **valide** le graphe avant d'écrire (un graphe
+cyclique ou des index hors bornes sont rejetés, pas persistés). Module **isolé**.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any, List, Optional
+
+from pydantic import BaseModel, Field, ValidationError
+
+from collegue.core.llm import LLMRole, model_preferences_for_role
+from collegue.core.llm.client import sample_with_timeout
+from collegue.planner._parsing import json_from_text
+from collegue.state.models import Decision, Task
+
+# Plafond dur sur le nombre de tâches d'une décomposition : une décomposition
+# hallucinée ne doit pas créer des milliers de lignes (et autant d'issues en P4).
+MAX_TASKS = 200
+
+DECOMPOSE_SYSTEM_PROMPT = """Tu es un planificateur logiciel senior. À partir d'un SPEC de projet, \
+tu le découpes en tâches exécutables et ordonnées.
+
+Réponds UNIQUEMENT par un objet JSON valide, sans texte autour :
+{"tasks": [{"title": "...", "acceptance": "...", "depends_on": [indices]}]}
+
+Règles :
+- "title": tâche concrète et atomique (string).
+- "acceptance": critère d'acceptation TESTABLE de la tâche (string).
+- "depends_on": liste d'INDEX (0-based) des AUTRES tâches de CETTE liste dont celle-ci dépend.
+- Le graphe de dépendances doit être ACYCLIQUE (pas de dépendance circulaire).
+- Une tâche ne dépend pas d'elle-même ; les index référencent des tâches existantes de la liste.
+- Au moins une tâche."""
+
+
+class _PlannedTask(BaseModel):
+    """Tâche telle que proposée par le LLM (dépendances par index, pas par ID DB)."""
+
+    title: str
+    acceptance: str = ""
+    depends_on: List[int] = Field(default_factory=list)
+
+
+class _Decomposition(BaseModel):
+    tasks: List[_PlannedTask] = Field(default_factory=list)
+
+
+def _coerce(data: dict) -> _Decomposition:
+    try:
+        return _Decomposition.model_validate(data)
+    except ValidationError as exc:
+        raise ValueError(f"Décomposition LLM invalide (champs manquants/typés): {exc}") from exc
+
+
+def _extract_decomposition(result: Any) -> _Decomposition:
+    candidate = getattr(result, "result", None)
+    if isinstance(candidate, _Decomposition):
+        return candidate
+    if isinstance(candidate, BaseModel):
+        candidate = candidate.model_dump()
+    if isinstance(candidate, str):
+        candidate = json_from_text(candidate)
+    if isinstance(candidate, dict):
+        return _coerce(candidate)
+    data = json_from_text(getattr(result, "text", "") or "")
+    if data is None:
+        raise ValueError("Le planificateur n'a pas retourné de décomposition exploitable (ni structuré ni JSON).")
+    return _coerce(data)
+
+
+def _topo_order(tasks: List[_PlannedTask]) -> List[int]:
+    """Ordre topologique des index ; lève ``ValueError`` si index invalide ou cycle."""
+    n = len(tasks)
+    indegree = [0] * n
+    adjacency: List[List[int]] = [[] for _ in range(n)]
+    for i, task in enumerate(tasks):
+        for dep in dict.fromkeys(task.depends_on):  # dédupe en gardant l'ordre
+            if not (0 <= dep < n):
+                raise ValueError(f"tâche #{i}: dépendance index {dep} hors limites (0..{n - 1}).")
+            if dep == i:
+                raise ValueError(f"tâche #{i} ne peut pas dépendre d'elle-même.")
+            adjacency[dep].append(i)
+            indegree[i] += 1
+    queue = deque(i for i in range(n) if indegree[i] == 0)
+    order: List[int] = []
+    while queue:
+        node = queue.popleft()
+        order.append(node)
+        for nxt in adjacency[node]:
+            indegree[nxt] -= 1
+            if indegree[nxt] == 0:
+                queue.append(nxt)
+    if len(order) != n:
+        raise ValueError("graphe de tâches cyclique : dépendances circulaires détectées.")
+    return order
+
+
+def _build_prompt(spec: Any) -> str:
+    spec_text = spec.to_markdown() if hasattr(spec, "to_markdown") else str(spec)
+    return f"SPEC du projet :\n{spec_text}\n\nDécoupe ce SPEC en tâches (JSON décrit par tes instructions système)."
+
+
+async def decompose(
+    spec: Any,
+    ctx: Any,
+    *,
+    manager: Any,
+    project_id: int,
+    settings_obj: Optional[object] = None,
+    temperature: float = 0.2,
+    max_tokens: int = 4096,
+) -> List[Any]:
+    """Décompose ``spec`` en tâches persistées pour ``project_id`` ; retourne les tâches créées.
+
+    ``spec`` peut être un :class:`~collegue.planner.spec_generator.Spec` ou le SPEC.md
+    (texte). Lève ``ValueError`` si la décomposition est vide/trop grande, non
+    exploitable, si le projet a déjà des tâches (idempotence), ou si le graphe de
+    dépendances est invalide (index hors bornes, auto-dépendance, cycle).
+
+    Persistance **atomique** : toutes les tâches + la décision sont écrites dans une
+    **seule** transaction — un échec en cours de route ne laisse aucun graphe partiel.
+    """
+    # Idempotence : ne pas ré-décomposer (un retry dupliquerait le graphe → des
+    # issues en double en P4). Le caller doit vider les tâches pour re-planifier.
+    if manager.get_tasks(project_id):
+        raise ValueError("projet déjà décomposé : vider les tâches existantes avant de redécomposer.")
+
+    sample_kwargs = {
+        "messages": _build_prompt(spec),
+        "system_prompt": DECOMPOSE_SYSTEM_PROMPT,
+        "result_type": _Decomposition,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+    }
+    prefs = model_preferences_for_role(LLMRole.PLANNER, settings_obj)
+    if prefs:
+        sample_kwargs["model_preferences"] = prefs
+
+    result = await sample_with_timeout(ctx, settings_obj=settings_obj, **sample_kwargs)
+    planned = _extract_decomposition(result).tasks
+    if not planned:
+        raise ValueError("Décomposition vide : aucune tâche produite.")
+    if len(planned) > MAX_TASKS:
+        raise ValueError(f"Décomposition trop grande ({len(planned)} tâches > MAX_TASKS={MAX_TASKS}).")
+
+    order = _topo_order(planned)  # valide le graphe (bornes + acyclique) AVANT toute écriture
+
+    # Tout dans une seule transaction (atomique : tout ou rien).
+    with manager.session() as session:
+        index_to_id: dict[int, int] = {}
+        for idx in order:
+            task = planned[idx]
+            dep_ids = [index_to_id[d] for d in dict.fromkeys(task.depends_on)]
+            row = Task(
+                project_id=project_id,
+                title=task.title,
+                acceptance=(task.acceptance or None),
+                depends_on=dep_ids,  # toujours une liste (jamais None) pour les consommateurs
+            )
+            session.add(row)
+            session.flush()  # obtient row.id pour résoudre les dépendances suivantes
+            index_to_id[idx] = row.id
+        session.add(
+            Decision(
+                project_id=project_id,
+                summary=f"Décomposition du SPEC en {len(planned)} tâches",
+                rationale="Graphe de dépendances validé (acyclique) ; dépendances résolues en IDs de tâches.",
+            )
+        )
+
+    return manager.get_tasks(project_id)

--- a/collegue/planner/spec_generator.py
+++ b/collegue/planner/spec_generator.py
@@ -20,7 +20,6 @@ Module **isolé** : non câblé au runtime (le pilote Phase 3 fournira le ``ctx`
 
 from __future__ import annotations
 
-import json
 import re
 from typing import Any, List, Optional
 
@@ -28,6 +27,7 @@ from pydantic import BaseModel, Field, ValidationError
 
 from collegue.core.llm import LLMRole, model_preferences_for_role
 from collegue.core.llm.client import sample_with_timeout
+from collegue.planner._parsing import json_from_text
 
 # Statuts de projet partagés avec P5 (transition planned → approved au gate humain).
 PROJECT_STATUS_PLANNED = "planned"
@@ -96,35 +96,6 @@ class Spec(BaseModel):
         )
 
 
-def _json_from_text(text: str) -> Optional[dict]:
-    """Extrait le premier objet JSON exploitable d'un texte (fallback structured-output).
-
-    Scan brace-balanced via ``raw_decode`` depuis chaque ``{`` : on retourne le
-    PREMIER objet complet qui décode (gère les blocs multiples, les ```json fences
-    et la prose qui suit, contrairement à un ``{.*}`` glouton).
-    """
-    if not text:
-        return None
-    cleaned = text.strip()
-    try:
-        whole = json.loads(cleaned)
-        if isinstance(whole, dict):
-            return whole
-    except (ValueError, TypeError):
-        pass
-    decoder = json.JSONDecoder()
-    for idx, ch in enumerate(cleaned):
-        if ch != "{":
-            continue
-        try:
-            obj, _ = decoder.raw_decode(cleaned[idx:])
-        except ValueError:
-            continue
-        if isinstance(obj, dict):
-            return obj
-    return None
-
-
 def _spec_from_dict(data: dict) -> Spec:
     """Valide un dict en Spec ; convertit ``ValidationError`` en ``ValueError`` (contrat du module)."""
     try:
@@ -141,10 +112,10 @@ def _extract_spec(result: Any) -> Spec:
     if isinstance(candidate, BaseModel):
         candidate = candidate.model_dump()
     if isinstance(candidate, str):
-        candidate = _json_from_text(candidate)
+        candidate = json_from_text(candidate)
     if isinstance(candidate, dict):
         return _spec_from_dict(candidate)
-    data = _json_from_text(getattr(result, "text", "") or "")
+    data = json_from_text(getattr(result, "text", "") or "")
     if data is None:
         raise ValueError("Le planificateur n'a pas retourné de SPEC exploitable (ni structuré ni JSON).")
     return _spec_from_dict(data)

--- a/tests/test_decomposer.py
+++ b/tests/test_decomposer.py
@@ -1,0 +1,220 @@
+"""Tests P2 (#353) : décomposition SPEC → graphe de tâches (state store)."""
+
+import json
+
+import pytest
+
+import collegue.planner.decomposer as dec
+from collegue.planner import Spec, decompose
+from collegue.state import ProjectStateManager
+
+
+class _Result:
+    def __init__(self, text="", result=None):
+        self.text = text
+        self.result = result
+
+
+class _Ctx:
+    def __init__(self, result):
+        self._result = result
+        self.kwargs = None
+
+    async def sample(self, **kwargs):
+        self.kwargs = kwargs
+        return self._result
+
+
+@pytest.fixture
+def manager(tmp_path):
+    return ProjectStateManager.from_url(f"sqlite:///{tmp_path / 'state.db'}", create=True)
+
+
+def _project(manager):
+    return manager.create_project(name="p", spec="# spec")
+
+
+def _decomp(tasks):
+    return _Result(result={"tasks": tasks})
+
+
+# --- découpage + persistance ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_decompose_persists_tasks(manager):
+    pid = _project(manager)
+    ctx = _Ctx(
+        _decomp(
+            [
+                {"title": "setup", "acceptance": "repo prêt", "depends_on": []},
+                {"title": "build", "acceptance": "tests verts", "depends_on": [0]},
+            ]
+        )
+    )
+    tasks = await decompose(Spec(title="T", acceptance_criteria=["ac"]), ctx, manager=manager, project_id=pid)
+    assert [t.title for t in tasks] == ["setup", "build"]
+    assert tasks[0].acceptance == "repo prêt"
+
+
+@pytest.mark.asyncio
+async def test_decompose_resolves_dependencies_to_ids(manager):
+    pid = _project(manager)
+    ctx = _Ctx(_decomp([{"title": "A", "depends_on": []}, {"title": "B", "depends_on": [0]}]))
+    tasks = await decompose("# SPEC texte", ctx, manager=manager, project_id=pid)
+    by_title = {t.title: t for t in tasks}
+    assert by_title["A"].depends_on == []  # toujours une liste (jamais None)
+    assert by_title["B"].depends_on == [by_title["A"].id]  # index 0 → vrai ID DB
+
+
+@pytest.mark.asyncio
+async def test_decompose_resolves_dependency_listed_later(manager):
+    # A (index 0) dépend de B (index 1) qui apparaît APRÈS dans la liste : l'ordre
+    # topo doit persister B avant A et résoudre la dépendance vers le vrai ID de B.
+    pid = _project(manager)
+    ctx = _Ctx(_decomp([{"title": "A", "depends_on": [1]}, {"title": "B", "depends_on": []}]))
+    tasks = await decompose("spec", ctx, manager=manager, project_id=pid)
+    by_title = {t.title: t for t in tasks}
+    assert by_title["B"].id < by_title["A"].id
+    assert by_title["A"].depends_on == [by_title["B"].id]
+
+
+@pytest.mark.asyncio
+async def test_decompose_dedups_duplicate_dependency(manager):
+    pid = _project(manager)
+    ctx = _Ctx(_decomp([{"title": "A", "depends_on": []}, {"title": "B", "depends_on": [0, 0]}]))
+    tasks = await decompose("spec", ctx, manager=manager, project_id=pid)
+    by_title = {t.title: t for t in tasks}
+    assert by_title["B"].depends_on == [by_title["A"].id]  # déduit → une seule entrée
+
+
+@pytest.mark.asyncio
+async def test_decompose_structured_result(manager):
+    pid = _project(manager)
+    decomp = dec._Decomposition(tasks=[dec._PlannedTask(title="x", depends_on=[])])
+    tasks = await decompose("spec", _Ctx(_Result(result=decomp)), manager=manager, project_id=pid)
+    assert [t.title for t in tasks] == ["x"]
+
+
+@pytest.mark.asyncio
+async def test_decompose_journals_decision(manager):
+    pid = _project(manager)
+    ctx = _Ctx(_decomp([{"title": "x", "depends_on": []}]))
+    await decompose("spec", ctx, manager=manager, project_id=pid)
+    decisions = manager.get_decisions(pid)
+    assert len(decisions) == 1
+    assert "Décomposition" in decisions[0].summary
+
+
+@pytest.mark.asyncio
+async def test_decompose_json_text_fallback(manager):
+    pid = _project(manager)
+    payload = json.dumps({"tasks": [{"title": "t1", "depends_on": []}]})
+    ctx = _Ctx(_Result(text="Voici:\n" + payload))
+    tasks = await decompose("spec", ctx, manager=manager, project_id=pid)
+    assert [t.title for t in tasks] == ["t1"]
+
+
+@pytest.mark.asyncio
+async def test_decompose_routes_planner_role(monkeypatch, manager):
+    monkeypatch.setattr(dec, "model_preferences_for_role", lambda role, settings_obj=None: ["planner-model"])
+    pid = _project(manager)
+    ctx = _Ctx(_decomp([{"title": "x", "depends_on": []}]))
+    await decompose("spec", ctx, manager=manager, project_id=pid)
+    assert ctx.kwargs["model_preferences"] == ["planner-model"]
+
+
+# --- validation du graphe (rien persisté si invalide) ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_decompose_rejects_empty(manager):
+    pid = _project(manager)
+    ctx = _Ctx(_decomp([]))
+    with pytest.raises(ValueError):
+        await decompose("spec", ctx, manager=manager, project_id=pid)
+    assert manager.get_tasks(pid) == []
+
+
+@pytest.mark.asyncio
+async def test_decompose_rejects_cycle(manager):
+    pid = _project(manager)
+    # A dépend de B, B dépend de A → cycle.
+    ctx = _Ctx(_decomp([{"title": "A", "depends_on": [1]}, {"title": "B", "depends_on": [0]}]))
+    with pytest.raises(ValueError):
+        await decompose("spec", ctx, manager=manager, project_id=pid)
+    assert manager.get_tasks(pid) == []  # rien persisté
+
+
+@pytest.mark.asyncio
+async def test_decompose_rejects_out_of_range_dependency(manager):
+    pid = _project(manager)
+    ctx = _Ctx(_decomp([{"title": "A", "depends_on": [5]}]))
+    with pytest.raises(ValueError):
+        await decompose("spec", ctx, manager=manager, project_id=pid)
+    assert manager.get_tasks(pid) == []
+
+
+@pytest.mark.asyncio
+async def test_decompose_rejects_self_dependency(manager):
+    pid = _project(manager)
+    ctx = _Ctx(_decomp([{"title": "A", "depends_on": [0]}]))
+    with pytest.raises(ValueError):
+        await decompose("spec", ctx, manager=manager, project_id=pid)
+    assert manager.get_tasks(pid) == []
+
+
+@pytest.mark.asyncio
+async def test_decompose_raises_on_garbage(manager):
+    pid = _project(manager)
+    ctx = _Ctx(_Result(text="pas de json"))
+    with pytest.raises(ValueError):
+        await decompose("spec", ctx, manager=manager, project_id=pid)
+
+
+@pytest.mark.asyncio
+async def test_decompose_rejects_malformed_tasks(manager):
+    # {"tasks": null} → ValidationError pydantic convertie en ValueError (contrat module).
+    pid = _project(manager)
+    ctx = _Ctx(_Result(result={"tasks": None}))
+    with pytest.raises(ValueError):
+        await decompose("spec", ctx, manager=manager, project_id=pid)
+
+
+@pytest.mark.asyncio
+async def test_decompose_rejects_too_many_tasks(manager):
+    pid = _project(manager)
+    big = [{"title": f"t{i}", "depends_on": []} for i in range(dec.MAX_TASKS + 1)]
+    ctx = _Ctx(_decomp(big))
+    with pytest.raises(ValueError):
+        await decompose("spec", ctx, manager=manager, project_id=pid)
+    assert manager.get_tasks(pid) == []  # rien persisté
+
+
+@pytest.mark.asyncio
+async def test_decompose_idempotency_guard(manager):
+    # Un 2e décompose sur un projet déjà décomposé est refusé (pas de duplication).
+    pid = _project(manager)
+    await decompose("spec", _Ctx(_decomp([{"title": "x", "depends_on": []}])), manager=manager, project_id=pid)
+    with pytest.raises(ValueError):
+        await decompose("spec", _Ctx(_decomp([{"title": "y", "depends_on": []}])), manager=manager, project_id=pid)
+    assert [t.title for t in manager.get_tasks(pid)] == ["x"]
+
+
+@pytest.mark.asyncio
+async def test_decompose_is_atomic_on_midloop_failure(monkeypatch, manager):
+    # Un échec d'insertion en cours de boucle → rollback total (aucune tâche, aucune décision).
+    pid = _project(manager)
+    real_task = dec.Task
+
+    def _boom_task(**kwargs):
+        if kwargs.get("title") == "BOOM":
+            raise RuntimeError("insertion échouée")
+        return real_task(**kwargs)
+
+    monkeypatch.setattr(dec, "Task", _boom_task)
+    ctx = _Ctx(_decomp([{"title": "ok", "depends_on": []}, {"title": "BOOM", "depends_on": [0]}]))
+    with pytest.raises(RuntimeError):
+        await decompose("spec", ctx, manager=manager, project_id=pid)
+    assert manager.get_tasks(pid) == []  # la 1re tâche a été rollback
+    assert manager.get_decisions(pid) == []  # pas de décision journalisée


### PR DESCRIPTION
## Objectif

Deuxième brique du **planificateur** Phase 1 (epic #351), sur P1. Transforme le `SPEC.md` en **graphe de tâches** exécutables (titre, critère d'acceptation, dépendances) persisté dans le state store (C6/C7). Closes #353.

## Changements

| Fichier | Changement |
|---|---|
| `collegue/planner/decomposer.py` | `decompose(spec, ctx, *, manager, project_id, …)` (rôle PLANNER) : tâches avec deps **par index** → validation graphe (bornes, pas d'auto-dép, acyclique) → persistance **atomique** + résolution index→ID + journal `Decision`. |
| `collegue/planner/_parsing.py` (nouveau) | `json_from_text` (parseur brace-balanced) **extrait en module partagé**. |
| `collegue/planner/spec_generator.py` | refactor : importe `json_from_text` de `_parsing` (plus de copie locale). |
| `tests/test_decomposer.py` (nouveau) | 17 tests. |

## Conception

Le LLM référence les dépendances par **index** (il ne connaît pas les IDs DB) ; le code valide le graphe **avant** d'écrire, puis persiste en **ordre topologique** dans **une seule transaction** (résolution index→ID via `flush`). Module isolé, testé avec `ctx` factice + state store SQLite.

## Trouvailles /review (passe adversariale) — corrigées

- **P1 — persistance NON ATOMIQUE.** `add_task` par-transaction : un échec en cours laissait un **graphe partiel** + aucune décision journalisée + **aucune idempotence** (retry → graphe dupliqué → issues en double en P4). **Fix** : tout dans **une transaction** (`manager.session()`) + **garde d'idempotence** (refuse de redécomposer un projet déjà décomposé).
- **P2 — pas de plafond de tâches.** Une décomposition hallucinée créait des milliers de lignes (et autant d'issues en P4) ; file Kahn en O(n²). **Fix** : `MAX_TASKS=200` (rejet avant écriture) + `deque`.
- **P3 — `[]→None` incohérent.** `depends_on` est désormais **toujours une liste** (consommateurs n'ont plus à gérer `None`).

## Validation

- **17 tests P2** : persistance + résolution deps→ID, **atomicité** (échec mid-loop → rollback total), **ordre topo** (dépendance listée après), chemin structuré, dedup `[0,0]`, rejets (vide/cycle/hors-bornes/auto-dép/trop grand/malformé), **idempotence**, fallback JSON, routage PLANNER. + **non-régression 1078 passed, 0 failed** (refactor `json_from_text` n'a pas cassé P1).
- Couverture **64.6% ≥ 60%** (planner/ 92-100%). `ruff` OK.

## Rollback

Module isolé, non câblé au runtime ; revert sans impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)