### PR TITLE
feat(executor): contrat CodeAgent + adaptateur OpenHands (E1)

### DIFF
--- a/collegue/executor/__init__.py
+++ b/collegue/executor/__init__.py
@@ -1,0 +1,22 @@
+"""Exécuteur d'une issue de bout en bout (Phase 2, epic #362).
+
+Automatise **une** issue : workspace en sandbox → agent codeur (OpenHands) →
+tests + revue experte → Pull Request gatée par la CI. E1 pose le contrat de
+l'agent codeur (:class:`CodeAgent`) et son adaptateur OpenHands.
+
+Module **isolé** : non importé par ``app.py``. Le pilote (Phase 3) câblera
+l'exécuteur sur le graphe de tâches. Import paresseux d'``OpenHandsAgent`` : il
+dépend de la couche LLM, mais surtout on garde ``collegue.executor`` importable
+sans rien tirer d'OpenHands.
+"""
+
+from collegue.executor.agent import AgentResult, CodeAgent, FakeCodeAgent, IssueSpec
+from collegue.executor.openhands_agent import OpenHandsAgent
+
+__all__ = [
+    "IssueSpec",
+    "AgentResult",
+    "CodeAgent",
+    "FakeCodeAgent",
+    "OpenHandsAgent",
+]

--- a/collegue/executor/agent.py
+++ b/collegue/executor/agent.py
@@ -1,0 +1,143 @@
+"""Contrat de l'agent codeur (E1, epic #362, brief §7 Phase 2).
+
+Frontière d'intégration de l'« exécuteur d'une issue » : un protocole
+:class:`CodeAgent` **indépendant** de la solution concrète (OpenHands ou autre),
+plus un :class:`FakeCodeAgent` déterministe pour la CI/les tests des enfants
+suivants (E2→E5). L'adaptateur OpenHands réel vit dans
+``collegue.executor.openhands_agent`` (exécution réelle derrière le marqueur
+``integration``).
+
+Découpage des responsabilités : l'agent **mute** le workspace (écrit/modifie des
+fichiers) ; la **capture autoritative du diff** (``git diff``) est faite par
+l'exécuteur (E2), pas ici. ``AgentResult.files_changed`` reste un *best-effort*
+auto-déclaré par l'agent.
+
+Module **isolé** : non câblé au runtime (le pilote Phase 3 câblera l'exécuteur).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping, Optional, Protocol, Tuple, runtime_checkable
+
+from collegue.textnorm import inline
+
+
+@dataclass(frozen=True)
+class IssueSpec:
+    """Issue normalisée passée à l'agent codeur.
+
+    ``number``/``title`` sont obligatoires ; ``body`` et ``acceptance_criteria``
+    sont optionnels. Le texte est **non fiable** (rédigé par un humain ou un LLM) :
+    :meth:`to_prompt` le passe par ``inline`` pour neutraliser l'injection Markdown
+    (pas de fausse section ``## ...`` ni de case ``- [x] ...`` qui détournerait la
+    consigne).
+    """
+
+    number: int
+    title: str
+    body: str = ""
+    acceptance_criteria: Tuple[str, ...] = ()
+
+    def to_prompt(self) -> str:
+        """Construit la consigne (sanitizée) donnée à l'agent.
+
+        Tout champ d'issue est ``inline``-isé : on accepte la perte de structure
+        multi-ligne du ``body`` en échange de la garantie qu'aucun contenu d'issue
+        ne peut forger une nouvelle ligne/section dans la consigne rendue.
+        """
+        lines = [f"Issue #{self.number}: {inline(self.title)}"]
+        body = inline(self.body)
+        if body:
+            lines += ["", body]
+        criteria = [inline(c) for c in self.acceptance_criteria if inline(c)]
+        if criteria:
+            lines += ["", "Critères d'acceptation :"]
+            lines += [f"- {c}" for c in criteria]
+        return "\n".join(lines)
+
+
+@dataclass
+class AgentResult:
+    """Résultat d'une passe de l'agent codeur sur une issue.
+
+    ``diff``/``files_changed`` sont auto-déclarés (best-effort) ; la capture
+    autoritative du diff revient à l'exécuteur (E2). ``success=False`` signale que
+    l'agent n'a pas pu produire de changement exploitable.
+    """
+
+    success: bool
+    diff: str = ""
+    files_changed: Tuple[str, ...] = ()
+    logs: str = ""
+    summary: str = ""
+
+
+@runtime_checkable
+class CodeAgent(Protocol):
+    """Protocole d'un agent capable d'implémenter une issue dans un workspace.
+
+    L'agent reçoit le chemin d'un workspace git déjà préparé (E2) et l'issue ; il
+    modifie les fichiers en place et renvoie un :class:`AgentResult`. Implémentations :
+    :class:`FakeCodeAgent` (CI) et ``OpenHandsAgent`` (réel, derrière ``integration``).
+    """
+
+    def implement_issue(self, workspace: str, issue: IssueSpec) -> AgentResult:
+        ...
+
+
+def _safe_join(workspace: str, relative: str) -> str:
+    """Joint ``relative`` à ``workspace`` en refusant toute évasion (``..``, absolu).
+
+    Même esprit que ``sandbox._validate_workspace`` : on ``realpath`` puis on vérifie
+    que le résultat reste confiné dans le workspace, pour qu'un chemin hostile ne
+    puisse pas écrire hors de la racine.
+    """
+    root = os.path.realpath(os.path.abspath(workspace))
+    target = os.path.realpath(os.path.join(root, relative))
+    if target == root:
+        raise ValueError(f"chemin vide / répertoire (pas un fichier): {relative!r}")
+    if os.path.commonpath([target, root]) != root:
+        raise ValueError(f"chemin hors du workspace {root}: {relative}")
+    return target
+
+
+class FakeCodeAgent:
+    """:class:`CodeAgent` déterministe pour la CI : écrit un jeu de fichiers fixe.
+
+    Sert de double de test aux enfants E2→E5 (workspace réel modifié → ``git diff``
+    non vide). ``succeed=False`` simule un agent qui échoue (aucun fichier écrit).
+    """
+
+    def __init__(
+        self,
+        files: Optional[Mapping[str, str]] = None,
+        *,
+        succeed: bool = True,
+        summary: str = "changement simulé",
+    ):
+        # Défaut : un fichier marqueur déterministe (suffit à produire un diff).
+        self._files = dict(files) if files is not None else {"COLLEGUE_FAKE.txt": "changement simulé\n"}
+        self._succeed = succeed
+        self._summary = summary
+
+    def implement_issue(self, workspace: str, issue: IssueSpec) -> AgentResult:
+        if not self._succeed:
+            return AgentResult(success=False, logs="fake agent : échec simulé", summary="échec simulé")
+        written = []
+        for relative, content in self._files.items():
+            path = _safe_join(workspace, relative)
+            # _safe_join garantit path != root, donc dirname(path) est non vide et
+            # confiné dans le workspace validé (pas de fallback sur l'arg brut).
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write(content)
+            written.append(relative)
+        files = tuple(sorted(written))
+        return AgentResult(
+            success=True,
+            files_changed=files,
+            summary=self._summary,
+            logs=f"fake agent : {len(files)} fichier(s) écrit(s) pour l'issue #{issue.number}",
+        )

--- a/collegue/executor/agent.py
+++ b/collegue/executor/agent.py
@@ -83,8 +83,7 @@ class CodeAgent(Protocol):
     :class:`FakeCodeAgent` (CI) et ``OpenHandsAgent`` (réel, derrière ``integration``).
     """
 
