### PR TITLE
feat(executor): ouverture de PR depuis un diff validé, dry_run par défaut (E4)

### DIFF
--- a/collegue/executor/__init__.py
+++ b/collegue/executor/__init__.py
@@ -14,6 +14,7 @@ reste donc importable partout sans installer OpenHands.
 from collegue.executor.agent import AgentResult, CodeAgent, FakeCodeAgent, IssueSpec
 from collegue.executor.command import CommandRunner, LocalCommandRunner
 from collegue.executor.openhands_agent import OpenHandsAgent
+from collegue.executor.pr import PrClients, PrResult, build_pr_body, exec_marker, open_pr
 from collegue.executor.quality_gate import (
     ExpertReviewer,
     FakeReviewer,
@@ -52,4 +53,10 @@ __all__ = [
     "QualityReport",
     "run_quality_gate",
     "outcome_from_review",
+    # E4 — ouverture de PR
+    "PrClients",
+    "PrResult",
+    "open_pr",
+    "build_pr_body",
+    "exec_marker",
 ]

--- a/collegue/executor/pr.py
+++ b/collegue/executor/pr.py
@@ -1,0 +1,183 @@
+"""Ouverture de la Pull Request d'une issue (E4, epic #362).
+
+Transforme un diff **validé** (E3) en Pull Request : crée la branche, committe les
+fichiers modifiés, ouvre la PR dont le corps porte **code + tests + rapport de
+revue** et ``Closes #N``. ``dry_run=True`` par défaut (aucune écriture) ; l'écriture
+réelle est exercée en ``integration``.
+
+Réutilise les commandes GitHub existantes (``BranchCommands`` / ``FileCommands`` /
+``PRCommands`` de ``collegue.tools.github_commands``) plutôt que d'en réimplémenter
+(non-goal §9). Idempotence : si une PR ouverte existe déjà pour la branche, on la
+retourne sans recréer ; un marqueur ``<!-- collegue-exec:<N> -->`` trace l'origine.
+
+Limite (MVP) : les fichiers sont poussés via la Contents API en **texte UTF-8**
+(stack cible web Python+JS/TS) ; les fichiers binaires ne sont pas supportés.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from collegue.executor.agent import IssueSpec
+from collegue.executor.quality_gate import QualityReport
+from collegue.executor.workspace import Workspace
+from collegue.textnorm import inline
+
+DEFAULT_BASE_BRANCH = "main"
+
+
+def exec_marker(issue_number: int) -> str:
+    """Marqueur HTML traçant la PR générée par l'exécuteur pour une issue."""
+    return f"<!-- collegue-exec:{int(issue_number)} -->"
+
+
+def _safe_rel_path(path: str) -> str:
+    """Chemin de dépôt sûr (anti-traversée) : pas d'absolu, pas de segment ``..``/``.``/vide."""
+    cleaned = path.strip().lstrip("/")
+    segments = cleaned.split("/")
+    if not cleaned or "\\" in cleaned or any(seg in ("", ".", "..") for seg in segments):
+        raise ValueError(f"chemin de fichier invalide: {path!r}")
+    return cleaned
+
+
+def _resolve_in_workspace(workspace_path: str, rel: str) -> str:
+    """Résout ``rel`` dans le workspace en **refusant toute évasion** (symlink inclus).
+
+    L'agent est **non fiable** : sans cette garde, un symlink ``x.py`` pointant vers
+    un secret de l'hôte (``~/.ssh/id_rsa``, ``.env``…) serait lu sur l'hôte et poussé
+    dans la PR. On refuse donc tout symlink et on vérifie le confinement via
+    ``realpath`` (déjoue aussi un répertoire intermédiaire symlinké).
+    """
+    full = os.path.join(workspace_path, rel)
+    if os.path.islink(full):
+        raise ValueError(f"symlink refusé dans le workspace: {rel!r}")
+    root = os.path.realpath(workspace_path)
+    real = os.path.realpath(full)
+    if real != root and os.path.commonpath([real, root]) != root:
+        raise ValueError(f"chemin hors du workspace: {rel!r}")
+    return full
+
+
+@dataclass
+class PrClients:
+    """Commandes GitHub nécessaires à l'ouverture d'une PR (injectables/mockables)."""
+
+    branches: object  # BranchCommands.ensure_branch(owner, repo, branch, from_branch)
+    files: object  # FileCommands.update_file/delete_file(owner, repo, path, message, content, branch)
+    prs: object  # PRCommands.find_pr_by_head / create_pr(owner, repo, title, head, base, body)
+
+
+@dataclass(frozen=True)
+class PrResult:
+    """Résultat (ou aperçu) d'une ouverture de PR."""
+
+    dry_run: bool
+    title: str
+    head: str
+    base: str
+    body: str
+    number: Optional[int] = None
+    html_url: Optional[str] = None
+    skipped: bool = False  # PR déjà existante (idempotence)
+
+
+def build_pr_body(quality_report: QualityReport, issue: IssueSpec) -> str:
+    """Corps de PR : contexte issue + rapport qualité (fencé) + ``Closes`` + marqueur."""
+    return "\n".join(
+        [
+            f"## Exécution automatique de l'issue #{int(issue.number)}",
+            "",
+            f"> {inline(issue.title)}",
+            "",
+            "_PR générée par l'exécuteur Collègue (Phase 2). Merge sous CI verte + approbation humaine._",
+            "",
+            quality_report.to_markdown(),
+            "",
+            f"Closes #{int(issue.number)}",
+            "",
+            exec_marker(issue.number),
+        ]
+    )
+
+
+def open_pr(
+    workspace: Workspace,
+    quality_report: QualityReport,
+    issue: IssueSpec,
+    owner: str,
+    repo: str,
+    *,
+    files_changed: Tuple[str, ...] = (),
+    base: str = DEFAULT_BASE_BRANCH,
+    clients: Optional[PrClients] = None,
+    dry_run: bool = True,
+    manager: Optional[object] = None,
+    project_id: Optional[int] = None,
+) -> PrResult:
+    """Ouvre (ou prévisualise) la PR de l'issue.
+
+    ``dry_run=True`` (défaut) : renvoie un aperçu fidèle (titre/head/base/corps)
+    **sans aucune écriture**. Sinon : idempotence (PR ouverte existante retournée),
+    création de branche, commit des fichiers (suppression incluse), ouverture de PR,
+    et journalisation du numéro de PR si ``manager``+``project_id`` sont fournis.
+    """
+    head = workspace.branch
+    title = f"{inline(issue.title)} (issue #{int(issue.number)})"
+    body = build_pr_body(quality_report, issue)
+
+    if dry_run:
+        return PrResult(dry_run=True, title=title, head=head, base=base, body=body)
+
+    clients = clients or _default_clients()
+
+    existing = clients.prs.find_pr_by_head(owner, repo, head, base=base)
+    if existing is not None:
+        return PrResult(
+            dry_run=False,
+            title=title,
+            head=head,
+            base=base,
+            body=body,
+            number=getattr(existing, "number", None),
+            html_url=getattr(existing, "html_url", None),
+            skipped=True,
+        )
+
+    clients.branches.ensure_branch(owner, repo, head, from_branch=base)
+
+    for path in files_changed:
+        rel = _safe_rel_path(path)
+        full = _resolve_in_workspace(workspace.path, rel)
+        message = f"collegue: issue #{int(issue.number)} — {rel}"
+        if os.path.isfile(full):
+            with open(full, "r", encoding="utf-8") as handle:
+                content = handle.read()
+            clients.files.update_file(owner, repo, rel, message, content, branch=head)
+        else:
+            # Fichier supprimé par l'agent : on le retire aussi sur la branche.
+            clients.files.delete_file(owner, repo, rel, message, branch=head)
+
+    pr = clients.prs.create_pr(owner, repo, title, head, base, body)
+    number = getattr(pr, "number", None)
+    html_url = getattr(pr, "html_url", None)
+
+    if manager is not None and project_id is not None and number is not None:
+        manager.record_decision(
+            project_id,
+            f"PR #{number} ouverte pour l'issue #{int(issue.number)}",
+            rationale=html_url,
+        )
+
+    return PrResult(dry_run=False, title=title, head=head, base=base, body=body, number=number, html_url=html_url)
+
+
+def _default_clients(token: Optional[str] = None) -> PrClients:  # pragma: no cover - chemin réel (integration)
+    from collegue.tools.github_commands import BranchCommands, FileCommands, PRCommands
+
+    return PrClients(
+        branches=BranchCommands(token=token),
+        files=FileCommands(token=token),
+        prs=PRCommands(token=token),
+    )

--- a/collegue/tools/github_commands/branches.py
+++ b/collegue/tools/github_commands/branches.py
@@ -68,3 +68,27 @@ class BranchCommands(GitHubClient):
         data = {"ref": f"refs/heads/{branch}", "sha": sha}
         resp = self._api_post(f"/repos/{owner}/{repo}/git/refs", data)
         return BranchInfo(name=branch, commit_sha=resp["object"]["sha"], protected=False)
+
+    def _branch_sha_or_none(self, owner: str, repo: str, branch: str) -> Optional[str]:
+        """SHA de la branche, ou None si elle n'existe pas (variante non-levante)."""
+        try:
+            return self._get_branch_sha(owner, repo, branch)
+        except ToolExecutionError:
+            return None
+
+    def ensure_branch(self, owner: str, repo: str, branch: str, from_branch: Optional[str] = None) -> BranchInfo:
+        """Retourne la branche existante ou la crée depuis ``from_branch``. Idempotent.
+
+        Évite le 422 « Reference already exists » lors d'un retry (ex. reprise après
+        échec partiel) et gère la course création (re-vérifie avant de propager).
+        """
+        existing = self._branch_sha_or_none(owner, repo, branch)
+        if existing is not None:
+            return BranchInfo(name=branch, commit_sha=existing, protected=False)
+        try:
+            return self.create_branch(owner, repo, branch, from_branch)
+        except ToolExecutionError:
+            again = self._branch_sha_or_none(owner, repo, branch)
+            if again is not None:
+                return BranchInfo(name=branch, commit_sha=again, protected=False)
+            raise

--- a/collegue/tools/github_commands/files.py
+++ b/collegue/tools/github_commands/files.py
@@ -50,3 +50,26 @@ class FileCommands(GitHubClient):
 
         resp = self._api_put(f"/repos/{owner}/{repo}/contents/{path}", data)
         return {"content": resp.get("content", {}), "commit": resp.get("commit", {})}
+
+    def delete_file(
+        self, owner: str, repo: str, path: str, message: str, branch: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        """Delete a file from the repo. No-op (returns None) if the file is absent.
+
+        The Contents API requires the current blob ``sha`` to delete; we look it up
+        first and skip cleanly if the file does not exist on ``branch``.
+        """
+        try:
+            current = self.get_file_content(owner, repo, path, branch)
+        except ToolExecutionError:
+            return None
+        sha = current.get("sha")
+        if not sha:
+            return None
+
+        data: Dict[str, Any] = {"message": message, "sha": sha}
+        if branch:
+            data["branch"] = branch
+
+        resp = self._request_json("DELETE", f"/repos/{owner}/{repo}/contents/{path}", json_data=data)
+        return {"commit": (resp or {}).get("commit", {})}

--- a/collegue/tools/github_commands/prs.py
+++ b/collegue/tools/github_commands/prs.py
@@ -87,6 +87,37 @@ class PRCommands(GitHubClient):
             for pr in data[:limit]
         ]
 
+    def find_pr_by_head(
+        self, owner: str, repo: str, head: str, base: Optional[str] = None, state: str = "open"
+    ) -> Optional[PRInfo]:
+        """PR filtrée nativement par branche ``head`` (``owner:branch``), ou None.
+
+        Idempotence fiable (vs scanner ``list_prs`` borné) : interroge directement
+        l'API avec le filtre ``head`` pour retrouver une PR déjà ouverte.
+        """
+        # head = "owner:branch" : on suppose une PR intra-dépôt (head sur le même
+        # owner). Un head cross-fork (autre owner) ne serait pas retrouvé ici.
+        params = {"head": f"{owner}:{head}", "state": state}
+        if base:
+            params["base"] = base
+        data = self._api_get(f"/repos/{owner}/{repo}/pulls", params)
+        if not data:
+            return None
+        pr = data[0]
+        return PRInfo(
+            number=pr["number"],
+            title=pr["title"],
+            state=pr["state"],
+            html_url=pr["html_url"],
+            user=pr["user"]["login"],
+            base_branch=pr["base"]["ref"],
+            head_branch=pr["head"]["ref"],
+            created_at=pr["created_at"],
+            updated_at=pr["updated_at"],
+            labels=[label["name"] for label in pr.get("labels", [])],
+            draft=pr.get("draft", False),
+        )
+
     def get_pr(self, owner: str, repo: str, pr_number: int) -> PRInfo:
         data = self._api_get(f"/repos/{owner}/{repo}/pulls/{pr_number}")
         return PRInfo(

--- a/tests/test_executor_pr.py
+++ b/tests/test_executor_pr.py
@@ -1,0 +1,236 @@
+"""Tests E4 (#366) : ouverture de PR (dry_run par défaut), clients GitHub mockés."""
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from collegue.executor import (
+    IssueSpec,
+    PrClients,
+    QualityReport,
+    Workspace,
+    build_pr_body,
+    exec_marker,
+    open_pr,
+)
+from collegue.state import ProjectStateManager
+from collegue.tools.base import ToolExecutionError
+from collegue.tools.github_commands import FileCommands
+
+ISSUE = IssueSpec(number=5, title="Ajouter le endpoint")
+REPORT = QualityReport(
+    tests_passed=True,
+    test_exit_code=0,
+    test_output="2 passed",
+    review_summary="RAS",
+    review_findings=(),
+    review_blocking=False,
+    passed=True,
+)
+
+
+class _FakeBranches:
+    def __init__(self):
+        self.created = []
+
+    def ensure_branch(self, owner, repo, branch, from_branch=None):
+        self.created.append((branch, from_branch))
+        return SimpleNamespace(name=branch)
+
+
+class _FakeFiles:
+    def __init__(self):
+        self.updated = []
+        self.deleted = []
+
+    def update_file(self, owner, repo, path, message, content, branch=None):
+        self.updated.append((path, content, branch))
+        return {}
+
+    def delete_file(self, owner, repo, path, message, branch=None):
+        self.deleted.append((path, branch))
+        return {}
+
+
+class _FakePRs:
+    def __init__(self, existing=None, number=101):
+        self._existing = existing  # PRInfo-like ou None
+        self._number = number
+        self.created = []
+
+    def find_pr_by_head(self, owner, repo, head, base=None, state="open"):
+        if self._existing is not None and getattr(self._existing, "head_branch", None) == head:
+            return self._existing
+        return None
+
+    def create_pr(self, owner, repo, title, head, base, body):
+        self.created.append({"title": title, "head": head, "base": base, "body": body})
+        return SimpleNamespace(number=self._number, html_url=f"https://gh/pull/{self._number}", head_branch=head)
+
+
+def _clients(existing=None):
+    return PrClients(branches=_FakeBranches(), files=_FakeFiles(), prs=_FakePRs(existing=existing))
+
+
+def _workspace(tmp_path, files=None):
+    ws_dir = tmp_path / "ws"
+    ws_dir.mkdir()
+    for rel, content in (files or {"a.py": "print('a')\n"}).items():
+        path = ws_dir / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    return Workspace(path=str(ws_dir), branch="collegue/issue-5", base_commit="basesha123")
+
+
+# --- dry-run --------------------------------------------------------------------
+
+
+def test_dry_run_writes_nothing(tmp_path):
+    ws = _workspace(tmp_path)
+    clients = _clients()
+    result = open_pr(ws, REPORT, ISSUE, "o", "r", files_changed=("a.py",), clients=clients, dry_run=True)
+    assert result.dry_run is True
+    assert result.head == "collegue/issue-5"
+    assert "Closes #5" in result.body
+    assert exec_marker(5) in result.body
+    assert clients.branches.created == []
+    assert clients.files.updated == []
+    assert clients.prs.created == []
+
+
+# --- écriture réelle ------------------------------------------------------------
+
+
+def test_real_creates_branch_files_and_pr(tmp_path):
+    ws = _workspace(tmp_path, {"a.py": "print('a')\n", "sub/b.py": "x = 1\n"})
+    clients = _clients()
+    result = open_pr(
+        ws, REPORT, ISSUE, "o", "r", files_changed=("a.py", "sub/b.py"), base="main", clients=clients, dry_run=False
+    )
+    assert result.dry_run is False
+    assert result.skipped is False
+    assert result.number == 101
+    assert result.html_url == "https://gh/pull/101"
+    # branche dédiée créée depuis base
+    assert clients.branches.created == [("collegue/issue-5", "main")]
+    # fichiers committés avec leur contenu
+    assert {p for p, _c, _b in clients.files.updated} == {"a.py", "sub/b.py"}
+    assert all(b == "collegue/issue-5" for _p, _c, b in clients.files.updated)
+    # une seule PR, corps complet
+    assert len(clients.prs.created) == 1
+    body = clients.prs.created[0]["body"]
+    assert "Closes #5" in body and "## Gate qualité" in body and exec_marker(5) in body
+
+
+def test_idempotent_when_pr_already_open(tmp_path):
+    ws = _workspace(tmp_path)
+    existing = SimpleNamespace(number=77, html_url="https://gh/pull/77", head_branch="collegue/issue-5")
+    clients = _clients(existing=existing)
+    result = open_pr(ws, REPORT, ISSUE, "o", "r", files_changed=("a.py",), clients=clients, dry_run=False)
+    assert result.skipped is True
+    assert result.number == 77
+    # rien recréé
+    assert clients.branches.created == []
+    assert clients.files.updated == []
+    assert clients.prs.created == []
+
+
+def test_deleted_file_is_removed_on_branch(tmp_path):
+    ws = _workspace(tmp_path, {"keep.py": "k\n"})  # "gone.py" n'existe pas sur disque
+    clients = _clients()
+    open_pr(ws, REPORT, ISSUE, "o", "r", files_changed=("keep.py", "gone.py"), clients=clients, dry_run=False)
+    assert {p for p, _c, _b in clients.files.updated} == {"keep.py"}
+    assert [p for p, _b in clients.files.deleted] == ["gone.py"]
+
+
+def test_persists_pr_number_to_decision_journal(tmp_path):
+    manager = ProjectStateManager.from_url(f"sqlite:///{tmp_path / 'state.db'}", create=True)
+    pid = manager.create_project(name="demo")
+    ws = _workspace(tmp_path)
+    open_pr(
+        ws,
+        REPORT,
+        ISSUE,
+        "o",
+        "r",
+        files_changed=("a.py",),
+        clients=_clients(),
+        dry_run=False,
+        manager=manager,
+        project_id=pid,
+    )
+    decisions = manager.get_decisions(pid)
+    assert any("PR #101" in d.summary for d in decisions)
+
+
+def test_path_traversal_rejected(tmp_path):
+    ws = _workspace(tmp_path)
+    with pytest.raises(ValueError):
+        open_pr(ws, REPORT, ISSUE, "o", "r", files_changed=("../evil.py",), clients=_clients(), dry_run=False)
+
+
+def test_dot_and_empty_segments_rejected(tmp_path):
+    ws = _workspace(tmp_path)
+    for bad in ("a/./b.py", "a//b.py"):
+        with pytest.raises(ValueError):
+            open_pr(ws, REPORT, ISSUE, "o", "r", files_changed=(bad,), clients=_clients(), dry_run=False)
+
+
+def test_symlink_escape_is_rejected_not_exfiltrated(tmp_path):
+    # Un agent non fiable crée un symlink pointant un secret hôte hors workspace.
+    # open_pr doit REFUSER (ValueError) et ne jamais lire/pousser le secret.
+    secret = tmp_path / "host_secret.txt"
+    secret.write_text("HOST PRIVATE KEY", encoding="utf-8")
+    ws = _workspace(tmp_path, {"real.py": "x = 1\n"})
+    os.symlink(secret, Path(ws.path) / "evil.py")
+    clients = _clients()
+    with pytest.raises(ValueError):
+        open_pr(ws, REPORT, ISSUE, "o", "r", files_changed=("evil.py",), clients=clients, dry_run=False)
+    # le contenu du secret n'a JAMAIS été poussé
+    assert all("HOST PRIVATE KEY" not in content for _p, content, _b in clients.files.updated)
+
+
+def test_title_is_inlined(tmp_path):
+    ws = _workspace(tmp_path)
+    issue = IssueSpec(number=5, title="Multi\nligne\ttitre")
+    result = open_pr(ws, REPORT, issue, "o", "r", clients=_clients(), dry_run=True)
+    assert "\n" not in result.title
+    assert result.title == "Multi ligne titre (issue #5)"
+
+
+# --- build_pr_body --------------------------------------------------------------
+
+
+def test_build_pr_body_structure():
+    body = build_pr_body(REPORT, ISSUE)
+    assert body.startswith("## Exécution automatique de l'issue #5")
+    assert "Closes #5" in body
+    assert exec_marker(5) in body
+
+
+# --- FileCommands.delete_file (ajout E4) ----------------------------------------
+
+
+def test_file_commands_delete_skips_when_absent():
+    fc = FileCommands(token="x")
+    fc.get_file_content = lambda *a, **k: (_ for _ in ()).throw(ToolExecutionError("404"))
+    assert fc.delete_file("o", "r", "p", "msg", branch="b") is None
+
+
+def test_file_commands_delete_calls_api_with_sha():
+    fc = FileCommands(token="x")
+    fc.get_file_content = lambda *a, **k: {"sha": "BLOBSHA"}
+    captured = {}
+
+    def _fake_request(method, endpoint, json_data=None):
+        captured.update(method=method, endpoint=endpoint, data=json_data)
+        return {"commit": {"sha": "c1"}}
+
+    fc._request_json = _fake_request
+    res = fc.delete_file("o", "r", "path/x.py", "msg", branch="b")
+    assert captured["method"] == "DELETE"
+    assert captured["data"]["sha"] == "BLOBSHA"
+    assert captured["data"]["branch"] == "b"
+    assert res["commit"] == {"sha": "c1"}


### PR DESCRIPTION
Quatrième enfant de l'epic #362 (**Phase 2 — exécuteur d'une issue**). `Closes #366`. Dépend de E2/E3 (mergés).

## Ce que ça ajoute

`collegue/executor/pr.py` — `open_pr(workspace, quality_report, issue, owner, repo, *, files_changed, base, clients, dry_run=True, manager, project_id) -> PrResult` :

- **Réutilise** les commandes GitHub existantes (`BranchCommands`/`FileCommands`/`PRCommands`) plutôt que d'en réécrire (non-goal §9). Ajouts **idempotents** alignés sur le pattern P3 :
  - `BranchCommands.ensure_branch` — idempotent (survit au retry après échec partiel / course).
  - `PRCommands.find_pr_by_head` — lookup filtré **nativement** par branche `head` (pas de doublon, vs scanner `list_prs` borné).
  - `FileCommands.delete_file` — complète `get`/`update` (no-op si le fichier est absent).
- **`dry_run=True` par défaut** : aperçu fidèle (titre/head/base/corps) **sans aucune écriture**.
- **Corps de PR** = contexte issue + `QualityReport.to_markdown()` (fencé) + `Closes #N` + marqueur `<!-- collegue-exec:N -->`. Titre **inline-isé** (anti-injection).
- Journalise le n° de PR (journal de décisions C7) si `manager`+`project_id` fournis.
- Écriture GitHub réelle derrière `integration`.

## 🔒 Sécurité (trouvée par la revue adversariale)

Un agent **non fiable** pouvait committer un **symlink** (`x.py → ~/.ssh/id_rsa`) : git le stage, `run_issue` le remonte dans `files_changed`, et `open_pr` le lisait **sur l'hôte** → le secret partait dans la PR (potentiellement publique). Exfiltration silencieuse par le code que le sandbox est censé contenir.

**Correctif** : `_resolve_in_workspace` refuse **tout symlink** et vérifie le **confinement `realpath`** (déjoue aussi un répertoire intermédiaire symlinké) ; `_safe_rel_path` durci (rejette segments `.`/`..`/vide, absolu, backslash). Test de non-exfiltration ajouté.

## Tests & qualité

- `tests/test_executor_pr.py` : **12 tests** — dry_run sans écriture, création branche+fichiers+PR, **idempotence** (PR existante → skip), suppression de fichier, persistance du n° de PR, **traversée / segments `.` / symlink** rejetés (+ non-exfiltration), titre inline, corps ; + `FileCommands.delete_file`.
- **Ruff** `check` + `format` clean. **Suite complète verte (exit 0, aucune régression)** — `ensure_branch`/`find_pr_by_head`/`delete_file` sont additifs.
- Import isolation préservée (`collegue.executor` ne tire pas `github_commands` ; import paresseux dans `_default_clients`).

## Hors périmètre (suite)

E5 = assemblage `execute_issue()` (E1→E4) + sync état issue/board (`todo→in_progress→in_review`), gate CI/merge documenté.