### PR TITLE
feat(executor): gate qualité tests + revue experte, fail-closed (E3)

### DIFF
--- a/collegue/executor/__init__.py
+++ b/collegue/executor/__init__.py
@@ -14,6 +14,16 @@ reste donc importable partout sans installer OpenHands.
 from collegue.executor.agent import AgentResult, CodeAgent, FakeCodeAgent, IssueSpec
 from collegue.executor.command import CommandRunner, LocalCommandRunner
 from collegue.executor.openhands_agent import OpenHandsAgent
+from collegue.executor.quality_gate import (
+    ExpertReviewer,
+    FakeReviewer,
+    QualityReport,
+    Reviewer,
+    ReviewFindingLite,
+    ReviewOutcome,
+    outcome_from_review,
+    run_quality_gate,
+)
 from collegue.executor.runner import ExecutionResult, run_issue
 from collegue.executor.workspace import Workspace, WorkspaceError, branch_for_issue, prepare_workspace
 
@@ -33,4 +43,13 @@ __all__ = [
     "prepare_workspace",
     "ExecutionResult",
     "run_issue",
+    # E3 — gate qualité
+    "Reviewer",
+    "ReviewOutcome",
+    "ReviewFindingLite",
+    "FakeReviewer",
+    "ExpertReviewer",
+    "QualityReport",
+    "run_quality_gate",
+    "outcome_from_review",
 ]

