### PR TITLE
feat(pilot): contrôleur budget-temps (deadline + budget, auto-pause) (F2)

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -59,6 +59,22 @@ class Settings(BaseSettings):
             return 0.0
         return f if math.isfinite(f) and f > 0 else 0.0
 
+    # Budget-temps du pilote (Phase 3) : durée mur max d'un run de projet, en
+    # secondes. À l'échéance, le pilote s'arrête (livraison). <= 0 (défaut) =
+    # pas de deadline. Voir collegue.pilot.budget.BudgetTimeController.
+    COLLEGUE_RUN_DEADLINE_SECONDS: float = 0.0
+
+    @field_validator("COLLEGUE_RUN_DEADLINE_SECONDS", mode="before")
+    @classmethod
+    def _normalize_run_deadline(cls, v):
+        # Même garde que LLM_CALL_TIMEOUT : nan/inf/négatif → 0 (désactivé), pour
+        # ne pas produire une deadline absurde.
+        try:
+            f = float(v)
+        except (TypeError, ValueError):
+            return 0.0
+        return f if math.isfinite(f) and f > 0 else 0.0
+
     ENGINE_INIT_TIMEOUT: float = 10.0
     ENGINE_WAIT_TIMEOUT: float = 30.0
     MAX_HISTORY_LENGTH: int = 20

