### PR TITLE
feat(pilot): câblage runtime opt-in (entrypoint) + reporting (F4)

### DIFF
--- a/collegue/pilot/__init__.py
+++ b/collegue/pilot/__init__.py
@@ -16,6 +16,7 @@ from collegue.pilot.budget import (
     ContinueDecision,
 )
 from collegue.pilot.driver import ProjectRunResult, TaskOutcome, run_project
+from collegue.pilot.runtime import format_run_report, run_project_from_settings
 from collegue.pilot.scheduler import (
     SchedulerError,
     is_blocked,
@@ -41,4 +42,7 @@ __all__ = [
     "run_project",
     "ProjectRunResult",
     "TaskOutcome",
+    # F4 — câblage runtime
+    "run_project_from_settings",
+    "format_run_report",
 ]

--- a/collegue/pilot/__main__.py
+++ b/collegue/pilot/__main__.py
@@ -1,0 +1,65 @@
+"""Entrypoint CLI du pilote (F4, epic #373) : ``python -m collegue.pilot``.
+
+Invocation **explicite et opt-in** du moteur autonome sur un projet existant
+(planifié via la Phase 1, exécutable via la Phase 2). ``dry_run`` par défaut ;
+``--execute`` active les écritures réelles (branches/commits/PR + transitions
+d'état). N'est **jamais** lancé automatiquement par le serveur MCP.
+
+Exemple :
+    python -m collegue.pilot --project-id 1 --repo-source /chemin/clone \\
+        --owner moi --repo mon-app            # dry-run (aperçu)
+    python -m collegue.pilot ... --execute    # écritures réelles
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from typing import List, Optional
+
+from collegue.pilot.runtime import format_run_report, run_project_from_settings
+
+# Codes de sortie : 0 = arrêt « normal », 1 = graphe coincé / garde-fou.
+_OK_STOPS = {"completed", "paused_budget", "deadline_reached"}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="collegue.pilot",
+        description="Pilote autonome : chaîne l'exécuteur d'issues sur le graphe de tâches sous budget-temps.",
+    )
+    parser.add_argument("--project-id", type=int, required=True, help="Id du projet (état durable).")
+    parser.add_argument("--repo-source", required=True, help="Dépôt git source (repo-agnostique).")
+    parser.add_argument("--owner", required=True, help="Owner GitHub cible des PR.")
+    parser.add_argument("--repo", required=True, help="Repo GitHub cible des PR.")
+    parser.add_argument("--base", default="main", help="Branche de base des PR (défaut: main).")
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Désactive le dry_run : écritures réelles (branches/commits/PR + état).",
+    )
+    parser.add_argument("--max-iterations", type=int, default=None, help="Garde-fou anti-boucle (optionnel).")
+    return parser
+
+
+async def _run(args: argparse.Namespace) -> int:
+    result = await run_project_from_settings(
+        args.project_id,
+        args.repo_source,
+        owner=args.owner,
+        repo=args.repo,
+        base=args.base,
+        dry_run=not args.execute,
+        max_iterations=args.max_iterations,
+    )
+    print(format_run_report(result, project_id=args.project_id))
+    return 0 if result.stop_reason in _OK_STOPS else 1
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    return asyncio.run(_run(args))
+
+
+if __name__ == "__main__":  # pragma: no cover - exécuté seulement via `python -m`
+    raise SystemExit(main())

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -1,0 +1,166 @@
+"""Câblage runtime du pilote (F4, epic #373, brief §7 Phase 3).
+
+Point d'assemblage qui **rend vivants** les modules jusqu'ici isolés : il
+construit les vraies dépendances depuis la configuration (état durable, sandbox
+Docker, agent OpenHands, reviewer expert, clients GitHub, contrôleur budget-temps)
+et lance ``run_project`` (F3).
+
+**Opt-in et sûr** (décision epic) : ce module n'est **jamais** importé par
+``app.py`` ni démarré dans le lifespan du serveur — il s'invoque explicitement via
+l'entrypoint ``python -m collegue.pilot`` (voir ``__main__``). ``dry_run`` est le
+défaut. L'exécution réelle de bout en bout (Docker + OpenHands + LLM + écriture
+GitHub) est derrière le marqueur ``integration`` ; en CI on injecte des doubles.
+
+Note ``ctx`` : le reviewer expert (``code_review``) a besoin d'un contexte de
+sampling LLM. En usage réel hors serveur MCP, fournir un ``ctx`` adéquat (ou un
+shim) — différé à l'intégration. Un outil MCP exposant le pilote est volontairement
+**reporté à la Phase 5** (durcissement/auth) : l'auto-découverte des outils
+l'activerait au démarrage, et le serveur tourne ``OAUTH_ENABLED=false`` par défaut.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import List, Optional
+
+from collegue.pilot.budget import BudgetTimeController
+from collegue.pilot.driver import ProjectRunResult, run_project
+
+GITHUB_TOKEN_ENV = "GITHUB_TOKEN"
+
+
+def _settings():
+    from collegue.config import settings
+
+    return settings
+
+
+# ── construction des dépendances réelles (integration) ─────────────────────────
+
+
+def _build_manager(settings_obj):  # pragma: no cover - infra réelle (integration)
+    from collegue.state import ProjectStateManager
+
+    url = getattr(settings_obj, "STATE_DATABASE_URL", None)
+    if not url:
+        raise RuntimeError("STATE_DATABASE_URL non configuré : impossible de piloter sans état durable.")
+    return ProjectStateManager.from_url(url)
+
+
+def _build_sandbox(settings_obj):  # pragma: no cover - infra réelle (integration)
+    from collegue.sandbox import DockerSandbox
+
+    # OpenHands appelle un LLM → le sandbox a besoin du réseau pour ce run précis
+    # (le défaut durci est ``network="none"``).
+    return DockerSandbox(network="bridge")
+
+
+def _build_agent(sandbox, settings_obj):  # pragma: no cover - infra réelle (integration)
+    from collegue.executor import OpenHandsAgent
+
+    return OpenHandsAgent(sandbox, settings_obj=settings_obj)
+
+
+def _build_reviewer(settings_obj):  # pragma: no cover - infra réelle (integration)
+    from collegue.executor.quality_gate import ExpertReviewer
+
+    return ExpertReviewer()
+
+
+def _build_clients(github_token):  # pragma: no cover - infra réelle (integration)
+    from collegue.executor.pr import _default_clients
+
+    return _default_clients(token=github_token)
+
+
+# ── point d'entrée assemblé ────────────────────────────────────────────────────
+
+
+async def run_project_from_settings(
+    project_id: int,
+    repo_source: str,
+    *,
+    owner: str,
+    repo: str,
+    ctx=None,
+    base: str = "main",
+    dry_run: bool = True,
+    settings_obj: Optional[object] = None,
+    github_token: Optional[str] = None,
+    manager=None,
+    sandbox=None,
+    agent=None,
+    reviewer=None,
+    clients=None,
+    budget=None,
+    max_iterations: Optional[int] = None,
+) -> ProjectRunResult:
+    """Assemble les dépendances (depuis la config) et lance ``run_project``.
+
+    Toute dépendance non fournie est construite depuis ``settings`` (chemin réel,
+    ``integration``) ; les tests injectent des doubles. ``dry_run`` par défaut.
+    En réel, journalise un résumé du run (``record_decision``).
+    """
+    settings_obj = settings_obj or _settings()
+    manager = manager or _build_manager(settings_obj)
+    sandbox = sandbox or _build_sandbox(settings_obj)
+    agent = agent or _build_agent(sandbox, settings_obj)
+    reviewer = reviewer or _build_reviewer(settings_obj)
+    clients = clients or _build_clients(github_token if github_token is not None else os.environ.get(GITHUB_TOKEN_ENV))
+    budget = budget or BudgetTimeController(settings_obj=settings_obj)
+
+    result = await run_project(
+        project_id,
+        repo_source,
+        ctx,
+        agent=agent,
+        owner=owner,
+        repo=repo,
+        manager=manager,
+        base=base,
+        budget=budget,
+        sandbox=sandbox,
+        reviewer=reviewer,
+        clients=clients,
+        dry_run=dry_run,
+        max_iterations=max_iterations,
+    )
+
+    # Reporting (journal de décisions) — réel uniquement (dry_run n'écrit rien).
+    if not dry_run:
+        prs = ", ".join(str(n) for n in result.opened_prs) or "aucune"
+        manager.record_decision(
+            project_id,
+            f"Run pilote: {result.stop_reason} — {result.iterations} tâche(s), PR {prs}",
+            rationale=f"statut projet={result.project_status or 'inchangé'}",
+        )
+
+    return result
+
+
+# ── reporting lisible ──────────────────────────────────────────────────────────
+
+
+def _remaining_label(budget) -> str:
+    if budget is None or not hasattr(budget, "time_remaining_seconds"):
+        return "n/a"
+    remaining = budget.time_remaining_seconds()
+    return "illimité" if remaining is None else f"{remaining:.0f}s"
+
+
+def format_run_report(result: ProjectRunResult, *, project_id: Optional[int] = None, budget=None) -> str:
+    """Rapport d'avancement lisible d'un run du pilote (pur, sans effet de bord)."""
+    lines: List[str] = [
+        "=== Rapport du pilote ===",
+        f"Projet : {project_id if project_id is not None else '?'}",
+        f"Arrêt : {result.stop_reason}",
+        f"Tâches traitées : {result.iterations}",
+    ]
+    for task in result.processed:
+        badge = "✓" if task.success else "✗"
+        pr = f" → PR #{task.pr_number}" if task.pr_number is not None else ""
+        lines.append(f"  [{badge}] #{task.task_id} {task.title} ({task.stage}){pr}")
+    lines.append(f"PRs ouvertes : {result.opened_prs or '(aucune)'}")
+    lines.append(f"Statut projet : {result.project_status or '(inchangé)'}")
+    lines.append(f"Budget-temps restant : {_remaining_label(budget)}")
+    return "\n".join(lines)

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -1,0 +1,233 @@
+"""Tests F4 (#377) : câblage runtime opt-in (entrypoint + assemblage) + reporting."""
+
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from collegue.executor import FakeCodeAgent, FakeReviewer, PrClients
+from collegue.pilot import ProjectRunResult, TaskOutcome, format_run_report, run_project_from_settings
+from collegue.pilot.__main__ import build_parser
+from collegue.sandbox import SandboxResult
+from collegue.state import ProjectStateManager
+
+# --- fakes (mêmes doubles que F3) -----------------------------------------------
+
+
+class _Sandbox:
+    def run_tests(self, workspace, command="pytest -q"):
+        return SandboxResult(exit_code=0, stdout="ok", stderr="")
+
+
+class _Branches:
+    def ensure_branch(self, owner, repo, branch, from_branch=None):
+        return SimpleNamespace(name=branch)
+
+
+class _Files:
+    def update_file(self, owner, repo, path, message, content, branch=None):
+        return {}
+
+    def delete_file(self, owner, repo, path, message, branch=None):
+        return {}
+
+
+class _PRs:
+    def find_pr_by_head(self, owner, repo, head, base=None, state="open"):
+        return None
+
+    def create_pr(self, owner, repo, title, head, base, body):
+        return SimpleNamespace(number=101, html_url="https://gh/pull/101", head_branch=head)
+
+
+def _clients():
+    return PrClients(branches=_Branches(), files=_Files(), prs=_PRs())
+
+
+class _Budget:
+    """Budget toujours OK (déterministe, sans collecteur global)."""
+
+    def should_continue(self):
+        return SimpleNamespace(action="continue", ok=True)
+
+    def time_remaining_seconds(self):
+        return None
+
+
+def _git(cwd, *args):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    src = tmp_path / "source"
+    src.mkdir()
+    _git(src, "init", "-q")
+    _git(src, "config", "user.email", "t@example.com")
+    _git(src, "config", "user.name", "Test")
+    (src / "existing.txt").write_text("original\n")
+    _git(src, "add", "-A")
+    _git(src, "commit", "-q", "-m", "init")
+    return str(src)
+
+
+@pytest.fixture
+def manager(tmp_path):
+    return ProjectStateManager.from_url(f"sqlite:///{tmp_path / 'state.db'}", create=True)
+
+
+def _linear(manager, n):
+    pid = manager.create_project(name="demo")
+    prev = None
+    for i in range(n):
+        prev = manager.add_task(pid, title=f"T{i}", depends_on=[prev] if prev else None)
+    return pid
+
+
+async def _run(manager, git_repo, pid, *, dry_run):
+    return await run_project_from_settings(
+        pid,
+        git_repo,
+        owner="o",
+        repo="r",
+        dry_run=dry_run,
+        manager=manager,
+        sandbox=_Sandbox(),
+        agent=FakeCodeAgent(),
+        reviewer=FakeReviewer(),
+        clients=_clients(),
+        budget=_Budget(),
+    )
+
+
+# --- assemblage + run -----------------------------------------------------------
+
+
+async def test_dry_run_builds_chain_without_writes(git_repo, manager):
+    pid = _linear(manager, 2)
+    result = await _run(manager, git_repo, pid, dry_run=True)
+    assert result.stop_reason == "completed"
+    assert result.iterations == 2
+    assert all(t.status == "todo" for t in manager.get_tasks(pid))  # aucune écriture
+    assert manager.get_decisions(pid) == []  # pas de résumé en dry_run
+
+
+async def test_real_run_records_summary_decision(git_repo, manager):
+    pid = _linear(manager, 1)
+    result = await _run(manager, git_repo, pid, dry_run=False)
+    assert result.stop_reason == "completed"
+    assert any("Run pilote" in d.summary for d in manager.get_decisions(pid))
+    assert manager.get_tasks(pid)[0].status == "in_review"
+
+
+# --- reporting ------------------------------------------------------------------
+
+
+def test_format_run_report_contents():
+    result = ProjectRunResult(
+        stop_reason="completed",
+        iterations=1,
+        processed=[TaskOutcome(task_id=5, title="Faire X", success=True, stage="pr", pr_number=42)],
+        project_status="improving",
+    )
+    report = format_run_report(result, project_id=7, budget=_Budget())
+    assert "Arrêt : completed" in report
+    assert "#5 Faire X (pr) → PR #42" in report
+    assert "improving" in report
+    assert "illimité" in report  # budget sans deadline
+
+
+def test_format_run_report_no_prs_and_no_budget():
+    result = ProjectRunResult(stop_reason="blocked", iterations=0, processed=[], project_status=None)
+    report = format_run_report(result)
+    assert "PRs ouvertes : (aucune)" in report
+    assert "Statut projet : (inchangé)" in report
+    assert "Budget-temps restant : n/a" in report
+
+
+# --- CLI parser -----------------------------------------------------------------
+
+
+def test_parser_defaults_dry_run():
+    ns = build_parser().parse_args(["--project-id", "3", "--repo-source", "/r", "--owner", "o", "--repo", "app"])
+    assert ns.project_id == 3
+    assert ns.repo_source == "/r"
+    assert ns.owner == "o" and ns.repo == "app"
+    assert ns.base == "main"
+    assert ns.execute is False  # dry_run par défaut
+    assert ns.max_iterations is None
+
+
+def test_parser_execute_and_overrides():
+    ns = build_parser().parse_args(
+        [
+            "--project-id",
+            "1",
+            "--repo-source",
+            "/r",
+            "--owner",
+            "o",
+            "--repo",
+            "a",
+            "--execute",
+            "--base",
+            "dev",
+            "--max-iterations",
+            "5",
+        ]
+    )
+    assert ns.execute is True
+    assert ns.base == "dev"
+    assert ns.max_iterations == 5
+
+
+def test_parser_requires_mandatory_args():
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["--owner", "o"])  # manque project-id/repo-source/repo
+
+
+# --- CLI main (glue + codes de sortie) ------------------------------------------
+
+_CLI_ARGS = ["--project-id", "1", "--repo-source", "/r", "--owner", "o", "--repo", "a"]
+
+
+def _patch_run(monkeypatch, result):
+    import collegue.pilot.__main__ as cli
+
+    async def _fake(*args, **kwargs):
+        return result
+
+    monkeypatch.setattr(cli, "run_project_from_settings", _fake)
+    return cli
+
+
+def test_main_returns_0_on_completed(monkeypatch, capsys):
+    cli = _patch_run(
+        monkeypatch,
+        ProjectRunResult(stop_reason="completed", iterations=1, processed=[], project_status="improving"),
+    )
+    assert cli.main(_CLI_ARGS) == 0
+    assert "Rapport du pilote" in capsys.readouterr().out
+
+
+def test_main_returns_1_on_blocked(monkeypatch):
+    cli = _patch_run(monkeypatch, ProjectRunResult(stop_reason="blocked", iterations=0, processed=[]))
+    assert cli.main(_CLI_ARGS) == 1
+
+
+# --- isolation ------------------------------------------------------------------
+
+
+def test_app_does_not_wire_pilot():
+    # Le serveur ne câble pas le pilote : il s'invoque via `python -m collegue.pilot`.
+    app_src = (Path(__file__).resolve().parent.parent / "collegue" / "app.py").read_text(encoding="utf-8")
+    assert "collegue.pilot" not in app_src
+    assert "from collegue.pilot" not in app_src
+
+
+def test_importing_pilot_does_not_pull_openhands_runtime():
+    import collegue.pilot  # noqa: F401
+
+    assert not any(name == "openhands" or name.startswith("openhands.") for name in sys.modules)


