### PR TITLE
feat(improve): boucle d'amélioration continue (G4)

### DIFF
--- a/collegue/executor/pr.py
+++ b/collegue/executor/pr.py
@@ -83,23 +83,27 @@ class PrResult:
     skipped: bool = False  # PR déjà existante (idempotence)
 
 
-def build_pr_body(quality_report: QualityReport, issue: IssueSpec) -> str:
-    """Corps de PR : contexte issue + rapport qualité (fencé) + ``Closes`` + marqueur."""
-    return "\n".join(
-        [
-            f"## Exécution automatique de l'issue #{int(issue.number)}",
-            "",
-            f"> {inline(issue.title)}",
-            "",
-            "_PR générée par l'exécuteur Collègue (Phase 2). Merge sous CI verte + approbation humaine._",
-            "",
-            quality_report.to_markdown(),
-            "",
-            f"Closes #{int(issue.number)}",
-            "",
-            exec_marker(issue.number),
-        ]
-    )
+def build_pr_body(quality_report: QualityReport, issue: IssueSpec, *, closes_issue: bool = True) -> str:
+    """Corps de PR : contexte issue + rapport qualité (fencé) + ``Closes`` + marqueur.
+
+    ``closes_issue=False`` omet la ligne ``Closes #N`` : à utiliser quand le numéro
+    ne référence PAS une vraie issue GitHub (ex. tâche d'amélioration G4, dont le
+    numéro est un compteur de round) — sinon on fermerait une issue sans rapport.
+    """
+    lines = [
+        f"## Exécution automatique de l'issue #{int(issue.number)}",
+        "",
+        f"> {inline(issue.title)}",
+        "",
+        "_PR générée par l'exécuteur Collègue (Phase 2). Merge sous CI verte + approbation humaine._",
+        "",
+        quality_report.to_markdown(),
+        "",
+    ]
+    if closes_issue:
+        lines += [f"Closes #{int(issue.number)}", ""]
+    lines.append(exec_marker(issue.number))
+    return "\n".join(lines)
 
 
 def open_pr(
@@ -115,6 +119,7 @@ def open_pr(
     dry_run: bool = True,
     manager: Optional[object] = None,
     project_id: Optional[int] = None,
+    closes_issue: bool = True,
 ) -> PrResult:
     """Ouvre (ou prévisualise) la PR de l'issue.
 
@@ -122,10 +127,11 @@ def open_pr(
     **sans aucune écriture**. Sinon : idempotence (PR ouverte existante retournée),
     création de branche, commit des fichiers (suppression incluse), ouverture de PR,
     et journalisation du numéro de PR si ``manager``+``project_id`` sont fournis.
+    ``closes_issue=False`` n'ajoute pas ``Closes #N`` (numéro ≠ vraie issue, ex. G4).
     """
     head = workspace.branch
     title = f"{inline(issue.title)} (issue #{int(issue.number)})"
-    body = build_pr_body(quality_report, issue)
+    body = build_pr_body(quality_report, issue, closes_issue=closes_issue)
 
     if dry_run:
         return PrResult(dry_run=True, title=title, head=head, base=base, body=body)

--- a/collegue/improve/__init__.py
+++ b/collegue/improve/__init__.py
@@ -10,6 +10,11 @@ câble pas l'exécuteur + le budget.
 """
 
 from collegue.improve.gate import DEFAULT_MIN_GAIN, GateDecision, evaluate
+from collegue.improve.loop import (
+    ImprovementResult,
+    PromotedImprovement,
+    run_improvement,
+)
 from collegue.improve.metrics import (
     DEFAULT_WEIGHTS,
     CompositeWeights,
@@ -46,4 +51,8 @@ __all__ = [
     "next_dimension",
     "build_improvement_task",
     "COVERAGE_TARGET",
+    # G4 — boucle d'amélioration
+    "run_improvement",
+    "ImprovementResult",
+    "PromotedImprovement",
 ]

--- a/collegue/improve/loop.py
+++ b/collegue/improve/loop.py
@@ -1,0 +1,199 @@
+"""Boucle d'amélioration continue (G4, epic #382, Phase 4 — capstone).
+
+Après le MVP, fait tourner : **mesurer (G1) → proposer (G3) → générer un diff
+(exécuteur) → mesurer après → gater (G2) → promouvoir (PR) ou jeter**, sous le
+budget-temps (F2), et **s'arrête sur rendements décroissants** (les gains
+plafonnent) ou au budget.
+
+Gate **AVANT la PR** : un diff qui régresse (tests/sécu) ou n'améliore pas le score
+n'ouvre **pas** de PR (« rollback » = abandon avant promotion). Le merge des PR
+d'amélioration reste **humain** (§6). ``dry_run`` par défaut (aucune écriture).
+
+``measure_fn`` est injectable (mesures scriptées en CI) ; les briques de
+l'exécuteur sont importées **paresseusement** pour garder ``collegue.improve``
+léger. Le câblage du **mode `improving`** du pilote (enchaîner build → amélioration)
+est laissé à l'appelant/F4 (optionnel) — ce module fournit l'entrée ``run_improvement``.
+
+Module **isolé** : non câblé au runtime.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+from collegue.improve.gate import DEFAULT_MIN_GAIN, evaluate
+from collegue.improve.metrics import DEFAULT_WEIGHTS, CompositeWeights, measure, persist
+from collegue.improve.proposer import AttemptRecord, build_improvement_task, next_dimension
+
+# Raisons d'arrêt.
+STOP_PLATEAU = "plateau"  # rendements décroissants : les gains plafonnent
+STOP_PAUSED_BUDGET = "paused_budget"
+STOP_DEADLINE = "deadline_reached"
+STOP_SAFETY_CAP = "safety_cap"
+
+
+@dataclass(frozen=True)
+class PromotedImprovement:
+    """Une amélioration promue en PR."""
+
+    dimension: str
+    delta: float
+    pr_number: Optional[int]
+
+
+@dataclass
+class ImprovementResult:
+    """Bilan d'un run d'amélioration continue."""
+
+    stop_reason: str
+    rounds: int
+    promoted: List[PromotedImprovement] = field(default_factory=list)
+    rejected: List[Tuple[str, str]] = field(default_factory=list)  # (dimension, raison)
+    initial_score: Optional[float] = None
+    final_score: Optional[float] = None
+
+    @property
+    def promoted_prs(self) -> List[int]:
+        return [p.pr_number for p in self.promoted if p.pr_number is not None]
+
+
+def _improvement_quality_report(dimension, before, after, delta):
+    """Synthétise un QualityReport (corps de PR) à partir du delta de métriques.
+
+    Réutilise le rendu fencé anti-injection d'E4 ; pas un gate E3 (le gate ici est
+    métrique, G2). La couverture est la métrique comparable fiable avant/après.
+    """
+    from collegue.executor.quality_gate import QualityReport
+
+    summary = (
+        f"Amélioration « {dimension} » : score composite {before.composite:.3f} → "
+        f"{after.composite:.3f} (Δ{delta:+.3f}). "
+        f"Couverture {before.coverage_pct:.0f}% → {after.coverage_pct:.0f}% ; "
+        f"findings sécu {before.security_findings} → {after.security_findings}."
+    )
+    return QualityReport(
+        tests_passed=after.tests_passed,
+        test_exit_code=0 if after.tests_passed else 1,
+        test_output="(amélioration continue — gate par métrique)",
+        review_summary=summary,
+        review_findings=(),
+        review_blocking=False,
+        passed=True,
+    )
+
+
+async def run_improvement(
+    project_id: int,
+    repo_source: str,
+    ctx,
+    *,
+    agent,
+    owner: str,
+    repo: str,
+    manager,
+    budget=None,  # BudgetTimeController (importé paresseusement) ; None → défaut
+    sandbox=None,
+    reviewer=None,
+    clients=None,
+    runner=None,
+    base: str = "main",
+    dry_run: bool = True,
+    plateau_rounds: int = 2,
+    min_gain: float = DEFAULT_MIN_GAIN,
+    max_iterations: int = 50,
+    weights: CompositeWeights = DEFAULT_WEIGHTS,
+    measure_fn=measure,
+) -> ImprovementResult:
+    """Fait tourner la boucle d'amélioration jusqu'au plateau ou au budget.
+
+    Pour chaque round : workspace → mesure baseline → propose une dimension →
+    exécute l'agent (diff) → mesure après → gate (G2). Si accepté : PR (E4) + métrique
+    persistée. Sinon : diff jeté. Stop quand ``plateau_rounds`` rounds consécutifs
+    n'apportent pas de gain (≥ ``min_gain``), ou au budget/deadline.
+    """
+    # Imports paresseux : garder l'import de ``collegue.improve`` léger. ``pilot.budget``
+    # est aussi lazy car importer le sous-module déclenche ``pilot/__init__`` (→ driver
+    # → exécuteur) — on ne veut pas tirer tout ça au simple import du package improve.
+    from collegue.executor.agent import IssueSpec
+    from collegue.executor.runner import run_issue
+    from collegue.executor.workspace import prepare_workspace
+    from collegue.pilot.budget import ACTION_PAUSED_BUDGET, BudgetTimeController
+
+    budget = budget or BudgetTimeController()
+    history: List[AttemptRecord] = []
+    result = ImprovementResult(stop_reason=STOP_PLATEAU, rounds=0)
+    plateau = 0
+    round_num = 0
+
+    while True:
+        if round_num >= max_iterations:
+            result.stop_reason = STOP_SAFETY_CAP
+            break
+        decision = budget.should_continue()
+        if not decision.ok:
+            result.stop_reason = STOP_PAUSED_BUDGET if decision.action == ACTION_PAUSED_BUDGET else STOP_DEADLINE
+            break
+
+        round_num += 1
+        task = IssueSpec(number=round_num, title=f"Amélioration continue (round {round_num})")
+        workspace = prepare_workspace(repo_source, task)
+
+        before = await measure_fn(workspace.path, ctx, sandbox=sandbox, reviewer=reviewer, diff="", weights=weights)
+        if result.initial_score is None:
+            result.initial_score = before.composite
+        result.final_score = before.composite
+
+        dimension = next_dimension(before, history=history)
+        improvement = build_improvement_task(dimension, before, number=round_num)
+        execution = run_issue(agent, workspace, improvement, runner=runner)
+
+        if not execution.changed:
+            # L'agent n'a rien produit : pas une amélioration → round « à vide ».
+            history.append(AttemptRecord(dimension, improved=False))
+            result.rejected.append((dimension.value, "aucun diff produit"))
+            plateau += 1
+            if plateau >= plateau_rounds:
+                result.stop_reason = STOP_PLATEAU
+                break
+            continue
+
+        after = await measure_fn(
+            workspace.path, ctx, sandbox=sandbox, reviewer=reviewer, diff=execution.diff, weights=weights
+        )
+        result.final_score = after.composite
+        gate = evaluate(before, after, min_gain=min_gain)
+        history.append(AttemptRecord(dimension, improved=gate.accepted))
+
+        if gate.accepted:
+            report = _improvement_quality_report(dimension.value, before, after, gate.delta)
+            from collegue.executor.pr import open_pr
+
+            pr = open_pr(
+                workspace,
+                report,
+                improvement,
+                owner,
+                repo,
+                files_changed=execution.files_changed,
+                base=base,
+                clients=clients,
+                dry_run=dry_run,
+                manager=manager,
+                project_id=project_id,
+                # Le numéro est un compteur de round, pas une vraie issue → pas de Closes.
+                closes_issue=False,
+            )
+            if not dry_run:
+                persist(manager, project_id, after)
+            result.promoted.append(PromotedImprovement(dimension.value, gate.delta, pr.number))
+            plateau = 0
+        else:
+            result.rejected.append((dimension.value, gate.reason))
+            plateau += 1
+            if plateau >= plateau_rounds:
+                result.stop_reason = STOP_PLATEAU
+                break
+
+    result.rounds = round_num
+    return result

