### PR TITLE
feat(executor): préparation workspace git + exécution agent → diff (E2)

### DIFF
--- a/collegue/executor/__init__.py
+++ b/collegue/executor/__init__.py
@@ -5,18 +5,32 @@ tests + revue experte → Pull Request gatée par la CI. E1 pose le contrat de
 l'agent codeur (:class:`CodeAgent`) et son adaptateur OpenHands.
 
 Module **isolé** : non importé par ``app.py``. Le pilote (Phase 3) câblera
-l'exécuteur sur le graphe de tâches. Import paresseux d'``OpenHandsAgent`` : il
-dépend de la couche LLM, mais surtout on garde ``collegue.executor`` importable
-sans rien tirer d'OpenHands.
+l'exécuteur sur le graphe de tâches. ``OpenHandsAgent`` est importé directement
+ici, mais ne tire **aucune** dépendance OpenHands (OpenHands tourne comme
+processus dans le sandbox, jamais importé en Python) — ``collegue.executor``
+reste donc importable partout sans installer OpenHands.
 """
 
 from collegue.executor.agent import AgentResult, CodeAgent, FakeCodeAgent, IssueSpec
+from collegue.executor.command import CommandRunner, LocalCommandRunner
 from collegue.executor.openhands_agent import OpenHandsAgent
+from collegue.executor.runner import ExecutionResult, run_issue
+from collegue.executor.workspace import Workspace, WorkspaceError, branch_for_issue, prepare_workspace
 
 __all__ = [
+    # E1 — contrat agent
     "IssueSpec",
     "AgentResult",
     "CodeAgent",
     "FakeCodeAgent",
     "OpenHandsAgent",
+    # E2 — workspace + exécution
+    "CommandRunner",
+    "LocalCommandRunner",
+    "Workspace",
+    "WorkspaceError",
+    "branch_for_issue",
+    "prepare_workspace",
+    "ExecutionResult",
+    "run_issue",
 ]

--- a/collegue/executor/command.py
+++ b/collegue/executor/command.py
@@ -1,0 +1,95 @@
+"""Exécution de commandes pour l'exécuteur (E2, epic #362).
+
+Deux backends partagent une même interface (:class:`CommandRunner`) — un
+``run_command(cmd, workspace) -> SandboxResult`` :
+
+- :class:`~collegue.sandbox.executor.DockerSandbox` (C8) : exécution **isolée**,
+  pour le code non fiable (agent OpenHands, suite de tests) et, en
+  ``integration``, la plomberie git sur un dépôt potentiellement hostile.
+- :class:`LocalCommandRunner` : exécution **locale** (hôte), **sans isolation**,
+  réservée à la CI sans Docker pour de la **plomberie git sur un dépôt de
+  confiance / fixture**. Jamais pour exécuter du code non fiable.
+
+``DockerSandbox`` satisfait déjà ce protocole — on réutilise donc le même
+:class:`SandboxResult` ici, et l'exécuteur (E2+) est paramétré par le runner.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from typing import List, Optional, Protocol, Union, runtime_checkable
+
+from collegue.sandbox.executor import TIMEOUT_EXIT_CODE, SandboxResult
+
+# Code de sortie conventionnel quand le binaire est introuvable (cf. shell 127).
+COMMAND_NOT_FOUND_EXIT_CODE = 127
+
+
+@runtime_checkable
+class CommandRunner(Protocol):
+    """Tout objet capable d'exécuter une commande dans un workspace.
+
+    Contrat identique à ``DockerSandbox.run_command`` afin que le sandbox durci et
+    le runner local soient interchangeables.
+    """
+
+    def run_command(self, cmd: Union[str, List[str]], workspace: str) -> SandboxResult: ...
+
+
+class LocalCommandRunner:
+    """Exécute des commandes EN LOCAL (hôte), sans aucune isolation.
+
+    Destiné à la **plomberie git** (clone, diff…) sur un dépôt de confiance en CI,
+    là où Docker n'est pas disponible. **Ne jamais** y exécuter du code non fiable
+    (agent, tests) : utiliser le :class:`DockerSandbox`.
+
+    La sortie est **bornée** (écrite sur disque puis relue avec un plafond), comme
+    le sandbox, pour qu'une sortie pathologique ne fasse pas exploser la mémoire.
+    """
+
+    def __init__(self, *, timeout: float = 120.0, max_output_bytes: int = 10 * 1024 * 1024):
+        self.timeout = timeout
+        self.max_output_bytes = max_output_bytes
+
+    def _read_capped(self, path: str) -> str:
+        with open(path, "rb") as handle:
+            data = handle.read(self.max_output_bytes + 1)
+        text = data[: self.max_output_bytes].decode("utf-8", errors="replace")
+        if len(data) > self.max_output_bytes:
+            text += f"\n[local] sortie tronquée à {self.max_output_bytes} octets"
+        return text
+
+    def run_command(self, cmd: Union[str, List[str]], workspace: str) -> SandboxResult:
+        argv = ["sh", "-c", cmd] if isinstance(cmd, str) else list(cmd)
+        out_f = tempfile.NamedTemporaryFile(prefix="local-out-", delete=False)
+        err_f = tempfile.NamedTemporaryFile(prefix="local-err-", delete=False)
+        out_path, err_path = out_f.name, err_f.name
+        timed_out = False
+        try:
+            try:
+                proc = subprocess.run(argv, cwd=workspace, stdout=out_f, stderr=err_f, timeout=self.timeout)
+                exit_code: Optional[int] = proc.returncode
+            except subprocess.TimeoutExpired:
+                exit_code = TIMEOUT_EXIT_CODE
+                timed_out = True
+            except FileNotFoundError:
+                exit_code = COMMAND_NOT_FOUND_EXIT_CODE
+            finally:
+                out_f.close()
+                err_f.close()
+
+            stdout = self._read_capped(out_path)
+            stderr = self._read_capped(err_path)
+            if exit_code == COMMAND_NOT_FOUND_EXIT_CODE:
+                stderr = (stderr + f"\n[local] binaire introuvable: {argv[0]}").strip()
+            if timed_out:
+                stderr += f"\n[local] délai dépassé après {self.timeout:g}s"
+            return SandboxResult(exit_code=exit_code, stdout=stdout, stderr=stderr, timed_out=timed_out)
+        finally:
+            for path in (out_path, err_path):
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass

