### PR TITLE
feat(planner): gate de validation humaine du plan (P5)

### DIFF
--- a/alembic/versions/0003_project_approved_plan_hash.py
+++ b/alembic/versions/0003_project_approved_plan_hash.py
@@ -1,0 +1,30 @@
+"""empreinte du plan approuvé sur projects (approved_plan_hash)
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-06-08
+
+Ajoute ``projects.approved_plan_hash`` : lie l'approbation humaine (P5) au contenu
+exact du plan (anti-TOCTOU). batch_alter_table pour rester portable SQLite/PostgreSQL.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0003"
+down_revision: Union[str, None] = "0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("projects") as batch_op:
+        batch_op.add_column(sa.Column("approved_plan_hash", sa.String(length=64), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("projects") as batch_op:
+        batch_op.drop_column("approved_plan_hash")

--- a/collegue/planner/__init__.py
+++ b/collegue/planner/__init__.py
@@ -9,6 +9,25 @@ enchaîne pas.
 """
 
 from collegue.planner.decomposer import decompose
+from collegue.planner.plan_review import (
+    PlanNotApproved,
+    PlanPreview,
+    approve_plan,
+    build_plan_preview,
+    is_approved,
+    require_approved,
+)
 from collegue.planner.spec_generator import Spec, generate_spec, persist_spec
 
-__all__ = ["Spec", "generate_spec", "persist_spec", "decompose"]
+__all__ = [
+    "Spec",
+    "generate_spec",
+    "persist_spec",
+    "decompose",
+    "PlanPreview",
+    "PlanNotApproved",
+    "build_plan_preview",
+    "approve_plan",
+    "is_approved",
+    "require_approved",
+]