--- a/tests/test_executor_pr.py
+++ b/tests/test_executor_pr.py
@@ -210,6 +210,17 @@ def test_build_pr_body_structure():
     assert exec_marker(5) in body
 
 
+def test_build_pr_body_closes_issue_flag():
+    # Défaut : ferme l'issue (comportement E5 inchangé).
+    assert "Closes #5" in build_pr_body(REPORT, ISSUE, closes_issue=True)
+    # closes_issue=False : pas de « Closes » (numéro ≠ vraie issue, ex. round G4),
+    # mais le marqueur + le rapport restent présents.
+    body = build_pr_body(REPORT, ISSUE, closes_issue=False)
+    assert "Closes #" not in body
+    assert exec_marker(5) in body
+    assert "## Gate qualité" in body
+
+
 # --- FileCommands.delete_file (ajout E4) ----------------------------------------
 
 

--- a/tests/test_improve_loop.py
+++ b/tests/test_improve_loop.py
@@ -1,0 +1,216 @@
+"""Tests G4 (#386) : boucle d'amélioration continue (mesures scriptées, fixture git)."""
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from collegue.executor import FakeCodeAgent
+from collegue.improve import ProjectQualityMetrics, run_improvement
+from collegue.pilot import ACTION_CONTINUE, ACTION_PAUSED_BUDGET, ContinueDecision
+from collegue.sandbox import SandboxResult  # noqa: F401  (cohérence d'env)
+from collegue.state import ProjectStateManager
+
+CONT = ContinueDecision(action=ACTION_CONTINUE, reason="ok")
+PAUSE = ContinueDecision(action=ACTION_PAUSED_BUDGET, reason="budget")
+
+
+def _metrics(composite, *, tests=True, security=0, measured=True, coverage=80.0, review=0.7):
+    return ProjectQualityMetrics(
+        coverage_pct=coverage,
+        review_score=review,
+        security_findings=security,
+        tests_passed=tests,
+        composite=composite,
+        coverage_measured=measured,
+    )
+
+
+class _Budget:
+    def __init__(self, seq=(CONT,)):
+        self._seq = list(seq)
+        self._i = 0
+
+    def should_continue(self):
+        d = self._seq[min(self._i, len(self._seq) - 1)]
+        self._i += 1
+        return d
+
+
+class _ScriptedMeasure:
+    """measure_fn factice : déroule une file de ProjectQualityMetrics (avant/après)."""
+
+    def __init__(self, seq):
+        self._seq = list(seq)
+        self._i = 0
+
+    async def __call__(self, workspace, ctx, *, sandbox=None, reviewer=None, diff="", weights=None):
+        m = self._seq[min(self._i, len(self._seq) - 1)]
+        self._i += 1
+        return m
+
+
+class _Branches:
+    def ensure_branch(self, owner, repo, branch, from_branch=None):
+        return SimpleNamespace(name=branch)
+
+
+class _Files:
+    def update_file(self, owner, repo, path, message, content, branch=None):
+        return {}
+
+    def delete_file(self, owner, repo, path, message, branch=None):
+        return {}
+
+
+class _PRs:
+    def __init__(self):
+        self.created = []
+
+    def find_pr_by_head(self, owner, repo, head, base=None, state="open"):
+        return None
+
+    def create_pr(self, owner, repo, title, head, base, body):
+        self.created.append({"head": head, "body": body})
+        return SimpleNamespace(number=101, html_url="https://gh/pull/101", head_branch=head)
+
+
+def _clients():
+    from collegue.executor import PrClients
+
+    return PrClients(branches=_Branches(), files=_Files(), prs=_PRs())
+
+
+def _git(cwd, *args):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    src = tmp_path / "source"
+    src.mkdir()
+    _git(src, "init", "-q")
+    _git(src, "config", "user.email", "t@example.com")
+    _git(src, "config", "user.name", "Test")
+    (src / "existing.txt").write_text("original\n")
+    _git(src, "add", "-A")
+    _git(src, "commit", "-q", "-m", "init")
+    return str(src)
+
+
+@pytest.fixture
+def manager(tmp_path):
+    return ProjectStateManager.from_url(f"sqlite:///{tmp_path / 'state.db'}", create=True)
+
+
+async def _run(git_repo, manager, *, measure_seq, agent=None, budget=None, dry_run=True, **kw):
+    return await run_improvement(
+        manager.create_project(name="demo"),
+        git_repo,
+        ctx=None,
+        agent=agent or FakeCodeAgent(),
+        owner="o",
+        repo="r",
+        manager=manager,
+        budget=budget or _Budget(),
+        clients=_clients(),
+        dry_run=dry_run,
+        measure_fn=_ScriptedMeasure(measure_seq),
+        **kw,
+    )
+
+
+# --- promotion + plateau --------------------------------------------------------
+
+
+async def test_promotes_gain_then_stops_on_plateau(git_repo, manager):
+    # R1: 0.5→0.7 (gain) ; R2: 0.7→0.7 (Δ0) ; R3: 0.7→0.7 (Δ0) → plateau (2 rounds).
+    seq = [_metrics(0.5), _metrics(0.7), _metrics(0.7), _metrics(0.7), _metrics(0.7), _metrics(0.7)]
+    result = await _run(git_repo, manager, measure_seq=seq, plateau_rounds=2)
+    assert result.stop_reason == "plateau"
+    assert result.rounds == 3
+    assert len(result.promoted) == 1
+    assert len(result.rejected) == 2
+    assert result.initial_score == 0.5
+    assert result.final_score == 0.7
+    assert result.promoted[0].delta == pytest.approx(0.2)
+
+
+async def test_real_run_promotes_and_persists_metric(git_repo, manager):
+    pid = manager.create_project(name="real")
+    seq = [_metrics(0.5), _metrics(0.7), _metrics(0.7), _metrics(0.7)]
+    clients = _clients()
+    result = await run_improvement(
+        pid,
+        git_repo,
+        ctx=None,
+        agent=FakeCodeAgent(),
+        owner="o",
+        repo="r",
+        manager=manager,
+        budget=_Budget(),
+        clients=clients,
+        dry_run=False,
+        plateau_rounds=2,
+        measure_fn=_ScriptedMeasure(seq),
+    )
+    assert result.promoted_prs == [101]  # PR réelle ouverte
+    assert any(m.name == "composite" for m in manager.get_metrics(pid))  # métrique persistée
+    # La PR d'amélioration ne doit PAS contenir « Closes #N » (le numéro est un
+    # compteur de round, pas une vraie issue → ne fermerait pas une issue au hasard).
+    body = clients.prs.created[0]["body"]
+    assert "Closes #" not in body
+
+
+async def test_importing_improve_stays_light():
+    # Importer collegue.improve ne doit PAS tirer le pilote/exécuteur/openhands
+    # (briques importées paresseusement dans run_improvement). Sous-process = fiable.
+    import os
+    import subprocess
+    import sys
+
+    code = (
+        "import sys, collegue.improve; "
+        "bad=[m for m in sys.modules if m.startswith(('collegue.executor','collegue.pilot','openhands'))]; "
+        "assert not bad, bad"
+    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=dict(os.environ))
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+# --- fail-closed (pas de promotion d'une régression) ----------------------------
+
+
+async def test_regression_is_not_promoted(git_repo, manager):
+    # Après : tests rouges → gate rejette quel que soit le score.
+    seq = [_metrics(0.7), _metrics(0.99, tests=False)]
+    result = await _run(git_repo, manager, measure_seq=seq, plateau_rounds=1)
+    assert result.promoted == []
+    assert result.stop_reason == "plateau"
+    assert "rouges" in result.rejected[0][1]
+
+
+async def test_no_diff_round_counts_as_no_gain(git_repo, manager):
+    # Agent qui n'écrit rien → aucun diff → round à vide (pas de promotion).
+    result = await _run(git_repo, manager, measure_seq=[_metrics(0.5)], agent=FakeCodeAgent(files={}), plateau_rounds=1)
+    assert result.promoted == []
+    assert result.rejected[0][1] == "aucun diff produit"
+    assert result.stop_reason == "plateau"
+
+
+# --- arrêts ---------------------------------------------------------------------
+
+
+async def test_budget_stops_loop(git_repo, manager):
+    seq = [_metrics(0.5), _metrics(0.7), _metrics(0.7), _metrics(0.7)]
+    result = await _run(git_repo, manager, measure_seq=seq, budget=_Budget([CONT, PAUSE]), plateau_rounds=5)
+    assert result.stop_reason == "paused_budget"
+    assert result.rounds == 1  # 1 round avant la pause
+
+
+async def test_safety_cap(git_repo, manager):
+    # Gain à chaque round (jamais de plateau) mais cap à 1 round.
+    seq = [_metrics(0.1), _metrics(0.5), _metrics(0.5), _metrics(0.9)]
+    result = await _run(git_repo, manager, measure_seq=seq, max_iterations=1, plateau_rounds=9)
+    assert result.stop_reason == "safety_cap"
+    assert result.rounds == 1


