### PR TITLE
feat(planner): synchronisation du plan vers GitHub (P4)

### DIFF
--- a/alembic/versions/0004_task_issue_number.py
+++ b/alembic/versions/0004_task_issue_number.py
@@ -1,0 +1,32 @@
+"""numéro d'issue GitHub sur tasks (issue_number)
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-06-08
+
+Ajoute ``tasks.issue_number`` : mapping task↔issue GitHub après synchronisation
+(P4) + garde d'idempotence. batch_alter_table pour rester portable SQLite/PostgreSQL.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0004"
+down_revision: Union[str, None] = "0003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("tasks") as batch_op:
+        batch_op.add_column(sa.Column("issue_number", sa.Integer(), nullable=True))
+        batch_op.create_unique_constraint("uq_tasks_project_issue", ["project_id", "issue_number"])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("tasks") as batch_op:
+        batch_op.drop_constraint("uq_tasks_project_issue", type_="unique")
+        batch_op.drop_column("issue_number")

--- a/collegue/planner/__init__.py
+++ b/collegue/planner/__init__.py
@@ -9,6 +9,7 @@ enchaîne pas.
 """
 
 from collegue.planner.decomposer import decompose
+from collegue.planner.github_sync import SyncClients, SyncError, SyncResult, build_sync_preview, sync_plan
 from collegue.planner.plan_review import (
     PlanNotApproved,
     PlanPreview,
@@ -30,4 +31,9 @@ __all__ = [
     "approve_plan",
     "is_approved",
     "require_approved",
+    "sync_plan",
+    "build_sync_preview",
+    "SyncResult",
+    "SyncClients",
+    "SyncError",
 ]

--- a/collegue/planner/github_sync.py
+++ b/collegue/planner/github_sync.py
@@ -1,0 +1,227 @@
+"""Synchronisation du plan vers GitHub (P4, #355) — dernier maillon de la Phase 1.
+
+Matérialise le graphe de tâches (P2) en **issues GitHub liées** : corps avec
+critère d'acceptation + références de dépendances, **labels**, **milestone**, ajout
+au **board** (P3). N'écrit qu'**après** la validation humaine (P5) :
+``sync_plan(dry_run=False)`` appelle ``require_approved`` et **refuse d'écrire** si
+le plan n'est pas approuvé (ou a changé depuis).
+
+- ``dry_run=True`` (défaut) : décrit le plan d'écriture **sans toucher GitHub**.
+- Idempotence : une tâche déjà synchronisée (``issue_number`` posé) n'est pas recréée.
+- Ordre : tri **topologique** explicite du graphe (raise sur cycle ou dépendance
+  pendante), donc les dépendances d'une tâche ont déjà un numéro d'issue quand on
+  la traite → références incluses dès la création (pas de réécriture de corps, pas
+  de drop silencieux d'arête).
+
+Limites connues (gap inhérent GitHub+DB, à durcir au câblage Phase 3) :
+- **Atomicité** : create_issue (GitHub) puis update_task (DB) ne sont pas
+  transactionnels. ``issue_number`` est persisté **immédiatement** après le create
+  (fenêtre minimale) ; un crash entre les deux pourrait, au retry, recréer une
+  issue. Les ``issue_number`` déjà écrits tracent ce qui a été créé.
+- **TOCTOU** : l'approbation est vérifiée une fois en tête ; en exécution
+  concurrente (Phase 3), une mutation du plan pendant la boucle échapperait au gate
+  (mono-écrivain aujourd'hui).
+- **Métadonnées** : labels/milestone/board ne sont appliqués qu'aux issues créées
+  par ce run (pas de réconciliation des issues déjà existantes).
+
+Module **isolé** : non câblé au runtime tant que le pilote (Phase 3) ne l'enchaîne pas.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from collegue.planner.plan_review import require_approved
+from collegue.tools.github_commands import (
+    IssueCommands,
+    LabelCommands,
+    MilestoneCommands,
+    ProjectCommands,
+)
+
+DEFAULT_LABELS = ["autonome"]
+
+
+class SyncError(Exception):
+    """Graphe de tâches invalide pour la synchronisation (cycle, dépendance pendante)."""
+
+
+def _topo_sort_tasks(tasks: List[Any]) -> List[Any]:
+    """Ordonne les tâches topologiquement (dépendances d'abord).
+
+    Lève :class:`SyncError` sur dépendance pendante (id absent du projet) ou cycle —
+    on ne s'appuie PAS sur l'ordre d'insertion (un humain/re-plan peut le casser).
+    """
+    by_id = {t.id: t for t in tasks}
+    indegree = {t.id: 0 for t in tasks}
+    adjacency: Dict[int, List[int]] = {t.id: [] for t in tasks}
+    for task in tasks:
+        for dep in dict.fromkeys(task.depends_on or []):
+            if dep not in by_id:
+                raise SyncError(f"tâche {task.id} dépend de {dep}, absente du projet.")
+            adjacency[dep].append(task.id)
+            indegree[task.id] += 1
+    queue = deque(tid for tid in indegree if indegree[tid] == 0)
+    order: List[Any] = []
+    while queue:
+        node = queue.popleft()
+        order.append(by_id[node])
+        for nxt in adjacency[node]:
+            indegree[nxt] -= 1
+            if indegree[nxt] == 0:
+                queue.append(nxt)
+    if len(order) != len(tasks):
+        raise SyncError("cycle détecté dans le graphe de tâches.")
+    return order
+
+
+@dataclass
+class SyncClients:
+    """Clients GitHub injectables (mockés en test)."""
+
+    issues: Any
+    labels: Any
+    milestones: Any
+    projects: Any
+
+
+@dataclass
+class SyncResult:
+    dry_run: bool
+    issues: List[Dict[str, Any]]
+    milestone: Optional[str] = None
+    board: Optional[str] = None
+
+
+def _default_clients(token: Optional[str]) -> SyncClients:
+    return SyncClients(
+        issues=IssueCommands(token=token),
+        labels=LabelCommands(token=token),
+        milestones=MilestoneCommands(token=token),
+        projects=ProjectCommands(token=token),
+    )
+
+
+def _issue_body(task: Any, dep_numbers: List[int]) -> str:
+    parts: List[str] = []
+    if task.acceptance:
+        parts.append(f"## Critère d'acceptation\n{task.acceptance}")
+    if dep_numbers:
+        parts.append("Dépend de : " + ", ".join(f"#{n}" for n in dep_numbers))
+    parts.append(f"<!-- collegue-task:{task.id} -->")  # marqueur de traçabilité
+    return "\n\n".join(parts)
+
+
+def build_sync_preview(
+    manager: Any,
+    project_id: int,
+    *,
+    labels: Optional[List[str]] = None,
+    milestone_title: Optional[str] = None,
+    board_title: Optional[str] = None,
+) -> SyncResult:
+    """Décrit ce qui serait créé, sans écrire (dry-run). ``depends_on`` = ids de tâches
+    (les numéros d'issue n'existent pas avant création)."""
+    labels = labels or DEFAULT_LABELS
+    tasks = manager.get_tasks(project_id)
+    issues = [
+        {
+            "task_id": t.id,
+            "issue_number": t.issue_number,
+            "title": t.title,
+            "labels": list(labels),
+            "depends_on": t.depends_on or [],
+        }
+        for t in tasks
+    ]
+    return SyncResult(dry_run=True, issues=issues, milestone=milestone_title, board=board_title)
+
+
+def sync_plan(
+    manager: Any,
+    project_id: int,
+    owner: str,
+    repo: str,
+    *,
+    dry_run: bool = True,
+    labels: Optional[List[str]] = None,
+    milestone_title: Optional[str] = None,
+    board_title: Optional[str] = None,
+    token: Optional[str] = None,
+    clients: Optional[SyncClients] = None,
+) -> SyncResult:
+    """Synchronise le plan d'un projet vers GitHub (issues + labels + milestone + board).
+
+    ``dry_run=True`` (défaut) ne touche pas GitHub. ``dry_run=False`` exige un plan
+    **approuvé** (lève :class:`~collegue.planner.plan_review.PlanNotApproved` sinon)
+    et crée les issues liées de façon idempotente.
+    """
+    labels = labels or DEFAULT_LABELS
+    if dry_run:
+        return build_sync_preview(
+            manager, project_id, labels=labels, milestone_title=milestone_title, board_title=board_title
+        )
+
+    # Garde-fou (contrat P5) : aucune écriture sans approbation humaine valide.
+    require_approved(manager, project_id)
+
+    clients = clients or _default_clients(token)
+    tasks = manager.get_tasks(project_id)
+    order = _topo_sort_tasks(tasks)  # dépendances d'abord ; raise sur cycle/dep pendante
+
+    # Mapping task.id → numéro d'issue (inclut celles déjà synchronisées).
+    task_to_issue: Dict[int, int] = {t.id: t.issue_number for t in tasks if t.issue_number}
+
+    # Rien de neuf à créer → ne pas brûler d'appels API (ensure_*). Idempotent.
+    if all(t.id in task_to_issue for t in tasks):
+        return SyncResult(
+            dry_run=False, issues=[{"task_id": t.id, "issue_number": t.issue_number, "skipped": True} for t in order]
+        )
+
+    # Pré-garantir labels / milestone / board (idempotent).
+    for name in labels:
+        clients.labels.ensure_label(owner, repo, name)
+    milestone = clients.milestones.ensure_milestone(owner, repo, milestone_title) if milestone_title else None
+    board = clients.projects.ensure_project(owner, board_title) if board_title else None
+
+    created: List[Dict[str, Any]] = []
+    for task in order:
+        if task.id in task_to_issue:
+            created.append({"task_id": task.id, "issue_number": task_to_issue[task.id], "skipped": True})
+            continue
+        # Ordre topo + validation → toutes les dépendances ont déjà un numéro (pas de drop silencieux).
+        dep_numbers = [task_to_issue[d] for d in dict.fromkeys(task.depends_on or [])]
+        issue = clients.issues.create_issue(owner, repo, title=task.title, body=_issue_body(task, dep_numbers))
+        number = issue.number
+        task_to_issue[task.id] = number
+        manager.update_task(task.id, issue_number=number)
+        if labels:
+            clients.labels.add_labels_to_issue(owner, repo, number, labels)
+        if milestone is not None:
+            clients.milestones.assign_milestone(owner, repo, number, milestone.number)
+        if board is not None:
+            node_id = clients.projects.issue_node_id(owner, repo, number)
+            clients.projects.add_issue_to_project(board.id, node_id)
+        created.append(
+            {
+                "task_id": task.id,
+                "issue_number": number,
+                "title": task.title,
+                "labels": list(labels),
+                "depends_on_issues": dep_numbers,
+            }
+        )
+
+    manager.record_decision(
+        project_id,
+        summary=f"Plan synchronisé sur GitHub : {len(created)} issue(s)",
+        rationale=f"repo={owner}/{repo}; milestone={milestone_title}; board={board_title}",
+    )
+    return SyncResult(
+        dry_run=False,
+        issues=created,
+        milestone=(milestone.title if milestone else None),
+        board=(board.title if board else None),
+    )

--- a/collegue/state/manager.py
+++ b/collegue/state/manager.py
@@ -158,6 +158,17 @@ class ProjectStateManager:
             task.status = status
             return True
 
+    def update_task(self, task_id: int, **fields: Any) -> bool:
+        """Met à jour des champs d'une tâche (status, issue_number…). False si absente."""
+        with self.session() as s:
+            task = s.get(Task, task_id)
+            if task is None:
+                return False
+            for key, value in fields.items():
+                if hasattr(task, key):
+                    setattr(task, key, value)
+            return True
+
     # ── decisions ───────────────────────────────────────────────────────────────
 
     def add_decision(self, project_id: int, summary: str, rationale: Optional[str] = None) -> int:

--- a/collegue/state/models.py
+++ b/collegue/state/models.py
@@ -91,6 +91,9 @@ class Project(Base):
 
 class Task(Base):
     __tablename__ = "tasks"
+    # Un numéro d'issue GitHub ne mappe qu'une seule tâche (NULL multiples permis :
+    # tâches non encore synchronisées). Intégrité du mapping task↔issue (P4).
+    __table_args__ = (UniqueConstraint("project_id", "issue_number", name="uq_tasks_project_issue"),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     project_id: Mapped[int] = mapped_column(ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True)
@@ -99,6 +102,9 @@ class Task(Base):
     status: Mapped[str] = mapped_column(String(32), nullable=False, default="todo", server_default="todo")
     # Liste d'IDs de tâches dont celle-ci dépend (graphe de tâches).
     depends_on: Mapped[Optional[list]] = mapped_column(JSON, nullable=True)
+    # Numéro d'issue GitHub une fois la tâche synchronisée (P4) ; NULL sinon.
+    # Sert de mapping task↔issue et de garde d'idempotence (ne pas recréer).
+    issue_number: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         UTCDateTime, nullable=False, default=_utcnow, server_default=func.now()
     )

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -1,0 +1,246 @@
+"""Tests P4 (#355) : synchronisation du plan vers GitHub (clients mockés)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from collegue.planner import PlanNotApproved, Spec, approve_plan, persist_spec, sync_plan
+from collegue.planner.github_sync import SyncClients, SyncError, _default_clients
+from collegue.state import ProjectStateManager
+
+
+@pytest.fixture
+def manager(tmp_path):
+    return ProjectStateManager.from_url(f"sqlite:///{tmp_path / 'state.db'}", create=True)
+
+
+class _FakeIssues:
+    def __init__(self, start=100):
+        self.created = []
+        self._next = start  # GitHub numérote de façon monotone (jamais réutilisé)
+
+    def create_issue(self, owner, repo, title, body=None):
+        self._next += 1
+        self.created.append({"title": title, "body": body, "number": self._next})
+        return SimpleNamespace(number=self._next, title=title)
+
+
+class _FakeLabels:
+    def __init__(self):
+        self.ensured = []
+        self.added = []
+
+    def ensure_label(self, owner, repo, name, color="ededed", description=None):
+        self.ensured.append(name)
+        return SimpleNamespace(name=name)
+
+    def add_labels_to_issue(self, owner, repo, issue_number, labels):
+        self.added.append((issue_number, list(labels)))
+        return list(labels)
+
+
+class _FakeMilestones:
+    def __init__(self):
+        self.assigned = []
+
+    def ensure_milestone(self, owner, repo, title, description=None, due_on=None):
+        return SimpleNamespace(number=7, title=title)
+
+    def assign_milestone(self, owner, repo, issue_number, milestone_number):
+        self.assigned.append((issue_number, milestone_number))
+
+
+class _FakeProjects:
+    def __init__(self):
+        self.added = []
+
+    def ensure_project(self, owner, title):
+        return SimpleNamespace(id="BOARD1", number=1, title=title)
+
+    def issue_node_id(self, owner, repo, issue_number):
+        return f"NODE{issue_number}"
+
+    def add_issue_to_project(self, project_id, node_id):
+        self.added.append((project_id, node_id))
+        return "ITEM"
+
+
+def _clients():
+    return SyncClients(_FakeIssues(), _FakeLabels(), _FakeMilestones(), _FakeProjects())
+
+
+def _planned(manager, *, approve=False):
+    pid = persist_spec(manager, name="demo", spec=Spec(title="Demo", acceptance_criteria=["AC1"]))
+    a = manager.add_task(pid, title="A", acceptance="critère A")
+    manager.add_task(pid, title="B", acceptance="critère B", depends_on=[a])
+    if approve:
+        approve_plan(manager, pid)
+    return pid
+
+
+# --- dry-run --------------------------------------------------------------------
+
+
+def test_dry_run_describes_without_writing(manager):
+    pid = _planned(manager)
+    clients = _clients()
+    result = sync_plan(manager, pid, "o", "r", dry_run=True, clients=clients)
+    assert result.dry_run is True
+    assert [i["title"] for i in result.issues] == ["A", "B"]
+    assert clients.issues.created == []  # AUCUNE écriture
+
+
+def test_dry_run_does_not_require_approval(manager):
+    pid = _planned(manager, approve=False)  # non approuvé
+    result = sync_plan(manager, pid, "o", "r", dry_run=True, clients=_clients())
+    assert result.dry_run is True  # le dry-run (lecture seule) ne nécessite pas l'approbation
+
+
+# --- gate (P5) ------------------------------------------------------------------
+
+
+def test_real_sync_requires_approval(manager):
+    pid = _planned(manager, approve=False)
+    clients = _clients()
+    with pytest.raises(PlanNotApproved):
+        sync_plan(manager, pid, "o", "r", dry_run=False, clients=clients)
+    assert clients.issues.created == []  # rien écrit sans approbation
+
+
+# --- écriture réelle (approuvée) ------------------------------------------------
+
+
+def test_real_sync_creates_linked_issues(manager):
+    pid = _planned(manager, approve=True)
+    clients = _clients()
+    result = sync_plan(
+        manager,
+        pid,
+        "o",
+        "r",
+        dry_run=False,
+        labels=["autonome", "feature"],
+        milestone_title="Phase 1",
+        board_title="Board",
+        clients=clients,
+    )
+    assert result.dry_run is False
+    assert len(clients.issues.created) == 2
+    # B (créée après A) référence le numéro d'issue de A dans son corps.
+    a_number = clients.issues.created[0]["number"]
+    b_body = clients.issues.created[1]["body"]
+    assert f"#{a_number}" in b_body
+    assert "## Critère d'acceptation" in b_body
+    # labels appliqués à chaque issue
+    assert len(clients.labels.added) == 2
+    # milestone assigné, ajout au board
+    assert len(clients.milestones.assigned) == 2
+    assert len(clients.projects.added) == 2
+    assert result.milestone == "Phase 1" and result.board == "Board"
+    # issue_number persisté sur les tâches (mapping task↔issue)
+    assert all(t.issue_number for t in manager.get_tasks(pid))
+
+
+def test_real_sync_journals_decision(manager):
+    pid = _planned(manager, approve=True)
+    sync_plan(manager, pid, "o", "r", dry_run=False, clients=_clients())
+    assert any("synchronis" in d.summary.lower() for d in manager.get_decisions(pid))
+
+
+def test_real_sync_is_idempotent(manager):
+    pid = _planned(manager, approve=True)
+    clients1 = _clients()
+    sync_plan(manager, pid, "o", "r", dry_run=False, clients=clients1)
+    assert len(clients1.issues.created) == 2
+    # 2e run : approbation toujours valide (issue_number ne fait pas partie du hash),
+    # rien n'est recréé.
+    clients2 = _clients()
+    result = sync_plan(manager, pid, "o", "r", dry_run=False, clients=clients2)
+    assert clients2.issues.created == []  # aucune recréation
+    assert all(i.get("skipped") for i in result.issues)
+
+
+def test_real_sync_minimal_without_milestone_or_board(manager):
+    pid = _planned(manager, approve=True)
+    clients = _clients()
+    sync_plan(manager, pid, "o", "r", dry_run=False, clients=clients)
+    assert len(clients.issues.created) == 2
+    assert clients.milestones.assigned == []  # pas de milestone demandé
+    assert clients.projects.added == []  # pas de board demandé
+
+
+def test_dry_run_echoes_milestone_and_board(manager):
+    pid = _planned(manager)
+    result = sync_plan(
+        manager, pid, "o", "r", dry_run=True, milestone_title="Phase 1", board_title="Board", clients=_clients()
+    )
+    assert result.milestone == "Phase 1" and result.board == "Board"
+
+
+# --- graphe invalide : aucune écriture (anti drop silencieux d'arête) ----------
+
+
+def test_real_sync_raises_on_dangling_dependency(manager):
+    pid = persist_spec(manager, name="d", spec=Spec(title="D", acceptance_criteria=["AC"]))
+    manager.add_task(pid, title="A", depends_on=[99999])  # dépendance vers un id absent
+    approve_plan(manager, pid)
+    clients = _clients()
+    with pytest.raises(SyncError):
+        sync_plan(manager, pid, "o", "r", dry_run=False, clients=clients)
+    assert clients.issues.created == []  # rien écrit
+
+
+def test_real_sync_raises_on_cycle(manager):
+    pid = persist_spec(manager, name="d", spec=Spec(title="D", acceptance_criteria=["AC"]))
+    a = manager.add_task(pid, title="A")
+    b = manager.add_task(pid, title="B", depends_on=[a])
+    manager.update_task(a, depends_on=[b])  # A↔B cycle
+    approve_plan(manager, pid)
+    with pytest.raises(SyncError):
+        sync_plan(manager, pid, "o", "r", dry_run=False, clients=_clients())
+
+
+# --- idempotence : pas de gaspillage d'API quand tout est déjà synchronisé ------
+
+
+def test_idempotent_rerun_skips_ensure_calls(manager):
+    pid = _planned(manager, approve=True)
+    sync_plan(manager, pid, "o", "r", dry_run=False, labels=["autonome"], clients=_clients())
+    # 2e run : tout est déjà synchronisé → aucun ensure_label (pas de brûlage d'API).
+    clients2 = _clients()
+    result = sync_plan(manager, pid, "o", "r", dry_run=False, labels=["autonome"], clients=clients2)
+    assert clients2.labels.ensured == []
+    assert clients2.issues.created == []
+    assert all(i.get("skipped") for i in result.issues)
+
+
+# --- échec partiel : pas de double-création au retry (idempotence) --------------
+
+
+def test_partial_failure_then_retry_no_duplicate(manager):
+    pid = _planned(manager, approve=True)
+
+    class _FailSecond(_FakeIssues):
+        def create_issue(self, owner, repo, title, body=None):
+            if title == "B":
+                raise RuntimeError("réseau coupé sur la 2e issue")
+            return super().create_issue(owner, repo, title, body)
+
+    clients = SyncClients(_FailSecond(), _FakeLabels(), _FakeMilestones(), _FakeProjects())
+    with pytest.raises(RuntimeError):
+        sync_plan(manager, pid, "o", "r", dry_run=False, clients=clients)
+    # A a été créée et son issue_number persisté ; B non.
+    tasks = {t.title: t for t in manager.get_tasks(pid)}
+    assert tasks["A"].issue_number is not None
+    assert tasks["B"].issue_number is None
+
+    # Retry : A est skippée (pas de doublon), seule B est créée. Numérotation
+    # monotone (GitHub ne réutilise jamais un numéro) → pas de collision avec A.
+    clients2 = SyncClients(_FakeIssues(start=200), _FakeLabels(), _FakeMilestones(), _FakeProjects())
+    sync_plan(manager, pid, "o", "r", dry_run=False, clients=clients2)
+    assert [c["title"] for c in clients2.issues.created] == ["B"]
+
+
+def test_default_clients_smoke():
+    clients = _default_clients(token="x")
+    assert clients.issues and clients.labels and clients.milestones and clients.projects


### PR DESCRIPTION
## Objectif

**Dernier maillon** de la Phase 1 (epic #351). Matérialise le graphe de tâches (P2) en **issues GitHub liées** (corps = critère d'acceptation + références de dépendances, **labels**, **milestone**, **board** via P3), **sous validation humaine** (P5). Closes #355.

## Changements

| Fichier | Changement |
|---|---|
| `collegue/planner/github_sync.py` | `sync_plan(manager, project_id, owner, repo, *, dry_run=True, …)` ; `build_sync_preview` ; `SyncClients`/`SyncResult`/`SyncError`. |
| `collegue/state/models.py` + `alembic/0004` | colonne `tasks.issue_number` + contrainte unique `(project_id, issue_number)`. |
| `collegue/state/manager.py` | `update_task(task_id, **fields)`. |
| `tests/test_github_sync.py` (nouveau) | 13 tests (clients mockés). |

## Conception

- `dry_run=True` (défaut) : **décrit** le plan sans toucher GitHub. `dry_run=False` : appelle `require_approved` (gate P5) → **refuse d'écrire si non approuvé**.
- **Tri topologique** explicite → dépendances créées d'abord → refs `#N` incluses dès la création (pas de réécriture).
- **Idempotence** : `task.issue_number` (mapping task↔issue) → re-run ne recrée pas.

## Trouvailles /review (passe adversariale intégrative) — corrigées

- **P1 — drop SILENCIEUX d'arête de dépendance.** L'ordre `id == topo` n'était pas garanti ; un `depends_on` vers un id supérieur faisait disparaître l'arête du graphe GitHub **sans erreur**. **Fix** : tri **topologique** explicite + `SyncError` sur cycle / dépendance pendante (aucun drop).
- **P2 — `ensure_*` gaspillés** quand tout est déjà synchronisé (brûlage d'API). **Fix** : skip si rien à créer.
- **P2 — pas d'unicité du mapping.** **Fix** : contrainte unique `(project_id, issue_number)` (migration 0004) — a d'ailleurs attrapé une collision de fake en test.
- **P3 — preview n'échoyait pas milestone/board.** **Fix** : `build_sync_preview` les rend.
- **Gaps inhérents documentés** : atomicité GitHub+DB (issue_number persisté immédiatement → fenêtre minimale, pas de doublon au retry — testé), TOCTOU check→write (mono-écrivain ; à durcir en concurrence Phase 3), réconciliation des métadonnées.

## Validation

- **13 tests P4** : dry-run sans écriture, gate P5 (non approuvé → pas d'écriture), issues liées + refs deps + labels/milestone/board, **idempotence**, **échec partiel → pas de doublon au retry**, cycle / dépendance pendante rejetés, preview. + **non-régression 1129 passed, 0 failed** (C6/C7 OK avec la nouvelle colonne + contrainte, `compare_metadata` vert).
- Couverture **65.7% ≥ 60%** (github_sync 100%). `ruff` OK. Écritures GitHub réelles = `integration` (hors CI).

## Rollback

Module isolé ; migration 0004 réversible. Revert sans impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)