### PR TITLE
feat(pilot): Project Driver — boucle execute_issue sous budget + checkpoints + bascule MVP (F3)

### DIFF
--- a/collegue/pilot/__init__.py
+++ b/collegue/pilot/__init__.py
@@ -15,6 +15,7 @@ from collegue.pilot.budget import (
     BudgetTimeController,
     ContinueDecision,
 )
+from collegue.pilot.driver import ProjectRunResult, TaskOutcome, run_project
 from collegue.pilot.scheduler import (
     SchedulerError,
     is_blocked,
@@ -36,4 +37,8 @@ __all__ = [
     "ACTION_CONTINUE",
     "ACTION_PAUSED_BUDGET",
     "ACTION_DEADLINE",
+    # F3 — Project Driver
+    "run_project",
+    "ProjectRunResult",
+    "TaskOutcome",
 ]

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -1,0 +1,215 @@
+"""Project Driver — pilote du moteur autonome (F3, epic #373, brief §7 Phase 3).
+
+Assemble F1 (ordonnanceur) + F2 (budget-temps) + l'exécuteur Phase 2
+(``execute_issue``) : tant que le budget/deadline tiennent et qu'il reste des
+tâches prêtes, exécuter la prochaine, checkpointer, et basculer en mode
+amélioration quand le MVP est atteint.
+
+Boucle **séquentielle et bornée** : chaque itération traite une tâche ``todo`` et
+la marque ``in_review`` (succès) ou ``failed`` (fail-closed). Le todo-set décroît
+strictement → terminaison garantie (backstop ``max_iterations`` par sécurité).
+
+``dry_run`` (défaut) : pipeline complet jusqu'aux **aperçus** de PR, **sans aucune
+écriture** (ni GitHub ni état) ; la progression est simulée via un *overlay* en
+mémoire (les statuts des objets ``Task`` détachés sont modifiés en RAM, pas en DB).
+
+**Jamais** ``done`` automatiquement (le merge humain le fera). Reprise : l'état
+persisté en DB (tâches déjà ``in_review``) est repris naturellement ; les
+checkpoints C7 numérotent la progression.
+
+Module **isolé** : non importé par ``app.py`` (F4 câblera).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from collegue.executor.agent import IssueSpec
+from collegue.executor.pipeline import execute_issue
+from collegue.pilot.budget import ACTION_DEADLINE, ACTION_PAUSED_BUDGET, BudgetTimeController
+from collegue.pilot.scheduler import next_task, remaining_tasks
+
+# Statut projet une fois le MVP construit (le moteur d'amélioration = Phase 4).
+PROJECT_STATUS_IMPROVING = "improving"
+TASK_STATUS_TODO = "todo"
+TASK_STATUS_IN_PROGRESS = "in_progress"
+TASK_STATUS_IN_REVIEW = "in_review"
+TASK_STATUS_FAILED = "failed"
+
+# Raisons d'arrêt du pilote.
+STOP_COMPLETED = "completed"  # plus rien à construire → MVP atteint
+STOP_PAUSED_BUDGET = "paused_budget"
+STOP_DEADLINE = "deadline_reached"
+STOP_BLOCKED = "blocked"  # graphe coincé (dépendance échouée)
+STOP_SAFETY_CAP = "safety_cap"  # garde-fou anti-boucle
+
+
+@dataclass
+class TaskOutcome:
+    """Résultat de l'exécution d'une tâche par le pilote."""
+
+    task_id: int
+    title: str
+    success: bool
+    stage: str
+    pr_number: Optional[int] = None
+
+
+@dataclass
+class ProjectRunResult:
+    """Bilan d'un run du pilote."""
+
+    stop_reason: str
+    iterations: int
+    processed: List[TaskOutcome] = field(default_factory=list)
+    project_status: Optional[str] = None  # statut projet final écrit (ex. improving), sinon None
+
+    @property
+    def opened_prs(self) -> List[int]:
+        return [t.pr_number for t in self.processed if t.pr_number is not None]
+
+
+def _issue_from_task(task) -> IssueSpec:
+    """Construit l'``IssueSpec`` exécutable depuis une tâche persistée.
+
+    Le numéro est celui de l'issue GitHub si la tâche est synchronisée
+    (``issue_number``), sinon l'id de tâche (branche/``Closes`` cohérents).
+    """
+    return IssueSpec(
+        number=task.issue_number or task.id,
+        title=task.title,
+        body=task.acceptance or "",
+    )
+
+
+async def run_project(
+    project_id: int,
+    repo_source: str,
+    ctx,
+    *,
+    agent,
+    owner: str,
+    repo: str,
+    manager,
+    base: str = "main",
+    budget: Optional[BudgetTimeController] = None,
+    sandbox=None,
+    reviewer=None,
+    runner=None,
+    clients=None,
+    dry_run: bool = True,
+    max_iterations: Optional[int] = None,
+) -> ProjectRunResult:
+    """Pilote un projet : chaîne ``execute_issue`` sur les tâches prêtes sous budget.
+
+    S'arrête quand : plus de tâche prête (``completed`` → bascule ``improving``),
+    budget/deadline atteint, graphe bloqué, ou garde-fou ``max_iterations``.
+    ``dry_run`` (défaut) ne persiste rien. Retourne un :class:`ProjectRunResult`.
+    """
+    budget = budget or BudgetTimeController()
+    tasks = manager.get_tasks(project_id)  # objets détachés : overlay mutable en mémoire
+
+    # Reprise : une tâche laissée `in_progress` est un reliquat d'un run interrompu
+    # (crash / pause budget en plein execute_issue). La boucle étant SÉQUENTIELLE,
+    # aucune tâche n'est réellement « en cours » au démarrage → on la repasse `todo`
+    # pour la re-tenter (et éviter qu'un `in_progress` coincé soit pris pour un MVP
+    # « terminé »). Persisté en réel ; overlay seul en dry_run.
+    for task in tasks:
+        if task.status == TASK_STATUS_IN_PROGRESS:
+            task.status = TASK_STATUS_TODO
+            if not dry_run:
+                manager.update_task_status(task.id, TASK_STATUS_TODO)
+
+    cap = max_iterations if max_iterations is not None else len(tasks) * 2 + 5
+
+    # Reprise : repartir du numéro d'itération du dernier checkpoint (l'état des
+    # tâches en DB fournit la vraie reprise — les tâches terminées sont ignorées).
+    latest = manager.get_latest_checkpoint(project_id) if not dry_run else None
+    iteration = latest.iteration if latest is not None else 0
+
+    processed: List[TaskOutcome] = []
+    stop_reason = STOP_COMPLETED
+
+    while True:
+        if len(processed) >= cap:
+            stop_reason = STOP_SAFETY_CAP
+            break
+
+        decision = budget.should_continue()
+        if not decision.ok:
+            stop_reason = STOP_PAUSED_BUDGET if decision.action == ACTION_PAUSED_BUDGET else STOP_DEADLINE
+            if decision.action not in (ACTION_PAUSED_BUDGET, ACTION_DEADLINE):  # défensif
+                stop_reason = decision.action
+            break
+
+        task = next_task(tasks)
+        if task is None:
+            # Plus aucune tâche prête. En séquentiel, plus aucun reliquat
+            # `in_progress` (remis à `todo` au démarrage) : s'il reste des tâches
+            # non terminées, c'est un graphe coincé (dépendance échouée) → bloqué ;
+            # sinon, tout est construit → MVP atteint.
+            stop_reason = STOP_COMPLETED if not remaining_tasks(tasks) else STOP_BLOCKED
+            break
+
+        outcome = await execute_issue(
+            _issue_from_task(task),
+            repo_source,
+            ctx,
+            agent=agent,
+            owner=owner,
+            repo=repo,
+            base=base,
+            sandbox=sandbox,
+            reviewer=reviewer,
+            runner=runner,
+            clients=clients,
+            manager=manager,
+            task_id=task.id,
+            project_id=project_id,
+            dry_run=dry_run,
+        )
+        iteration += 1
+        pr_number = outcome.pr.number if outcome.pr is not None else None
+        processed.append(
+            TaskOutcome(
+                task_id=task.id,
+                title=task.title,
+                success=outcome.success,
+                stage=outcome.stage,
+                pr_number=pr_number,
+            )
+        )
+
+        # Overlay en mémoire : avance le statut de la tâche pour l'ordonnancement.
+        # En réel, le succès est déjà persisté par execute_issue (→ in_review) ; on
+        # ne persiste donc que l'échec (fail-closed) pour ne pas re-sélectionner la
+        # tâche et débloquer la détection de blocage.
+        task.status = TASK_STATUS_IN_REVIEW if outcome.success else TASK_STATUS_FAILED
+        if not dry_run:
+            if not outcome.success:
+                manager.update_task_status(task.id, TASK_STATUS_FAILED)
+            # Checkpoint C7 : le numéro d'itération sert à la reprise ; ``state_json``
+            # est un instantané d'audit (la reprise effective lit les statuts en DB).
+            manager.save_checkpoint(
+                project_id,
+                iteration,
+                state_json={"processed_task_ids": [t.task_id for t in processed]},
+            )
+
+    project_status: Optional[str] = None
+    # Bascule MVP→amélioration uniquement si tout est construit sans échec, et
+    # seulement en réel (dry_run n'écrit rien — le stop_reason "completed" suffit
+    # à signaler que le MVP serait atteint).
+    # `processed` non vide : un projet vide (0 tâche) ne doit PAS basculer (la
+    # vacuité de ``not any(...)`` le ferait passer à tort).
+    if stop_reason == STOP_COMPLETED and processed and not any(not t.success for t in processed) and not dry_run:
+        manager.update_project(project_id, status=PROJECT_STATUS_IMPROVING)
+        project_status = PROJECT_STATUS_IMPROVING
+
+    return ProjectRunResult(
+        stop_reason=stop_reason,
+        iterations=len(processed),
+        processed=processed,
+        project_status=project_status,
+    )

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -1,0 +1,229 @@
+"""Tests F3 (#376) : Project Driver — boucle execute_issue sous budget + bascule MVP.
+
+Pipeline réel par tâche (prepare_workspace + run_issue sur git fixture) avec
+sandbox/reviewer/clients factices. Budget injecté (déterministe).
+"""
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from collegue.executor import FakeCodeAgent, FakeReviewer, PrClients
+from collegue.pilot import (
+    ACTION_CONTINUE,
+    ACTION_DEADLINE,
+    ACTION_PAUSED_BUDGET,
+    ContinueDecision,
+    run_project,
+)
+from collegue.sandbox import SandboxResult
+from collegue.state import ProjectStateManager
+
+CONT = ContinueDecision(action=ACTION_CONTINUE, reason="ok")
+PAUSE = ContinueDecision(action=ACTION_PAUSED_BUDGET, reason="budget")
+DEADLINE = ContinueDecision(action=ACTION_DEADLINE, reason="deadline")
+
+
+class _Budget:
+    """Budget factice : déroule une séquence de décisions (dernière répétée)."""
+
+    def __init__(self, seq):
+        self._seq = list(seq)
+        self._i = 0
+
+    def should_continue(self):
+        d = self._seq[min(self._i, len(self._seq) - 1)]
+        self._i += 1
+        return d
+
+
+def _always():
+    return _Budget([CONT])
+
+
+class _Sandbox:
+    def __init__(self, ok=True):
+        self._ok = ok
+
+    def run_tests(self, workspace, command="pytest -q"):
+        return SandboxResult(exit_code=0 if self._ok else 1, stdout="out", stderr="")
+
+
+class _Branches:
+    def ensure_branch(self, owner, repo, branch, from_branch=None):
+        return SimpleNamespace(name=branch)
+
+
+class _Files:
+    def update_file(self, owner, repo, path, message, content, branch=None):
+        return {}
+
+    def delete_file(self, owner, repo, path, message, branch=None):
+        return {}
+
+
+class _PRs:
+    def find_pr_by_head(self, owner, repo, head, base=None, state="open"):
+        return None
+
+    def create_pr(self, owner, repo, title, head, base, body):
+        return SimpleNamespace(number=101, html_url="https://gh/pull/101", head_branch=head)
+
+
+def _clients():
+    return PrClients(branches=_Branches(), files=_Files(), prs=_PRs())
+
+
+def _git(cwd, *args):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    src = tmp_path / "source"
+    src.mkdir()
+    _git(src, "init", "-q")
+    _git(src, "config", "user.email", "t@example.com")
+    _git(src, "config", "user.name", "Test")
+    (src / "existing.txt").write_text("original\n")
+    _git(src, "add", "-A")
+    _git(src, "commit", "-q", "-m", "init")
+    return str(src)
+
+
+@pytest.fixture
+def manager(tmp_path):
+    return ProjectStateManager.from_url(f"sqlite:///{tmp_path / 'state.db'}", create=True)
+
+
+def _linear_project(manager, n=3):
+    pid = manager.create_project(name="demo")
+    prev = None
+    for i in range(n):
+        prev = manager.add_task(pid, title=f"T{i}", depends_on=[prev] if prev else None)
+    return pid
+
+
+async def _run(manager, repo, pid, *, budget=None, dry_run=True, sandbox=None, **kw):
+    return await run_project(
+        pid,
+        repo,
+        ctx=None,
+        agent=FakeCodeAgent(),
+        owner="o",
+        repo="r",
+        manager=manager,
+        budget=budget or _always(),
+        sandbox=sandbox or _Sandbox(ok=True),
+        reviewer=FakeReviewer(),
+        clients=_clients(),
+        dry_run=dry_run,
+        **kw,
+    )
+
+
+# --- bout en bout ---------------------------------------------------------------
+
+
+async def test_dry_run_builds_whole_chain_without_writes(repo, manager):
+    pid = _linear_project(manager, 3)
+    result = await _run(manager, repo, pid, dry_run=True)
+    assert result.stop_reason == "completed"
+    assert result.iterations == 3
+    assert all(t.success for t in result.processed)
+    assert result.project_status is None  # dry_run n'écrit rien
+    # aucune transition persistée
+    assert all(t.status == "todo" for t in manager.get_tasks(pid))
+
+
+async def test_real_run_advances_states_and_switches_to_improving(repo, manager):
+    pid = _linear_project(manager, 2)
+    result = await _run(manager, repo, pid, dry_run=False)
+    assert result.stop_reason == "completed"
+    assert result.iterations == 2
+    assert result.project_status == "improving"
+    assert all(t.status == "in_review" for t in manager.get_tasks(pid))
+    assert manager.get_project(pid).status == "improving"
+    assert result.opened_prs == [101, 101]
+
+
+# --- arrêts ---------------------------------------------------------------------
+
+
+async def test_budget_pause_stops_mid_run(repo, manager):
+    pid = _linear_project(manager, 3)
+    result = await _run(manager, repo, pid, dry_run=False, budget=_Budget([CONT, PAUSE]))
+    assert result.stop_reason == "paused_budget"
+    assert result.iterations == 1  # une tâche traitée avant la pause
+    assert result.project_status is None  # pas de bascule MVP
+
+
+async def test_budget_stops_before_first_task(repo, manager):
+    # Budget déjà épuisé à la 1re itération : 0 tâche traitée, pas de bascule.
+    pid = _linear_project(manager, 2)
+    result = await _run(manager, repo, pid, dry_run=False, budget=_Budget([PAUSE]))
+    assert result.stop_reason == "paused_budget"
+    assert result.iterations == 0
+    assert result.project_status is None
+    assert all(t.status == "todo" for t in manager.get_tasks(pid))
+
+
+async def test_deadline_stops_run(repo, manager):
+    pid = _linear_project(manager, 2)
+    result = await _run(manager, repo, pid, dry_run=False, budget=_Budget([CONT, DEADLINE]))
+    assert result.stop_reason == "deadline_reached"
+    assert result.iterations == 1
+
+
+async def test_interrupted_in_progress_task_is_retried(repo, manager):
+    # Reliquat `in_progress` (run précédent interrompu) → repassé `todo` et re-tenté,
+    # PAS pris pour un MVP terminé.
+    pid = _linear_project(manager, 1)
+    tasks = manager.get_tasks(pid)
+    manager.update_task_status(tasks[0].id, "in_progress")
+    result = await _run(manager, repo, pid, dry_run=False)
+    assert result.stop_reason == "completed"
+    assert result.iterations == 1  # re-tentée
+    assert result.project_status == "improving"
+    assert manager.get_tasks(pid)[0].status == "in_review"
+
+
+async def test_failed_task_blocks_dependents(repo, manager):
+    # Tests rouges sur T0 → fail-closed ; T1 (dépend de T0) devient bloquée.
+    pid = _linear_project(manager, 2)
+    result = await _run(manager, repo, pid, dry_run=False, sandbox=_Sandbox(ok=False))
+    assert result.iterations == 1
+    assert result.processed[0].success is False
+    assert result.processed[0].stage == "gate"
+    assert result.stop_reason == "blocked"
+    assert result.project_status is None
+    statuses = {t.title: t.status for t in manager.get_tasks(pid)}
+    assert statuses["T0"] == "failed"
+    assert statuses["T1"] == "todo"  # jamais lancée
+
+
+async def test_resume_skips_already_done(repo, manager):
+    pid = _linear_project(manager, 2)
+    tasks = manager.get_tasks(pid)
+    manager.update_task_status(tasks[0].id, "in_review")  # T0 déjà faite (run précédent)
+    result = await _run(manager, repo, pid, dry_run=False)
+    assert result.iterations == 1  # seule T1 traitée
+    assert result.processed[0].task_id == tasks[1].id
+
+
+async def test_safety_cap_stops_runaway(repo, manager):
+    pid = _linear_project(manager, 3)
+    result = await _run(manager, repo, pid, dry_run=True, max_iterations=1)
+    assert result.stop_reason == "safety_cap"
+    assert result.iterations == 1
+
+
+async def test_empty_project_completes_without_switching(repo, manager):
+    pid = manager.create_project(name="empty")
+    result = await _run(manager, repo, pid, dry_run=False)
+    assert result.stop_reason == "completed"
+    assert result.iterations == 0
+    # Projet vide : pas de MVP construit → pas de bascule improving (anti-vacuité).
+    assert result.project_status is None
+    assert manager.get_project(pid).status != "improving"


### PR DESCRIPTION
Capstone du pilote — epic #373 (**Phase 3**). `Closes #376`. Dépend de F1+F2 (mergés).

## Ce que ça ajoute

`collegue/pilot/driver.py` — `run_project(project_id, repo_source, ctx, *, agent, owner, repo, manager, base, budget, sandbox, reviewer, runner, clients, dry_run=True, max_iterations)` (async) : enchaîne **F1** (ordonnanceur) + **F2** (budget-temps) + **`execute_issue`** (Phase 2).

- **Boucle séquentielle bornée** : *overlay* en mémoire (`todo→in_review/failed`) qui borne la boucle et simule la progression en `dry_run` ; à chaque tour `budget.should_continue()` → puis la prochaine tâche prête → `execute_issue` → **checkpoint C7**.
- **Arrêts** : `completed` (MVP) | `paused_budget` | `deadline_reached` | `blocked` (dépendance échouée) | `safety_cap`.
- **Bascule MVP→`improving`** seulement si tout est construit **sans échec** (réel). **Jamais `done`** automatiquement. `BudgetExceeded` (BaseException) **traverse** `run_project`.
- **`dry_run` par défaut** : pipeline complet jusqu'aux aperçus, **aucune écriture** (état/GitHub).
- **Reprise** : l'état persisté en DB est repris ; les checkpoints numérotent la progression.

## Revue multi-agents (ultracode) — 14 agents, 4 dimensions

Corrections des findings **confirmés** :
- 🔴 **CRITIQUE** : une tâche `in_progress` laissée par un run **interrompu** (crash / pause budget en plein `execute_issue`) faisait conclure à tort `completed` (+ bascule `improving`). **Fix** : reset `in_progress→todo` au démarrage (boucle séquentielle ⇒ tout `in_progress` initial est un reliquat à re-tenter), et décision `completed`/`blocked` via `remaining_tasks` (n'utilise plus `is_blocked`, dont la sémantique concurrente ne convient pas au pilote séquentiel).
- 🟠 Projet **vide** basculait `improving` par **vacuité** (`not any(...)` sur liste vide) → ajout `and processed`.
- 🟠 Exports F3 manquants dans `__all__` → ajoutés.
- 🟡 `state_json` du checkpoint documenté (instantané d'audit ; la reprise lit les statuts DB).

## Tests & qualité

- `tests/test_pilot_driver.py` : **10 tests** — `dry_run` sans écriture, run réel→`improving`, **pause budget mid-run ET immédiate (0 itér)**, **deadline**, **blocage** sur échec (dépendant non lancé), **reprise** (skip des tâches faites), **re-tentative d'un `in_progress` interrompu**, **safety cap**, **projet vide sans bascule**.
- **Ruff** `check`+`format` clean. **35 tests pilote** verts, **suite complète verte (exit 0, aucune régression)**.
- Import isolation : `collegue.pilot` ne tire pas `app.py` ; pas d'import circulaire.

## Hors périmètre (dernier enfant)

F4 = câblage runtime **opt-in** (outil MCP + entrypoint, pas d'auto-start) + reporting d'avancement → rend les modules isolés vivants.