### PR TITLE
feat(executor): assemblage execute_issue() + sync état, gate CI/merge (E5)

### DIFF
--- a/collegue/executor/__init__.py
+++ b/collegue/executor/__init__.py
@@ -14,6 +14,7 @@ reste donc importable partout sans installer OpenHands.
 from collegue.executor.agent import AgentResult, CodeAgent, FakeCodeAgent, IssueSpec
 from collegue.executor.command import CommandRunner, LocalCommandRunner
 from collegue.executor.openhands_agent import OpenHandsAgent
+from collegue.executor.pipeline import ExecutionOutcome, execute_issue
 from collegue.executor.pr import PrClients, PrResult, build_pr_body, exec_marker, open_pr
 from collegue.executor.quality_gate import (
     ExpertReviewer,
@@ -59,4 +60,7 @@ __all__ = [
     "open_pr",
     "build_pr_body",
     "exec_marker",
+    # E5 — assemblage du pipeline
+    "execute_issue",
+    "ExecutionOutcome",
 ]

--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -1,0 +1,148 @@
+"""Assemblage de l'exécuteur d'une issue de bout en bout (E5, epic #362).
+
+``execute_issue`` enchaîne les briques E1→E4 en un point d'entrée **isolé** :
+
+    prepare_workspace (E2) → run_issue (E2) → run_quality_gate (E3) → open_pr (E4)
+
+et **synchronise l'état** de la tâche : ``todo → in_progress`` au démarrage,
+``→ in_review`` quand la PR est ouverte. **Jamais** ``done`` automatiquement : le
+merge reste **humain**, et la **CI gate** le merge (la PR est ouverte mais ne peut
+être mergée qu'avec la CI verte + approbation — sémantique GitHub, pas gérée ici).
+
+**Fail-closed** : si l'agent ne produit aucun diff, ou si le gate qualité ne passe
+pas, on **s'arrête** — aucune PR, l'état **ne dépasse pas** ``in_progress``.
+
+``dry_run=True`` (défaut) : pipeline complet jusqu'à un **aperçu** de PR, **sans
+aucune écriture** (ni GitHub, ni transition d'état) — utile pour visualiser ce qui
+serait fait.
+
+Module **isolé** : non importé par ``app.py``. Le pilote (Phase 3) appellera
+``execute_issue`` sur le graphe de tâches (en respectant dépendances + budget) et
+prendra en charge le déplacement de carte de board (il détient le mapping des
+items du board) — délibérément hors périmètre ici.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from collegue.executor.agent import CodeAgent, IssueSpec
+from collegue.executor.command import CommandRunner
+from collegue.executor.pr import PrClients, PrResult, open_pr
+from collegue.executor.quality_gate import QualityReport, Reviewer, run_quality_gate
+from collegue.executor.runner import ExecutionResult, run_issue
+from collegue.executor.workspace import Workspace, prepare_workspace
+
+TASK_STATUS_TODO = "todo"
+TASK_STATUS_IN_PROGRESS = "in_progress"
+TASK_STATUS_IN_REVIEW = "in_review"
+
+# Étapes possibles d'arrêt/aboutissement du pipeline.
+STAGE_RUN = "run"  # exécution de l'agent (diff)
+STAGE_GATE = "gate"  # gate qualité (tests + revue)
+STAGE_PR = "pr"  # ouverture de PR
+
+
+@dataclass
+class ExecutionOutcome:
+    """Résultat de bout en bout de l'exécution d'une issue."""
+
+    success: bool  # le pipeline est allé jusqu'à la PR (gate passé)
+    stage: str  # dernière étape atteinte : run | gate | pr
+    workspace: Workspace
+    execution: ExecutionResult
+    quality_report: Optional[QualityReport] = None
+    pr: Optional[PrResult] = None
+    final_status: Optional[str] = None  # statut de tâche effectivement écrit (None si dry_run / pas de manager)
+
+
+def _set_status(manager, task_id, status: str, *, enabled: bool) -> Optional[str]:
+    """Transition d'état si activée (réel + manager + task_id). Retourne le statut écrit."""
+    if not enabled or manager is None or task_id is None:
+        return None
+    manager.update_task_status(task_id, status)
+    return status
+
+
+async def execute_issue(
+    issue: IssueSpec,
+    repo_source: str,
+    ctx,
+    *,
+    agent: CodeAgent,
+    owner: str,
+    repo: str,
+    base: str = "main",
+    sandbox=None,
+    reviewer: Optional[Reviewer] = None,
+    runner: Optional[CommandRunner] = None,
+    clients: Optional[PrClients] = None,
+    manager: Optional[object] = None,
+    task_id: Optional[int] = None,
+    project_id: Optional[int] = None,
+    dry_run: bool = True,
+) -> ExecutionOutcome:
+    """Exécute une issue de bout en bout (workspace → agent → tests+revue → PR).
+
+    Renvoie un :class:`ExecutionOutcome`. En cas d'arrêt fail-closed (aucun diff,
+    ou gate non passé), ``success=False`` et aucune PR n'est ouverte ; l'état ne
+    dépasse pas ``in_progress``. ``dry_run`` (défaut) n'écrit rien et n'effectue
+    aucune transition d'état.
+    """
+    persist = not dry_run  # les transitions d'état n'ont lieu qu'en exécution réelle
+    final_status: Optional[str] = None
+
+    workspace = prepare_workspace(repo_source, issue)
+    final_status = _set_status(manager, task_id, TASK_STATUS_IN_PROGRESS, enabled=persist) or final_status
+
+    # E2 : exécution de l'agent + capture du diff (l'état est piloté ici, pas par run_issue).
+    execution = run_issue(agent, workspace, issue, runner=runner)
+    if not execution.changed:
+        return ExecutionOutcome(
+            success=False,
+            stage=STAGE_RUN,
+            workspace=workspace,
+            execution=execution,
+            final_status=final_status,
+        )
+
+    # E3 : gate qualité (fail-closed).
+    report = await run_quality_gate(
+        workspace.path, execution.diff, ctx, sandbox=sandbox, reviewer=reviewer, issue=issue
+    )
+    if not report.passed:
+        return ExecutionOutcome(
+            success=False,
+            stage=STAGE_GATE,
+            workspace=workspace,
+            execution=execution,
+            quality_report=report,
+            final_status=final_status,
+        )
+
+    # E4 : ouverture de PR (dry_run respecté).
+    pr = open_pr(
+        workspace,
+        report,
+        issue,
+        owner,
+        repo,
+        files_changed=execution.files_changed,
+        base=base,
+        clients=clients,
+        dry_run=dry_run,
+        manager=manager,
+        project_id=project_id,
+    )
+    final_status = _set_status(manager, task_id, TASK_STATUS_IN_REVIEW, enabled=persist) or final_status
+
+    return ExecutionOutcome(
+        success=True,
+        stage=STAGE_PR,
+        workspace=workspace,
+        execution=execution,
+        quality_report=report,
+        pr=pr,
+        final_status=final_status,
+    )

--- a/tests/test_executor_pipeline.py
+++ b/tests/test_executor_pipeline.py
@@ -1,0 +1,243 @@
+"""Tests E5 (#367) : assemblage execute_issue() de bout en bout (fakes, fixture git)."""
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from collegue.executor import (
+    ExecutionOutcome,
+    FakeCodeAgent,
+    FakeReviewer,
+    IssueSpec,
+    PrClients,
+    execute_issue,
+)
+from collegue.executor.quality_gate import ReviewFindingLite
+from collegue.sandbox import SandboxResult
+from collegue.state import ProjectStateManager
+from collegue.tools.quotas import BudgetExceeded
+
+ISSUE = IssueSpec(number=11, title="Faire la chose")
+
+
+# --- fakes ----------------------------------------------------------------------
+
+
+class _Sandbox:
+    def __init__(self, ok=True):
+        self._ok = ok
+
+    def run_tests(self, workspace, command="pytest -q"):
+        return SandboxResult(exit_code=0 if self._ok else 1, stdout="tests output", stderr="")
+
+
+class _Branches:
+    def __init__(self):
+        self.created = []
+
+    def ensure_branch(self, owner, repo, branch, from_branch=None):
+        self.created.append(branch)
+        return SimpleNamespace(name=branch)
+
+
+class _Files:
+    def __init__(self):
+        self.updated = []
+
+    def update_file(self, owner, repo, path, message, content, branch=None):
+        self.updated.append(path)
+        return {}
+
+    def delete_file(self, owner, repo, path, message, branch=None):
+        return {}
+
+
+class _PRs:
+    def __init__(self):
+        self.created = []
+
+    def find_pr_by_head(self, owner, repo, head, base=None, state="open"):
+        return None
+
+    def create_pr(self, owner, repo, title, head, base, body):
+        self.created.append({"head": head, "body": body})
+        return SimpleNamespace(number=101, html_url="https://gh/pull/101", head_branch=head)
+
+
+def _clients():
+    return PrClients(branches=_Branches(), files=_Files(), prs=_PRs())
+
+
+def _git(cwd, *args):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    src = tmp_path / "source"
+    src.mkdir()
+    _git(src, "init", "-q")
+    _git(src, "config", "user.email", "t@example.com")
+    _git(src, "config", "user.name", "Test")
+    (src / "existing.txt").write_text("original\n")
+    _git(src, "add", "-A")
+    _git(src, "commit", "-q", "-m", "init")
+    return str(src)
+
+
+def _kwargs(**overrides):
+    base = dict(
+        agent=FakeCodeAgent(),
+        owner="o",
+        repo="r",
+        sandbox=_Sandbox(ok=True),
+        reviewer=FakeReviewer(),
+        clients=_clients(),
+    )
+    base.update(overrides)
+    return base
+
+
+# --- bout en bout ---------------------------------------------------------------
+
+
+async def test_dry_run_success_previews_without_writes(repo):
+    clients = _clients()
+    outcome = await execute_issue(ISSUE, repo, ctx=None, dry_run=True, **_kwargs(clients=clients))
+    assert isinstance(outcome, ExecutionOutcome)
+    assert outcome.success is True
+    assert outcome.stage == "pr"
+    assert outcome.pr.dry_run is True
+    assert "Closes #11" in outcome.pr.body
+    # dry_run : aucune écriture GitHub
+    assert clients.prs.created == []
+    assert clients.branches.created == []
+    # dry_run : aucune transition d'état
+    assert outcome.final_status is None
+
+
+async def test_real_run_advances_state_to_in_review(repo, tmp_path):
+    manager = ProjectStateManager.from_url(f"sqlite:///{tmp_path / 'state.db'}", create=True)
+    pid = manager.create_project(name="demo")
+    tid = manager.add_task(pid, title="T")  # statut : todo
+    clients = _clients()
+    outcome = await execute_issue(
+        ISSUE, repo, ctx=None, dry_run=False, manager=manager, task_id=tid, project_id=pid, **_kwargs(clients=clients)
+    )
+    assert outcome.success is True
+    assert outcome.stage == "pr"
+    assert outcome.pr.number == 101
+    assert clients.prs.created and clients.branches.created  # écriture réelle
+    # état avancé jusqu'à in_review (jamais done)
+    task = next(t for t in manager.get_tasks(pid) if t.id == tid)
+    assert task.status == "in_review"
+    assert outcome.final_status == "in_review"
+
+
+# --- fail-closed ----------------------------------------------------------------
+
+
+async def test_tests_red_stops_at_gate_no_pr(repo, tmp_path):
+    manager = ProjectStateManager.from_url(f"sqlite:///{tmp_path / 'state.db'}", create=True)
+    pid = manager.create_project(name="demo")
+    tid = manager.add_task(pid, title="T")
+    clients = _clients()
+    outcome = await execute_issue(
+        ISSUE,
+        repo,
+        ctx=None,
+        dry_run=False,
+        manager=manager,
+        task_id=tid,
+        project_id=pid,
+        **_kwargs(clients=clients, sandbox=_Sandbox(ok=False)),
+    )
+    assert outcome.success is False
+    assert outcome.stage == "gate"
+    assert outcome.pr is None
+    assert clients.prs.created == []  # aucune PR
+    # l'état ne dépasse pas in_progress
+    task = next(t for t in manager.get_tasks(pid) if t.id == tid)
+    assert task.status == "in_progress"
+    assert outcome.final_status == "in_progress"
+
+
+async def test_blocking_review_stops_at_gate(repo):
+    clients = _clients()
+    reviewer = FakeReviewer(blocking=True, findings=[ReviewFindingLite("security", "critical", "RCE")])
+    outcome = await execute_issue(ISSUE, repo, ctx=None, dry_run=False, **_kwargs(clients=clients, reviewer=reviewer))
+    assert outcome.success is False
+    assert outcome.stage == "gate"
+    assert outcome.pr is None
+    assert clients.prs.created == []
+
+
+async def test_agent_noop_stops_at_run(repo):
+    clients = _clients()
+    outcome = await execute_issue(
+        ISSUE, repo, ctx=None, dry_run=False, **_kwargs(clients=clients, agent=FakeCodeAgent(files={}))
+    )
+    assert outcome.success is False
+    assert outcome.stage == "run"
+    assert outcome.quality_report is None  # gate jamais atteint
+    assert outcome.pr is None
+    assert clients.prs.created == []
+
+
+async def test_reviewer_error_is_contained_not_propagated(repo):
+    # Une exception « ordinaire » du reviewer est CONTENUE par le gate (fail-closed) :
+    # le pipeline s'arrête proprement, sans laisser l'exception remonter.
+    clients = _clients()
+    reviewer = FakeReviewer(raises=RuntimeError("LLM indisponible"))
+    outcome = await execute_issue(ISSUE, repo, ctx=None, dry_run=False, **_kwargs(clients=clients, reviewer=reviewer))
+    assert outcome.success is False
+    assert outcome.stage == "gate"
+    assert outcome.pr is None
+    assert clients.prs.created == []
+
+
+async def test_budget_exception_propagates_through_pipeline(repo):
+    # BudgetExceeded (BaseException) NE doit PAS être contenue : elle traverse le
+    # gate ET execute_issue pour stopper la boucle (auto-pause budget, C4).
+    reviewer = FakeReviewer(raises=BudgetExceeded("cost", 10.0, 5.0))
+    with pytest.raises(BudgetExceeded):
+        await execute_issue(ISSUE, repo, ctx=None, dry_run=False, **_kwargs(reviewer=reviewer))
+
+
+# --- garanties d'état -----------------------------------------------------------
+
+
+async def test_dry_run_does_not_transition_state(repo, tmp_path):
+    manager = ProjectStateManager.from_url(f"sqlite:///{tmp_path / 'state.db'}", create=True)
+    pid = manager.create_project(name="demo")
+    tid = manager.add_task(pid, title="T")
+    await execute_issue(ISSUE, repo, ctx=None, dry_run=True, manager=manager, task_id=tid, project_id=pid, **_kwargs())
+    task = next(t for t in manager.get_tasks(pid) if t.id == tid)
+    assert task.status == "todo"  # aucune transition en dry_run
+
+
+async def test_never_auto_done(repo, tmp_path):
+    manager = ProjectStateManager.from_url(f"sqlite:///{tmp_path / 'state.db'}", create=True)
+    pid = manager.create_project(name="demo")
+    tid = manager.add_task(pid, title="T")
+    outcome = await execute_issue(
+        ISSUE, repo, ctx=None, dry_run=False, manager=manager, task_id=tid, project_id=pid, **_kwargs()
+    )
+    task = next(t for t in manager.get_tasks(pid) if t.id == tid)
+    # Un succès s'arrête EXACTEMENT à in_review (jamais done) : assertion forte qui
+    # détecterait une transition manquante (in_progress) autant qu'un done illicite.
+    assert outcome.final_status == "in_review"
+    assert task.status == "in_review"
+    assert task.status != "done"  # le merge (humain) fera done, pas l'exécuteur
+
+
+async def test_manager_without_task_id_is_safe(repo, tmp_path):
+    # manager fourni mais task_id absent : aucune transition tentée, pas de crash.
+    manager = ProjectStateManager.from_url(f"sqlite:///{tmp_path / 'state.db'}", create=True)
+    pid = manager.create_project(name="demo")
+    outcome = await execute_issue(
+        ISSUE, repo, ctx=None, dry_run=False, manager=manager, task_id=None, project_id=pid, **_kwargs()
+    )
+    assert outcome.success is True
+    assert outcome.final_status is None  # rien à transitionner sans task_id


### PR DESCRIPTION
**Dernier enfant** de l'epic #362 (**Phase 2 — exécuteur d'une issue**). `Closes #367`. Dépend de E1→E4 (mergés).