--- a/collegue/pilot/__init__.py
+++ b/collegue/pilot/__init__.py
@@ -8,6 +8,13 @@ F1 pose l'ordonnanceur (sélection des tâches prêtes). Module **isolé** tant 
 le câblage runtime (F4) n'expose pas le pilote.
 """
 
+from collegue.pilot.budget import (
+    ACTION_CONTINUE,
+    ACTION_DEADLINE,
+    ACTION_PAUSED_BUDGET,
+    BudgetTimeController,
+    ContinueDecision,
+)
 from collegue.pilot.scheduler import (
     SchedulerError,
     is_blocked,
@@ -17,9 +24,16 @@ from collegue.pilot.scheduler import (
 )
 
 __all__ = [
+    # F1 — ordonnanceur
     "SchedulerError",
     "ready_tasks",
     "next_task",
     "remaining_tasks",
     "is_blocked",
+    # F2 — contrôleur budget-temps
+    "BudgetTimeController",
+    "ContinueDecision",
+    "ACTION_CONTINUE",
+    "ACTION_PAUSED_BUDGET",
+    "ACTION_DEADLINE",
 ]

--- a/collegue/pilot/budget.py
+++ b/collegue/pilot/budget.py
@@ -1,0 +1,141 @@
+"""Contrôleur budget-temps du pilote (F2, epic #373, brief §7 Phase 3).
+
+À chaque itération, le pilote demande à :class:`BudgetTimeController.should_continue`
+s'il peut lancer la prochaine tâche : **continuer**, **pause budget** (plafond
+`$`/tokens atteint, C4) ou **deadline atteinte** (durée mur dépassée).
+
+Distinct du chokepoint LLM (C4) : ici on **décide proactivement** d'arrêter la
+boucle *avant* de lancer une tâche — on ne lève pas ``BudgetExceeded`` (c'est le
+rôle de ``enforce_budget`` au niveau appel LLM).
+
+Horloge **injectable** (pas de ``datetime.now()`` direct) → tests déterministes
+sans patcher le temps.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Optional
+
+from collegue.monitoring.metrics import BudgetStatus, get_metrics_collector
+
+# Décisions possibles.
+ACTION_CONTINUE = "continue"
+ACTION_PAUSED_BUDGET = "paused_budget"
+ACTION_DEADLINE = "deadline_reached"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _aware(dt: Optional[datetime]) -> Optional[datetime]:
+    """Force un datetime à être *aware* UTC (les naïfs planteraient les comparaisons).
+
+    Même garde que ``state.models.UTCDateTime`` : un ``started_at`` ou une horloge
+    naïfs (ex. ``Project.created_at`` parsé sans tz) ne doivent pas faire planter le
+    contrôleur — on normalise en UTC.
+    """
+    if dt is not None and dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+@dataclass(frozen=True)
+class ContinueDecision:
+    """Décision du contrôleur pour l'itération courante."""
+
+    action: str  # continue | paused_budget | deadline_reached
+    reason: str
+    budget_status: Optional[BudgetStatus] = None
+
+    @property
+    def ok(self) -> bool:
+        """True si le pilote peut continuer."""
+        return self.action == ACTION_CONTINUE
+
+
+class BudgetTimeController:
+    """Décide à chaque itération si le pilote continue (budget + deadline).
+
+    ``deadline_seconds`` : durée mur max depuis ``started_at`` ; si ``None``, lue
+    dans les settings (``COLLEGUE_RUN_DEADLINE_SECONDS``) ; ``<= 0`` = pas de
+    deadline. ``collector`` (métriques C4) et ``clock`` sont injectables.
+    """
+
+    def __init__(
+        self,
+        *,
+        started_at: Optional[datetime] = None,
+        deadline_seconds: Optional[float] = None,
+        collector=None,
+        settings_obj: Optional[object] = None,
+        clock: Optional[Callable[[], datetime]] = None,
+    ):
+        self._clock = clock or _utcnow
+        self._started_at = _aware(started_at) or _aware(self._clock())
+        self._settings = settings_obj
+        self._collector = collector
+        if deadline_seconds is None:
+            deadline_seconds = getattr(self._resolve_settings(), "COLLEGUE_RUN_DEADLINE_SECONDS", 0.0) or 0.0
+        self._deadline_seconds = float(deadline_seconds)
+        # Deadline absolue (aware) ou None si pas de limite de temps.
+        self._deadline: Optional[datetime] = (
+            self._started_at + timedelta(seconds=self._deadline_seconds) if self._deadline_seconds > 0 else None
+        )
+
+    def _resolve_settings(self):
+        if self._settings is not None:
+            return self._settings
+        from collegue.config import settings
+
+        return settings
+
+    def _collector_obj(self):
+        return self._collector or get_metrics_collector()
+
+    def _now(self) -> datetime:
+        """Heure courante *aware* (coercition UTC si l'horloge injectée est naïve)."""
+        return _aware(self._clock())
+
+    @property
+    def deadline(self) -> Optional[datetime]:
+        return self._deadline
+
+    def time_remaining_seconds(self) -> Optional[float]:
+        """Secondes restantes avant la deadline, ou ``None`` si pas de deadline.
+
+        Peut être **négatif** si appelé après l'échéance (``should_continue`` arrête
+        le pilote avant ce cas dans la boucle normale).
+        """
+        if self._deadline is None:
+            return None
+        return (self._deadline - self._now()).total_seconds()
+
+    def should_continue(self) -> ContinueDecision:
+        """Décision pour l'itération courante : continue / pause budget / deadline."""
+        # Deadline d'abord : si le temps est écoulé, on s'arrête quoi qu'il arrive.
+        if self._deadline is not None and self._now() >= self._deadline:
+            return ContinueDecision(
+                action=ACTION_DEADLINE,
+                reason=f"deadline atteinte (durée mur {self._deadline_seconds:g}s écoulée)",
+            )
+        # Budget dur $/tokens (réutilise la garde C4). On passe les plafonds depuis
+        # les settings injectés (cohérent avec la deadline), et on respecte
+        # BUDGET_EXHAUSTED_ACTION : "warn" = non bloquant (comme enforce_budget).
+        settings = self._resolve_settings()
+        status = self._collector_obj().would_exceed_budget(
+            max_cost_usd=getattr(settings, "MAX_COST_USD", None),
+            max_tokens=getattr(settings, "MAX_TOKENS_BUDGET", None),
+        )
+        if status is not None:
+            action = str(getattr(settings, "BUDGET_EXHAUSTED_ACTION", "pause") or "pause").strip().lower()
+            reason = f"budget {status.limit_type} atteint : {status.current:.4f} >= {status.limit:.4f}"
+            if action != "warn":
+                return ContinueDecision(action=ACTION_PAUSED_BUDGET, reason=reason, budget_status=status)
+            # "warn" : on n'arrête pas le pilote (appels LLM non bloqués), info conservée.
+            return ContinueDecision(
+                action=ACTION_CONTINUE, reason=f"{reason} — action=warn (non bloquant)", budget_status=status
+            )
+        return ContinueDecision(action=ACTION_CONTINUE, reason="budget et deadline OK")