--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -1,0 +1,262 @@
+"""Gate qualité d'un diff produit par l'agent (E3, epic #362).
+
+Deux vérifications, **fail-closed** :
+
+1. **Tests** dans le :class:`~collegue.sandbox.executor.DockerSandbox` (C8) sur
+   l'arbre patché — du code non fiable ne tourne donc jamais sur l'hôte.
+2. **Revue experte** via l'outil ``code_review`` existant (rôle LLM ``REVIEWER``),
+   derrière un :class:`Reviewer` injectable (mocké en CI, réel en ``integration``).
+
+``passed`` n'est vrai que si les tests passent **et** la revue ne bloque pas
+**et** aucune erreur n'est survenue. Toute incertitude (tests non exécutables,
+exception du reviewer) ⇒ ``passed=False`` : on ne laisse jamais un doute valider
+le diff. Les ``BaseException`` (ex. ``BudgetExceeded``, C4) ne sont **pas**
+avalées — elles remontent.
+
+:meth:`QualityReport.to_markdown` produit le rapport pour le corps de PR (E4) ;
+le texte de revue (potentiellement non fiable) est **inline-isé puis fencé** pour
+qu'il ne puisse pas forger de fausse bannière/section (cf. P5).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Protocol, Tuple, runtime_checkable
+
+from collegue.executor.agent import IssueSpec
+from collegue.sandbox.executor import DockerSandbox
+from collegue.textnorm import inline
+
+DEFAULT_TEST_COMMAND = "pytest -q"
+# Triple-backtick de remplacement : neutralise les fences pour qu'un texte non
+# fiable ne puisse pas refermer le bloc de code et forger une fausse section.
+_FENCE = "```"
+_FENCE_SAFE = "ʼʼʼ"
+
+
+def _fence_safe_line(text) -> str:
+    """Une ligne sûre dans un bloc fencé : inline-isée + fences neutralisés."""
+    return inline(text).replace(_FENCE, _FENCE_SAFE)
+
+
+# En-dessous de ce score (cf. seuil interne de code_review), la revue bloque.
+DEFAULT_MIN_QUALITY = 0.5
+# Sévérités qui bloquent à elles seules, quel que soit le score. On inclut
+# ``error`` (pas seulement ``critical``) : l'expert code_review émet ``error`` pour
+# des problèmes sérieux (complexité élevée, motifs d'injection) et traite lui-même
+# critical+error comme graves. Comme le score est normalisé par la taille, un seul
+# ``error`` sur un gros diff donnerait un score ~0.96 et passerait sinon — le gate
+# resterait laxiste. On reste donc fail-closed côté sévérité.
+BLOCKING_SEVERITIES = frozenset({"critical", "error"})
+
+
+@dataclass(frozen=True)
+class ReviewFindingLite:
+    """Finding de revue, découplé du modèle Pydantic de ``code_review``."""
+
+    category: str
+    severity: str
+    title: str
+
+
+@dataclass(frozen=True)
+class ReviewOutcome:
+    """Résultat normalisé d'une revue."""
+
+    summary: str
+    quality_score: float
+    findings: Tuple[ReviewFindingLite, ...] = ()
+    blocking: bool = False
+
+
+@runtime_checkable
+class Reviewer(Protocol):
+    """Revue d'un diff. Async pour autoriser un reviewer LLM (rôle REVIEWER)."""
+
+    async def review(self, diff: str, ctx, *, issue: Optional[IssueSpec] = None) -> ReviewOutcome: ...
+
+
+@dataclass
+class QualityReport:
+    """Verdict combiné tests + revue d'un diff."""
+
+    tests_passed: bool
+    test_exit_code: int
+    test_output: str
+    review_summary: str
+    review_findings: Tuple[ReviewFindingLite, ...]
+    review_blocking: bool
+    passed: bool
+    review_error: Optional[str] = None
+
+    def to_markdown(self) -> str:
+        """Rapport Markdown pour le corps de PR (texte de revue fencé, anti-injection)."""
+        tests_badge = "✅ réussis" if self.tests_passed else "❌ échec"
+        lines = [
+            "## Gate qualité",
+            "",
+            f"**Tests** : {tests_badge} (code de sortie {self.test_exit_code})",
+            "",
+            "<details><summary>Sortie des tests</summary>",
+            "",
+            "```text",
+            # multi-ligne préservé ; on neutralise seulement le délimiteur de fence.
+            self.test_output.replace(_FENCE, _FENCE_SAFE) or "(vide)",
+            "```",
+            "",
+            "</details>",
+            "",
+            f"**Revue experte** : {'⛔ bloquante' if self.review_blocking else '✅ non bloquante'}",
+        ]
+        if self.review_error:
+            lines.append(f"> ⚠️ revue indisponible : {_fence_safe_line(self.review_error)}")
+        lines += ["", "```text", _fence_safe_line(self.review_summary) or "(pas de résumé)"]
+        for finding in self.review_findings:
+            lines.append(
+                "- "
+                f"[{_fence_safe_line(finding.severity)}] "
+                f"{_fence_safe_line(finding.category)} : {_fence_safe_line(finding.title)}"
+            )
+        lines += ["```", "", f"**Verdict** : {'✅ PASSÉ' if self.passed else '❌ NON PASSÉ'}"]
+        return "\n".join(lines)
+
+
+class FakeReviewer:
+    """:class:`Reviewer` déterministe pour la CI (aucun LLM)."""
+
+    def __init__(
+        self,
+        *,
+        summary: str = "revue simulée : RAS",
+        quality_score: float = 0.9,
+        findings: Optional[List[ReviewFindingLite]] = None,
+        blocking: bool = False,
+        raises: Optional[Exception] = None,
+    ):
+        self._summary = summary
+        self._quality_score = quality_score
+        self._findings = tuple(findings or ())
+        self._blocking = blocking
+        self._raises = raises
+
+    async def review(self, diff: str, ctx, *, issue: Optional[IssueSpec] = None) -> ReviewOutcome:
+        if self._raises is not None:
+            raise self._raises
+        return ReviewOutcome(
+            summary=self._summary,
+            quality_score=self._quality_score,
+            findings=self._findings,
+            blocking=self._blocking,
+        )
+
+
+async def run_quality_gate(
+    workspace: str,
+    diff: str,
+    ctx,
+    *,
+    sandbox: Optional[DockerSandbox] = None,
+    reviewer: Optional[Reviewer] = None,
+    issue: Optional[IssueSpec] = None,
+    test_command: str = DEFAULT_TEST_COMMAND,
+) -> QualityReport:
+    """Exécute les tests (sandbox) + la revue (reviewer) sur un diff. Fail-closed.
+
+    ``sandbox``/``reviewer`` sont injectables (mockés en CI). Tout échec ou
+    indisponibilité ⇒ ``passed=False``. Les ``BaseException`` remontent.
+    """
+    sandbox = sandbox or DockerSandbox()
+    reviewer = reviewer or _default_reviewer()
+
+    # 1. Tests dans le sandbox. Une incapacité à les exécuter = non passé
+    #    (fail-closed), pas une exception qui remonterait.
+    try:
+        test_res = sandbox.run_tests(workspace, test_command)
+        tests_passed = test_res.ok
+        test_exit_code = test_res.exit_code
+        test_output = "\n".join(part for part in (test_res.stdout, test_res.stderr) if part).strip()
+    except Exception as exc:  # noqa: BLE001 - fail-closed ; BaseException (budget) remonte
+        tests_passed = False
+        test_exit_code = -1
+        test_output = f"tests non exécutables : {exc}"
+
+    # 2. Revue. Une exception du reviewer = bloquant (fail-closed).
+    review_error: Optional[str] = None
+    try:
+        outcome = await reviewer.review(diff, ctx, issue=issue)
+        review_summary = outcome.summary
+        review_findings = outcome.findings
+        review_blocking = outcome.blocking
+    except Exception as exc:  # noqa: BLE001 - fail-closed ; BaseException (budget) remonte
+        review_error = str(exc) or repr(exc)
+        review_summary = "revue indisponible (erreur)"
+        review_findings = ()
+        review_blocking = True
+
+    passed = bool(tests_passed and not review_blocking and review_error is None)
+    return QualityReport(
+        tests_passed=tests_passed,
+        test_exit_code=test_exit_code,
+        test_output=test_output,
+        review_summary=review_summary,
+        review_findings=review_findings,
+        review_blocking=review_blocking,
+        passed=passed,
+        review_error=review_error,
+    )
+
+
+def _default_reviewer() -> Reviewer:
+    """Reviewer par défaut : l'expert ``code_review`` réel (rôle REVIEWER)."""
+    return ExpertReviewer()
+
+
+def outcome_from_review(response, *, min_quality: float = DEFAULT_MIN_QUALITY) -> ReviewOutcome:
+    """Mappe une ``CodeReviewResponse`` vers un :class:`ReviewOutcome` (pur, testable).
+
+    Bloquant si le score est sous le seuil **ou** s'il existe un finding de sévérité
+    bloquante (``critical`` ou ``error``, cf. :data:`BLOCKING_SEVERITIES`).
+    """
+    findings = tuple(
+        ReviewFindingLite(category=f.category, severity=f.severity, title=f.title) for f in response.findings
+    )
+    blocking = response.quality_score < min_quality or any(f.severity in BLOCKING_SEVERITIES for f in findings)
+    return ReviewOutcome(
+        summary=response.summary,
+        quality_score=response.quality_score,
+        findings=findings,
+        blocking=blocking,
+    )
+
+
+class ExpertReviewer:
+    """Adaptateur :class:`Reviewer` vers l'outil expert ``code_review`` (réel).
+
+    Réutilise l'expert existant (non-goal §9 : ne pas le réécrire). L'exécution
+    réelle (analyse statique + boucle agentique LLM, rôle ``REVIEWER``) a lieu en
+    ``integration`` ; ``code_review`` n'est importé que paresseusement ici pour ne
+    pas alourdir l'import de l'exécuteur. Le **mapping** réponse→outcome
+    (:func:`outcome_from_review`) est, lui, pur et testé en CI.
+    """
+
+    def __init__(self, *, min_quality: float = DEFAULT_MIN_QUALITY, tool=None):
+        self._min_quality = min_quality
+        self._tool = tool  # injectable pour les tests ; sinon construit à la volée
+
+    async def review(self, diff: str, ctx, *, issue: Optional[IssueSpec] = None) -> ReviewOutcome:
+        from collegue.tools.code_review.models import CodeReviewRequest
+
+        tool = self._tool or self._build_tool()
+        request = CodeReviewRequest(
+            code=diff or "(diff vide)",
+            language="python",
+            context=issue.to_prompt() if issue is not None else None,
+        )
+        response = await tool.execute_async(request, ctx=ctx)
+        return outcome_from_review(response, min_quality=self._min_quality)
+
+    @staticmethod
+    def _build_tool():  # pragma: no cover - chemin réel (integration)
+        from collegue.tools.code_review.tool import CodeReviewTool
+
+        return CodeReviewTool()

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -1,0 +1,198 @@
+"""Tests E3 (#365) : gate qualité (tests sandbox + revue experte), fail-closed.
+
+Sandbox et reviewer mockés (pas de Docker, pas de LLM) ; les variantes réelles
+sont couvertes en ``integration``.
+"""
+
+import pytest
+
+from collegue.executor import (
+    ExpertReviewer,
+    FakeReviewer,
+    IssueSpec,
+    QualityReport,
+    Reviewer,
+    ReviewFindingLite,
+    outcome_from_review,
+    run_quality_gate,
+)
+from collegue.sandbox import SandboxResult, SandboxUnavailable
+from collegue.tools.code_review.models import CodeReviewResponse, ReviewFinding
+from collegue.tools.quotas import BudgetExceeded
+
+ISSUE = IssueSpec(number=5, title="T")
+DIFF = "diff --git a/x b/x\n+print('x')\n"
+
+
+class _FakeSandbox:
+    def __init__(self, result=None, *, raises=None):
+        self._result = result
+        self._raises = raises
+        self.calls = []
+
+    def run_tests(self, workspace, command="pytest -q"):
+        self.calls.append((workspace, command))
+        if self._raises is not None:
+            raise self._raises
+        return self._result
+
+
+def _green():
+    return _FakeSandbox(SandboxResult(exit_code=0, stdout="2 passed", stderr=""))
+
+
+def _red():
+    return _FakeSandbox(SandboxResult(exit_code=1, stdout="", stderr="1 failed"))
+
+
+# --- verdict combiné ------------------------------------------------------------
+
+
+async def test_passed_when_tests_green_and_review_ok():
+    report = await run_quality_gate("/ws", DIFF, ctx=None, sandbox=_green(), reviewer=FakeReviewer())
+    assert report.tests_passed is True
+    assert report.review_blocking is False
+    assert report.review_error is None
+    assert report.passed is True
+
+
+async def test_failed_when_tests_red():
+    report = await run_quality_gate("/ws", DIFF, ctx=None, sandbox=_red(), reviewer=FakeReviewer())
+    assert report.tests_passed is False
+    assert report.passed is False  # peu importe la revue
+
+
+async def test_failed_when_review_blocks():
+    report = await run_quality_gate("/ws", DIFF, ctx=None, sandbox=_green(), reviewer=FakeReviewer(blocking=True))
+    assert report.tests_passed is True
+    assert report.review_blocking is True
+    assert report.passed is False
+
+
+# --- fail-closed ----------------------------------------------------------------
+
+
+async def test_reviewer_exception_is_fail_closed():
+    reviewer = FakeReviewer(raises=RuntimeError("LLM indisponible"))
+    report = await run_quality_gate("/ws", DIFF, ctx=None, sandbox=_green(), reviewer=reviewer)
+    assert report.review_error is not None
+    assert report.review_blocking is True  # fail-closed
+    assert report.passed is False
+
+
+async def test_tests_not_runnable_is_fail_closed():
+    sandbox = _FakeSandbox(raises=SandboxUnavailable("docker absent"))
+    report = await run_quality_gate("/ws", DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    assert report.tests_passed is False
+    assert "non exécutables" in report.test_output
+    assert report.passed is False
+
+
+async def test_budget_exception_propagates_through_gate():
+    # BudgetExceeded est une BaseException : le `except Exception` du gate NE doit
+    # PAS l'avaler (cf. C4) ; elle remonte pour stopper la boucle.
+    reviewer = FakeReviewer(raises=BudgetExceeded("cost", 10.0, 5.0))
+    with pytest.raises(BudgetExceeded):
+        await run_quality_gate("/ws", DIFF, ctx=None, sandbox=_green(), reviewer=reviewer)
+
+
+# --- to_markdown : anti-injection ----------------------------------------------
+
+
+def test_to_markdown_neutralizes_fence_and_heading_injection():
+    report = QualityReport(
+        tests_passed=True,
+        test_exit_code=0,
+        test_output="ok\n## pas une section",
+        review_summary="```python\n## fausse section injectée",
+        review_findings=(ReviewFindingLite(category="security", severity="critical", title="x\n```\n# evil"),),
+        review_blocking=True,
+        passed=False,
+    )
+    md = report.to_markdown()
+    # Le texte de revue/tests ne peut pas démarrer une nouvelle section.
+    assert "\n## fausse section" not in md
+    assert "\n# evil" not in md
+    # Les fences hostiles sont neutralisées (remplacées).
+    assert "ʼʼʼ" in md
+    # La structure de fences reste celle qu'on émet (4 lignes : 2 ouvrantes
+    # ```text + 2 fermantes ```), aucune fence injectée par le contenu hostile.
+    fences = [line for line in md.splitlines() if line.strip() in ("```", "```text")]
+    assert len(fences) == 4
+    # Le contenu reste présent (juste désarmé) + verdict affiché.
+    assert "fausse section injectée" in md
+    assert "❌ NON PASSÉ" in md
+
+
+# --- outcome_from_review (mapping pur) ------------------------------------------
+
+
+def _response(score, findings=()):
+    return CodeReviewResponse(quality_score=score, findings=list(findings), summary="résumé", language="python")
+
+
+def test_outcome_blocking_below_quality_threshold():
+    outcome = outcome_from_review(_response(0.3))
+    assert outcome.blocking is True
+
+
+def test_outcome_not_blocking_above_threshold():
+    outcome = outcome_from_review(_response(0.9))
+    assert outcome.blocking is False
+    assert outcome.quality_score == 0.9
+
+
+def test_outcome_blocking_on_critical_finding_even_if_score_high():
+    crit = ReviewFinding(category="security", severity="critical", title="RCE", description="d")
+    outcome = outcome_from_review(_response(0.95, [crit]))
+    assert outcome.blocking is True
+    assert outcome.findings[0].severity == "critical"
+
+
+def test_outcome_blocking_on_error_finding_even_if_score_high():
+    # Un finding `error` sur un gros diff (score ~0.96) doit bloquer : sinon le gate
+    # serait laxiste (le score normalisé par la taille noierait l'erreur).
+    err = ReviewFinding(category="security", severity="error", title="injection", description="d")
+    outcome = outcome_from_review(_response(0.96, [err]))
+    assert outcome.blocking is True
+
+
+def test_outcome_not_blocking_on_warning_only():
+    warn = ReviewFinding(category="naming", severity="warning", title="nom", description="d")
+    outcome = outcome_from_review(_response(0.9, [warn]))
+    assert outcome.blocking is False
+
+
+# --- ExpertReviewer : mapping via l'outil (tool factice) ------------------------
+
+
+class _FakeTool:
+    def __init__(self, response):
+        self._response = response
+        self.calls = []
+
+    async def execute_async(self, request, ctx=None):
+        self.calls.append((request, ctx))
+        return self._response
+
+
+async def test_expert_reviewer_maps_tool_response():
+    crit = ReviewFinding(category="security", severity="critical", title="RCE", description="d")
+    tool = _FakeTool(_response(0.4, [crit]))
+    reviewer = ExpertReviewer(tool=tool)
+    outcome = await reviewer.review(DIFF, ctx=None, issue=ISSUE)
+    assert outcome.blocking is True
+    assert outcome.summary == "résumé"
+    # La requête a bien porté le diff et le contexte de l'issue.
+    request = tool.calls[0][0]
+    assert request.code == DIFF
+    assert request.context == ISSUE.to_prompt()
+
+
+# --- protocole ------------------------------------------------------------------
+
+
+def test_reviewer_protocol_runtime_checkable():
+    assert isinstance(FakeReviewer(), Reviewer)
+    assert isinstance(ExpertReviewer(), Reviewer)
+    assert not isinstance(object(), Reviewer)


### PR DESCRIPTION
Troisième enfant de l'epic #362 (**Phase 2 — exécuteur d'une issue**). `Closes #365`. Dépend de E2 (mergé).

