### PR TITLE
feat(improve): mesure de métriques projet en sandbox → score composite (G1)

### DIFF
--- a/collegue/improve/__init__.py
+++ b/collegue/improve/__init__.py
@@ -1,0 +1,30 @@
+"""Moteur d'amélioration continue (Phase 4, epic #382).
+
+Après le MVP (mode ``improving`` du pilote), fait cycler les experts pour élever
+un **score de qualité du projet généré**, en ne promouvant que les changements
+qui progressent **sans régression** (gating par métrique), et s'arrête sur
+rendements décroissants / budget.
+
+G1 pose la mesure des métriques. Module **isolé** tant que la boucle (G4) ne
+câble pas l'exécuteur + le budget.
+"""
+
+from collegue.improve.metrics import (
+    DEFAULT_WEIGHTS,
+    CompositeWeights,
+    ProjectQualityMetrics,
+    composite_score,
+    measure,
+    parse_coverage,
+    persist,
+)
+
+__all__ = [
+    "ProjectQualityMetrics",
+    "CompositeWeights",
+    "DEFAULT_WEIGHTS",
+    "parse_coverage",
+    "composite_score",
+    "measure",
+    "persist",
+]

--- a/collegue/improve/metrics.py
+++ b/collegue/improve/metrics.py
@@ -1,0 +1,134 @@
+"""Mesure des métriques de qualité du projet généré (G1, epic #382, Phase 4).
+
+Mesure **déterministe en sandbox** de la qualité du projet, agrégée en un **score
+composite** pluggable : couverture de tests ↑ + score de revue (``code_review``) ↑
+− findings sécu ↓, avec ``tests_passed`` comme garde dure (utilisée par le gate G2).
+
+Le « score du dashboard » du serveur (latence/coût de SES experts) ne convient
+PAS ici : on mesure la qualité du **projet généré**, pas celle de Collègue.
+
+Module **isolé** : non câblé au runtime (la boucle G4 l'orchestrera).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+# Catégorie de findings considérée « sécurité » dans la revue experte.
+SECURITY_CATEGORY = "security"
+# Commande de couverture par défaut (parsée depuis la sortie pytest-cov).
+DEFAULT_COVERAGE_COMMAND = "pytest -q --cov --cov-report=term-missing"
+
+# Regex de la ligne récapitulative TOTAL de pytest-cov : « TOTAL  120  6  95% ».
+# On exige un espace juste après TOTAL (rejette un fichier nommé « TOTAL.py »).
+_TOTAL_RE = re.compile(r"^\s*TOTAL\s+.*?(\d+(?:\.\d+)?)%", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class CompositeWeights:
+    """Pondérations du score composite (extensibles)."""
+
+    coverage: float = 1.0  # par point de couverture normalisé (0–1)
+    review: float = 1.0  # par point de score de revue (0–1)
+    security: float = 0.1  # pénalité par finding de sécurité
+
+
+DEFAULT_WEIGHTS = CompositeWeights()
+
+
+@dataclass(frozen=True)
+class ProjectQualityMetrics:
+    """Instantané des métriques de qualité d'un projet (à un instant/itération)."""
+
+    coverage_pct: float  # 0–100 (0.0 si non mesurée — voir coverage_measured)
+    review_score: float  # 0–1
+    security_findings: int
+    tests_passed: bool
+    composite: float
+    # False si la couverture n'a PAS pu être mesurée (pas de ligne TOTAL). Le gate
+    # (G2) doit alors traiter le delta de couverture comme inconnu (fail-closed),
+    # plutôt que de confondre « non mesuré » avec « 0 % réel ».
+    coverage_measured: bool = True
+
+
+def parse_coverage(output: str) -> Optional[float]:
+    """Extrait le pourcentage de couverture de la ligne ``TOTAL`` de pytest-cov.
+
+    Retourne ``None`` si aucune ligne ``TOTAL … NN%`` n'est présente (sortie
+    tronquée, pas de couverture mesurée…). Gère les pourcentages décimaux.
+    """
+    if not output:
+        return None
+    match = _TOTAL_RE.search(output)
+    return float(match.group(1)) if match else None
+
+
+def composite_score(
+    coverage_pct: float,
+    review_score: float,
+    security_findings: int,
+    *,
+    weights: CompositeWeights = DEFAULT_WEIGHTS,
+) -> float:
+    """Score composite pondéré (monotone : ↑couverture/revue → ↑ ; ↑sécu → ↓).
+
+    La couverture (0–100) est normalisée en 0–1 ; le score de revue est déjà 0–1 ;
+    chaque finding de sécurité retire ``weights.security``.
+    """
+    return (
+        weights.coverage * (coverage_pct / 100.0) + weights.review * review_score - weights.security * security_findings
+    )
+
+
+def _count_security_findings(outcome) -> int:
+    """Compte les findings de catégorie sécurité d'un :class:`ReviewOutcome` (E3)."""
+    return sum(1 for finding in getattr(outcome, "findings", ()) if finding.category == SECURITY_CATEGORY)
+
+
+async def measure(
+    workspace: str,
+    ctx,
+    *,
+    sandbox,
+    reviewer,
+    diff: str = "",
+    issue=None,
+    coverage_command: str = DEFAULT_COVERAGE_COMMAND,
+    weights: CompositeWeights = DEFAULT_WEIGHTS,
+) -> ProjectQualityMetrics:
+    """Mesure couverture (sandbox) + revue + findings sécu → métriques composites.
+
+    ``sandbox``/``reviewer`` sont injectables (mockés en CI). La couverture vient
+    du parsing de la sortie pytest-cov ; ``tests_passed`` = exit 0. Le score de
+    revue et le compte sécu viennent de l'``ExpertReviewer`` (E3) sur le diff.
+    """
+    test_res = sandbox.run_tests(workspace, coverage_command)
+    tests_passed = bool(test_res.ok)
+    raw_coverage = parse_coverage(test_res.stdout)
+    coverage_measured = raw_coverage is not None
+    coverage_pct = raw_coverage if coverage_measured else 0.0  # composite conservateur
+
+    outcome = await reviewer.review(diff, ctx, issue=issue)
+    review_score = float(getattr(outcome, "quality_score", 0.0))
+    security_findings = _count_security_findings(outcome)
+
+    return ProjectQualityMetrics(
+        coverage_pct=coverage_pct,
+        review_score=review_score,
+        security_findings=security_findings,
+        tests_passed=tests_passed,
+        composite=composite_score(coverage_pct, review_score, security_findings, weights=weights),
+        coverage_measured=coverage_measured,
+    )
+
+
+def persist(manager, project_id: int, metrics: ProjectQualityMetrics) -> None:
+    """Enregistre les métriques (modèle ``Metric``, C6) pour suivi/itérations."""
+    manager.add_metric(project_id, "coverage_pct", metrics.coverage_pct)
+    manager.add_metric(project_id, "review_score", metrics.review_score)
+    manager.add_metric(project_id, "security_findings", float(metrics.security_findings))
+    manager.add_metric(project_id, "tests_passed", 1.0 if metrics.tests_passed else 0.0)
+    manager.add_metric(project_id, "coverage_measured", 1.0 if metrics.coverage_measured else 0.0)
+    manager.add_metric(project_id, "composite", metrics.composite)

