### PR TITLE
feat(github+executor): plomberie merge/revert/branch-delete (H1)

### DIFF
--- a/collegue/executor/__init__.py
+++ b/collegue/executor/__init__.py
@@ -26,6 +26,13 @@ from collegue.executor.quality_gate import (
     outcome_from_review,
     run_quality_gate,
 )
+from collegue.executor.revert import (
+    RevertError,
+    RevertResult,
+    prepare_revert,
+    revert_commit,
+    revert_pr_preview,
+)
 from collegue.executor.runner import ExecutionResult, run_issue
 from collegue.executor.workspace import Workspace, WorkspaceError, branch_for_issue, prepare_workspace
 
@@ -63,4 +70,10 @@ __all__ = [
     # E5 — assemblage du pipeline
     "execute_issue",
     "ExecutionOutcome",
+    # H1 (Phase 5) — primitive de revert (capacité locale, sans push)
+    "RevertResult",
+    "RevertError",
+    "revert_commit",
+    "prepare_revert",
+    "revert_pr_preview",
 ]

--- a/collegue/executor/revert.py
+++ b/collegue/executor/revert.py
@@ -1,0 +1,148 @@
+"""Revert d'un commit mergé (H1, epic #391, Phase 5).
+
+Primitive **git** réutilisable par la garde post-merge (H3) : à partir d'un commit
+déjà mergé sur ``main``, produit un commit d'annulation sur une branche dédiée —
+**sans rien pousser ni merger** (capacité seule, décision : aucun déclenchement auto
+en H1). Le push de la branche + l'ouverture de la PR de revert relèvent de H3 /
+``integration``.
+
+Plomberie git **locale** sur un dépôt de confiance (clone d'un ``repo_source``),
+comme :mod:`collegue.executor.workspace`. Jamais d'exécution de code non fiable ici.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from typing import Optional
+
+from collegue.executor.command import CommandRunner, LocalCommandRunner
+
+# SHA git (court ou complet). Validé avant d'être passé à ``git`` (défense en
+# profondeur : l'argv n'est pas un shell, mais on refuse tout ce qui n'est pas un SHA).
+_SHA_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
+REVERT_BRANCH_PREFIX = "collegue/revert-"
+# Identité de commit du bot (le clone peut n'avoir aucune config git en CI/Docker).
+_BOT_EMAIL = "collegue-bot@users.noreply.github.com"
+_BOT_NAME = "Collègue Bot"
+
+
+@dataclass(frozen=True)
+class RevertResult:
+    """Résultat d'un revert local (aucune écriture distante)."""
+
+    reverted: bool
+    message: str
+    revert_sha: Optional[str] = None
+    branch: Optional[str] = None
+    workspace: Optional[str] = None
+
+
+class RevertError(RuntimeError):
+    """Échec de préparation du revert (source invalide, SHA invalide, git en erreur)."""
+
+
+def _validate_sha(sha: str) -> str:
+    if not sha or not _SHA_RE.match(sha):
+        raise RevertError(f"SHA de commit invalide: {sha!r}")
+    return sha
+
+
+def revert_commit(
+    workspace_path: str,
+    sha: str,
+    *,
+    merge_parent: Optional[int] = None,
+    runner: Optional[CommandRunner] = None,
+    git_bin: str = "git",
+) -> RevertResult:
+    """``git revert --no-edit`` de ``sha`` dans un workspace déjà préparé.
+
+    ``merge_parent`` (ex. ``1``) est requis pour révertir un **commit de merge**
+    (option ``-m``). **Fail-closed** : si le revert échoue (conflit…), on **abort**
+    (laisse le workspace propre) et on renvoie ``reverted=False`` avec le message —
+    le caller (H3) décide ; on ne laisse jamais un état conflictuel exploitable.
+    """
+    _validate_sha(sha)
+    runner = runner or LocalCommandRunner()
+
+    # Identité fournie en ``-c`` (éphémère, pas de config persistante) : le revert
+    # crée un commit, et un workspace cloné en CI/Docker peut n'avoir AUCUNE identité
+    # git → le commit échouerait. ``revert_commit`` est réutilisé directement par H3,
+    # donc l'identité doit vivre ici, pas seulement dans ``prepare_revert``.
+    cmd = [git_bin, "-c", f"user.email={_BOT_EMAIL}", "-c", f"user.name={_BOT_NAME}", "revert", "--no-edit"]
+    if merge_parent is not None:
+        cmd += ["-m", str(int(merge_parent))]
+    cmd.append(sha)
+
+    res = runner.run_command(cmd, workspace_path)
+    if not res.ok:
+        # Best-effort : nettoyer un revert partiel/conflictuel pour ne pas bloquer un retry.
+        runner.run_command([git_bin, "revert", "--abort"], workspace_path)
+        return RevertResult(
+            reverted=False,
+            message=(res.stderr.strip() or res.stdout.strip() or "git revert a échoué"),
+            workspace=workspace_path,
+        )
+
+    head = runner.run_command([git_bin, "rev-parse", "HEAD"], workspace_path)
+    revert_sha = head.stdout.strip() if head.ok else None
+    return RevertResult(reverted=True, message="revert appliqué", revert_sha=revert_sha, workspace=workspace_path)
+
+
+def prepare_revert(
+    repo_source: str,
+    sha: str,
+    *,
+    merge_parent: Optional[int] = None,
+    branch: Optional[str] = None,
+    runner: Optional[CommandRunner] = None,
+    git_bin: str = "git",
+    dest_root: Optional[str] = None,
+) -> RevertResult:
+    """Clone ``repo_source``, crée une branche de revert depuis la tête clonée et y
+    applique le revert de ``sha``. **Ne pousse rien** (capacité locale ; le push +
+    l'ouverture de la PR de revert = H3 / ``integration``).
+    """
+    _validate_sha(sha)
+    runner = runner or LocalCommandRunner()
+    source = os.path.realpath(os.path.abspath(repo_source))
+    if not os.path.isdir(os.path.join(source, ".git")):
+        raise RevertError(f"repo_source n'est pas un dépôt git: {repo_source}")
+
+    parent = dest_root or tempfile.mkdtemp(prefix="collegue-revert-")
+    os.makedirs(parent, exist_ok=True)
+    dest = os.path.join(parent, "workspace")
+    clone = runner.run_command([git_bin, "clone", "--quiet", source, dest], parent)
+    if not clone.ok:
+        raise RevertError(f"git clone a échoué: {clone.stderr.strip() or clone.stdout.strip()}")
+
+    # L'identité de commit est fournie par ``revert_commit`` (en ``-c``), pas besoin de
+    # config persistante ici.
+    revert_branch = branch or f"{REVERT_BRANCH_PREFIX}{sha[:12]}"
+    checkout = runner.run_command([git_bin, "checkout", "-q", "-b", revert_branch], dest)
+    if not checkout.ok:
+        raise RevertError(f"git checkout -b {revert_branch} a échoué: {checkout.stderr.strip()}")
+
+    result = revert_commit(dest, sha, merge_parent=merge_parent, runner=runner, git_bin=git_bin)
+    # Rattacher le nom de branche (``revert_commit`` ne le connaît pas).
+    return RevertResult(
+        reverted=result.reverted,
+        message=result.message,
+        revert_sha=result.revert_sha,
+        branch=revert_branch,
+        workspace=dest,
+    )
+
+
+def revert_pr_preview(sha: str, *, base: str = "main", reason: str = "") -> dict:
+    """Titre + corps proposés pour la PR de revert (**aperçu dry_run**, sans écriture)."""
+    _validate_sha(sha)
+    short = sha[:12]
+    lines = [f"Annulation automatique du commit `{short}` (garde post-merge).", ""]
+    if reason:
+        lines += [f"Raison : {reason}", ""]
+    lines.append("PR de revert générée par Collègue (Phase 5, H3). Merge sous approbation humaine (§6).")
+    return {"title": f"Revert de {short} sur {base}", "body": "\n".join(lines)}