## Ce que ça ajoute — `collegue/executor/quality_gate.py`

`run_quality_gate(workspace, diff, ctx, *, sandbox, reviewer, issue, test_command)` → `QualityReport`, **fail-closed** :

1. **Tests** dans le `DockerSandbox` (C8) sur l'arbre patché — le code non fiable ne tourne jamais sur l'hôte.
2. **Revue experte** via un `Reviewer` injectable.

**Fail-closed** : `passed` = tests verts **ET** revue non bloquante **ET** aucune erreur.
- Tests non exécutables (sandbox indisponible) → `tests_passed=False`.
- Exception du reviewer → `review_blocking=True`, `review_error` renseigné.
- Les `BaseException` (`BudgetExceeded`, C4) **ne sont pas avalées** par les `except Exception` → elles remontent et stoppent la boucle.

**Reviewer** (`Protocol` async) :
- `FakeReviewer` — double déterministe (CI).
- `ExpertReviewer` — adaptateur **fin** vers l'outil `code_review` existant (rôle LLM `REVIEWER`, `execute_async(request, ctx=ctx)`), **importé paresseusement** (importer `collegue.executor` ne tire pas `code_review`). Exécution réelle en `integration`.
- `outcome_from_review` — mapping **pur** (testé) : bloquant si `quality_score < 0.5` **ou** sévérité `critical`/`error`.