--- a/tests/test_improve_metrics.py
+++ b/tests/test_improve_metrics.py
@@ -1,0 +1,137 @@
+"""Tests G1 (#383) : mesure des métriques de qualité projet (sandbox/reviewer mockés)."""
+
+import pytest
+
+from collegue.executor import FakeReviewer
+from collegue.executor.quality_gate import ReviewFindingLite
+from collegue.improve import (
+    CompositeWeights,
+    ProjectQualityMetrics,
+    composite_score,
+    measure,
+    parse_coverage,
+    persist,
+)
+from collegue.sandbox import SandboxResult
+from collegue.state import ProjectStateManager
+
+COV_OUTPUT = """Name        Stmts   Miss  Cover   Missing
+-----------------------------------------------
+foo.py         10      1    90%   7
+-----------------------------------------------
+TOTAL          10      1    90%
+"""
+
+
+class _Sandbox:
+    def __init__(self, *, stdout=COV_OUTPUT, ok=True):
+        self._stdout = stdout
+        self._ok = ok
+
+    def run_tests(self, workspace, command="pytest -q"):
+        return SandboxResult(exit_code=0 if self._ok else 1, stdout=self._stdout, stderr="")
+
+
+# --- parse_coverage -------------------------------------------------------------
+
+
+def test_parse_coverage_total_line():
+    assert parse_coverage(COV_OUTPUT) == 90.0
+
+
+def test_parse_coverage_decimal():
+    assert parse_coverage("TOTAL   200   10   80.5%") == 80.5
+
+
+def test_parse_coverage_zero_and_full():
+    assert parse_coverage("TOTAL  5  5  0%") == 0.0
+    assert parse_coverage("TOTAL  5  0  100%") == 100.0
+
+
+def test_parse_coverage_absent_or_empty():
+    assert parse_coverage("pas de ligne total ici") is None
+    assert parse_coverage("") is None
+
+
+def test_parse_coverage_ignores_file_named_total():
+    # Un fichier « TOTAL.py » ne doit pas être pris pour la ligne récapitulative.
+    out = "TOTAL.py   10   5   50%\n----\nTOTAL      10   1   90%\n"
+    assert parse_coverage(out) == 90.0
+    assert parse_coverage("TOTAL.py   10   5   50%\n") is None
+
+
+# --- composite_score ------------------------------------------------------------
+
+
+def test_composite_monotonic():
+    base = composite_score(50.0, 0.5, 1)
+    assert composite_score(60.0, 0.5, 1) > base  # ↑ couverture → ↑
+    assert composite_score(50.0, 0.7, 1) > base  # ↑ revue → ↑
+    assert composite_score(50.0, 0.5, 3) < base  # ↑ sécu → ↓
+
+
+def test_composite_weights_tunable():
+    w = CompositeWeights(coverage=2.0, review=0.0, security=0.0)
+    # review/security ignorés ; couverture 100 % → 2.0
+    assert composite_score(100.0, 0.9, 5, weights=w) == pytest.approx(2.0)
+
+
+# --- measure --------------------------------------------------------------------
+
+
+async def test_measure_aggregates_all_dimensions():
+    reviewer = FakeReviewer(
+        quality_score=0.8,
+        findings=[
+            ReviewFindingLite("security", "critical", "RCE"),
+            ReviewFindingLite("naming", "warning", "x"),  # non-sécu : ignoré
+        ],
+    )
+    m = await measure("/ws", ctx=None, sandbox=_Sandbox(), reviewer=reviewer, diff="d")
+    assert isinstance(m, ProjectQualityMetrics)
+    assert m.coverage_pct == 90.0
+    assert m.review_score == 0.8
+    assert m.security_findings == 1  # seul le finding sécu compte
+    assert m.tests_passed is True
+    assert m.coverage_measured is True
+    assert m.composite == pytest.approx(1.0 * 0.9 + 1.0 * 0.8 - 0.1 * 1)
+
+
+async def test_measure_tests_red_and_no_coverage():
+    reviewer = FakeReviewer(quality_score=0.5, findings=[])
+    m = await measure("/ws", ctx=None, sandbox=_Sandbox(stdout="boom", ok=False), reviewer=reviewer)
+    assert m.tests_passed is False
+    assert m.coverage_pct == 0.0  # pas de ligne TOTAL → 0
+    assert m.coverage_measured is False  # « non mesuré » distingué d'un vrai 0 %
+    assert m.security_findings == 0
+
+
+async def test_measure_genuine_zero_coverage_is_measured():
+    # 0 % RÉEL (ligne TOTAL présente) doit être marqué mesuré (distinct de None).
+    reviewer = FakeReviewer(quality_score=0.5, findings=[])
+    m = await measure("/ws", ctx=None, sandbox=_Sandbox(stdout="TOTAL  5  5  0%\n"), reviewer=reviewer)
+    assert m.coverage_pct == 0.0
+    assert m.coverage_measured is True
+
+
+# --- persist --------------------------------------------------------------------
+
+
+def test_persist_writes_metrics(tmp_path):
+    manager = ProjectStateManager.from_url(f"sqlite:///{tmp_path / 'state.db'}", create=True)
+    pid = manager.create_project(name="demo")
+    m = ProjectQualityMetrics(
+        coverage_pct=90.0, review_score=0.8, security_findings=1, tests_passed=True, composite=1.6
+    )
+    persist(manager, pid, m)
+    names = {metric.name for metric in manager.get_metrics(pid)}
+    assert names == {
+        "coverage_pct",
+        "review_score",
+        "security_findings",
+        "tests_passed",
+        "coverage_measured",
+        "composite",
+    }
+    assert manager.get_metrics(pid, "composite")[0].value == pytest.approx(1.6)
+    assert manager.get_metrics(pid, "tests_passed")[0].value == 1.0


