### PR TITLE
feat(pilot): observabilité du run autonome — audit + ledger de coût (H4)

### DIFF
--- a/collegue/pilot/__init__.py
+++ b/collegue/pilot/__init__.py
@@ -8,6 +8,15 @@ F1 pose l'ordonnanceur (sélection des tâches prêtes). Module **isolé** tant 
 le câblage runtime (F4) n'expose pas le pilote.
 """
 
+from collegue.pilot.audit import (
+    NullAuditLog,
+    RunAuditLog,
+    RunCostLedger,
+    RunEvent,
+    default_process_cost_source,
+    export_run_audit,
+    run_cost_summary,
+)
 from collegue.pilot.budget import (
     ACTION_CONTINUE,
     ACTION_DEADLINE,
@@ -45,4 +54,12 @@ __all__ = [
     # F4 — câblage runtime
     "run_project_from_settings",
     "format_run_report",
+    # H4 (Phase 5) — observabilité du run autonome
+    "RunAuditLog",
+    "NullAuditLog",
+    "RunEvent",
+    "RunCostLedger",
+    "run_cost_summary",
+    "export_run_audit",
+    "default_process_cost_source",
 ]

--- a/collegue/pilot/audit.py
+++ b/collegue/pilot/audit.py
@@ -1,0 +1,234 @@
+"""Observabilité du run autonome (H4, epic #391, Phase 5).
+
+L'observabilité existante (``MetricsCollector``, ``activity_log``, Sentry/OTel)
+trace les appels d'outils du **serveur MCP**, pas les actions du **run autonome**.
+Ce module comble ce trou : un **journal d'audit append-only** des actions du
+pilote/executor (tâche démarrée, gate, PR, budget, checkpoint, arrêt) + un **ledger
+de coût/tokens par run** + un **export auditable** (JSON déterministe).
+
+Émission **non intrusive** : le pilote prend un journal injectable dont le défaut
+(:class:`NullAuditLog`) est un no-op — les modules isolés et la suite existante ne
+changent pas. La persistance (DB ``decisions``/``metrics``, C6) est **opt-in** via un
+``manager`` ; sans lui, tout reste en mémoire (tests / ``dry_run``). L'audit ne doit
+**jamais** casser le run : la persistance est best-effort (exceptions avalées).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+# Types d'événements du run (toutes les actions de l'agent → auditables).
+CostSource = Callable[[], Tuple[float, int]]
+
+TASK_STARTED = "task_started"
+DIFF_PRODUCED = "diff_produced"
+GATE_DECISION = "gate_decision"
+PR_OPENED = "pr_opened"
+AUTOMERGE_DECISION = "automerge_decision"
+BUDGET_EVENT = "budget_event"
+CHECKPOINT_SAVED = "checkpoint_saved"
+RUN_STOP = "run_stop"
+COST_OBSERVED = "cost_observed"
+
+# Noms des métriques persistées pour le ledger de coût par run.
+METRIC_RUN_COST_USD = "run_cost_usd"
+METRIC_RUN_TOKENS = "run_tokens"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _json_safe(value: Any) -> Any:
+    """Rend une valeur sûre pour JSON : remplace les floats non finis (NaN/inf) par None.
+
+    ``json.dumps`` sérialise NaN/Infinity en jetons bruts **invalides** (RFC 8259) ;
+    un export d'audit doit rester lisible par un parseur strict (jq, jsonb, JS).
+    """
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if isinstance(value, dict):
+        return {k: _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    return value
+
+
+def default_process_cost_source() -> Tuple[float, int]:
+    """``(usd, tokens)`` cumulés du process via ``MetricsCollector`` (best-effort).
+
+    Source de coût prête à brancher dans le pilote (param ``cost_source``). Import
+    paresseux + best-effort : renvoie ``(0.0, 0)`` si l'observabilité serveur n'est
+    pas disponible, sans jamais lever.
+    """
+    try:
+        from collegue.monitoring.metrics import get_metrics_collector
+
+        usd, tokens = get_metrics_collector()._cumulative_totals()
+        return float(usd), int(tokens)
+    except Exception:
+        return 0.0, 0
+
+
+@dataclass(frozen=True)
+class RunEvent:
+    """Un événement d'audit horodaté (UTC ISO 8601)."""
+
+    kind: str
+    ts: str
+    iteration: Optional[int] = None
+    detail: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"kind": self.kind, "ts": self.ts, "iteration": self.iteration, "detail": self.detail}
+
+
+@dataclass
+class RunCostLedger:
+    """Coût USD + tokens cumulés d'un run."""
+
+    usd: float = 0.0
+    tokens: int = 0
+
+    def add(self, *, usd: float = 0.0, tokens: int = 0) -> Tuple[float, int]:
+        """Ajoute au ledger en ignorant les valeurs aberrantes. Renvoie le delta RETENU.
+
+        Fail-safe : on rejette NaN/inf, négatifs, et les ``bool`` (``True`` est un
+        ``int`` → un drapeau passé par erreur ne doit pas compter pour 1). Le delta
+        retenu permet à l'appelant de tracer une valeur cohérente avec le ledger.
+        """
+        acc_usd, acc_tokens = 0.0, 0
+        if isinstance(usd, (int, float)) and not isinstance(usd, bool) and math.isfinite(usd) and usd > 0:
+            acc_usd = float(usd)
+            self.usd += acc_usd
+        if isinstance(tokens, int) and not isinstance(tokens, bool) and tokens > 0:
+            acc_tokens = tokens
+            self.tokens += acc_tokens
+        return acc_usd, acc_tokens
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"usd": round(self.usd, 6), "tokens": self.tokens}
+
+
+class RunAuditLog:
+    """Journal d'audit append-only d'un run autonome + ledger de coût par run."""
+
+    def __init__(
+        self,
+        project_id: Optional[int] = None,
+        *,
+        manager: Optional[object] = None,
+        clock: Optional[Callable[[], datetime]] = None,
+        persist: bool = False,
+    ):
+        self.project_id = project_id
+        self._manager = manager
+        self._clock = clock or _utcnow
+        # Persistance opt-in et seulement si on a de quoi écrire. On valide la capacité
+        # du manager AU DÉMARRAGE (fail-fast) plutôt que d'avaler des AttributeError à
+        # chaque appel — sinon une persistance « activée » mais inopérante ressemble à
+        # une persistance qui marche (perte de données silencieuse).
+        wants_persist = bool(persist and manager is not None and project_id is not None)
+        if wants_persist and not (hasattr(manager, "record_decision") and hasattr(manager, "add_metric")):
+            raise ValueError("persist=True mais le manager n'expose pas record_decision/add_metric")
+        self._persist = wants_persist
+        self.events: List[RunEvent] = []
+        self.cost = RunCostLedger()
+
+    def record(self, kind: str, *, iteration: Optional[int] = None, **detail: Any) -> RunEvent:
+        """Enregistre un événement (et le persiste si activé). Best-effort."""
+        event = RunEvent(kind=kind, ts=self._clock().isoformat(), iteration=iteration, detail=detail)
+        self.events.append(event)
+        if self._persist:
+            try:
+                self._manager.record_decision(
+                    self.project_id,
+                    f"[run] {kind}",
+                    rationale=json.dumps(detail, default=str, ensure_ascii=False),
+                )
+            except Exception:
+                pass  # l'audit ne doit jamais casser le run
+        return event
+
+    def record_cost(self, *, usd: float = 0.0, tokens: int = 0, iteration: Optional[int] = None) -> None:
+        """Ajoute au ledger de coût du run + trace l'événement (et persiste si activé).
+
+        L'événement porte les valeurs **retenues** par le ledger (pas les valeurs
+        brutes) : le flux d'événements et le ledger réconcilient toujours, et aucun
+        NaN/inf brut n'atterrit dans l'export. Un delta nul (ex. tâche sans appel LLM)
+        n'émet aucun événement (bruit évité)."""
+        acc_usd, acc_tokens = self.cost.add(usd=usd, tokens=tokens)
+        if not acc_usd and not acc_tokens:
+            return
+        self.record(COST_OBSERVED, iteration=iteration, usd=acc_usd, tokens=acc_tokens)
+        if self._persist:
+            try:
+                self._manager.add_metric(self.project_id, METRIC_RUN_COST_USD, float(self.cost.usd))
+                self._manager.add_metric(self.project_id, METRIC_RUN_TOKENS, float(self.cost.tokens))
+            except Exception:
+                pass
+
+    def cost_summary(self) -> Dict[str, Any]:
+        return self.cost.to_dict()
+
+    def export(self) -> Dict[str, Any]:
+        """Vue auditable du run (déterministe, **sérialisable JSON strict**).
+
+        Les floats non finis (NaN/inf) qu'un appelant aurait pu glisser via
+        ``record(...)`` sont neutralisés en ``None`` pour garantir un JSON valide.
+        """
+        return _json_safe(
+            {
+                "project_id": self.project_id,
+                "cost": self.cost.to_dict(),
+                "event_count": len(self.events),
+                "events": [e.to_dict() for e in self.events],
+            }
+        )
+
+    def export_json(self) -> str:
+        # allow_nan=False : ceinture + bretelles (l'export est déjà neutralisé).
+        return json.dumps(self.export(), default=str, ensure_ascii=False, allow_nan=False)
+
+
+class NullAuditLog(RunAuditLog):
+    """Variante **no-op** : n'enregistre rien (défaut du pilote, zéro effet de bord)."""
+
+    def __init__(self) -> None:
+        super().__init__(project_id=None)
+
+    def record(self, kind: str, *, iteration: Optional[int] = None, **detail: Any) -> RunEvent:
+        # Ne rien stocker ni horodater : retour symbolique pour respecter la signature.
+        return RunEvent(kind=kind, ts="", iteration=iteration, detail=detail)
+
+    def record_cost(self, *, usd: float = 0.0, tokens: int = 0, iteration: Optional[int] = None) -> None:
+        return None
+
+
+def run_cost_summary(manager: object, project_id: int) -> Dict[str, Any]:
+    """Coût/tokens du run depuis les métriques **persistées** (dernier total cumulé).
+
+    Lit le ledger écrit par :meth:`RunAuditLog.record_cost` (métriques
+    ``run_cost_usd``/``run_tokens``) ; la dernière valeur de chaque nom est le total
+    final du run. ``{"usd": 0.0, "tokens": 0}`` si rien n'a été enregistré.
+
+    S'appuie sur l'ordre d'insertion de ``get_metrics`` (``ORDER BY Metric.id``,
+    autoincrément) : la dernière ligne d'un nom est le cumul le plus récent.
+    """
+    usd = 0.0
+    tokens = 0
+    for metric in manager.get_metrics(project_id):
+        if metric.name == METRIC_RUN_COST_USD:
+            usd = metric.value
+        elif metric.name == METRIC_RUN_TOKENS:
+            tokens = int(metric.value)
+    return {"usd": round(usd, 6), "tokens": tokens}
+
+
+def export_run_audit(audit: RunAuditLog) -> Dict[str, Any]:
+    """Export auditable d'un :class:`RunAuditLog` (helper public, miroir de ``.export``)."""
+    return audit.export()

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -27,6 +27,17 @@ from typing import List, Optional
 
 from collegue.executor.agent import IssueSpec
 from collegue.executor.pipeline import execute_issue