--- a/collegue/executor/runner.py
+++ b/collegue/executor/runner.py
@@ -1,0 +1,81 @@
+"""Exécution d'une issue dans un workspace préparé (E2, epic #362).
+
+Fait tourner le :class:`~collegue.executor.agent.CodeAgent` sur un
+:class:`~collegue.executor.workspace.Workspace`, puis capture le **diff
+autoritatif** via git (l'``AgentResult.files_changed`` auto-déclaré ne fait pas
+foi). Le diff est lu via un :class:`~collegue.executor.command.CommandRunner` :
+``LocalCommandRunner`` en CI, ``DockerSandbox`` en ``integration`` (git dans le
+conteneur). La sortie est bornée par le plafond du runner (anti-OOM).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from collegue.executor.agent import AgentResult, CodeAgent, IssueSpec
+from collegue.executor.command import CommandRunner, LocalCommandRunner
+from collegue.executor.workspace import Workspace, WorkspaceError
+
+TASK_STATUS_IN_PROGRESS = "in_progress"
+
+
+@dataclass(frozen=True)
+class ExecutionResult:
+    """Résultat de l'exécution d'une issue (avant tests/revue, E3)."""
+
+    agent_result: AgentResult
+    changed: bool  # l'agent a-t-il produit un diff non vide ?
+    diff: str  # diff unifié vs HEAD (capé par le runner)
+    files_changed: Tuple[str, ...]  # fichiers modifiés/ajoutés/supprimés (autoritatif)
+    success: bool  # agent OK ET au moins un changement
+
+
+def run_issue(
+    agent: CodeAgent,
+    workspace: Workspace,
+    issue: IssueSpec,
+    *,
+    runner: Optional[CommandRunner] = None,
+    manager: Optional[object] = None,
+    task_id: Optional[int] = None,
+    git_bin: str = "git",
+) -> ExecutionResult:
+    """Exécute ``agent`` sur ``workspace`` pour ``issue`` et capture le diff.
+
+    Si ``manager`` et ``task_id`` sont fournis, marque la tâche ``in_progress`` au
+    démarrage (la suite — ``in_review`` / fail-closed — est gérée par E5).
+
+    Un diff vide (agent no-op) n'est **pas** une erreur : ``changed=False`` et
+    ``success=False`` sans exception. En revanche une erreur git de bas niveau
+    (workspace cassé) lève :class:`WorkspaceError`.
+    """
+    runner = runner or LocalCommandRunner()
+
+    if manager is not None and task_id is not None:
+        manager.update_task_status(task_id, TASK_STATUS_IN_PROGRESS)
+
+    agent_result = agent.implement_issue(workspace.path, issue)
+
+    # Diff autoritatif : on stage tout (inclut les fichiers neufs/supprimés) puis on
+    # lit le diff vs HEAD. `git diff --staged` retourne 0 même quand il y a des
+    # changements ; un code non nul = vraie erreur de plomberie → on lève.
+    add = runner.run_command([git_bin, "add", "-A"], workspace.path)
+    if not add.ok:
+        raise WorkspaceError(f"git add a échoué: {add.stderr.strip() or add.stdout.strip()}")
+    diff_res = runner.run_command([git_bin, "diff", "--staged"], workspace.path)
+    if not diff_res.ok:
+        raise WorkspaceError(f"git diff a échoué: {diff_res.stderr.strip()}")
+    names_res = runner.run_command([git_bin, "diff", "--staged", "--name-only"], workspace.path)
+    if not names_res.ok:
+        raise WorkspaceError(f"git diff --name-only a échoué: {names_res.stderr.strip()}")
+
+    files_changed = tuple(line for line in names_res.stdout.splitlines() if line.strip())
+    changed = bool(files_changed)
+    return ExecutionResult(
+        agent_result=agent_result,
+        changed=changed,
+        diff=diff_res.stdout,
+        files_changed=files_changed,
+        success=bool(agent_result.success and changed),
+    )

--- a/collegue/executor/workspace.py
+++ b/collegue/executor/workspace.py
@@ -1,0 +1,89 @@
+"""Préparation d'un workspace git pour exécuter une issue (E2, epic #362).
+
+Repo-agnostique (décision epic #362) : on prend un ``repo_source`` (dépôt git
+existant) et une :class:`~collegue.executor.agent.IssueSpec`, et on produit un
+**workspace isolé** — un clone dans un répertoire temporaire, sur une **branche
+dédiée** ``collegue/issue-<N>``, avec le **commit de base** mémorisé.
+
+Opération **hôte** par nature : le dépôt source vit sur l'hôte (pas dans un
+sandbox), donc le clone/branche se fait en local. C'est de la plomberie git sur
+un dépôt de confiance/fixture ; l'exécution de code non fiable (l'agent, les
+tests) viendra plus tard et passera, elle, par le :class:`DockerSandbox`.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from dataclasses import dataclass
+
+from collegue.executor.agent import IssueSpec
+from collegue.executor.command import LocalCommandRunner
+
+BRANCH_PREFIX = "collegue/issue-"
+
+
+@dataclass(frozen=True)
+class Workspace:
+    """Workspace git prêt pour l'agent."""
+
+    path: str  # racine du clone (à monter dans le sandbox pour l'exécution)
+    branch: str  # branche dédiée à l'issue
+    base_commit: str  # SHA du commit de base (avant le travail de l'agent)
+
+
+class WorkspaceError(RuntimeError):
+    """Échec de préparation du workspace (source invalide, git en erreur…)."""
+
+
+def branch_for_issue(number: int) -> str:
+    """Nom de branche déterministe et sûr pour une issue (numéro = entier)."""
+    return f"{BRANCH_PREFIX}{int(number)}"
+
+
+def prepare_workspace(
+    repo_source: str,
+    issue: IssueSpec,
+    *,
+    dest_root: str | None = None,
+    git_bin: str = "git",
+) -> Workspace:
+    """Clone ``repo_source`` dans un workspace dédié sur une branche par issue.
+
+    Args:
+        repo_source: chemin d'un dépôt git existant (working tree avec ``.git``).
+        issue: l'issue à traiter (son numéro nomme la branche).
+        dest_root: répertoire parent où créer le workspace (défaut : un tmpdir).
+        git_bin: binaire git (injectable pour les tests).
+
+    Returns:
+        :class:`Workspace` (chemin du clone, branche, commit de base).
+
+    Raises:
+        WorkspaceError: si la source n'est pas un dépôt git ou si git échoue.
+    """
+    source = os.path.realpath(os.path.abspath(repo_source))
+    if not os.path.isdir(os.path.join(source, ".git")):
+        raise WorkspaceError(f"repo_source n'est pas un dépôt git: {repo_source}")
+
+    parent = dest_root or tempfile.mkdtemp(prefix="collegue-exec-")
+    os.makedirs(parent, exist_ok=True)
+    dest = os.path.join(parent, "workspace")
+
+    runner = LocalCommandRunner()
+
+    clone = runner.run_command([git_bin, "clone", "--quiet", source, dest], parent)
+    if not clone.ok:
+        raise WorkspaceError(f"git clone a échoué: {clone.stderr.strip() or clone.stdout.strip()}")
+
+    head = runner.run_command([git_bin, "rev-parse", "HEAD"], dest)
+    if not head.ok or not head.stdout.strip():
+        raise WorkspaceError(f"impossible de lire le commit de base: {head.stderr.strip()}")
+    base_commit = head.stdout.strip()
+
+    branch = branch_for_issue(issue.number)
+    checkout = runner.run_command([git_bin, "checkout", "-q", "-b", branch], dest)
+    if not checkout.ok:
+        raise WorkspaceError(f"git checkout -b {branch} a échoué: {checkout.stderr.strip()}")
+
+    return Workspace(path=dest, branch=branch, base_commit=base_commit)