### PR DESCRIPTION
**Dernier enfant** de l'epic #373 (**Phase 3**). `Closes #377`. Dépend de F1–F3 (mergés). **Rend vivants les modules isolés** via un point d'entrée explicite, sans changer le comportement par défaut du serveur.

## Ce que ça ajoute

- **`collegue/pilot/runtime.py`** — `run_project_from_settings(...)` assemble les **vraies dépendances** depuis la config (`ProjectStateManager.from_url(STATE_DATABASE_URL)`, `DockerSandbox(network="bridge")`, `OpenHandsAgent`, `ExpertReviewer`, clients GitHub via `GITHUB_TOKEN`, `BudgetTimeController`) et lance `run_project`. **Deps injectables** (doubles en CI ; réel derrière `integration`). `dry_run` par défaut ; en réel, journalise un **résumé du run** (`record_decision`). `format_run_report()` → rapport d'avancement lisible (arrêt, tâches, PRs, statut projet, **budget-temps restant**).
- **`collegue/pilot/__main__.py`** — entrypoint `python -m collegue.pilot --project-id … --repo-source … --owner … --repo … [--execute] [--base] [--max-iterations]`. `dry_run` par défaut ; `--execute` active les écritures réelles. Codes de sortie : `0` (arrêt normal) / `1` (bloqué / garde-fou).