--- a/tests/test_pilot_budget.py
+++ b/tests/test_pilot_budget.py
@@ -1,0 +1,164 @@
+"""Tests F2 (#375) : contrôleur budget-temps (deadline + budget, auto-pause)."""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from collegue.config import Settings
+from collegue.monitoring.metrics import BudgetStatus
+from collegue.pilot import BudgetTimeController
+
+T0 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class _Collector:
+    """Collecteur factice : renvoie un BudgetStatus fixe (ou None = sous budget)."""
+
+    def __init__(self, status=None):
+        self._status = status
+
+    def would_exceed_budget(self, *args, **kwargs):
+        return self._status
+
+
+def _clock(dt):
+    return lambda: dt
+
+
+def _ctrl(*, deadline_seconds=0.0, status=None, now=T0, started_at=T0):
+    return BudgetTimeController(
+        started_at=started_at,
+        deadline_seconds=deadline_seconds,
+        collector=_Collector(status),
+        clock=_clock(now),
+    )
+
+
+# --- continue -------------------------------------------------------------------
+
+
+def test_continue_under_budget_before_deadline():
+    d = _ctrl(deadline_seconds=100, now=T0 + timedelta(seconds=10)).should_continue()
+    assert d.action == "continue"
+    assert d.ok is True
+
+
+def test_no_deadline_and_no_budget_always_continues():
+    # deadline 0 + collecteur sous budget → continue même loin dans le futur.
+    d = _ctrl(deadline_seconds=0, now=T0 + timedelta(days=365)).should_continue()
+    assert d.ok is True
+    assert _ctrl(deadline_seconds=0).deadline is None
+
+
+# --- deadline -------------------------------------------------------------------
+
+
+def test_deadline_reached():
+    d = _ctrl(deadline_seconds=10, now=T0 + timedelta(seconds=11)).should_continue()
+    assert d.action == "deadline_reached"
+    assert d.ok is False
+
+
+def test_exactly_at_deadline_stops():
+    # comparaison >= : à l'instant pile de la deadline, on s'arrête.
+    d = _ctrl(deadline_seconds=10, now=T0 + timedelta(seconds=10)).should_continue()
+    assert d.action == "deadline_reached"
+
+
+def test_time_remaining_seconds():
+    ctrl = _ctrl(deadline_seconds=100, now=T0 + timedelta(seconds=30))
+    assert abs(ctrl.time_remaining_seconds() - 70) < 1e-6
+    assert _ctrl(deadline_seconds=0).time_remaining_seconds() is None
+
+
+# --- budget ---------------------------------------------------------------------
+
+
+def test_paused_when_budget_exhausted():
+    status = BudgetStatus(exceeded=True, limit_type="cost", current=10.0, limit=5.0)
+    d = _ctrl(deadline_seconds=100, status=status, now=T0 + timedelta(seconds=1)).should_continue()
+    assert d.action == "paused_budget"
+    assert d.ok is False
+    assert d.budget_status is status
+
+
+def test_warn_mode_budget_does_not_pause():
+    # BUDGET_EXHAUSTED_ACTION="warn" : budget dépassé mais on continue (comme C4
+    # n'y bloque pas les appels LLM). budget_status reste informatif.
+    status = BudgetStatus(exceeded=True, limit_type="cost", current=10.0, limit=5.0)
+    ctrl = BudgetTimeController(
+        started_at=T0,
+        deadline_seconds=100,
+        collector=_Collector(status),
+        settings_obj=SimpleNamespace(MAX_COST_USD=5.0, MAX_TOKENS_BUDGET=0, BUDGET_EXHAUSTED_ACTION="warn"),
+        clock=_clock(T0 + timedelta(seconds=1)),
+    )
+    d = ctrl.should_continue()
+    assert d.ok is True
+    assert d.budget_status is status
+
+
+def test_deadline_takes_precedence_over_budget():
+    # deadline ET budget dépassés → deadline d'abord (vérifiée en premier).
+    status = BudgetStatus(exceeded=True, limit_type="tokens", current=99, limit=10)
+    d = _ctrl(deadline_seconds=10, status=status, now=T0 + timedelta(seconds=20)).should_continue()
+    assert d.action == "deadline_reached"
+
+
+# --- robustesse datetime naïf ---------------------------------------------------
+
+
+def test_naive_started_at_and_clock_do_not_crash():
+    # started_at ET horloge naïfs : pas de TypeError (coercition UTC), comportement
+    # cohérent (deadline 10s, +11s naïf → atteinte).
+    naive_start = datetime(2026, 1, 1, 12, 0, 0)  # sans tzinfo
+    ctrl = BudgetTimeController(
+        started_at=naive_start,
+        deadline_seconds=10,
+        collector=_Collector(None),
+        clock=lambda: datetime(2026, 1, 1, 12, 0, 11),  # naïf aussi
+    )
+    assert ctrl.should_continue().action == "deadline_reached"
+    assert ctrl.time_remaining_seconds() < 0
+
+
+def test_caps_forwarded_to_collector():
+    # La consistance settings→budget : les plafonds injectés sont bien transmis
+    # à would_exceed_budget (pas un repli silencieux sur les globals).
+    seen = {}
+
+    class _Capturing:
+        def would_exceed_budget(self, max_cost_usd=None, max_tokens=None):
+            seen["cost"] = max_cost_usd
+            seen["tokens"] = max_tokens
+            return None
+
+    BudgetTimeController(
+        started_at=T0,
+        deadline_seconds=0,
+        collector=_Capturing(),
+        settings_obj=SimpleNamespace(MAX_COST_USD=7.5, MAX_TOKENS_BUDGET=42, BUDGET_EXHAUSTED_ACTION="pause"),
+        clock=_clock(T0),
+    ).should_continue()
+    assert seen == {"cost": 7.5, "tokens": 42}
+
+
+# --- deadline depuis les settings ----------------------------------------------
+
+
+def test_deadline_resolved_from_settings():
+    ctrl = BudgetTimeController(
+        started_at=T0,
+        settings_obj=SimpleNamespace(COLLEGUE_RUN_DEADLINE_SECONDS=10.0),
+        collector=_Collector(None),
+        clock=_clock(T0 + timedelta(seconds=15)),
+    )
+    assert ctrl.should_continue().action == "deadline_reached"
+
+
+# --- validateur de config -------------------------------------------------------
+
+
+def test_config_deadline_validator_neutralizes_bad_values():
+    assert Settings(COLLEGUE_RUN_DEADLINE_SECONDS=-5).COLLEGUE_RUN_DEADLINE_SECONDS == 0.0
+    assert Settings(COLLEGUE_RUN_DEADLINE_SECONDS=float("nan")).COLLEGUE_RUN_DEADLINE_SECONDS == 0.0
+    assert Settings(COLLEGUE_RUN_DEADLINE_SECONDS=30).COLLEGUE_RUN_DEADLINE_SECONDS == 30.0