--- a/collegue/tools/github_commands/__init__.py
+++ b/collegue/tools/github_commands/__init__.py
@@ -16,7 +16,7 @@ from .issues import IssueCommands, IssueInfo
 from .labels import LabelCommands, LabelInfo
 from .milestones import MilestoneCommands, MilestoneInfo
 from .projects import ProjectCommands, ProjectInfo
-from .prs import Comment, FileChange, PRCommands, PRInfo
+from .prs import Comment, FileChange, MergeResult, PRCommands, PRInfo
 from .repos import RepoCommands, RepoInfo
 from .search import SearchCommands, SearchResult
 from .workflows import WorkflowCommands, WorkflowRun
@@ -29,6 +29,7 @@ __all__ = [
     "PRInfo",
     "FileChange",
     "Comment",
+    "MergeResult",
     "IssueCommands",
     "IssueInfo",
     "BranchCommands",

--- a/collegue/tools/github_commands/branches.py
+++ b/collegue/tools/github_commands/branches.py
@@ -4,12 +4,16 @@ Branch Commands for GitHub Operations.
 Handles branch listing, creation, and commit operations.
 """
 
-from typing import List, Optional
+from typing import Iterable, List, Optional
 
 from pydantic import BaseModel
 
 from ..base import ToolExecutionError
 from ..clients import GitHubClient
+from ._helpers import validate_ref
+
+# Branches refusées par défaut à la suppression (garde-fou contre la perte de la base).
+PROTECTED_BRANCHES = ("main", "master")
 
 
 class BranchInfo(BaseModel):
@@ -92,3 +96,64 @@ class BranchCommands(GitHubClient):
             if again is not None:
                 return BranchInfo(name=branch, commit_sha=again, protected=False)
             raise
+
+    def delete_branch(
+        self,
+        owner: str,
+        repo: str,
+        branch: str,
+        *,
+        protect: Iterable[str] = PROTECTED_BRANCHES,
+        default_branch: Optional[str] = None,
+    ) -> bool:
+        """Supprime une branche. **Idempotent** + **refuse les branches protégées**.
+
+        - Refuse ``main``/``master``, tout nom dans ``protect``, **et la vraie branche
+          par défaut du dépôt** (résolue via l'API) : un dépôt dont la base est
+          ``develop``/``trunk`` est protégé aussi, pas seulement ``main``/``master``.
+          La résolution est **fail-closed** : si on ne peut pas déterminer la base, on
+          refuse (op destructive). Le caller peut passer ``default_branch`` pour
+          éviter le round-trip.
+        - La comparaison est normalisée (casse + ``/``/``.`` final) en défense en
+          profondeur contre les variantes.
+        - Idempotent : si la branche n'existe pas (déjà supprimée), renvoie ``True``
+          sans erreur. Gère aussi la **course** (suppression concurrente pendant
+          l'appel) en re-vérifiant l'absence avant de propager.
+        """
+        validate_ref(owner, "owner")
+        validate_ref(repo, "repo")
+        # Les noms de branche GitHub peuvent contenir des '/' (``feat/x``), donc on
+        # ne réutilise pas ``validate_ref`` (alphanum strict) : on bloque seulement la
+        # traversée / les caractères dangereux avant interpolation dans l'URL.
+        if not branch or branch.startswith("/") or ".." in branch or any(c.isspace() for c in branch):
+            raise ToolExecutionError(f"nom de branche invalide: {branch!r}")
+
+        def _norm(name: str) -> str:
+            return name.strip().rstrip("/.").lower()
+
+        norm = _norm(branch)
+        # 1) Garde littérale (main/master) : refus SANS round-trip réseau.
+        if norm in {_norm(p) for p in protect if p}:
+            raise ToolExecutionError(f"refus de supprimer la branche protégée: {branch!r}")
+        # 2) Vraie branche par défaut (fail-closed si non résolvable).
+        if default_branch is None:
+            try:
+                repo_info = self._api_get(f"/repos/{owner}/{repo}") or {}
+            except ToolExecutionError as e:
+                raise ToolExecutionError(
+                    f"branche par défaut de {owner}/{repo} non résolue — refus de supprimer (fail-closed)"
+                ) from e
+            default_branch = repo_info.get("default_branch")
+        if default_branch and norm == _norm(default_branch):
+            raise ToolExecutionError(f"refus de supprimer la branche par défaut: {branch!r}")
+
+        if self._branch_sha_or_none(owner, repo, branch) is None:
+            return True  # déjà absente → succès idempotent
+        try:
+            self._request_json("DELETE", f"/repos/{owner}/{repo}/git/refs/heads/{branch}")
+        except ToolExecutionError:
+            # Course : supprimée entre-temps ? Si oui, succès idempotent ; sinon propage.
+            if self._branch_sha_or_none(owner, repo, branch) is None:
+                return True
+            raise
+        return True

--- a/collegue/tools/github_commands/prs.py
+++ b/collegue/tools/github_commands/prs.py
@@ -8,7 +8,11 @@ from typing import List, Optional
 
 from pydantic import BaseModel
 
+from ..base import ToolExecutionError
 from ..clients import GitHubClient
+from ._helpers import validate_ref
+
+_MERGE_METHODS = ("merge", "squash", "rebase")
 
 
 class PRInfo(BaseModel):
@@ -62,6 +66,13 @@ class Comment(BaseModel):
     created_at: str
     path: Optional[str] = None
     line: Optional[int] = None
+
+
+class MergeResult(BaseModel):
+    merged: bool
+    sha: Optional[str] = None
+    message: str = ""
+    already_merged: bool = False
 
 
 class PRCommands(GitHubClient):
@@ -192,3 +203,63 @@ class PRCommands(GitHubClient):
             updated_at=resp["updated_at"],
             draft=resp.get("draft", False),
         )
+
+    def merge_pr(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        *,
+        method: str = "squash",
+        commit_title: Optional[str] = None,
+        commit_message: Optional[str] = None,
+        expected_head_sha: Optional[str] = None,
+    ) -> MergeResult:
+        """Merge une PR ouverte. **Idempotent** + **garde anti-course**.
+
+        - Idempotence : si la PR est déjà mergée, retourne ``already_merged`` sans
+          re-tenter (un second merge renverrait 405).
+        - Garde anti-course : si ``expected_head_sha`` est fourni et ne correspond pas
+          à la tête actuelle de la PR, **refuse** (on ne merge pas un état non vu). Le
+          SHA est aussi transmis à l'API GitHub (double vérification côté serveur).
+
+        ``method`` ∈ {merge, squash, rebase}. **Fail-closed** : toute erreur HTTP
+        inattendue propage (``ToolExecutionError``) — on ne « réussit » jamais
+        silencieusement. Aucun auto-déclenchement ici (H1, capacité seule) : c'est un
+        appel explicite, la décision de merger appartient à H2 (auto-merge).
+        """
+        validate_ref(owner, "owner")
+        validate_ref(repo, "repo")
+        if method not in _MERGE_METHODS:
+            raise ToolExecutionError(f"méthode de merge invalide: {method!r} (attendu: {_MERGE_METHODS})")
+
+        current = self._api_get(f"/repos/{owner}/{repo}/pulls/{pr_number}")
+        if not isinstance(current, dict) or "state" not in current:
+            # Réponse vide/partielle : on n'a pas confirmé l'état de la PR → on ne merge
+            # pas un état non vu (fail-closed).
+            raise ToolExecutionError(f"état de la PR #{pr_number} indisponible — refus de merger (fail-closed)")
+        if current.get("merged"):
+            return MergeResult(
+                merged=True, sha=current.get("merge_commit_sha"), message="PR déjà mergée", already_merged=True
+            )
+        if current.get("state") == "closed":
+            raise ToolExecutionError(f"PR #{pr_number} fermée sans merge — refus de merger")
+        head_sha = (current.get("head") or {}).get("sha")
+        if expected_head_sha and head_sha != expected_head_sha:
+            raise ToolExecutionError(
+                f"la tête de la PR #{pr_number} a bougé (attendu {expected_head_sha}, vu {head_sha}) — "
+                "refus (anti-course)"
+            )
+
+        body: dict = {"merge_method": method}
+        if commit_title:
+            body["commit_title"] = commit_title
+        if commit_message:
+            body["commit_message"] = commit_message
+        if expected_head_sha:
+            body["sha"] = expected_head_sha
+
+        resp = self._api_put(f"/repos/{owner}/{repo}/pulls/{pr_number}/merge", body) or {}
+        # Un merge réussi renvoie toujours ``{"merged": true, "sha": ...}`` ; l'absence
+        # de confirmation = échec (défaut False), jamais un succès supposé (fail-closed).
+        return MergeResult(merged=bool(resp.get("merged", False)), sha=resp.get("sha"), message=resp.get("message", ""))

--- a/tests/test_executor_revert.py
+++ b/tests/test_executor_revert.py
@@ -1,0 +1,104 @@
+"""Tests H1 (#392) : primitive de revert git (revert_commit + prepare_revert).
+
+Vrai ``git`` sur un dépôt fixture (pas de Docker, pas de réseau) — comme
+``test_executor_workspace``. Vérifie l'annulation effective, le fail-closed sur SHA
+inconnu (abort → workspace propre), et la pureté de l'aperçu de PR.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from collegue.executor.revert import RevertError, prepare_revert, revert_commit, revert_pr_preview
+
+
+def _git(cwd, *args):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _head(cwd):
+    return subprocess.run(["git", "rev-parse", "HEAD"], cwd=cwd, capture_output=True, text=True).stdout.strip()
+
+
+@pytest.fixture
+def source_repo(tmp_path):
+    """Dépôt source : 2 commits (v1 puis v2) ; renvoie (chemin, sha_du_commit_v2)."""
+    src = tmp_path / "source"
+    src.mkdir()
+    _git(src, "init", "-q")
+    _git(src, "config", "user.email", "t@example.com")
+    _git(src, "config", "user.name", "Test")
+    (src / "file.txt").write_text("v1\n")
+    _git(src, "add", "-A")
+    _git(src, "commit", "-q", "-m", "v1")
+    (src / "file.txt").write_text("v2\n")
+    _git(src, "add", "-A")
+    _git(src, "commit", "-q", "-m", "v2")
+    return str(src), _head(src)
+
+
+def _clone_with_identity(src, dest):
+    _git(dest.parent, "clone", "--quiet", src, str(dest))
+    _git(dest, "config", "user.email", "bot@example.com")
+    _git(dest, "config", "user.name", "Bot")
+
+
+def test_revert_commit_undoes_change(tmp_path, source_repo):
+    src, sha2 = source_repo
+    dest = tmp_path / "clone"
+    _clone_with_identity(src, dest)
+
+    res = revert_commit(str(dest), sha2)
+    assert res.reverted and res.revert_sha
+    assert (dest / "file.txt").read_text() == "v1\n"  # contenu annulé
+    head = _head(dest)
+    assert head == res.revert_sha and head != sha2  # nouveau commit (le revert)
+
+
+def test_revert_commit_works_without_preset_identity(tmp_path, source_repo):
+    # Clone SANS config user.* : l'identité ``-c`` du bot doit permettre le commit de revert.
+    src, sha2 = source_repo
+    dest = tmp_path / "clone"
+    _git(dest.parent, "clone", "--quiet", src, str(dest))
+    res = revert_commit(str(dest), sha2)
+    assert res.reverted and res.revert_sha
+    assert (dest / "file.txt").read_text() == "v1\n"
+
+
+def test_revert_commit_invalid_sha():
+    with pytest.raises(RevertError):
+        revert_commit("/tmp", "not-a-sha")
+
+
+def test_revert_commit_unknown_sha_fails_closed(tmp_path, source_repo):
+    src, _ = source_repo
+    dest = tmp_path / "clone"
+    _clone_with_identity(src, dest)
+    # SHA bien formé mais inexistant → git revert échoue → reverted False, workspace propre.
+    res = revert_commit(str(dest), "0123456789abcdef0123456789abcdef01234567")
+    assert not res.reverted
+    status = subprocess.run(["git", "status", "--porcelain"], cwd=dest, capture_output=True, text=True).stdout
+    assert status.strip() == ""  # l'abort a nettoyé
+
+
+def test_prepare_revert_clones_branches_and_reverts(source_repo):
+    src, sha2 = source_repo
+    res = prepare_revert(src, sha2)
+    assert res.reverted
+    assert res.branch and res.branch.startswith("collegue/revert-")
+    assert (Path(res.workspace) / "file.txt").read_text() == "v1\n"
+
+
+def test_prepare_revert_rejects_non_repo(tmp_path):
+    with pytest.raises(RevertError):
+        prepare_revert(str(tmp_path / "nope"), "0123456789abcdef")
+
+
+def test_revert_pr_preview_is_pure():
+    out = revert_pr_preview("0123456789abcdef", base="main", reason="tests rouges")
+    assert "0123456789ab" in out["title"]
+    assert "tests rouges" in out["body"]
+    assert "§6" in out["body"]
+    with pytest.raises(RevertError):
+        revert_pr_preview("nope")

--- a/tests/test_github_merge_delete.py
+++ b/tests/test_github_merge_delete.py
@@ -1,0 +1,182 @@
+"""Tests H1 (#392) : merge_pr (PRCommands) + delete_branch (BranchCommands).
+
+Client HTTP **mocké** (pas de réseau en CI) : on remplace les méthodes bas niveau
+(``_api_get``/``_api_put``/``_request_json``/``_branch_sha_or_none``) par des fakes
+qui enregistrent les appels, et on vérifie idempotence, garde anti-course, refus des
+branches protégées et fail-closed.
+"""
+
+import pytest
+
+from collegue.tools.base import ToolExecutionError
+from collegue.tools.github_commands import BranchCommands, MergeResult, PRCommands
+
+
+class _Recorder:
+    def __init__(self):
+        self.calls = []
+
+
+def _pr_with(get_payload, *, put_payload=None):
+    pr = PRCommands(token=None)
+    rec = _Recorder()
+
+    def fake_get(endpoint, params=None):
+        rec.calls.append(("GET", endpoint))
+        return get_payload
+
+    def fake_put(endpoint, data):
+        rec.calls.append(("PUT", endpoint, data))
+        return put_payload or {}
+
+    pr._api_get = fake_get
+    pr._api_put = fake_put
+    return pr, rec
+
+
+# --- merge_pr -------------------------------------------------------------------
+
+
+def test_merge_pr_success():
+    pr, rec = _pr_with(
+        {"merged": False, "state": "open", "head": {"sha": "abc1234def567"}},
+        put_payload={"merged": True, "sha": "mergedsha123", "message": "merged"},
+    )
+    res = pr.merge_pr("o", "r", 7, method="squash", expected_head_sha="abc1234def567")
+    assert isinstance(res, MergeResult)
+    assert res.merged and res.sha == "mergedsha123" and not res.already_merged
+    assert any(c[0] == "PUT" for c in rec.calls)
+
+
+def test_merge_pr_idempotent_when_already_merged():
+    # PR déjà mergée : état réel renvoyé par GitHub = state closed + merged true.
+    pr, rec = _pr_with({"merged": True, "state": "closed", "merge_commit_sha": "x9"})
+    res = pr.merge_pr("o", "r", 7)
+    assert res.merged and res.already_merged and res.sha == "x9"
+    assert not any(c[0] == "PUT" for c in rec.calls)  # pas de second merge (405 évité)
+
+
+def test_merge_pr_sha_guard_refuses_moved_head():
+    pr, _ = _pr_with({"merged": False, "state": "open", "head": {"sha": "aaa1111"}})
+    with pytest.raises(ToolExecutionError):
+        pr.merge_pr("o", "r", 7, expected_head_sha="bbb2222")
+
+
+def test_merge_pr_refuses_closed_unmerged():
+    pr, _ = _pr_with({"merged": False, "state": "closed", "head": {"sha": "aaa1111"}})
+    with pytest.raises(ToolExecutionError):
+        pr.merge_pr("o", "r", 7)
+
+
+def test_merge_pr_invalid_method():
+    pr, _ = _pr_with({"merged": False, "state": "open", "head": {"sha": "z"}})
+    with pytest.raises(ToolExecutionError):
+        pr.merge_pr("o", "r", 7, method="rebandon")
+
+
+def test_merge_pr_invalid_owner():
+    pr, _ = _pr_with({})
+    with pytest.raises(ToolExecutionError):
+        pr.merge_pr("o/..", "r", 7)  # owner avec traversée → refus avant tout appel
+
+
+def test_merge_pr_fails_closed_on_unknown_state():
+    # GET vide/partiel (pas de ``state``) → état non confirmé → refus de merger.
+    pr, rec = _pr_with({})
+    with pytest.raises(ToolExecutionError):
+        pr.merge_pr("o", "r", 7)
+    assert not any(c[0] == "PUT" for c in rec.calls)  # jamais de merge sur un état non vu
+
+
+def test_merge_pr_empty_put_response_is_not_merged():
+    # PUT sans corps de confirmation → on ne suppose PAS le succès (merged défaut False).
+    pr, _ = _pr_with({"merged": False, "state": "open", "head": {"sha": "h1"}})  # put_payload None → {}
+    res = pr.merge_pr("o", "r", 7)
+    assert res.merged is False
+
+
+# --- delete_branch --------------------------------------------------------------
+
+
+def _branches(sha_seq, *, default_branch="main", repo_get_error=False):
+    """``sha_seq`` : valeurs successives renvoyées par ``_branch_sha_or_none``.
+
+    ``default_branch`` : branche par défaut renvoyée par le GET ``/repos/{o}/{r}``.
+    ``repo_get_error`` : si vrai, ce GET lève (simule une base non résolvable).
+    """
+    br = BranchCommands(token=None)
+    rec = _Recorder()
+    seq = list(sha_seq)
+
+    def fake_sha(owner, repo, branch):
+        return seq.pop(0) if seq else None
+
+    def fake_get(endpoint, params=None):
+        rec.calls.append(("GET", endpoint))
+        if repo_get_error:
+            raise ToolExecutionError("repo introuvable")
+        return {"default_branch": default_branch}
+
+    def fake_request(method, endpoint, **kw):
+        rec.calls.append((method, endpoint))
+        return None
+
+    br._branch_sha_or_none = fake_sha
+    br._api_get = fake_get
+    br._request_json = fake_request
+    return br, rec
+
+
+def test_delete_branch_deletes_existing():
+    br, rec = _branches(["sha-exists"])
+    assert br.delete_branch("o", "r", "feat/x") is True
+    assert any(c[0] == "DELETE" for c in rec.calls)
+
+
+def test_delete_branch_idempotent_when_absent():
+    br, rec = _branches([None])
+    assert br.delete_branch("o", "r", "feat/x") is True
+    assert not any(c[0] == "DELETE" for c in rec.calls)  # rien à supprimer
+
+
+def test_delete_branch_refuses_protected():
+    br, rec = _branches(["sha", "sha"])
+    for protected in ("main", "master"):
+        with pytest.raises(ToolExecutionError):
+            br.delete_branch("o", "r", protected)
+    assert rec.calls == []  # aucun appel réseau pour une branche protégée
+
+
+def test_delete_branch_refuses_traversal():
+    br, _ = _branches(["sha"])
+    with pytest.raises(ToolExecutionError):
+        br.delete_branch("o", "r", "../evil")
+
+
+def test_delete_branch_allows_slash_in_name():
+    # Un nom de branche légitime avec '/' ne doit PAS être rejeté.
+    br, rec = _branches(["sha"])
+    assert br.delete_branch("o", "r", "feat/h1-merge") is True
+
+
+def test_delete_branch_protects_real_default_branch():
+    # La VRAIE branche par défaut (ici ``develop``) est protégée, pas seulement main/master.
+    br, rec = _branches(["sha"], default_branch="develop")
+    with pytest.raises(ToolExecutionError):
+        br.delete_branch("o", "r", "develop")
+    assert not any(c[0] == "DELETE" for c in rec.calls)
+
+
+def test_delete_branch_default_param_skips_repo_get():
+    # Quand le caller fournit ``default_branch``, pas de round-trip GET /repos.
+    br, rec = _branches(["sha"], default_branch="main")
+    with pytest.raises(ToolExecutionError):
+        br.delete_branch("o", "r", "trunk", default_branch="trunk")
+    assert not any(c[0] == "GET" for c in rec.calls)
+
+
+def test_delete_branch_fail_closed_when_default_unresolvable():
+    # GET /repos échoue → on ne peut pas garantir qu'on ne supprime pas la base → refus.
+    br, _ = _branches(["sha"], repo_get_error=True)
+    with pytest.raises(ToolExecutionError):
+        br.delete_branch("o", "r", "feat/x")


### PR DESCRIPTION
## H1 — Plomberie merge / revert / branch-delete (Phase 5, epic #391)

Socle de l'auto-merge (H2) et de l'auto-revert (H3) : les primitives brutes, **sans aucun déclenchement automatique** (capacité seule).

### Ajouts
- **`PRCommands.merge_pr`** — merge une PR. Idempotent (court-circuit `already_merged` si déjà mergée, évite le 405) ; **garde anti-course** (`expected_head_sha` refusé si la tête a bougé, + transmis à l'API) ; méthode squash/merge/rebase.
- **`BranchCommands.delete_branch`** — supprime une branche. Idempotent (404 → déjà absente) ; **refuse les branches protégées** : `main`/`master` ET la **vraie branche par défaut du dépôt** (résolue via l'API). Autorise les `/` légitimes, bloque la traversée.
- **`collegue/executor/revert.py`** — `revert_commit` / `prepare_revert` : `git revert --no-edit` (option `-m` pour un merge) dans un workspace cloné, identité bot en `-c` (marche sans config git préalable). **Ne pousse jamais** (push + PR de revert = H3). `revert_pr_preview` : aperçu pur.

### Fail-closed partout
- merge : état PR non confirmé (réponse vide/partielle) → **refus** ; PUT non confirmé → `merged=False` (jamais un succès supposé).
- delete : si la branche par défaut n'est pas résolvable → **refus** (op destructive).
- revert : un revert qui échoue (conflit) → `--abort` (workspace propre) + `reverted=False`.

### Revue
Revue adversariale (red-team) avant ship — 4 constats réels corrigés :
1. **(critique)** `delete_branch` ne protégeait que `main`/`master` littéraux → un dépôt à base `develop`/`trunk` n'était pas protégé. Corrigé : résolution de la vraie branche par défaut (fail-closed).
2-3. **(haut)** `merge_pr` fail-closed incomplet sur réponses API vides/partielles (GET → merge d'un état non vu ; PUT vide → `merged=True` par défaut). Corrigé.
4. **(moyen)** `revert_commit` nécessitait une identité git que seul `prepare_revert` posait → identité `-c` déplacée dans `revert_commit` (réutilisable par H3).

### Tests
- `tests/test_github_merge_delete.py` (client mocké) : merge idempotent/anti-course/fail-closed, delete idempotent/protégé/défaut-réel/traversée.
- `tests/test_executor_revert.py` (vrai git) : annulation effective, fail-closed sur SHA inconnu, identité sans config préalable, aperçu pur.
- **Suite complète verte** hors `integration` : 1309 tests, 0 échec. `ruff check` + `ruff format --check` clean.

Avance #392. `dry_run`/capacité seule : aucun merge/delete/revert n'est déclenché automatiquement (c'est H2/H3, gardés off par défaut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)