## Décision : outil MCP différé à la Phase 5

L'**auto-découverte** des outils (`collegue/tools/`) activerait un outil `run_project` **au démarrage du serveur**, et le serveur tourne **`OAUTH_ENABLED=false` par défaut** → exposer un outil capable de lancer Docker / ouvrir des PR est une **surface de risque**. L'**entrypoint** satisfait déjà tous les critères d'acceptation (opt-in, pas d'auto-start, `dry_run`, reporting) **sans toucher `app.py`**. L'outil MCP (avec auth/garde) est reporté au durcissement (Phase 5).

## Critères d'acceptation

- [x] Le serveur MCP démarre **sans rien changer** par défaut (pilote non lancé tant qu'on ne l'invoque pas) — `app.py` ne référence pas `pilot` (test).
- [x] L'entrypoint lance `run_project` en `dry_run` et renvoie un **rapport d'avancement**.
- [x] Reporting : budget/deadline restants + tâches/PRs visibles (journal `record_decision` + `format_run_report`).
- [x] Tests CI : invocation **mockée** (pas de Docker/LLM/GitHub réels) ; exécution réelle derrière `integration`.

## Tests & qualité

- `tests/test_pilot_runtime.py` : **11 tests** — assemblage `dry_run` sans écriture, run réel + résumé journalisé, **reporting** (cas budget/PRs/vide), **parseur CLI** (défauts/`--execute`/obligatoires), **glue `main` + codes de sortie** (completed→0, blocked→1), **isolation** `app`↔`pilot`.
- **Ruff** `check`+`format` clean. **44 tests pilote**, **suite complète verte (exit 0, aucune régression)**. `python -m collegue.pilot --help` OK.
- Passe `/review` adversariale (contexte frais, exécution prouvée) : **aucun défaut** ; 2 nits corrigés (formatage liste de PR, test de la glue CLI).

## ✅ Clôture de la Phase 3

Avec F4, le pilote chaîne l'exécuteur sur le graphe sous budget-temps et les modules (`state/`, `sandbox/`, `planner/`, `executor/`, `pilot/`) sont **câblables au runtime** via `python -m collegue.pilot`. Préfigure la **Phase 4** (moteur d'amélioration continue : gating métrique + rollback + rendements décroissants).