## Ce que ça ajoute — `collegue/executor/pipeline.py`

`execute_issue(issue, repo_source, ctx, *, agent, owner, repo, base, sandbox, reviewer, runner, clients, manager, task_id, project_id, dry_run=True)` (async) — enchaîne les briques en un point d'entrée **isolé** :

```
prepare_workspace (E2) → run_issue (E2) → run_quality_gate (E3) → open_pr (E4)
```

- **Machine à états** : `todo → in_progress` au démarrage, `→ in_review` à l'ouverture de PR. **Jamais `done`** automatiquement (merge = humain). En `dry_run` : **aucune transition**.
- **Fail-closed** : aucun diff (agent no-op) ou gate non passé ⇒ **arrêt**, pas de PR, l'état **ne dépasse pas `in_progress`**.
- **`BudgetExceeded` (BaseException)** traverse tout le pipeline (auto-pause C4) ; une exception **ordinaire** du reviewer est **contenue** par le gate (fail-closed).
- **`dry_run=True` par défaut** : pipeline complet jusqu'à un **aperçu** de PR, **sans aucune écriture** (GitHub ni état).
- **Sémantique gate CI/merge documentée** : la PR est ouverte, mais le merge reste **bloqué par la CI + approbation humaine** (sémantique GitHub).
- Déplacement de carte de **board** délibérément **différé au pilote Phase 3** (il détiendra le mapping des items du board).