### PR DESCRIPTION
Deuxième enfant de l'epic #373 (**Phase 3 — pilote + ordonnanceur**). `Closes #375`. Dépend de F1 (mergé).

## Ce que ça ajoute

`collegue/pilot/budget.py` — `BudgetTimeController.should_continue() -> ContinueDecision` (`continue` | `paused_budget` | `deadline_reached`) : le pilote demande à chaque itération s'il peut lancer la prochaine tâche.

- **Deadline mur** : durée depuis `started_at` ; **horloge injectable** (tests déterministes) ; vérifiée **en premier** (`>=`). Nouveau setting `COLLEGUE_RUN_DEADLINE_SECONDS` (config, validateur façon `LLM_CALL_TIMEOUT` : `nan`/`inf`/négatif → 0 = désactivé).
- **Budget `$`/tokens** : réutilise `MetricsCollector.would_exceed_budget` (C4) ; plafonds pris dans les **settings injectés** (cohérence) ; **respecte `BUDGET_EXHAUSTED_ACTION`** — `"warn"` ne met **pas** en pause (comme `enforce_budget`), `"pause"` arrête.
- Ne lève **pas** `BudgetExceeded` : décision **proactive** de boucle (le chokepoint LLM C4 garde le hard-stop).

## 🔒 Robustesse (trouvée par la revue adversariale)

Un `started_at` (ou une horloge) **naïf** — p.ex. un `Project.created_at` parsé sans tz — faisait planter `should_continue`/`time_remaining_seconds` (`TypeError` naïf vs aware). **Correctif** : coercition UTC (façon `state.models.UTCDateTime`). Tests naïfs ajoutés.

## Tests & qualité

- `tests/test_pilot_budget.py` : **12 tests** — continue, deadline (dont pile à l'échéance), **précédence deadline > budget**, budget `pause` vs `warn`, **plafonds transmis** au collecteur, **datetime naïf** sans crash, deadline depuis settings, validateur config (`nan`/négatif → 0).
- **Ruff** `check` + `format` clean. **Suite complète verte (exit 0, aucune régression)** — `config.py` modifié de façon additive.
- Import isolation préservée.

## Hors périmètre (suite)

F3 = Project Driver (boucle `execute_issue` sous F1+F2 + checkpoints C7 + bascule MVP) ; F4 = câblage runtime opt-in + reporting.