--- a/tests/test_executor_workspace.py
+++ b/tests/test_executor_workspace.py
@@ -1,0 +1,178 @@
+"""Tests E2 (#364) : préparation du workspace git + exécution agent → diff.
+
+Utilise git en local sur un dépôt-fixture (pas de Docker) ; la variante sandbox
+réelle est couverte en ``integration``.
+"""
+
+import subprocess
+
+import pytest
+
+from collegue.executor import (
+    CommandRunner,
+    FakeCodeAgent,
+    IssueSpec,
+    LocalCommandRunner,
+    Workspace,
+    WorkspaceError,
+    branch_for_issue,
+    prepare_workspace,
+    run_issue,
+)
+from collegue.sandbox import DockerSandbox
+from collegue.state import ProjectStateManager
+
+ISSUE = IssueSpec(number=11, title="Faire la chose")
+
+
+def _git(cwd, *args):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _git_out(cwd, *args):
+    return subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True).stdout.strip()
+
+
+def _make_repo(path, files=None):
+    files = files or {"existing.txt": "original\n"}
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q")
+    _git(path, "config", "user.email", "t@example.com")
+    _git(path, "config", "user.name", "Test")
+    for rel, content in files.items():
+        (path / rel).write_text(content)
+    _git(path, "add", "-A")
+    _git(path, "commit", "-q", "-m", "init")
+    return str(path)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    return _make_repo(tmp_path / "source")
+
+
+# --- branch_for_issue -----------------------------------------------------------
+
+
+def test_branch_for_issue():
+    assert branch_for_issue(42) == "collegue/issue-42"
+
+
+# --- prepare_workspace ----------------------------------------------------------
+
+
+def test_prepare_workspace_clones_on_dedicated_branch(repo, tmp_path):
+    base = _git_out(repo, "rev-parse", "HEAD")
+    ws = prepare_workspace(repo, ISSUE, dest_root=str(tmp_path / "out"))
+    assert isinstance(ws, Workspace)
+    assert ws.path != repo  # clone, pas la source
+    assert (tmp_path / "out" / "workspace" / ".git").exists()
+    assert ws.branch == "collegue/issue-11"
+    assert _git_out(ws.path, "rev-parse", "--abbrev-ref", "HEAD") == "collegue/issue-11"
+    assert ws.base_commit == base
+    assert (tmp_path / "out" / "workspace" / "existing.txt").read_text() == "original\n"
+
+
+def test_prepare_workspace_rejects_non_git_source(tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    with pytest.raises(WorkspaceError):
+        prepare_workspace(str(plain), ISSUE, dest_root=str(tmp_path / "out"))
+
+
+def test_prepare_workspace_rejects_missing_source(tmp_path):
+    with pytest.raises(WorkspaceError):
+        prepare_workspace(str(tmp_path / "nope"), ISSUE, dest_root=str(tmp_path / "out"))
+
+
+# --- run_issue : capture du diff ------------------------------------------------
+
+
+def test_run_issue_captures_new_file(repo, tmp_path):
+    ws = prepare_workspace(repo, ISSUE, dest_root=str(tmp_path / "out"))
+    result = run_issue(FakeCodeAgent(), ws, ISSUE)
+    assert result.changed is True
+    assert result.success is True
+    assert "COLLEGUE_FAKE.txt" in result.files_changed
+    assert "COLLEGUE_FAKE.txt" in result.diff
+    assert "changement simulé" in result.diff
+
+
+def test_run_issue_captures_modified_and_new(repo, tmp_path):
+    ws = prepare_workspace(repo, ISSUE, dest_root=str(tmp_path / "out"))
+    agent = FakeCodeAgent({"existing.txt": "modifié\n", "src/new.py": "x = 1\n"})
+    result = run_issue(agent, ws, ISSUE)
+    assert set(result.files_changed) == {"existing.txt", "src/new.py"}
+    assert result.changed is True
+
+
+def test_run_issue_noop_is_not_error(repo, tmp_path):
+    ws = prepare_workspace(repo, ISSUE, dest_root=str(tmp_path / "out"))
+    result = run_issue(FakeCodeAgent(files={}), ws, ISSUE)  # n'écrit rien
+    assert result.changed is False
+    assert result.success is False  # rien produit
+    assert result.agent_result.success is True  # mais pas une erreur de l'agent
+    assert result.files_changed == ()
+
+
+def test_run_issue_agent_failure(repo, tmp_path):
+    ws = prepare_workspace(repo, ISSUE, dest_root=str(tmp_path / "out"))
+    result = run_issue(FakeCodeAgent(succeed=False), ws, ISSUE)
+    assert result.agent_result.success is False
+    assert result.changed is False
+    assert result.success is False
+
+
+def test_run_issue_raises_on_non_git_workspace(tmp_path):
+    # Workspace pointant un dossier qui n'est pas un dépôt git : `git add` échoue
+    # → WorkspaceError (plomberie cassée), pas un faux « aucun changement ».
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    ws = Workspace(path=str(plain), branch="x", base_commit="0" * 40)
+    with pytest.raises(WorkspaceError):
+        run_issue(FakeCodeAgent(), ws, ISSUE)
+
+
+def test_run_issue_transitions_task_to_in_progress(repo, tmp_path):
+    manager = ProjectStateManager.from_url(f"sqlite:///{tmp_path / 'state.db'}", create=True)
+    pid = manager.create_project(name="demo")
+    tid = manager.add_task(pid, title="T")  # statut par défaut : todo
+    ws = prepare_workspace(repo, ISSUE, dest_root=str(tmp_path / "out"))
+    run_issue(FakeCodeAgent(), ws, ISSUE, manager=manager, task_id=tid)
+    task = next(t for t in manager.get_tasks(pid) if t.id == tid)
+    assert task.status == "in_progress"
+
+
+# --- LocalCommandRunner ---------------------------------------------------------
+
+
+def test_runners_satisfy_command_runner_protocol():
+    # LocalCommandRunner (CI) et DockerSandbox (integration) sont interchangeables.
+    assert isinstance(LocalCommandRunner(), CommandRunner)
+    assert isinstance(DockerSandbox(), CommandRunner)
+
+
+def test_local_runner_success(tmp_path):
+    res = LocalCommandRunner().run_command(["sh", "-c", "printf hi"], str(tmp_path))
+    assert res.ok is True
+    assert res.stdout == "hi"
+
+
+def test_local_runner_nonzero_exit(tmp_path):
+    res = LocalCommandRunner().run_command(["sh", "-c", "exit 3"], str(tmp_path))
+    assert res.exit_code == 3
+    assert res.ok is False
+
+
+def test_local_runner_missing_binary(tmp_path):
+    res = LocalCommandRunner().run_command(["collegue-no-such-bin"], str(tmp_path))
+    assert res.exit_code == 127
+    assert res.ok is False
+    assert "introuvable" in res.stderr
+
+
+def test_local_runner_caps_output(tmp_path):
+    runner = LocalCommandRunner(max_output_bytes=10)
+    res = runner.run_command(["sh", "-c", "printf 'a%.0s' $(seq 1 50)"], str(tmp_path))
+    assert "tronquée" in res.stdout
+    assert len(res.stdout.encode("utf-8")) < 60  # bien borné


### PR DESCRIPTION
Deuxième enfant de l'epic #362 (**Phase 2 — exécuteur d'une issue**). `Closes #364`. Dépend de E1 (mergé).

