### PR TITLE
feat(pilot): ordonnanceur de graphe — sélection des tâches prêtes (F1)

### DIFF
--- a/collegue/pilot/__init__.py
+++ b/collegue/pilot/__init__.py
@@ -1,0 +1,25 @@
+"""Pilote / ordonnanceur du moteur autonome (Phase 3, epic #373).
+
+Chaîne l'exécuteur (Phase 2) sur le graphe de tâches en respectant les
+dépendances (DAG) et un budget-temps, et — via le câblage F4 — rend vivants les
+modules jusqu'ici isolés (``state/``, ``sandbox/``, ``planner/``, ``executor/``).
+
+F1 pose l'ordonnanceur (sélection des tâches prêtes). Module **isolé** tant que
+le câblage runtime (F4) n'expose pas le pilote.
+"""
+
+from collegue.pilot.scheduler import (
+    SchedulerError,
+    is_blocked,
+    next_task,
+    ready_tasks,
+    remaining_tasks,
+)
+
+__all__ = [
+    "SchedulerError",
+    "ready_tasks",
+    "next_task",
+    "remaining_tasks",
+    "is_blocked",
+]

--- a/collegue/pilot/scheduler.py
+++ b/collegue/pilot/scheduler.py
@@ -1,0 +1,118 @@
+"""Ordonnanceur de graphe de tâches (F1, epic #373, brief §7 Phase 3).
+
+Sélectionne, dans le graphe de tâches **persisté**, les tâches **prêtes** à
+exécuter : celles encore à faire (``todo``) dont **toutes** les dépendances sont
+terminées. Calcul **pur** sur l'état (aucune exécution ici) ; le pilote (F3)
+consomme la sélection.
+
+Statuts (alignés Phase 2 ``todo``→``in_progress``→``in_review``) :
+- **satisfaisants** (débloquent un dépendant) : ``in_review``, ``done``, ``merged``.
+  Une PR ouverte (``in_review``) suffit à débloquer la suite — on n'attend pas le
+  merge humain pour enchaîner la construction du MVP.
+- **en cours** : ``in_progress`` (ni prête ni terminée).
+- **prête** : ``todo`` avec toutes ses dépendances satisfaites.
+- tout autre statut non satisfaisant et non actif (ex. ``failed``) bloque ses
+  dépendants → peut mener à un **blocage** (cf. :func:`is_blocked`).
+
+Module **isolé** : non câblé au runtime (F4 câblera le pilote).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Sequence
+
+# Statuts qui SATISFONT une dépendance (débloquent un dépendant).
+SATISFIED_STATUSES = frozenset({"in_review", "done", "merged"})
+# Statuts « en cours » : du travail progresse, pas un blocage.
+ACTIVE_STATUSES = frozenset({"in_progress"})
+# Statut d'une tâche pas encore démarrée.
+PENDING_STATUS = "todo"
+
+
+class SchedulerError(RuntimeError):
+    """Graphe de tâches invalide (cycle, dépendance absente)."""
+
+
+def _by_id(tasks: Sequence) -> Dict[int, object]:
+    return {task.id: task for task in tasks}
+
+
+def _deps(task) -> List[int]:
+    return list(task.depends_on or [])
+
+
+def _validate_graph(tasks: Sequence) -> None:
+    """Lève :class:`SchedulerError` si une dépendance est absente ou si le graphe a un cycle."""
+    by_id = _by_id(tasks)
+    for task in tasks:
+        for dep in _deps(task):
+            if dep not in by_id:
+                raise SchedulerError(f"la tâche {task.id} dépend d'un id absent du graphe: {dep}")
+
+    # Détection de cycle par coloriage (DFS itératif → pas de limite de récursion ;
+    # le graphe est borné par MAX_TASKS=200 côté planner, mais on reste prudent).
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color = {task.id: WHITE for task in tasks}
+    for root in tasks:
+        if color[root.id] != WHITE:
+            continue
+        stack = [(root.id, iter(_deps(root)))]
+        color[root.id] = GRAY
+        while stack:
+            node, deps_iter = stack[-1]
+            advanced = False
+            for dep in deps_iter:
+                if color[dep] == GRAY:
+                    raise SchedulerError(f"cycle de dépendances détecté impliquant la tâche {dep}")
+                if color[dep] == WHITE:
+                    color[dep] = GRAY
+                    stack.append((dep, iter(_deps(by_id[dep]))))
+                    advanced = True
+                    break
+            if not advanced:
+                color[node] = BLACK
+                stack.pop()
+
+
+def ready_tasks(tasks: Sequence) -> List:
+    """Tâches prêtes (``todo`` + dépendances satisfaites), en ordre déterministe (par id).
+
+    Les tâches prêtes sont à la « frontière » du graphe (dépendances déjà
+    terminées) donc mutuellement indépendantes : trier par id est déterministe et
+    cohérent avec un ordre topologique. Lève :class:`SchedulerError` si le graphe
+    est invalide (cycle / dépendance absente).
+    """
+    _validate_graph(tasks)
+    by_id = _by_id(tasks)
+    ready = [
+        task
+        for task in tasks
+        if task.status == PENDING_STATUS and all(by_id[dep].status in SATISFIED_STATUSES for dep in _deps(task))
+    ]
+    return sorted(ready, key=lambda task: task.id)
+
+
+def next_task(tasks: Sequence) -> Optional[object]:
+    """Prochaine tâche prête (la plus prioritaire), ou ``None`` s'il n'y en a pas."""
+    ready = ready_tasks(tasks)
+    return ready[0] if ready else None
+
+
+def remaining_tasks(tasks: Sequence) -> List:
+    """Tâches non terminées (statut hors :data:`SATISFIED_STATUSES`)."""
+    return [task for task in tasks if task.status not in SATISFIED_STATUSES]
+
+
+def is_blocked(tasks: Sequence) -> bool:
+    """True si des tâches restent, mais aucune n'est prête **et** aucune n'est en cours.
+
+    Signale un graphe « coincé » (p.ex. un dépendant d'une tâche ``failed``), pour
+    que le pilote (F3) s'arrête au lieu de boucler. Lève :class:`SchedulerError`
+    sur un graphe invalide (via :func:`ready_tasks`).
+    """
+    remaining = remaining_tasks(tasks)
+    if not remaining:
+        return False
+    if ready_tasks(tasks):
+        return False
+    return not any(task.status in ACTIVE_STATUSES for task in remaining)

--- a/tests/test_pilot_scheduler.py
+++ b/tests/test_pilot_scheduler.py
@@ -1,0 +1,158 @@
+"""Tests F1 (#374) : ordonnanceur de graphe — sélection des tâches prêtes (DAG)."""
+
+import pytest
+
+from collegue.pilot import SchedulerError, is_blocked, next_task, ready_tasks, remaining_tasks
+from collegue.state import ProjectStateManager
+
+
+@pytest.fixture
+def manager(tmp_path):
+    return ProjectStateManager.from_url(f"sqlite:///{tmp_path / 'state.db'}", create=True)
+
+
+def _ids(tasks):
+    return [t.id for t in tasks]
+
+
+# --- graphe linéaire A→B→C ------------------------------------------------------
+
+
+def test_linear_chain_unblocks_step_by_step(manager):
+    pid = manager.create_project(name="demo")
+    a = manager.add_task(pid, title="A")
+    b = manager.add_task(pid, title="B", depends_on=[a])
+    c = manager.add_task(pid, title="C", depends_on=[b])
+
+    assert _ids(ready_tasks(manager.get_tasks(pid))) == [a]  # seul A
+    manager.update_task_status(a, "in_review")
+    assert _ids(ready_tasks(manager.get_tasks(pid))) == [b]  # A faite → B
+    manager.update_task_status(b, "done")
+    assert _ids(ready_tasks(manager.get_tasks(pid))) == [c]  # B faite → C
+    manager.update_task_status(c, "in_review")
+    assert ready_tasks(manager.get_tasks(pid)) == []
+    assert remaining_tasks(manager.get_tasks(pid)) == []
+
+
+# --- branches parallèles --------------------------------------------------------
+
+
+def test_parallel_branches_ready_in_deterministic_order(manager):
+    pid = manager.create_project(name="demo")
+    a = manager.add_task(pid, title="A")
+    b = manager.add_task(pid, title="B")
+    c = manager.add_task(pid, title="C", depends_on=[a, b])
+
+    assert _ids(ready_tasks(manager.get_tasks(pid))) == [a, b]  # trié par id
+    assert next_task(manager.get_tasks(pid)).id == a
+    # C reste bloquée tant que A ET B ne sont pas satisfaites
+    manager.update_task_status(a, "in_review")
+    assert _ids(ready_tasks(manager.get_tasks(pid))) == [b]
+    manager.update_task_status(b, "in_review")
+    assert _ids(ready_tasks(manager.get_tasks(pid))) == [c]
+
+
+def test_dependency_on_higher_id_no_false_cycle(manager):
+    # A (id plus petit) dépend de B (id plus grand) : DAG valide. La validation
+    # visite B comme dépendance de A, puis l'atteint à nouveau comme racine (déjà
+    # noire) → pas de faux cycle. La « prête » suit les dépendances, pas l'id.
+    pid = manager.create_project(name="demo")
+    a = manager.add_task(pid, title="A")
+    b = manager.add_task(pid, title="B")
+    manager.update_task(a, depends_on=[b])  # A → B (id_a < id_b)
+    assert _ids(ready_tasks(manager.get_tasks(pid))) == [b]  # B d'abord, malgré l'id
+    manager.update_task_status(b, "done")
+    assert _ids(ready_tasks(manager.get_tasks(pid))) == [a]
+
+
+def test_diamond_dependency_no_false_cycle(manager):
+    # Diamant D→{A,B}→C : aucune fausse détection de cycle ; seule D est prête.
+    pid = manager.create_project(name="demo")
+    d = manager.add_task(pid, title="D")
+    a = manager.add_task(pid, title="A", depends_on=[d])
+    b = manager.add_task(pid, title="B", depends_on=[d])
+    manager.add_task(pid, title="C", depends_on=[a, b])
+    assert _ids(ready_tasks(manager.get_tasks(pid))) == [d]
+
+
+def test_in_review_satisfies_dependency(manager):
+    # Une PR ouverte (in_review) suffit à débloquer la suivante (pas besoin du merge).
+    pid = manager.create_project(name="demo")
+    a = manager.add_task(pid, title="A")
+    b = manager.add_task(pid, title="B", depends_on=[a])
+    manager.update_task_status(a, "in_review")
+    assert _ids(ready_tasks(manager.get_tasks(pid))) == [b]
+
+
+# --- next_task / vide -----------------------------------------------------------
+
+
+def test_next_task_none_when_nothing_ready(manager):
+    pid = manager.create_project(name="demo")
+    a = manager.add_task(pid, title="A")
+    manager.update_task_status(a, "in_progress")  # en cours, pas prête
+    assert next_task(manager.get_tasks(pid)) is None
+
+
+# --- graphes invalides ----------------------------------------------------------
+
+
+def test_cycle_raises(manager):
+    pid = manager.create_project(name="demo")
+    a = manager.add_task(pid, title="A")
+    b = manager.add_task(pid, title="B", depends_on=[a])
+    manager.update_task(a, depends_on=[b])  # A↔B
+    with pytest.raises(SchedulerError):
+        ready_tasks(manager.get_tasks(pid))
+
+
+def test_dangling_dependency_raises(manager):
+    pid = manager.create_project(name="demo")
+    manager.add_task(pid, title="A", depends_on=[99999])
+    with pytest.raises(SchedulerError):
+        ready_tasks(manager.get_tasks(pid))
+
+
+def test_self_dependency_is_a_cycle(manager):
+    pid = manager.create_project(name="demo")
+    a = manager.add_task(pid, title="A")
+    manager.update_task(a, depends_on=[a])
+    with pytest.raises(SchedulerError):
+        ready_tasks(manager.get_tasks(pid))
+
+
+# --- blocage --------------------------------------------------------------------
+
+
+def test_is_blocked_when_dependency_failed(manager):
+    pid = manager.create_project(name="demo")
+    a = manager.add_task(pid, title="A")
+    manager.add_task(pid, title="B", depends_on=[a])
+    manager.update_task_status(a, "failed")  # ni satisfaite ni active
+    tasks = manager.get_tasks(pid)
+    assert ready_tasks(tasks) == []  # B non prête (dep failed)
+    assert is_blocked(tasks) is True
+
+
+def test_not_blocked_while_a_task_is_in_progress(manager):
+    pid = manager.create_project(name="demo")
+    a = manager.add_task(pid, title="A")
+    manager.add_task(pid, title="B", depends_on=[a])
+    manager.update_task_status(a, "in_progress")  # progresse → pas un blocage
+    tasks = manager.get_tasks(pid)
+    assert ready_tasks(tasks) == []
+    assert is_blocked(tasks) is False
+
+
+def test_not_blocked_when_work_is_ready(manager):
+    pid = manager.create_project(name="demo")
+    manager.add_task(pid, title="A")
+    tasks = manager.get_tasks(pid)
+    assert is_blocked(tasks) is False  # A est prête
+
+
+def test_not_blocked_when_all_done(manager):
+    pid = manager.create_project(name="demo")
+    a = manager.add_task(pid, title="A")
+    manager.update_task_status(a, "done")
+    assert is_blocked(manager.get_tasks(pid)) is False


### PR DESCRIPTION
Premier enfant de l'epic #373 (**Phase 3 — pilote + ordonnanceur**). `Closes #374`.

## Ce que ça ajoute

Nouveau module **ISOLÉ** `collegue/pilot/` (non câblé au runtime — F4 câblera). `collegue/pilot/scheduler.py` — **calcul pur** sur le graphe de tâches persisté :

- **`ready_tasks(tasks)`** — tâches `todo` dont **toutes** les dépendances sont satisfaites (`in_review`/`done`/`merged`), triées par id (déterministe). Une PR ouverte (`in_review`) suffit à débloquer la suite — on n'attend pas le merge humain pour enchaîner la construction du MVP.
- **`next_task`** / **`remaining_tasks`** / **`is_blocked`** — `is_blocked` = il reste des tâches, aucune n'est prête **et** aucune n'est en cours (p.ex. un dépendant d'une tâche `failed`) → le pilote (F3) s'arrêtera au lieu de boucler.
- **`_validate_graph`** — DFS **itératif** (pas de récursion) détectant les **cycles** (dont l'auto-dépendance) et les **dépendances absentes** → `SchedulerError`.

## Statuts

`todo`→`in_progress`→`in_review` (Phase 2). Satisfont une dépendance : `in_review`/`done`/`merged`. Documenté dans le module.

## Tests & qualité

- `tests/test_pilot_scheduler.py` : **13 tests** sur `ProjectStateManager` SQLite — chaîne linéaire, branches parallèles, **diamant**, dépendance sur id supérieur (sans faux cycle), `cycle`/`self-dep`/`dépendance absente` → `SchedulerError`, blocages (`failed` dep), `in_progress` non bloquant, tout terminé.
- **Ruff** `check` + `format` clean. Couverture module ~98 %.
- Passe `/review` adversariale (contexte frais, **fuzz de 20 000 graphes** vs détecteur de cycle de référence — 0 écart) : aucun défaut ; +2 tests de couverture ajoutés (diamant / id supérieur).
- Import isolation : importer `collegue.pilot` ne tire aucune dépendance lourde ni `app.py`.

## Hors périmètre (suite)

F2 = contrôleur budget-temps ; F3 = Project Driver (boucle `execute_issue` sous budget + checkpoints + bascule MVP) ; F4 = câblage runtime opt-in + reporting.