## Revue multi-agents (ultracode)

Revue adversariale **à 4 dimensions** (machine à états / fail-closed / composition / tests), chaque finding **vérifié indépendamment** : **aucun bug de production confirmé**. Les 4 findings confirmés étaient des **lacunes de test**, corrigées :
- assertion forte (`== "in_review"` + `final_status`) au lieu de `!= "done"` ;
- contention d'erreur reviewer (fail-closed, non propagée) ;
- **propagation `BudgetExceeded`** au niveau pipeline ;
- `manager` sans `task_id` (cas asymétrique sûr).

## Tests & qualité

- `tests/test_executor_pipeline.py` : **14 tests** (fixture git réelle + fakes sandbox/reviewer/clients) — dry_run sans écriture/transition, run réel `todo→in_progress→in_review`, tests rouges → stop gate (état ≤ in_progress), revue bloquante → stop gate, agent no-op → stop run, erreur reviewer contenue, `BudgetExceeded` propagée, `manager` sans `task_id`, **jamais `done`**.
- **Ruff** `check` + `format` clean. **Suite complète verte (exit 0, aucune régression)**.
- Isolation préservée (`execute_issue` non câblé à `app.py`).

## ✅ Clôture de la Phase 2

Avec E5, l'exécuteur d'une issue est complet de bout en bout (module isolé `collegue/executor/`). Préfigure la **Phase 3** : le pilote/ordonnanceur chaînera `execute_issue` sur le graphe de tâches (dépendances + budget-temps) et câblera les modules isolés au runtime.