### PR TITLE
feat(improve): gate par métrique avant PR, fail-closed (G2)

### DIFF
--- a/collegue/improve/__init__.py
+++ b/collegue/improve/__init__.py
@@ -9,6 +9,7 @@ G1 pose la mesure des métriques. Module **isolé** tant que la boucle (G4) ne
 câble pas l'exécuteur + le budget.
 """
 
+from collegue.improve.gate import DEFAULT_MIN_GAIN, GateDecision, evaluate
 from collegue.improve.metrics import (
     DEFAULT_WEIGHTS,
     CompositeWeights,
@@ -20,6 +21,7 @@ from collegue.improve.metrics import (
 )
 
 __all__ = [
+    # G1 — métriques
     "ProjectQualityMetrics",
     "CompositeWeights",
     "DEFAULT_WEIGHTS",
@@ -27,4 +29,8 @@ __all__ = [
     "composite_score",
     "measure",
     "persist",
+    # G2 — gate
+    "GateDecision",
+    "evaluate",
+    "DEFAULT_MIN_GAIN",
 ]

--- a/collegue/improve/gate.py
+++ b/collegue/improve/gate.py
@@ -1,0 +1,82 @@
+"""Gate par métrique — décision de promotion d'un diff (G2, epic #382, Phase 4).
+
+Compare deux instantanés :class:`ProjectQualityMetrics` (avant/après un diff
+d'amélioration) et décide si le changement doit être **promu en PR**. **Fail-closed** :
+on ne promeut que si l'objectif progresse **sans régression** ; toute incertitude
+(tests rouges, mesurabilité de la couverture qui change, sécu aggravée, gain sous
+le bruit) ⇒ **rejet** (le diff est jeté — « rollback » avant promotion).
+
+Gate **AVANT la PR** (décision epic) : aucune régression ne peut donc atteindre
+``main`` ; le merge de la PR promue reste **humain** (§6).
+
+Fonction **pure** : aucun effet de bord, entièrement testable.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from collegue.improve.metrics import ProjectQualityMetrics
+
+# Gain composite minimal pour promouvoir (évite de promouvoir du bruit / surplace).
+DEFAULT_MIN_GAIN = 0.01
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """Verdict de promotion d'un diff d'amélioration."""
+
+    accepted: bool
+    reason: str
+    delta: float  # composite après − avant
+    before: ProjectQualityMetrics
+    after: ProjectQualityMetrics
+
+
+def evaluate(
+    before: ProjectQualityMetrics,
+    after: ProjectQualityMetrics,
+    *,
+    min_gain: float = DEFAULT_MIN_GAIN,
+) -> GateDecision:
+    """Décide si l'amélioration (``before`` → ``after``) est promue. Fail-closed.
+
+    Règles (toutes requises pour accepter) :
+
+    1. **Garde dure** : ``after.tests_passed`` (tests rouges ⇒ rejet immédiat).
+    2. **Scores finis** : ``before``/``after`` composites finis — un score ``NaN``/``inf``
+       (mesure corrompue) passerait sinon la garde de gain (``NaN < x`` est ``False``)
+       et ferait échouer le fail-closed ⇒ rejet.
+    3. **Mesurabilité stable** : ``before.coverage_measured == after.coverage_measured``
+       — un changement qui casse/active la mesure de couverture rend le delta de
+       couverture non fiable (cf. G1) ⇒ rejet.
+    4. **Pas de régression sécu** : ``after.security_findings <= before.security_findings``.
+    5. **Gain réel** : ``after.composite >= before.composite + min_gain``.
+
+    ``min_gain`` négatif inverserait la garde « pas de régression » → borné à 0.
+    """
+    min_gain = max(0.0, min_gain)
+    delta = after.composite - before.composite
+
+    def reject(reason: str) -> GateDecision:
+        return GateDecision(accepted=False, reason=reason, delta=delta, before=before, after=after)
+
+    if not after.tests_passed:
+        return reject("tests rouges après le diff (garde dure)")
+    if not (math.isfinite(before.composite) and math.isfinite(after.composite)):
+        return reject("score composite non fini (NaN/inf) — mesure non fiable")
+    if before.coverage_measured != after.coverage_measured:
+        return reject("mesurabilité de la couverture instable (avant≠après) — delta non fiable")
+    if after.security_findings > before.security_findings:
+        return reject(f"régression sécu : {after.security_findings} > {before.security_findings} findings")
+    if delta < min_gain:
+        return reject(f"gain insuffisant : Δ={delta:.4f} < min_gain={min_gain:.4f}")
+
+    return GateDecision(
+        accepted=True,
+        reason=f"gain composite Δ={delta:.4f} sans régression",
+        delta=delta,
+        before=before,
+        after=after,
+    )

--- a/tests/test_improve_gate.py
+++ b/tests/test_improve_gate.py
@@ -1,0 +1,109 @@
+"""Tests G2 (#384) : gate par métrique avant PR (gain sans régression, fail-closed)."""
+
+import math
+
+from collegue.improve import ProjectQualityMetrics, composite_score, evaluate
+
+
+def _m(*, coverage=80.0, review=0.7, security=0, tests=True, measured=True):
+    return ProjectQualityMetrics(
+        coverage_pct=coverage,
+        review_score=review,
+        security_findings=security,
+        tests_passed=tests,
+        composite=composite_score(coverage, review, security),
+        coverage_measured=measured,
+    )
+
+
+# --- acceptation ----------------------------------------------------------------
+
+
+def test_accept_on_real_gain_without_regression():
+    before = _m(coverage=70.0)
+    after = _m(coverage=90.0)  # +20 pts couverture → composite ↑
+    d = evaluate(before, after)
+    assert d.accepted is True
+    assert d.delta > 0
+
+
+def test_accept_gain_from_review_when_coverage_unmeasurable_both_sides():
+    # Projet sans couverture mesurable (both False) : le gain vient de la revue.
+    before = _m(coverage=0.0, review=0.5, measured=False)
+    after = _m(coverage=0.0, review=0.8, measured=False)
+    d = evaluate(before, after)
+    assert d.accepted is True
+
+
+# --- rejets fail-closed ---------------------------------------------------------
+
+
+def test_reject_when_tests_red():
+    d = evaluate(_m(), _m(coverage=99.0, tests=False))  # énorme « gain » mais tests rouges
+    assert d.accepted is False
+    assert "tests rouges" in d.reason
+
+
+def test_reject_on_security_regression():
+    d = evaluate(_m(security=1, coverage=70.0), _m(security=2, coverage=90.0))
+    assert d.accepted is False
+    assert "sécu" in d.reason
+
+
+def test_reject_on_insufficient_gain():
+    before = _m(coverage=80.0)
+    after = _m(coverage=80.0)  # composite identique → Δ=0
+    d = evaluate(before, after)
+    assert d.accepted is False
+    assert "gain insuffisant" in d.reason
+    assert d.delta == 0.0
+
+
+def test_reject_on_coverage_measurability_flip():
+    # Couverture non mesurée avant (0 % traité), mesurée après (90 %) → faux gain.
+    before = _m(coverage=0.0, measured=False)
+    after = _m(coverage=90.0, measured=True)
+    d = evaluate(before, after)
+    assert d.accepted is False
+    assert "mesurabilité" in d.reason
+
+
+# --- min_gain -------------------------------------------------------------------
+
+
+def test_min_gain_threshold_filters_noise():
+    before = _m(coverage=80.0)
+    after = _m(coverage=80.5)  # gain minuscule
+    assert evaluate(before, after, min_gain=0.05).accepted is False  # sous le seuil
+    assert evaluate(before, after, min_gain=0.001).accepted is True  # au-dessus
+
+
+def test_reject_non_finite_composite():
+    # Score NaN/inf : la garde de gain (NaN < x = False) laisserait passer → fail-closed.
+    before = _m(coverage=70.0)
+    for bad in (math.nan, math.inf):
+        after = ProjectQualityMetrics(
+            coverage_pct=90.0,
+            review_score=0.8,
+            security_findings=0,
+            tests_passed=True,
+            composite=bad,
+            coverage_measured=True,
+        )
+        d = evaluate(before, after)
+        assert d.accepted is False
+        assert "non fini" in d.reason
+
+
+def test_negative_min_gain_is_clamped_no_regression_promoted():
+    # min_gain négatif inverserait la garde « pas de régression » → borné à 0.
+    before = _m(coverage=80.0)
+    after = _m(coverage=60.0)  # composite ↓ (régression)
+    assert evaluate(before, after, min_gain=-1.0).accepted is False
+
+
+def test_delta_is_composite_difference():
+    before = _m(coverage=60.0)
+    after = _m(coverage=80.0)
+    d = evaluate(before, after)
+    assert d.delta == after.composite - before.composite


### PR DESCRIPTION
Deuxième enfant de l'epic #382 (**Phase 4 — amélioration continue**). `Closes #384`. Dépend de G1 (mergé).

## Ce que ça ajoute

`collegue/improve/gate.py` — `evaluate(before, after, *, min_gain) -> GateDecision` (fonction **pure**) : décide si un diff d'amélioration doit être **promu en PR**.

Promu **uniquement si** l'objectif progresse **sans régression** :
- **garde dure** : tests verts après le diff ;
- **mesurabilité stable** : `coverage_measured` identique avant/après (anti faux-gain via le 0 %-non-mesuré de G1) ;
- **pas de régression sécu** : `security_findings` n'augmente pas ;
- **gain réel** : `composite(after) >= composite(before) + min_gain`.

Toute incertitude → **rejet** (le diff est jeté = « rollback » avant promotion). **Gate AVANT la PR** (décision epic) : aucune régression n'atteint `main` ; le merge de la PR reste **humain** (§6).

## 🔒 Durcissement (trouvé par `/review` adversarial)

- **Scores non finis** : un `composite` `NaN`/`inf` passait la garde de gain (`NaN < x` = `False`) → rejet explicite (fail-closed).
- **`min_gain` négatif** inversait la garde « pas de régression » → **borné à 0**.

Latent aujourd'hui (`measure()` assainit), mais `evaluate` est un gate public que G4 / le round-trip des `Metric` persistés peuvent alimenter directement.

## Tests & qualité

- `tests/test_improve_gate.py` : **12 tests** — acceptation (gain réel ; gain via revue sans couverture mesurable), rejets (tests rouges / régression sécu / gain insuffisant / **flip de mesurabilité** / **NaN-inf** / **min_gain négatif**), seuil `min_gain`, `delta`.
- **Ruff** `check`+`format` clean. Module `collegue/improve/` isolé (pas câblé au runtime).

Shippé via `/review` (2 défauts corrigés) + `/ship`.

## Hors périmètre (suite)

G3 = cycle d'experts (proposeur dimension → `IssueSpec`) ; G4 = boucle d'amélioration + arrêt sur rendements décroissants.