**`QualityReport.to_markdown()`** — rapport pour le corps de PR (E4) ; le texte de revue/tests (non fiable) est **inline-isé + fences neutralisées** (` ``` ` → `ʼʼʼ`) ⇒ impossible de forger une fausse section/bannière ou de casser le bloc de code (P5).

## Tests & qualité

- `tests/test_executor_quality_gate.py` : **14 tests** — verdict combiné (vert / tests rouges / revue bloquante), **fail-closed** (reviewer exception, sandbox indisponible, **propagation `BudgetExceeded`**), **anti-injection markdown** (backticks/headings/`<details>` neutralisés + contrôle du nombre de fences), mapping `critical`/`error`/`warning`, `ExpertReviewer` via tool factice (bon appel `execute_async`, requête portant diff+contexte), protocole `Reviewer`.
- **Ruff** `check` + `format` clean. ~98 % de couverture sur `quality_gate.py`. 47 tests exécuteur au total verts.
- Passe `/review` adversariale (contexte frais, propriétés anti-injection + fail-closed **prouvées** via vrais renderers Markdown) : aucun défaut bloquant ; **élargi le blocage à `error`** (l'expert traite lui-même `error` comme grave ; le score normalisé par la taille noierait sinon une erreur) + test de fences renforcé.

## Hors périmètre (suite)

E4 = ouverture de PR (`github_commands/pulls`, `dry_run`) ; E5 = assemblage `execute_issue()` + sync état/board.