### PR DESCRIPTION
Premier enfant de l'epic #382 (**Phase 4 — amélioration continue**). `Closes #383`.

## Ce que ça ajoute

Nouveau module **ISOLÉ** `collegue/improve/`. `collegue/improve/metrics.py` — mesure **déterministe en sandbox** de la qualité du **projet généré** :

- **`ProjectQualityMetrics`** — `coverage_pct`, `review_score`, `security_findings`, `tests_passed`, `composite`, **`coverage_measured`**.
- **`parse_coverage`** — extrait le `%` de la ligne `TOTAL` de pytest-cov (regex exigeant un espace après `TOTAL` → **ignore un fichier nommé `TOTAL.py`** ; gère décimaux / 0 / 100).
- **`composite_score`** — score pondéré (couverture/100 ↑ + revue ↑ − sécu ↓), **monotone**, pondérations `CompositeWeights` extensibles.
- **`measure`** (async) — tests + couverture en sandbox (`DockerSandbox.run_tests`) + **revue experte** (`ExpertReviewer` E3 : score + findings sécu) → métriques composites. `sandbox`/`reviewer` **injectables** (mockés CI ; réel derrière `integration`).
- **`persist`** — enregistre les métriques via `Metric` (C6).

## Revue adversariale

Fuzz de ~20 sorties pytest-cov réelles (term/term-missing, branch, CRLF, décimaux, `TOTAL.py`/`TOTALS.py`, colonne Missing avec plages…) → `parse_coverage` **robuste**. Correction du point soulevé : **`coverage_measured`** distingue désormais « couverture non mesurée » (None) d'un « 0 % réel » — le gate G2 traitera l'inconnu en **fail-closed** au lieu d'un faux gain depuis 0.

## Tests & qualité

- `tests/test_improve_metrics.py` : **12 tests** — parse (`TOTAL`/décimal/0/100/absent/`TOTAL.py`), composite (monotone + pondéré), `measure` (agrégé / tests rouges / **0 % réel vs non mesuré**), `persist` round-trip.
- **Ruff** `check`+`format` clean. Import isolation OK (`collegue.improve` ne tire ni `app.py` ni dépendance lourde ; `code_review` reste paresseux).

## Hors périmètre (suite)

G2 = gate par métrique avant PR (gain sans régression, fail-closed) ; G3 = cycle d'experts (proposeur) ; G4 = boucle d'amélioration + arrêt sur rendements décroissants.