-    def implement_issue(self, workspace: str, issue: IssueSpec) -> AgentResult:
-        ...
+    def implement_issue(self, workspace: str, issue: IssueSpec) -> AgentResult: ...
 
 
 def _safe_join(workspace: str, relative: str) -> str:

--- a/collegue/executor/openhands_agent.py
+++ b/collegue/executor/openhands_agent.py
@@ -1,0 +1,98 @@
+"""Adaptateur OpenHands du contrat :class:`CodeAgent` (E1, epic #362).
+
+OpenHands est le codeur autonome retenu (décision §8). Il est **lourd** (runtime
+propre, configuration LLM, Docker) : on ne l'importe donc **jamais** comme
+dépendance Python de Collègue. Il tourne comme **processus** dans l'image du
+:class:`~collegue.sandbox.executor.DockerSandbox` (C8). Conséquence : aucun
+``import openhands`` ici — l'adaptateur ne fait que **construire la commande**
+headless et la **lancer via le sandbox**.
+
+Testabilité (cf. C8) : la **construction** de la commande et la **résolution du
+modèle** (rôle ``CODER``) sont pures et testées sans OpenHands ; l'**exécution
+réelle** est derrière le marqueur ``integration``.
+
+Pré-requis d'une exécution réelle (différés, integration) :
+- l'image sandbox doit embarquer OpenHands et ses dépendances ;
+- OpenHands a besoin du réseau (appels LLM) : utiliser un ``DockerSandbox`` avec
+  ``network`` ≠ ``none`` pour ce run précis ;
+- la **clé API** (secrète) est injectée au niveau du sandbox via l'environnement
+  (``-e LLM_API_KEY`` sans valeur dans l'argv, pour ne pas fuiter dans ``ps``),
+  **pas** dans la commande construite ici. Seul le **nom du modèle** (non secret)
+  est mis dans la commande.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+from collegue.core.llm.roles import LLMRole, resolve_role
+from collegue.executor.agent import AgentResult, IssueSpec
+
+# Point d'entrée headless d'OpenHands (module exécuté dans le conteneur sandbox).
+OPENHANDS_ENTRYPOINT = "openhands.core.main"
+
+
+class OpenHandsAgent:
+    """:class:`CodeAgent` pilotant OpenHands en headless dans le ``DockerSandbox``.
+
+    ``sandbox`` est un objet exposant ``run_command(argv, workspace) -> SandboxResult``
+    (duck-typing : un faux sandbox suffit en CI). ``role`` détermine le couple
+    (provider, modèle) via :func:`resolve_role` (défaut : ``CODER``).
+    """
+
+    def __init__(
+        self,
+        sandbox,
+        *,
+        role: LLMRole = LLMRole.CODER,
+        settings_obj: Optional[object] = None,
+        entrypoint: str = OPENHANDS_ENTRYPOINT,
+        python_bin: str = "python",
+    ):
+        self._sandbox = sandbox
+        self._role = role
+        self._settings = settings_obj
+        self._entrypoint = entrypoint
+        self._python_bin = python_bin
+
+    def resolved_model(self) -> Tuple[str, str]:
+        """Retourne ``(provider, model)`` pour le rôle de cet agent (défaut CODER).
+
+        Délègue à :func:`resolve_role` : config dédiée au rôle si présente, sinon
+        fallback sur le couple global ``LLM_PROVIDER`` / ``LLM_MODEL``.
+        """
+        return resolve_role(self._role, self._settings)
+
+    def build_command(self, issue: IssueSpec) -> List[str]:
+        """Construit l'argv OpenHands headless (pur, testable sans OpenHands).
+
+        Le **nom du modèle** (non secret) est passé via ``env LLM_MODEL=...`` ; la
+        clé API reste hors argv (injectée par le sandbox à l'exécution réelle). La
+        consigne est ``issue.to_prompt()`` (déjà sanitizée contre l'injection).
+        On passe un **argv** (pas de ``sh -c``) : aucun risque d'injection shell via
+        le texte de l'issue.
+        """
+        _provider, model = self.resolved_model()
+        return [
+            "env",
+            f"LLM_MODEL={model}",
+            self._python_bin,
+            "-m",
+            self._entrypoint,
+            "-t",
+            issue.to_prompt(),
+        ]
+
+    def implement_issue(self, workspace: str, issue: IssueSpec) -> AgentResult:
+        """Lance OpenHands dans le sandbox sur ``workspace`` pour ``issue``.
+
+        Le diff autoritatif est capturé par l'exécuteur (E2) ; ici on ne renvoie que
+        le statut (code de sortie du sandbox) et les logs.
+        """
+        result = self._sandbox.run_command(self.build_command(issue), workspace)
+        logs = "\n".join(part for part in (result.stdout, result.stderr) if part).strip()
+        return AgentResult(
+            success=result.ok,
+            logs=logs,
+            summary=f"OpenHands sur l'issue #{issue.number}",
+        )

--- a/collegue/planner/_parsing.py
+++ b/collegue/planner/_parsing.py
@@ -8,18 +8,14 @@ prose ou de blocs ```json). Évite la duplication entre ``spec_generator`` et
 from __future__ import annotations
 
 import json
-import re
-from typing import Any, Optional
+from typing import Optional
 
+# ``inline`` vit dans un module léger et sans dépendance (importable hors planner,
+# ex. par l'exécuteur Phase 2) ; on le ré-exporte ici pour ne pas changer la
+# surface publique de ``_parsing`` (les modules du planner l'importent d'ici).
+from collegue.textnorm import inline
 
-def inline(text: Any) -> str:
-    """Réduit une valeur à une seule ligne (anti-injection Markdown).
-
-    Écrase tout enchaînement d'espaces/sauts de ligne en une espace : un champ
-    issu du LLM ne peut donc pas démarrer une nouvelle ligne dans un document
-    rendu (pas de fausse section ``## ...`` ni de case ``- [x] ...``).
-    """
-    return re.sub(r"\s+", " ", str(text)).strip()
+__all__ = ["inline", "json_from_text"]
 
 
 def json_from_text(text: str) -> Optional[dict]:

--- a/collegue/textnorm.py
+++ b/collegue/textnorm.py
@@ -1,0 +1,23 @@
+"""Normalisation de texte partagée (anti-injection Markdown).
+
+Module **léger et sans dépendance** (seulement la stdlib) : il peut être importé
+par n'importe quel sous-système sans tirer de dépendance lourde. C'est pourquoi
+``inline`` vit ici plutôt que dans ``collegue.planner._parsing`` (dont le package
+``planner`` charge l'état SQLAlchemy au moindre import de sous-module).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+def inline(text: Any) -> str:
+    """Réduit une valeur à une seule ligne (anti-injection Markdown).
+
+    Écrase tout enchaînement d'espaces/sauts de ligne en une espace : un champ
+    issu d'une source non fiable (LLM, issue) ne peut donc pas démarrer une
+    nouvelle ligne dans un document rendu (pas de fausse section ``## ...`` ni de
+    case ``- [x] ...``).
+    """
+    return re.sub(r"\s+", " ", str(text)).strip()

--- a/tests/test_executor_agent.py
+++ b/tests/test_executor_agent.py
@@ -1,0 +1,189 @@
+"""Tests E1 (#363) : contrat CodeAgent + adaptateur OpenHands (isolé, fake en CI)."""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from collegue.executor import AgentResult, CodeAgent, FakeCodeAgent, IssueSpec, OpenHandsAgent
+from collegue.sandbox import SandboxResult
+
+# --- IssueSpec / sanitisation ---------------------------------------------------
+
+
+def test_issue_to_prompt_sanitizes_markdown_injection():
+    issue = IssueSpec(
+        number=42,
+        title="Ajouter   le  endpoint",
+        body="Ligne 1\n## Fausse section\n- [x] faux critère coché",
+        acceptance_criteria=("Retourne 200", "  Gère\nles\terreurs  "),
+    )
+    prompt = issue.to_prompt()
+    # Titre/critères inline-isés : pas de saut de ligne forgé par le contenu d'issue.
+    assert "Issue #42: Ajouter le endpoint" in prompt
+    # Le body multi-ligne est réduit à UNE seule ligne (le contenu reste, mais ne
+    # peut plus forger de fausse section ## ni de case - [x]).
+    assert "Ligne 1 ## Fausse section - [x] faux critère coché" in prompt
+    assert "\n## Fausse section" not in prompt  # ne démarre jamais une ligne
+    assert "- Gère les erreurs" in prompt  # critère ré-inliné
+
+
+def test_issue_to_prompt_minimal():
+    prompt = IssueSpec(number=1, title="Titre").to_prompt()
+    assert prompt == "Issue #1: Titre"
+
+
+def test_issue_to_prompt_drops_blank_criteria():
+    prompt = IssueSpec(number=1, title="T", acceptance_criteria=("", "   ", "Vrai")).to_prompt()
+    assert "- Vrai" in prompt
+    assert prompt.count("- ") == 1  # les critères vides sont ignorés
+
+
+# --- FakeCodeAgent --------------------------------------------------------------
+
+
+def test_fake_agent_writes_default_marker(tmp_path):
+    agent = FakeCodeAgent()
+    result = agent.implement_issue(str(tmp_path), IssueSpec(number=7, title="T"))
+    assert result.success is True
+    assert result.files_changed == ("COLLEGUE_FAKE.txt",)
+    assert (tmp_path / "COLLEGUE_FAKE.txt").read_text(encoding="utf-8") == "changement simulé\n"
+
+
+def test_fake_agent_writes_custom_nested_files(tmp_path):
+    agent = FakeCodeAgent({"src/app.py": "print('hi')\n", "README.md": "# Hi\n"})
+    result = agent.implement_issue(str(tmp_path), IssueSpec(number=1, title="T"))
+    assert result.success is True
+    assert result.files_changed == ("README.md", "src/app.py")  # trié
+    assert (tmp_path / "src" / "app.py").read_text(encoding="utf-8") == "print('hi')\n"
+
+
+def test_fake_agent_failure_writes_nothing(tmp_path):
+    result = FakeCodeAgent(succeed=False).implement_issue(str(tmp_path), IssueSpec(number=1, title="T"))
+    assert result.success is False
+    assert result.files_changed == ()
+    assert list(tmp_path.iterdir()) == []  # aucun fichier écrit
+
+
+def test_fake_agent_rejects_path_traversal(tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    agent = FakeCodeAgent({"../evil.txt": "pwn"})
+    with pytest.raises(ValueError):
+        agent.implement_issue(str(work), IssueSpec(number=1, title="T"))
+    assert not (tmp_path / "evil.txt").exists()  # rien écrit hors du workspace
+
+
+def test_fake_agent_rejects_absolute_path(tmp_path):
+    agent = FakeCodeAgent({"/etc/passwd": "pwn"})
+    with pytest.raises(ValueError):
+        agent.implement_issue(str(tmp_path), IssueSpec(number=1, title="T"))
+
+
+def test_fake_agent_rejects_empty_or_dir_path(tmp_path):
+    # Un nom vide / "." résout vers la racine du workspace : refusé proprement
+    # (ValueError), pas d'IsADirectoryError opaque au moment du open().
+    for bad in ("", "."):
+        with pytest.raises(ValueError):
+            FakeCodeAgent({bad: "x"}).implement_issue(str(tmp_path), IssueSpec(number=1, title="T"))
+
+
+# --- Protocole ------------------------------------------------------------------
+
+
+def test_codeagent_protocol_runtime_checkable():
+    assert isinstance(FakeCodeAgent(), CodeAgent)
+    assert isinstance(OpenHandsAgent(sandbox=object()), CodeAgent)
+    assert not isinstance(object(), CodeAgent)
+
+
+# --- OpenHandsAgent (construction pure, sans OpenHands) --------------------------
+
+
+def _settings(**kw):
+    base = {"LLM_PROVIDER": "gemini", "LLM_MODEL": "global-model"}
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def test_openhands_resolved_model_uses_coder_role():
+    agent = OpenHandsAgent(
+        sandbox=object(),
+        settings_obj=_settings(LLM_PROVIDER_CODER="openai", LLM_MODEL_CODER="gpt-coder"),
+    )
+    assert agent.resolved_model() == ("openai", "gpt-coder")
+
+
+def test_openhands_resolved_model_falls_back_to_global():
+    agent = OpenHandsAgent(sandbox=object(), settings_obj=_settings())
+    assert agent.resolved_model() == ("gemini", "global-model")
+
+
+def test_openhands_build_command_carries_task_and_model_not_secret():
+    agent = OpenHandsAgent(sandbox=object(), settings_obj=_settings(LLM_MODEL_CODER="coder-x"))
+    issue = IssueSpec(number=9, title="Faire la chose")
+    argv = agent.build_command(issue)
+    assert argv[0] == "env"
+    assert "LLM_MODEL=coder-x" in argv
+    assert "-t" in argv
+    assert argv[argv.index("-t") + 1] == issue.to_prompt()
+    assert "openhands.core.main" in argv
+    # La clé API ne doit jamais apparaître dans l'argv (fuite via ps).
+    assert not any("API_KEY" in part for part in argv)
+
+
+class _FakeSandbox:
+    """Sandbox factice : enregistre l'argv et renvoie un SandboxResult canné."""
+
+    def __init__(self, result: SandboxResult):
+        self._result = result
+        self.calls = []
+
+    def run_command(self, argv, workspace):
+        self.calls.append((list(argv), workspace))
+        return self._result
+
+
+def test_openhands_implement_issue_success_maps_sandbox_result():
+    sandbox = _FakeSandbox(SandboxResult(exit_code=0, stdout="ok", stderr=""))
+    agent = OpenHandsAgent(sandbox=sandbox, settings_obj=_settings())
+    issue = IssueSpec(number=3, title="T")
+    result = agent.implement_issue("/work", issue)
+    assert isinstance(result, AgentResult)
+    assert result.success is True
+    assert "ok" in result.logs
+    # Le sandbox a bien reçu l'argv construit, sur le bon workspace.
+    assert sandbox.calls == [(agent.build_command(issue), "/work")]
+
+
+def test_openhands_implement_issue_failure_is_not_success():
+    sandbox = _FakeSandbox(SandboxResult(exit_code=1, stdout="", stderr="boom"))
+    agent = OpenHandsAgent(sandbox=sandbox, settings_obj=_settings())
+    result = agent.implement_issue("/work", IssueSpec(number=1, title="T"))
+    assert result.success is False
+    assert "boom" in result.logs
+
+
+def test_openhands_implement_issue_timeout_is_not_success():
+    sandbox = _FakeSandbox(SandboxResult(exit_code=124, stdout="", stderr="", timed_out=True))
+    agent = OpenHandsAgent(sandbox=sandbox, settings_obj=_settings())
+    assert agent.implement_issue("/work", IssueSpec(number=1, title="T")).success is False
+
+
+# --- Isolation ------------------------------------------------------------------
+
+
+def test_importing_executor_does_not_pull_openhands():
+    # Importer l'exécuteur ne doit tirer aucune dépendance OpenHands (elle vit
+    # dans l'image sandbox, pas dans le package Python).
+    import collegue.executor  # noqa: F401
+
+    assert not any(name == "openhands" or name.startswith("openhands.") for name in sys.modules)
+
+
+def test_app_does_not_wire_executor():
+    # Garde d'isolation : app.py ne câble pas l'exécuteur (le pilote Phase 3 le fera).
+    app_src = (Path(__file__).resolve().parent.parent / "collegue" / "app.py").read_text(encoding="utf-8")
+    assert "collegue.executor" not in app_src
+    assert "from collegue.executor" not in app_src


### PR DESCRIPTION
Premier enfant de l'epic #362 (**Phase 2 — exécuteur d'une issue**). Pose la **frontière d'intégration** de l'agent codeur. `Closes #363`.

## Ce que ça ajoute

Nouveau module **ISOLÉ** `collegue/executor/` (non câblé au runtime — le pilote Phase 3 le câblera) :

- **`agent.py`**
  - `IssueSpec` (number/title/body/acceptance) + `to_prompt()` qui **sanitize** chaque champ via `inline()` (anti-injection markdown : un contenu d'issue ne peut pas forger de fausse section `##` ni de case `- [x]`).
  - `AgentResult` (success / diff / files_changed / logs / summary).
  - `CodeAgent` **Protocol** (`@runtime_checkable`) : `implement_issue(workspace, issue) -> AgentResult`.
  - `FakeCodeAgent` : double déterministe pour la CI (écrit un jeu de fichiers → diff réel pour E2+), avec garde `_safe_join` anti-évasion (`..`, chemin absolu, `""`/`"."` → `ValueError`).
- **`openhands_agent.py`** — `OpenHandsAgent(CodeAgent)`
  - OpenHands tourne comme **processus dans le `DockerSandbox`** (C8), **jamais** importé en Python (dépendance lourde tenue hors du package).
  - `resolved_model()` → couple (provider, modèle) du rôle **CODER** via `resolve_role` (`.env`, fallback global).
  - `build_command()` met le **nom du modèle** (non secret) dans l'argv ; la **clé API reste hors argv** (pas de fuite via `ps`). Argv (pas de `sh -c`) → pas d'injection shell par le texte d'issue.
  - Exécution réelle d'OpenHands derrière le marqueur `integration` (réseau + creds configurés au niveau sandbox).

## Refactor de support

- `inline` extrait vers **`collegue/textnorm.py`** (module léger, stdlib only) pour qu'importer l'exécuteur ne tire **pas** `planner → state → sqlalchemy`. `collegue/planner/_parsing.py` le **ré-exporte** (surface publique inchangée, 3 modules planner intacts).

## Tests & qualité

- `tests/test_executor_agent.py` : **18 tests** — sanitisation, écriture de fichiers, anti-évasion (`..`/absolu/vide), Protocol `runtime_checkable`, résolution de modèle (rôle CODER + fallback), construction d'argv (modèle présent, **clé API absente**), mapping succès/échec/timeout du sandbox, et **gardes d'isolation** (import n'amène pas OpenHands ; `app.py` ne câble pas l'exécuteur).
- Couverture du nouveau code ~99 %. **Ruff** clean. Tests exécutés dans `collegue-app:latest`.
- Passe `/review` adversariale (contexte frais) : aucun défaut bloquant ; 3 nits corrigés (rejet propre des chemins vides, `makedirs` sur chemin validé, assertion de test renforcée).

## Hors périmètre (enfants suivants)

E2 capture le diff autoritatif (`git diff`) ; E3 = tests + revue experte ; E4 = ouverture de PR ; E5 = assemblage `execute_issue()` + sync état.