--- a/collegue/planner/_parsing.py
+++ b/collegue/planner/_parsing.py
@@ -8,7 +8,18 @@ prose ou de blocs ```json). Évite la duplication entre ``spec_generator`` et
 from __future__ import annotations
 
 import json
-from typing import Optional
+import re
+from typing import Any, Optional
+
+
+def inline(text: Any) -> str:
+    """Réduit une valeur à une seule ligne (anti-injection Markdown).
+
+    Écrase tout enchaînement d'espaces/sauts de ligne en une espace : un champ
+    issu du LLM ne peut donc pas démarrer une nouvelle ligne dans un document
+    rendu (pas de fausse section ``## ...`` ni de case ``- [x] ...``).
+    """
+    return re.sub(r"\s+", " ", str(text)).strip()
 
 
 def json_from_text(text: str) -> Optional[dict]:

--- a/collegue/planner/plan_review.py
+++ b/collegue/planner/plan_review.py
@@ -1,0 +1,168 @@
+"""Gate de validation humaine du plan (P5, #356).
+
+Garde-fou du brief (§Phase 1) : le plan **n'avance pas** sans accord humain.
+``build_plan_preview`` agrège un résumé lisible (SPEC + tâches + critères
+d'acceptation + dépendances ; les hypothèses sont déjà dans le SPEC, P1) à partir
+du state store (via ``load_snapshot`` de C7). ``approve_plan`` lie l'approbation au
+**contenu exact** du plan (empreinte SHA-256 persistée) ; ``is_approved`` recompute
+l'empreinte et la compare → toute **mutation du plan après approbation invalide le
+gate** (anti-TOCTOU). ``require_approved`` lève si non approuvé.
+
+Contrat P4 (à respecter impérativement) : la couche d'écriture GitHub DOIT appeler
+``require_approved`` avant toute écriture ; sans cela le garde-fou est contournable.
+
+Module **isolé** : non câblé au runtime tant que le pilote (Phase 3) ne l'enchaîne pas.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from collegue.planner._parsing import inline
+from collegue.planner.status import PROJECT_STATUS_APPROVED
+from collegue.state import load_snapshot
+from collegue.state.models import Decision, Project
+
+
+class PlanNotApproved(Exception):
+    """Le plan n'a pas été approuvé (ou a changé depuis) — P4 doit refuser d'écrire."""
+
+
+@dataclass
+class PlanPreview:
+    """Résumé lisible d'un plan, soumis à validation humaine avant écriture GitHub."""
+
+    project_id: int
+    name: str
+    status: str
+    approved: bool
+    spec: Optional[str]
+    tasks: List[Dict[str, Any]]
+    task_count: int
+
+    def to_markdown(self) -> str:
+        lines = [
+            f"# Plan : {inline(self.name)}",
+            "",
+            f"Statut : `{self.status}` · Tâches : {self.task_count} · "
+            f"Approuvé : {'✅ oui' if self.approved else '❌ non'}",
+            "",
+            "## SPEC",
+            # SPEC clôturé dans un bloc de code : son Markdown (titres, cases) est
+            # inerte → impossible de forger un faux bandeau « approuvé » dans l'aperçu.
+            "```",
+            (self.spec or "(aucun SPEC)").replace("```", "ʼʼʼ"),
+            "```",
+            "",
+            "## Tâches",
+        ]
+        if not self.tasks:
+            lines.append("_(aucune tâche)_")
+        for task in self.tasks:
+            deps = ", ".join(f"#{d}" for d in (task.get("depends_on") or []))
+            suffix = f" — dépend de {deps}" if deps else ""
+            lines.append(f"- [{task['id']}] {inline(task['title'])}{suffix}")
+            acceptance = inline(task.get("acceptance") or "")
+            if acceptance:
+                lines.append(f"  - critère : {acceptance}")
+        return "\n".join(lines)
+
+
+def _plan_hash(project: Any, tasks: List[Any]) -> str:
+    """Empreinte stable du plan (SPEC + tâches) — base de l'anti-TOCTOU."""
+    payload = {
+        "spec": getattr(project, "spec", None) or "",
+        "tasks": sorted(
+            (
+                {
+                    "id": t.id,
+                    "title": t.title,
+                    "acceptance": t.acceptance,
+                    "depends_on": t.depends_on or [],
+                }
+                for t in tasks
+            ),
+            key=lambda d: d["id"],
+        ),
+    }
+    blob = json.dumps(payload, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def build_plan_preview(manager: Any, project_id: int) -> Optional[PlanPreview]:
+    """Construit l'aperçu d'un plan depuis le state store, ou ``None`` si absent."""
+    snapshot = load_snapshot(manager, project_id)
+    if snapshot is None:
+        return None
+    project = snapshot.project
+    tasks = [
+        {
+            "id": t["id"],
+            "title": t["title"],
+            "acceptance": t.get("acceptance"),
+            "depends_on": t.get("depends_on") or [],
+        }
+        for t in snapshot.tasks
+    ]
+    return PlanPreview(
+        project_id=project_id,
+        name=project.get("name", ""),
+        status=project.get("status", ""),
+        approved=is_approved(manager, project_id),
+        spec=project.get("spec"),
+        tasks=tasks,
+        task_count=len(tasks),
+    )
+
+
+def is_approved(manager: Any, project_id: int) -> bool:
+    """True si le plan est approuvé **et inchangé** depuis l'approbation (anti-TOCTOU)."""
+    project = manager.get_project(project_id)
+    if project is None or project.status != PROJECT_STATUS_APPROVED:
+        return False
+    tasks = manager.get_tasks(project_id)
+    return bool(project.approved_plan_hash) and project.approved_plan_hash == _plan_hash(project, tasks)
+
+
+def approve_plan(manager: Any, project_id: int, *, actor: str = "human") -> bool:
+    """Approuve le plan (lie l'approbation à son contenu). Retourne False si projet absent.
+
+    Préconditions : le projet a un SPEC et au moins une tâche. Idempotent : ré-approuver
+    le même plan ne fait rien. Lève ``ValueError`` si le plan est incomplet.
+    """
+    project = manager.get_project(project_id)
+    if project is None:
+        return False
+    tasks = manager.get_tasks(project_id)
+    if not tasks or not (project.spec or "").strip():
+        raise ValueError("Plan incomplet (SPEC ou tâches manquants) : rien à approuver.")
+
+    current_hash = _plan_hash(project, tasks)
+    if project.status == PROJECT_STATUS_APPROVED and project.approved_plan_hash == current_hash:
+        return True  # idempotent : déjà approuvé pour CE plan exact
+
+    # Atomique : statut + empreinte + décision dans une seule transaction.
+    with manager.session() as session:
+        row = session.get(Project, project_id)
+        row.status = PROJECT_STATUS_APPROVED
+        row.approved_plan_hash = current_hash
+        session.add(
+            Decision(
+                project_id=project_id,
+                summary="Plan approuvé (validation humaine)",
+                rationale=f"actor={actor}; plan_hash={current_hash}",
+            )
+        )
+    return True
+
+
+def require_approved(manager: Any, project_id: int) -> None:
+    """Lève :class:`PlanNotApproved` si le plan n'est pas approuvé/inchangé (garde pour P4)."""
+    if not is_approved(manager, project_id):
+        raise PlanNotApproved(
+            f"Projet {project_id} non approuvé (ou modifié depuis l'approbation) : "
+            "validation humaine requise avant écriture GitHub."
+        )

--- a/collegue/planner/spec_generator.py
+++ b/collegue/planner/spec_generator.py
@@ -20,17 +20,14 @@ Module **isolé** : non câblé au runtime (le pilote Phase 3 fournira le ``ctx`
 
 from __future__ import annotations
 
-import re
 from typing import Any, List, Optional
 
 from pydantic import BaseModel, Field, ValidationError
 
 from collegue.core.llm import LLMRole, model_preferences_for_role
 from collegue.core.llm.client import sample_with_timeout
-from collegue.planner._parsing import json_from_text
-
-# Statuts de projet partagés avec P5 (transition planned → approved au gate humain).
-PROJECT_STATUS_PLANNED = "planned"
+from collegue.planner._parsing import inline, json_from_text
+from collegue.planner.status import PROJECT_STATUS_PLANNED
 
 SPEC_SYSTEM_PROMPT = """Tu es un planificateur logiciel senior. À partir d'une problématique \
 (souvent une seule phrase), tu produis un contrat de projet clair et actionnable.
@@ -52,16 +49,6 @@ explicites dans "assumptions" et avance.
 - Reste concis et concret."""
 
 
-def _inline(text: Any) -> str:
-    """Réduit une valeur à une seule ligne (anti-injection Markdown).
-
-    Écrase tout enchaînement d'espaces/sauts de ligne en une espace : un champ LLM
-    ne peut donc pas démarrer une nouvelle ligne, donc pas de fausse section
-    (``## ...``) ni de case déjà cochée (``- [x] ...``) dans le SPEC rendu.
-    """
-    return re.sub(r"\s+", " ", str(text)).strip()
-
-
 class Spec(BaseModel):
     """Contrat de projet structuré, rendu en SPEC.md."""
 
@@ -78,18 +65,18 @@ class Spec(BaseModel):
         toutes les sections sont présentes (les vides portent une note)."""
 
         def bullets(items: List[str], placeholder: str) -> str:
-            cleaned = [_inline(i) for i in (items or []) if str(i).strip()]
+            cleaned = [inline(i) for i in (items or []) if str(i).strip()]
             return "\n".join(f"- {i}" for i in cleaned) if cleaned else f"_{placeholder}_"
 
         def checks(items: List[str], placeholder: str) -> str:
-            cleaned = [_inline(i) for i in (items or []) if str(i).strip()]
+            cleaned = [inline(i) for i in (items or []) if str(i).strip()]
             return "\n".join(f"- [ ] {i}" for i in cleaned) if cleaned else f"_{placeholder}_"
 
         return (
-            f"# {_inline(self.title)}\n\n"
-            f"{_inline(self.summary)}\n\n"
+            f"# {inline(self.title)}\n\n"
+            f"{inline(self.summary)}\n\n"
             f"## Objectifs\n{bullets(self.objectives, 'À préciser.')}\n\n"
-            f"## Périmètre\n{_inline(self.scope) or '_À préciser._'}\n\n"
+            f"## Périmètre\n{inline(self.scope) or '_À préciser._'}\n\n"
             f"## Contraintes\n{bullets(self.constraints, 'Aucune contrainte identifiée.')}\n\n"
             f"## Hypothèses\n{bullets(self.assumptions, 'Aucune hypothèse (problématique non ambiguë).')}\n\n"
             f"## Critères d'acceptation\n{checks(self.acceptance_criteria, 'À préciser.')}\n"

--- a/collegue/planner/status.py
+++ b/collegue/planner/status.py
@@ -1,0 +1,9 @@
+"""Statuts de projet partagés par le planificateur (P1/P5).
+
+Source unique pour la transition du cycle de vie d'un projet planifié :
+``planned`` (SPEC + tâches générés) → ``approved`` (validé par l'humain, P5).
+P4 refuse d'écrire dans GitHub tant que le statut n'est pas ``approved``.
+"""
+
+PROJECT_STATUS_PLANNED = "planned"
+PROJECT_STATUS_APPROVED = "approved"

--- a/collegue/state/models.py
+++ b/collegue/state/models.py
@@ -75,6 +75,10 @@ class Project(Base):
     updated_at: Mapped[datetime] = mapped_column(
         UTCDateTime, nullable=False, default=_utcnow, onupdate=_utcnow, server_default=func.now()
     )
+    # Empreinte du plan (SPEC + tâches) au moment de l'approbation humaine (P5).
+    # Lie l'approbation à un contenu précis : toute mutation ultérieure du plan
+    # invalide le gate (anti-TOCTOU). NULL tant que non approuvé.
+    approved_plan_hash: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
 
     # Cascade gérée par l'ORM (cascade="all, delete-orphan") : marche partout.
     # ondelete="CASCADE" reste sur la FK pour PostgreSQL (défense en profondeur ;

--- a/tests/test_plan_review.py
+++ b/tests/test_plan_review.py
@@ -1,0 +1,175 @@
+"""Tests P5 (#356) : gate de validation humaine du plan."""
+
+import pytest
+
+from collegue.planner import (
+    PlanNotApproved,
+    Spec,
+    approve_plan,
+    build_plan_preview,
+    decompose,
+    is_approved,
+    persist_spec,
+    require_approved,
+)
+from collegue.planner.status import PROJECT_STATUS_APPROVED, PROJECT_STATUS_PLANNED
+from collegue.state import ProjectStateManager
+
+
+@pytest.fixture
+def manager(tmp_path):
+    return ProjectStateManager.from_url(f"sqlite:///{tmp_path / 'state.db'}", create=True)
+
+
+class _Result:
+    def __init__(self, result):
+        self.result = result
+        self.text = ""
+
+
+class _Ctx:
+    def __init__(self, result):
+        self._result = result
+
+    async def sample(self, **kwargs):
+        return self._result
+
+
+def _planned_no_tasks(manager):
+    """Projet planifié : SPEC persisté, sans tâches (pour décomposer ensuite)."""
+    spec = Spec(title="Demo", assumptions=["mono-user"], acceptance_criteria=["AC1"])
+    return persist_spec(manager, name="demo", spec=spec)
+
+
+def _planned_with_tasks(manager):
+    """Projet planifié complet : SPEC + une tâche (prêt à approuver)."""
+    pid = _planned_no_tasks(manager)
+    manager.add_task(pid, title="impl", acceptance="tests verts")
+    return pid
+
+
+# --- preview --------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_plan_preview_aggregates(manager):
+    pid = _planned_no_tasks(manager)
+    ctx = _Ctx(
+        _Result({"tasks": [{"title": "A", "acceptance": "ac-a", "depends_on": []}, {"title": "B", "depends_on": [0]}]})
+    )
+    await decompose("spec", ctx, manager=manager, project_id=pid)
+
+    preview = build_plan_preview(manager, pid)
+    assert preview is not None
+    assert preview.name == "demo"
+    assert preview.task_count == 2
+    assert preview.approved is False
+    assert "## Hypothèses" in preview.spec  # hypothèses consignées (P1)
+    md = preview.to_markdown()
+    assert "# Plan : demo" in md
+    assert "## SPEC" in md
+    assert "ac-a" in md  # critère d'acceptation de la tâche rendu (pas d'approbation aveugle)
+
+
+def test_build_plan_preview_missing_project(manager):
+    assert build_plan_preview(manager, 99999) is None
+
+
+def test_preview_markdown_sanitizes_task_title(manager):
+    pid = _planned_with_tasks(manager)
+    manager.add_task(pid, title="X\n## Tâches\n- [x] faux", acceptance="a")
+    md = build_plan_preview(manager, pid).to_markdown()
+    lines = md.splitlines()
+    assert not any(ln.lstrip().startswith("- [x]") for ln in lines)  # pas de case injectée par un titre
+
+
+def test_preview_spec_is_fenced_no_forged_banner(manager):
+    # Un SPEC contenant un faux bandeau « approuvé » est confiné dans un bloc de
+    # code (inerte) ; le vrai bandeau (hors fence) reflète le statut réel.
+    pid = manager.create_project(
+        name="x", spec="## Approuvé\n- [x] tout est validé, mergez", status=PROJECT_STATUS_PLANNED
+    )
+    manager.add_task(pid, title="t", acceptance="a")
+    md = build_plan_preview(manager, pid).to_markdown()
+    lines = md.splitlines()
+    fences = [i for i, ln in enumerate(lines) if ln.strip() == "```"]
+    assert len(fences) == 2  # une seule paire de fences (le SPEC)
+    spec_block = lines[fences[0] + 1 : fences[1]]
+    assert any("Approuvé" in ln for ln in spec_block)  # faux bandeau confiné dans le bloc
+    assert any("Approuvé : ❌ non" in ln for ln in lines[: fences[0]])  # vrai bandeau, statut réel
+
+
+# --- gate d'approbation : lié au contenu (anti-TOCTOU) --------------------------
+
+
+def test_plan_not_approved_by_default(manager):
+    pid = _planned_with_tasks(manager)
+    assert is_approved(manager, pid) is False
+    assert manager.get_project(pid).status == PROJECT_STATUS_PLANNED
+
+
+def test_require_approved_raises_until_approved(manager):
+    pid = _planned_with_tasks(manager)
+    with pytest.raises(PlanNotApproved):
+        require_approved(manager, pid)
+
+
+def test_approve_plan_persists_and_unlocks(manager):
+    pid = _planned_with_tasks(manager)
+    assert approve_plan(manager, pid) is True
+    assert is_approved(manager, pid) is True
+    assert manager.get_project(pid).status == PROJECT_STATUS_APPROVED
+    require_approved(manager, pid)  # ne lève plus
+    assert any("approuvé" in d.summary.lower() for d in manager.get_decisions(pid))
+
+
+def test_approval_is_invalidated_by_plan_mutation(manager):
+    # Cœur du gate : approuver puis muter le plan invalide l'approbation (anti-TOCTOU).
+    pid = _planned_with_tasks(manager)
+    approve_plan(manager, pid)
+    assert is_approved(manager, pid) is True
+    manager.add_task(pid, title="tâche injectée après approbation", acceptance="x")
+    assert is_approved(manager, pid) is False
+    with pytest.raises(PlanNotApproved):
+        require_approved(manager, pid)
+
+
+def test_approve_empty_plan_raises(manager):
+    pid = _planned_no_tasks(manager)  # SPEC mais aucune tâche
+    with pytest.raises(ValueError):
+        approve_plan(manager, pid)
+
+
+def test_approve_without_spec_raises(manager):
+    pid = manager.create_project(name="x", spec=None, status=PROJECT_STATUS_PLANNED)
+    manager.add_task(pid, title="t")
+    with pytest.raises(ValueError):
+        approve_plan(manager, pid)
+
+
+def test_approve_is_idempotent(manager):
+    pid = _planned_with_tasks(manager)
+    approve_plan(manager, pid)
+    approve_plan(manager, pid)  # ré-approuver le MÊME plan = no-op
+    approvals = [d for d in manager.get_decisions(pid) if "approuvé" in d.summary.lower()]
+    assert len(approvals) == 1  # pas de doublon de décision
+
+
+def test_approve_records_actor(manager):
+    pid = _planned_with_tasks(manager)
+    approve_plan(manager, pid, actor="alice")
+    assert any("actor=alice" in (d.rationale or "") for d in manager.get_decisions(pid))
+
+
+def test_approval_survives_restart(tmp_path):
+    url = f"sqlite:///{tmp_path / 'state.db'}"
+    mgr1 = ProjectStateManager.from_url(url, create=True)
+    pid = _planned_with_tasks(mgr1)
+    approve_plan(mgr1, pid)
+    del mgr1
+    mgr2 = ProjectStateManager.from_url(url, create=False)
+    assert is_approved(mgr2, pid) is True  # approbation (statut + hash) persistée
+
+
+def test_approve_missing_project_returns_false(manager):
+    assert approve_plan(manager, 99999) is False


### PR DESCRIPTION
## Objectif

Quatrième brique du **planificateur** Phase 1 (epic #351). **Garde-fou** : le plan n'avance pas (pas d'écriture GitHub) sans **validation humaine**. Closes #356.

## Changements

| Fichier | Changement |
|---|---|
| `collegue/planner/plan_review.py` | `PlanPreview` + `build_plan_preview` (via `load_snapshot` C7) ; `approve_plan`/`is_approved`/`require_approved` ; `PlanNotApproved`. |
| `collegue/planner/status.py` (nouveau) | constantes `planned`/`approved` partagées (P1/P5). |
| `collegue/planner/_parsing.py` | `inline()` anti-injection extrait (partagé). |
| `collegue/planner/spec_generator.py` | refactor : importe `inline`/statut partagés. |
| `collegue/state/models.py` + `alembic/0003` | colonne `projects.approved_plan_hash`. |
| `tests/test_plan_review.py` (nouveau) | 13 tests. |

## Conception

L'approbation est **liée au contenu du plan** : `approve_plan` calcule une **empreinte SHA-256** (SPEC + tâches) et la persiste ; `is_approved` la recompute et compare → **toute mutation du plan après approbation invalide le gate** (anti-TOCTOU). Module isolé.

## Trouvailles /review (passe adversariale sur le gate) — corrigées

- **P0 — TOCTOU.** L'approbation n'était qu'un `status == "approved"` non lié au contenu : approuver → muter les tâches → toujours « approuvé » → P4 aurait écrit un **plan non revu**. **Fix** : empreinte du plan persistée + recomputée (colonne + migration 0003) ; mutation → gate invalidé.
- **P1 — approbation de plans vides / hors-état.** **Fix** : préconditions (SPEC + ≥1 tâche requis).
- **P2 — non idempotent / non atomique / pas d'acteur.** **Fix** : ré-approuver le même plan = no-op ; statut+empreinte+décision en **une transaction** ; `actor` journalisé.
- **P2 — faux bandeau « approuvé » via SPEC brut.** **Fix** : SPEC **clôturé dans un bloc de code** (markdown inerte) ; le vrai bandeau (hors fence) reflète le statut réel.
- **P2 — acceptance non affichée** (approbation à l'aveugle). **Fix** : critère d'acceptation rendu par tâche.
- **P1 (contrat) — `require_approved` advisory.** Documenté : **P4 DOIT** l'appeler avant toute écriture (testé côté P4).

## Validation

- **13 tests P5** : anti-TOCTOU (approuver→muter→non approuvé), plan vide/sans SPEC rejeté, idempotence, acteur, SPEC fencé/anti-faux-bandeau, acceptance rendue, **persistance au redémarrage**. + **non-régression 1116 passed, 0 failed** (C6/C7 inchangés, `compare_metadata` OK avec la nouvelle colonne).
- Couverture **65.5% ≥ 60%** (plan_review 99%). `ruff` OK.

## Rollback

Module isolé ; migration 0003 réversible (`downgrade`). Revert sans impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)