### PR DESCRIPTION
## G4 — Boucle d'amélioration continue (capstone Phase 4, epic #382)

Dernier maillon de la Phase 4. `run_improvement` ferme la boucle du moteur d'amélioration : **mesurer (G1) → proposer une dimension (G3) → générer un diff (exécuteur) → mesurer après → gater (G2) → promouvoir en PR ou jeter**, sous budget-temps (F2), avec **arrêt sur rendements décroissants**.

### Comportement
- **Gate AVANT la PR (fail-closed).** Un diff qui régresse (tests rouges / findings sécu en hausse) ou qui n'améliore pas le score composite (Δ < `min_gain`) **n'ouvre pas de PR** — il est jeté. Rien d'incertain n'atteint le dépôt.
- **Arrêts.** `plateau` (N rounds consécutifs sans gain), `paused_budget`, `deadline_reached`, `safety_cap` (cap d'itérations anti-boucle folle).
- **Merge humain (§6).** Les PR d'amélioration restent à merger par un humain ; `dry_run=True` par défaut (aucune écriture).
- **PR sans `Closes`.** Le numéro de round n'est pas une vraie issue → `closes_issue=False` (nouveau flag sur `build_pr_body`/`open_pr`, défaut `True` pour ne rien changer à E5). Évite de fermer une issue au hasard.

### Isolation
- `measure_fn` injectable → mesures scriptées en CI (pas de Docker/LLM/git réel requis pour la logique).
- Briques exécuteur/pilote importées **paresseusement** → `import collegue.improve` reste léger (vérifié par un test d'isolation en sous-process : aucun module `collegue.executor`/`collegue.pilot`/`openhands` chargé au simple import du package).
- Module **non câblé au runtime** ; le mode `improving` du pilote est laissé à F4.

### Revue
Revue multi-agents (7 agents) avant ship : **aucun bug de logique** dans la boucle (fail-closed, terminaison, gating corrects). 3 constats corrigés :
1. Régression d'isolation d'import (`pilot.budget` tirait `pilot/__init__ → driver → executor`) → import de `budget` rendu paresseux + test d'isolation ajouté.
2-3. Couverture de test manquante sur `closes_issue` → assertions ajoutées côté boucle (PR d'amélioration sans `Closes`) et côté E4 (`build_pr_body(closes_issue=False)`).

### Tests
- `tests/test_improve_loop.py` (nouveau) : promotion + plateau, run réel avec PR + métrique persistée, régression non promue, round à vide, arrêt budget, safety cap, isolation d'import.
- `tests/test_executor_pr.py` : `closes_issue` (défaut True vs False).
- **Suite complète verte** hors `integration` : 1305 tests passent (1252 + 53 git-dépendants), 0 échec. `ruff check` + `ruff format --check` clean.

Clôt #386. Le merge de cette PR termine la **Phase 4** (epic #382).

🤖 Generated with [Claude Code](https://claude.com/claude-code)