### PR TITLE
feat(improve): cycle d'experts — proposeur de la prochaine amélioration (G3)

### DIFF
--- a/collegue/improve/__init__.py
+++ b/collegue/improve/__init__.py
@@ -19,6 +19,13 @@ from collegue.improve.metrics import (
     parse_coverage,
     persist,
 )
+from collegue.improve.proposer import (
+    COVERAGE_TARGET,
+    AttemptRecord,
+    Dimension,
+    build_improvement_task,
+    next_dimension,
+)
 
 __all__ = [
     # G1 — métriques
@@ -33,4 +40,10 @@ __all__ = [
     "GateDecision",
     "evaluate",
     "DEFAULT_MIN_GAIN",
+    # G3 — proposeur
+    "Dimension",
+    "AttemptRecord",
+    "next_dimension",
+    "build_improvement_task",
+    "COVERAGE_TARGET",
 ]

--- a/collegue/improve/proposer.py
+++ b/collegue/improve/proposer.py
@@ -1,0 +1,160 @@
+"""Cycle d'experts — proposeur de la prochaine amélioration (G3, epic #382, Phase 4).
+
+Choisit la **dimension** d'amélioration la plus utile (stratégie *pire-métrique-
+d'abord* avec **rotation** pour ne pas boucler sur une dimension qui stagne), puis
+en fait une **tâche exécutable** (:class:`IssueSpec`) que l'exécuteur (Phase 2)
+transformera en diff.
+
+Pur calcul : aucune exécution ici (la boucle G4 lance la tâche). Réutilise les
+experts existants (non-goal §9) — la génération du diff passe par l'exécuteur.
+
+Module **isolé** : non câblé au runtime. ``IssueSpec`` est importé paresseusement
+(dans :func:`build_improvement_task`) pour garder l'import de ``collegue.improve``
+léger.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Sequence
+
+from collegue.improve.metrics import ProjectQualityMetrics
+from collegue.textnorm import inline
+
+# Sous ce taux de couverture, on cible la dimension « couverture ».
+COVERAGE_TARGET = 90.0
+
+
+class Dimension(str, Enum):
+    """Dimension d'amélioration, chacune adossée à un expert."""
+
+    COVERAGE = "coverage"
+    SECURITY = "security"
+    REFACTORING = "refactoring"
+    DOCUMENTATION = "documentation"
+    CONSISTENCY = "consistency"
+
+
+# Dimensions de « polissage qualité » cyclées en round-robin (pas de métrique
+# dédiée qui les priorise — on les fait tourner pour varier les angles).
+_QUALITY_CYCLE = (Dimension.REFACTORING, Dimension.DOCUMENTATION, Dimension.CONSISTENCY)
+
+
+@dataclass(frozen=True)
+class AttemptRecord:
+    """Tentative passée : dimension essayée + a-t-elle amélioré le score ?"""
+
+    dimension: Dimension
+    improved: bool
+
+
+def _rotate_quality(history: Sequence[AttemptRecord]) -> List[Dimension]:
+    """Cycle qualité réordonné pour démarrer APRÈS la dernière dimension qualité essayée."""
+    last_quality = None
+    for attempt in reversed(list(history)):
+        if attempt.dimension in _QUALITY_CYCLE:
+            last_quality = attempt.dimension
+            break
+    if last_quality is None:
+        return list(_QUALITY_CYCLE)
+    idx = _QUALITY_CYCLE.index(last_quality)
+    return list(_QUALITY_CYCLE[idx + 1 :] + _QUALITY_CYCLE[: idx + 1])
+
+
+def _least_recently_tried(candidates: Sequence[Dimension], history: Sequence[AttemptRecord]) -> Dimension:
+    """Parmi ``candidates``, la dimension essayée le moins récemment (jamais = priorité)."""
+    hist = list(history)
+
+    def last_index(dimension: Dimension) -> int:
+        for i in range(len(hist) - 1, -1, -1):
+            if hist[i].dimension == dimension:
+                return i
+        return -1  # jamais essayée → la plus prioritaire
+
+    return min(candidates, key=last_index)
+
+
+def next_dimension(metrics: ProjectQualityMetrics, *, history: Sequence[AttemptRecord] = ()) -> Dimension:
+    """Choisit la prochaine dimension : pire-métrique-d'abord, avec rotation.
+
+    Priorité : sécurité (si findings) → couverture (si sous la cible et mesurée) →
+    cycle qualité (refactoring/doc/consistency, round-robin). Une dimension essayée
+    récemment **sans amélioration** (``history``) est sautée pour ne pas boucler.
+
+    Si **tout** est bloqué, on ne renvoie pas « rien » : on choisit la dimension
+    essayée le moins récemment (rotation du fallback, évite de marteler la même).
+    Le **vrai** garde-fou anti-boucle est l'arrêt sur rendements décroissants de la
+    boucle (G4) : une dimension dont le gate rejette en boucle finit par stopper le
+    run quand les gains plafonnent — ce n'est pas le rôle du proposeur.
+    """
+    window = list(history)[-len(Dimension) :]
+    stalled = {attempt.dimension for attempt in window if not attempt.improved}
+
+    candidates: List[Dimension] = []
+    if metrics.security_findings > 0:
+        candidates.append(Dimension.SECURITY)
+    # ``math.isfinite`` : une couverture NaN ne doit pas être prise pour « saine »
+    # (NaN < cible est False) — on ne cible alors pas la couverture (fail-silent évité).
+    if metrics.coverage_measured and math.isfinite(metrics.coverage_pct) and metrics.coverage_pct < COVERAGE_TARGET:
+        candidates.append(Dimension.COVERAGE)
+    candidates.extend(_rotate_quality(history))
+
+    for dimension in candidates:
+        if dimension not in stalled:
+            return dimension
+    return _least_recently_tried(candidates, history)
+
+
+# Gabarits de consigne par dimension : (titre, corps, critères d'acceptation).
+_TEMPLATES = {
+    Dimension.COVERAGE: (
+        "Améliorer la couverture de tests",
+        "Ajouter des tests pour augmenter la couverture (actuellement {coverage:.0f} %), "
+        "sans casser les tests existants.",
+        ("La couverture de tests augmente", "Tous les tests passent"),
+    ),
+    Dimension.SECURITY: (
+        "Corriger les problèmes de sécurité",
+        "Corriger les {security} problème(s) de sécurité détecté(s) (secrets, IaC, motifs à risque).",
+        ("Le nombre de findings de sécurité diminue", "Aucun nouveau finding", "Tous les tests passent"),
+    ),
+    Dimension.REFACTORING: (
+        "Refactoring pour la qualité",
+        "Améliorer lisibilité et structure sans changer le comportement observable.",
+        ("Le score de revue augmente", "Tous les tests passent", "Aucun changement de comportement"),
+    ),
+    Dimension.DOCUMENTATION: (
+        "Améliorer la documentation",
+        "Documenter les modules/fonctions clés (docstrings, README) pour la maintenabilité.",
+        ("La documentation des éléments publics s'améliore", "Tous les tests passent"),
+    ),
+    Dimension.CONSISTENCY: (
+        "Améliorer la cohérence du code",
+        "Uniformiser nommage, conventions et patterns pour réduire la charge cognitive.",
+        ("Le score de revue augmente", "Tous les tests passent"),
+    ),
+}
+
+
+def build_improvement_task(dimension: Dimension, metrics: ProjectQualityMetrics, *, number: int = 0):
+    """Construit l'``IssueSpec`` d'amélioration pour une dimension (consigne sanitizée).
+
+    ``number`` est le numéro de tâche/issue à utiliser (0 par défaut ; la boucle G4
+    fournit un numéro réel). ``IssueSpec`` est importé paresseusement.
+    """
+    from collegue.executor.agent import IssueSpec
+
+    title, body_template, acceptance = _TEMPLATES[dimension]
+    # Bornes d'affichage : pas de « -2 problème(s) » dans la consigne (build est public).
+    body = body_template.format(
+        coverage=max(0.0, metrics.coverage_pct) if math.isfinite(metrics.coverage_pct) else 0.0,
+        security=max(0, metrics.security_findings),
+    )
+    return IssueSpec(
+        number=int(number),
+        title=inline(title),
+        body=inline(body),
+        acceptance_criteria=tuple(inline(criterion) for criterion in acceptance),
+    )

--- a/tests/test_improve_proposer.py
+++ b/tests/test_improve_proposer.py
@@ -1,0 +1,126 @@
+"""Tests G3 (#385) : cycle d'experts — proposeur (dimension → IssueSpec)."""
+
+import math
+
+from collegue.improve import (
+    AttemptRecord,
+    Dimension,
+    ProjectQualityMetrics,
+    build_improvement_task,
+    next_dimension,
+)
+
+
+def _m(*, coverage=95.0, security=0, measured=True):
+    return ProjectQualityMetrics(
+        coverage_pct=coverage,
+        review_score=0.7,
+        security_findings=security,
+        tests_passed=True,
+        composite=0.0,
+        coverage_measured=measured,
+    )
+
+
+# --- next_dimension : pire-métrique-d'abord -------------------------------------
+
+
+def test_security_first_when_findings_present():
+    assert next_dimension(_m(security=2, coverage=50.0)) is Dimension.SECURITY
+
+
+def test_coverage_when_below_target_and_no_security():
+    assert next_dimension(_m(security=0, coverage=50.0)) is Dimension.COVERAGE
+
+
+def test_coverage_skipped_when_unmeasured():
+    # Couverture non mesurée → pas de cible couverture, on passe au cycle qualité.
+    d = next_dimension(_m(security=0, coverage=0.0, measured=False))
+    assert d in (Dimension.REFACTORING, Dimension.DOCUMENTATION, Dimension.CONSISTENCY)
+
+
+def test_quality_cycle_when_metrics_healthy():
+    # Couverture haute + 0 sécu → polissage qualité (refactoring en tête).
+    assert next_dimension(_m(security=0, coverage=95.0)) is Dimension.REFACTORING
+
+
+# --- rotation -------------------------------------------------------------------
+
+
+def test_stalled_security_is_skipped():
+    # Sécu présente MAIS la dernière tentative sécu n'a rien amélioré → on saute.
+    metrics = _m(security=2, coverage=50.0)
+    history = [AttemptRecord(Dimension.SECURITY, improved=False)]
+    assert next_dimension(metrics, history=history) is Dimension.COVERAGE
+
+
+def test_quality_round_robin_advances():
+    # Dernière dimension qualité = REFACTORING → la suivante démarre à DOCUMENTATION.
+    metrics = _m(security=0, coverage=95.0)
+    history = [AttemptRecord(Dimension.REFACTORING, improved=True)]
+    assert next_dimension(metrics, history=history) is Dimension.DOCUMENTATION
+
+
+def test_all_stalled_falls_back_to_first_candidate():
+    # Tout a stagné récemment → on ne renvoie pas « rien », mais le 1er candidat.
+    metrics = _m(security=1, coverage=50.0)
+    history = [
+        AttemptRecord(Dimension.SECURITY, improved=False),
+        AttemptRecord(Dimension.COVERAGE, improved=False),
+        AttemptRecord(Dimension.REFACTORING, improved=False),
+        AttemptRecord(Dimension.DOCUMENTATION, improved=False),
+        AttemptRecord(Dimension.CONSISTENCY, improved=False),
+    ]
+    assert next_dimension(metrics, history=history) is Dimension.SECURITY
+
+
+def test_all_stalled_fallback_rotates_not_hammering_one():
+    # Tout bloqué, SECURITY essayée le PLUS récemment → le fallback ne re-choisit pas
+    # SECURITY mais la dimension la moins récemment essayée (rotation).
+    metrics = _m(security=1, coverage=50.0)
+    history = [
+        AttemptRecord(Dimension.COVERAGE, improved=False),
+        AttemptRecord(Dimension.REFACTORING, improved=False),
+        AttemptRecord(Dimension.DOCUMENTATION, improved=False),
+        AttemptRecord(Dimension.CONSISTENCY, improved=False),
+        AttemptRecord(Dimension.SECURITY, improved=False),
+    ]
+    assert next_dimension(metrics, history=history) is not Dimension.SECURITY
+
+
+def test_nan_coverage_not_targeted():
+    # Couverture NaN (mesurée) ne doit pas être prise pour saine → pas de COVERAGE.
+    d = next_dimension(_m(security=0, coverage=math.nan, measured=True))
+    assert d is not Dimension.COVERAGE
+
+
+# --- build_improvement_task -----------------------------------------------------
+
+
+def test_build_task_coverage():
+    task = build_improvement_task(Dimension.COVERAGE, _m(coverage=72.0), number=42)
+    assert task.number == 42
+    assert "couverture" in task.title.lower()
+    assert "72" in task.body
+    assert task.acceptance_criteria  # critères non vides
+    # tout est inline-isé (pas de saut de ligne forgé)
+    assert "\n" not in task.title and all("\n" not in c for c in task.acceptance_criteria)
+
+
+def test_build_task_security_counts_findings():
+    task = build_improvement_task(Dimension.SECURITY, _m(security=3), number=1)
+    assert "sécurité" in task.title.lower()
+    assert "3" in task.body
+
+
+def test_build_task_each_dimension_has_template():
+    for dim in Dimension:
+        task = build_improvement_task(dim, _m(), number=0)
+        assert task.title and task.acceptance_criteria
+
+
+def test_build_task_clamps_negative_security_in_body():
+    # build est public : un compte sécu négatif ne doit pas produire « -2 problème(s) ».
+    task = build_improvement_task(Dimension.SECURITY, _m(security=-2), number=0)
+    assert "-2" not in task.body
+    assert " 0 problème" in task.body


### PR DESCRIPTION
Troisième enfant de l'epic #382 (**Phase 4 — amélioration continue**). `Closes #385`.

## Ce que ça ajoute

`collegue/improve/proposer.py` — pur calcul :

- **`Dimension`** : `coverage` / `security` / `refactoring` / `documentation` / `consistency` (chacune adossée à un expert existant).
- **`next_dimension(metrics, *, history)`** — **pire-métrique-d'abord** : sécurité (si findings) → couverture (si < cible **et** mesurée) → cycle qualité (round-robin). Saute les dimensions récemment **stagnantes** ; fallback = la dimension **la moins récemment essayée** (rotation, ne martèle pas la même).
- **`build_improvement_task(dimension, metrics, *, number)` → `IssueSpec`** — consigne **sanitizée** (`inline`) ; `IssueSpec` importé **paresseusement** (import de `collegue.improve` reste léger).

## 🔒 Durcissement (trouvé par `/review` adversarial)

- **Fallback all-stalled** : `return candidates[0]` re-tirait la même dimension stagnante en boucle → remplacé par **least-recently-tried** (le vrai garde-fou anti-boucle reste l'**arrêt sur rendements décroissants** de G4, documenté).
- **Couverture `NaN`** prise pour « saine » (`NaN < cible` = `False`) → guard `math.isfinite` (fail-silent évité).
- **Compte sécu négatif** affiché dans la consigne (`build` est public) → borné à 0.

## Tests & qualité

- `tests/test_improve_proposer.py` : **13 tests** — priorité (sécu/couverture/qualité), couverture non mesurée / `NaN`, round-robin qualité, stall sauté, **fallback qui tourne**, all-stalled, une tâche par dimension, **clamp sécu négatif**.
- **Ruff** `check`+`format` clean. 34 tests `collegue/improve/` verts. Import isolation OK (lazy `IssueSpec`).

Shippé via `/review` (3 durcissements) + `/ship`.

## Hors périmètre (capstone)

G4 = boucle d'amélioration (mesurer → proposer → diff → gate → promouvoir/jeter) + arrêt sur rendements décroissants, sous budget (F2), mode `improving` du pilote.