+from collegue.pilot.audit import (
+    BUDGET_EVENT,
+    CHECKPOINT_SAVED,
+    GATE_DECISION,
+    PR_OPENED,
+    RUN_STOP,
+    TASK_STARTED,
+    CostSource,
+    NullAuditLog,
+    RunAuditLog,
+)
 from collegue.pilot.budget import ACTION_DEADLINE, ACTION_PAUSED_BUDGET, BudgetTimeController
 from collegue.pilot.scheduler import next_task, remaining_tasks
 
@@ -100,15 +111,30 @@ async def run_project(
     clients=None,
     dry_run: bool = True,
     max_iterations: Optional[int] = None,
+    audit: Optional[RunAuditLog] = None,
+    cost_source: Optional[CostSource] = None,
 ) -> ProjectRunResult:
     """Pilote un projet : chaîne ``execute_issue`` sur les tâches prêtes sous budget.
 
     S'arrête quand : plus de tâche prête (``completed`` → bascule ``improving``),
     budget/deadline atteint, graphe bloqué, ou garde-fou ``max_iterations``.
     ``dry_run`` (défaut) ne persiste rien. Retourne un :class:`ProjectRunResult`.
+
+    ``audit`` (H4) : journal d'audit du run, **non intrusif** — défaut
+    :class:`NullAuditLog` (no-op) → comportement inchangé si non fourni.
+    ``cost_source`` (H4) : callable ``() -> (usd, tokens)`` cumulés ; si fourni, le
+    coût **par tâche** est échantillonné (delta) et alimente le ledger du run.
+    ``None`` (défaut) → pas d'échantillonnage (``collegue.pilot.audit`` fournit
+    ``default_process_cost_source`` à brancher par le runtime).
     """
     budget = budget or BudgetTimeController()