## Ce que ça ajoute (module isolé `collegue/executor/`)

- **`command.py`** — `CommandRunner` (Protocol) + `LocalCommandRunner`
  - Interface unique `run_command(cmd, workspace) -> SandboxResult`, **déjà satisfaite par `DockerSandbox`** (C8) → **CI = runner local**, **integration = sandbox**, interchangeables.
  - `LocalCommandRunner` : exécution **hôte sans isolation**, **sortie bornée** (temp-file + plafond, façon C8, anti-OOM). **Réservé à la plomberie git de confiance** ; le code non fiable (agent, tests) passe par le sandbox.
- **`workspace.py`** — `prepare_workspace(repo_source, issue)`
  - Clone **repo-agnostique** du `HEAD` dans un tmpdir, sur une **branche dédiée** `collegue/issue-<N>`, **commit de base mémorisé**. Source non-git → `WorkspaceError`.
- **`runner.py`** — `run_issue(agent, workspace, issue, …)`
  - Lance l'agent puis capture le **diff autoritatif** : `git add -A` + `git diff --staged` (nouveaux / modifiés / supprimés / renommés ; `--name-only` = liste de fichiers).
  - Diff vide (agent no-op) → `changed=False`/`success=False` **sans erreur** ; erreur git de bas niveau → `WorkspaceError` (fail-loud).
  - Transition d'état `todo → in_progress` si `manager`+`task_id` fournis (la suite `in_review`/fail-closed est gérée par E5).

## Tests & qualité

- `tests/test_executor_workspace.py` : **15 tests** sur git réel (fixture, pas de Docker) — clone+branche, base commit, rejet source non-git/absente, capture diff (nouveau / modifié+nouveau / no-op / échec agent), `WorkspaceError` sur workspace non-git, transition d'état (`ProjectStateManager` SQLite), protocole `CommandRunner` (local **et** `DockerSandbox`), runner local (succès / exit≠0 / binaire absent / cap de sortie).
- **Ruff** `check` + `format` clean. Suite complète verte (exit 0, aucune régression). Couverture du module ~91 %.
- Passe `/review` adversariale (contexte frais) : aucun défaut bloquant ; corrigé une **docstring fausse** (« import paresseux » → en réalité eager mais sans dépendance OpenHands) + 2 lacunes de test (protocole `DockerSandbox`, branche `WorkspaceError`).

## Hors périmètre (suite)

E3 = gate qualité (tests sandbox + revue experte, fail-closed) ; E4 = ouverture de PR ; E5 = assemblage `execute_issue()` + sync état/board.