+    audit = audit or NullAuditLog()
     tasks = manager.get_tasks(project_id)  # objets détachés : overlay mutable en mémoire
+
+    # Coût par run : on échantillonne le cumul process avant/après chaque tâche et on
+    # enregistre le delta (le ledger ignore les deltas nuls/aberrants).
+    sample_cost = cost_source is not None
+    last_usd, last_tokens = cost_source() if sample_cost else (0.0, 0)
 
     # Reprise : une tâche laissée `in_progress` est un reliquat d'un run interrompu
     # (crash / pause budget en plein execute_issue). La boucle étant SÉQUENTIELLE,
@@ -141,6 +167,7 @@ async def run_project(
             stop_reason = STOP_PAUSED_BUDGET if decision.action == ACTION_PAUSED_BUDGET else STOP_DEADLINE
             if decision.action not in (ACTION_PAUSED_BUDGET, ACTION_DEADLINE):  # défensif
                 stop_reason = decision.action
+            audit.record(BUDGET_EVENT, iteration=iteration, action=decision.action, reason=decision.reason)
             break
 
         task = next_task(tasks)
@@ -152,6 +179,7 @@ async def run_project(
             stop_reason = STOP_COMPLETED if not remaining_tasks(tasks) else STOP_BLOCKED
             break
 
+        audit.record(TASK_STARTED, iteration=iteration + 1, task_id=task.id, title=task.title)
         outcome = await execute_issue(
             _issue_from_task(task),
             repo_source,
@@ -170,7 +198,14 @@ async def run_project(
             dry_run=dry_run,
         )
         iteration += 1
+        if sample_cost:
+            cur_usd, cur_tokens = cost_source()
+            audit.record_cost(usd=cur_usd - last_usd, tokens=int(cur_tokens - last_tokens), iteration=iteration)
+            last_usd, last_tokens = cur_usd, cur_tokens
         pr_number = outcome.pr.number if outcome.pr is not None else None
+        audit.record(GATE_DECISION, iteration=iteration, task_id=task.id, success=outcome.success, stage=outcome.stage)
+        if pr_number is not None:
+            audit.record(PR_OPENED, iteration=iteration, task_id=task.id, pr_number=pr_number, dry_run=dry_run)
         processed.append(
             TaskOutcome(
                 task_id=task.id,
@@ -196,6 +231,9 @@ async def run_project(
                 iteration,
                 state_json={"processed_task_ids": [t.task_id for t in processed]},
             )
+            audit.record(CHECKPOINT_SAVED, iteration=iteration)
+
+    audit.record(RUN_STOP, iteration=iteration, reason=stop_reason, iterations=len(processed))
 
     project_status: Optional[str] = None
     # Bascule MVP→amélioration uniquement si tout est construit sans échec, et

--- a/tests/test_pilot_audit.py
+++ b/tests/test_pilot_audit.py
@@ -1,0 +1,251 @@
+"""Tests H4 (#395) : observabilité du run autonome (journal d'audit + ledger coût)."""
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from collegue.executor import FakeCodeAgent, FakeReviewer, PrClients
+from collegue.pilot import run_project
+from collegue.pilot.audit import (
+    COST_OBSERVED,
+    GATE_DECISION,
+    RUN_STOP,
+    TASK_STARTED,
+    NullAuditLog,
+    RunAuditLog,
+    export_run_audit,
+    run_cost_summary,
+)
+from collegue.sandbox import SandboxResult
+from collegue.state import ProjectStateManager
+
+
+def _fixed_clock():
+    return datetime(2026, 6, 9, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# --- RunAuditLog (mémoire) ------------------------------------------------------
+
+
+def test_records_events_with_timestamp_and_iteration():
+    log = RunAuditLog(project_id=1, clock=_fixed_clock)
+    log.record(TASK_STARTED, iteration=1, task_id=7, title="T")
+    log.record(GATE_DECISION, iteration=1, task_id=7, success=True, stage="pr")
+    assert [e.kind for e in log.events] == [TASK_STARTED, GATE_DECISION]
+    assert log.events[0].ts == "2026-06-09T12:00:00+00:00"
+    assert log.events[0].detail["task_id"] == 7
+
+
+def test_cost_ledger_accumulates_and_ignores_aberrant():
+    log = RunAuditLog(project_id=1, clock=_fixed_clock)
+    log.record_cost(usd=0.01, tokens=100)
+    log.record_cost(usd=0.02, tokens=50)
+    log.record_cost(usd=float("nan"), tokens=-10)  # aberrant → ignoré
+    log.record_cost(usd=-1.0, tokens=5)  # usd négatif ignoré, tokens comptés
+    assert log.cost_summary() == {"usd": 0.03, "tokens": 155}
+
+
+def test_export_is_json_serializable_and_round_trips():
+    log = RunAuditLog(project_id=42, clock=_fixed_clock)
+    log.record(TASK_STARTED, iteration=1, task_id=1, title="T")
+    log.record_cost(usd=0.05, tokens=200)
+    blob = log.export_json()
+    data = json.loads(blob)
+    assert data == export_run_audit(log)
+    assert data["project_id"] == 42
+    assert data["cost"] == {"usd": 0.05, "tokens": 200}
+    assert data["event_count"] == len(data["events"]) == 2
+    assert any(e["kind"] == COST_OBSERVED for e in data["events"])
+
+
+def test_null_audit_log_is_noop():
+    log = NullAuditLog()
+    log.record(TASK_STARTED, iteration=1, task_id=1)
+    log.record_cost(usd=1.0, tokens=10)
+    assert log.events == []
+    assert log.cost_summary() == {"usd": 0.0, "tokens": 0}
+
+
+def test_cost_ledger_rejects_bool():
+    # ``True``/``False`` sont des int → ne doivent PAS compter pour 1 (confusion de type).
+    log = RunAuditLog(project_id=1, clock=_fixed_clock)
+    log.record_cost(usd=True, tokens=True)
+    assert log.cost_summary() == {"usd": 0.0, "tokens": 0}
+
+
+def test_cost_observed_event_matches_ledger():
+    # L'événement COST_OBSERVED porte les valeurs RETENUES (réconcilie avec le ledger).
+    log = RunAuditLog(project_id=1, clock=_fixed_clock)
+    log.record_cost(usd=0.02, tokens=50)
+    log.record_cost(usd=float("inf"), tokens=-5)  # aberrant → aucun événement émis
+    cost_events = [e for e in log.events if e.kind == COST_OBSERVED]
+    assert len(cost_events) == 1
+    assert cost_events[0].detail == {"usd": 0.02, "tokens": 50}
+
+
+def test_export_sanitizes_non_finite_floats():
+    # Un float non fini glissé via record(...) ne doit pas produire un JSON invalide.
+    log = RunAuditLog(project_id=1, clock=_fixed_clock)
+    log.record("custom", value=float("inf"))
+    data = json.loads(log.export_json())  # ne lève pas (JSON valide)
+    assert data["events"][0]["detail"]["value"] is None
+
+
+def test_persist_requires_capable_manager():
+    # persist=True avec un manager incapable → erreur AU DÉMARRAGE (pas de perte silencieuse).
+    with pytest.raises(ValueError):
+        RunAuditLog(1, manager=object(), persist=True)
+
+
+# --- persistance + run_cost_summary (SQLite réel) -------------------------------
+
+
+@pytest.fixture
+def manager(tmp_path):
+    return ProjectStateManager.from_url(f"sqlite:///{tmp_path / 'state.db'}", create=True)
+
+
+def test_persists_events_and_cost_and_reads_back(manager):
+    pid = manager.create_project(name="audit")
+    log = RunAuditLog(pid, manager=manager, clock=_fixed_clock, persist=True)
+    log.record(TASK_STARTED, iteration=1, task_id=1, title="T")
+    log.record_cost(usd=0.03, tokens=120)
+    log.record_cost(usd=0.04, tokens=80)
+    # Événement → journal de décisions ; coût → métriques persistées (dernier total).
+    assert any("[run] task_started" in d.summary for d in manager.get_decisions(pid))
+    assert run_cost_summary(manager, pid) == {"usd": 0.07, "tokens": 200}
+
+
+def test_run_cost_summary_zero_when_no_metrics(manager):
+    pid = manager.create_project(name="empty")
+    assert run_cost_summary(manager, pid) == {"usd": 0.0, "tokens": 0}
+
+
+def test_persistence_failure_does_not_break_run():
+    # Manager dont record_decision lève : l'audit doit avaler l'erreur (best-effort).
+    class _Boom:
+        def record_decision(self, *a, **k):
+            raise RuntimeError("db down")
+
+        def add_metric(self, *a, **k):
+            raise RuntimeError("db down")
+
+    log = RunAuditLog(1, manager=_Boom(), clock=_fixed_clock, persist=True)
+    log.record(TASK_STARTED, iteration=1)  # ne lève pas
+    log.record_cost(usd=0.01, tokens=10)  # ne lève pas
+    assert len(log.events) == 2  # tracé en mémoire malgré l'échec de persistance
+
+
+# --- émission par le pilote (driver) --------------------------------------------
+
+
+class _Sandbox:
+    def run_tests(self, workspace, command="pytest -q"):
+        return SandboxResult(exit_code=0, stdout="out", stderr="")
+
+
+def _clients():
+    branches = SimpleNamespace(ensure_branch=lambda *a, **k: SimpleNamespace(name="b"))
+    files = SimpleNamespace(update_file=lambda *a, **k: {}, delete_file=lambda *a, **k: {})
+    prs = SimpleNamespace(
+        find_pr_by_head=lambda *a, **k: None,
+        create_pr=lambda *a, **k: SimpleNamespace(number=101, html_url="https://gh/pull/101", head_branch="b"),
+    )
+    return PrClients(branches=branches, files=files, prs=prs)
+
+
+def _git(cwd, *args):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    src = tmp_path / "source"
+    src.mkdir()
+    _git(src, "init", "-q")
+    _git(src, "config", "user.email", "t@example.com")
+    _git(src, "config", "user.name", "Test")
+    (src / "existing.txt").write_text("original\n")
+    _git(src, "add", "-A")
+    _git(src, "commit", "-q", "-m", "init")
+    return str(src)
+
+
+async def test_driver_emits_audit_trail(repo, manager):
+    pid = manager.create_project(name="demo")
+    manager.add_task(pid, title="T0")
+    log = RunAuditLog(pid, clock=_fixed_clock)
+    result = await run_project(
+        pid,
+        repo,
+        ctx=None,
+        agent=FakeCodeAgent(),
+        owner="o",
+        repo="r",
+        manager=manager,
+        sandbox=_Sandbox(),
+        reviewer=FakeReviewer(),
+        clients=_clients(),
+        dry_run=True,
+        audit=log,
+    )
+    assert result.stop_reason == "completed"
+    kinds = [e.kind for e in log.events]
+    assert TASK_STARTED in kinds and GATE_DECISION in kinds
+    assert kinds[-1] == RUN_STOP  # le dernier événement clôt le run
+    stop = log.events[-1]
+    assert stop.detail["reason"] == "completed"
+
+
+async def test_driver_records_cost_from_source(repo, manager):
+    # cost_source fournit le cumul process ; le pilote enregistre le delta par tâche.
+    pid = manager.create_project(name="cost")
+    manager.add_task(pid, title="T0")
+    seq = [(0.0, 0), (0.02, 150)]  # avant la boucle, puis après T0
+    state = {"n": 0}
+
+    def source():
+        value = seq[min(state["n"], len(seq) - 1)]
+        state["n"] += 1
+        return value
+
+    log = RunAuditLog(pid, clock=_fixed_clock)
+    await run_project(
+        pid,
+        repo,
+        ctx=None,
+        agent=FakeCodeAgent(),
+        owner="o",
+        repo="r",
+        manager=manager,
+        sandbox=_Sandbox(),
+        reviewer=FakeReviewer(),
+        clients=_clients(),
+        dry_run=True,
+        audit=log,
+        cost_source=source,
+    )
+    assert log.cost_summary() == {"usd": 0.02, "tokens": 150}
+
+
+async def test_driver_default_audit_is_noop(repo, manager):
+    # Sans `audit`, run_project utilise NullAuditLog → comportement inchangé, pas d'erreur.
+    pid = manager.create_project(name="demo2")
+    manager.add_task(pid, title="T0")
+    result = await run_project(
+        pid,
+        repo,
+        ctx=None,
+        agent=FakeCodeAgent(),
+        owner="o",
+        repo="r",
+        manager=manager,
+        sandbox=_Sandbox(),
+        reviewer=FakeReviewer(),
+        clients=_clients(),
+        dry_run=True,
+    )
+    assert result.stop_reason == "completed"


### PR DESCRIPTION
## H4 — Observabilité du run autonome (Phase 5, epic #391)

Critère du brief : **toutes les actions de l'agent sont traçables et auditables**. L'observabilité existante (`MetricsCollector`, `activity_log`, Sentry/OTel) trace les appels d'outils du **serveur MCP**, pas les actions du **run autonome**. H4 comble ce trou.

### Ajouts (`collegue/pilot/audit.py`)
- **`RunAuditLog`** — journal append-only des actions du run : `task_started`, `gate_decision`, `pr_opened`, `budget_event`, `checkpoint_saved`, `run_stop`, `cost_observed`, horodatés (UTC) + liés à `iteration`.
- **`RunCostLedger`** — coût USD + tokens **par run**. Rejette NaN/inf/négatifs **et les `bool`** (`True` est un `int`). Les événements `cost_observed` portent les valeurs **retenues** → flux d'événements et ledger réconcilient toujours.
- **`run_cost_summary(manager, pid)`** — lit le ledger persisté ; **`default_process_cost_source`** branche `MetricsCollector._cumulative_totals`.
- **`export()` / `export_json()`** — vue auditable **JSON strict** : les floats non finis sont neutralisés en `null` (jamais de `NaN`/`Infinity` brut, valides pour jq/jsonb/JS).

### Câblage non intrusif (`run_project`)
- `audit` (défaut **`NullAuditLog`**, no-op) → **comportement strictement inchangé** sans audit.
- `cost_source` (optionnel) → échantillonne le coût process **avant/après chaque tâche** et enregistre le delta dans le ledger. Sans `cost_source`, pas d'échantillonnage (le runtime/F4 branchera `default_process_cost_source`).

### Revue
Revue adversariale (red-team) avant ship — 5 constats réels corrigés :
1. **(haut)** ledger de coût **jamais alimenté** dans un vrai run (record_cost mort) → câblage `cost_source` dans le pilote (échantillonnage delta par tâche).
2. **(haut)** `export_json` pouvait émettre du JSON **invalide** (NaN/Infinity bruts) → neutralisation + `allow_nan=False`.
3. **(moyen)** événements `cost_observed` divergeaient du ledger (brut vs filtré) → l'événement porte la valeur retenue.
4. **(moyen)** `bool` accepté comme coût → garde `not isinstance(..., bool)`.
5. **(moyen)** persistance « activée » mais inopérante (manager sans méthodes) = perte silencieuse → **validation fail-fast au démarrage**.

### Tests
- `tests/test_pilot_audit.py` : événements + horodatage, ledger (NaN/inf/négatif/bool), réconciliation événement↔ledger, export JSON strict, persistance + `run_cost_summary` (SQLite réel), best-effort sur échec DB, **émission par le pilote** + coût par tâche, NullAuditLog no-op.
- **Suite complète verte** hors `integration` : 1323 tests, 0 échec. `ruff check` + `ruff format --check` clean.

Avance #395. Indépendant ; débloque H6 (audit des appels de l'outil MCP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)