### PR TITLE
feat(pilot): moteur de politique d'auto-merge (opt-in, off, fail-closed) (H2)

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -115,6 +115,21 @@ class Settings(BaseSettings):
         action = str(v).strip().lower()
         return action if action in ("pause", "warn") else "pause"
 
+    # ── Auto-merge progressif (Phase 5, H2) ──────────────────────────────────
+    # §6 reste le DÉFAUT : approbation humaine avant chaque merge dans main.
+    # L'auto-merge ne s'active QUE si AUTO_MERGE_ENABLED est vrai ET le diff passe
+    # une allowlist STRICTE de faible risque (chemins + plafond LOC + toutes les
+    # vérifs CI vertes). Off par défaut (opt-in assumé) ; fail-closed (tout doute →
+    # pas d'auto-merge, la PR reste pour un humain). Un auto-revert (H3) borne le risque.
+    AUTO_MERGE_ENABLED: bool = False
+    AUTO_MERGE_MAX_LOC: int = 50
+    # Motifs de chemins à faible risque (séparés par des virgules ; '**' = sous-dossiers).
+    # Défaut = balisage/texte NON exécutable seulement. Tout code/exécutable/config
+    # (.py, .sh, .yml, migrations, .github, conftest.py…) reste bloqué par une garde
+    # dure même s'il est ajouté ici (cf. collegue.pilot.automerge.is_sensitive).
+    AUTO_MERGE_PATH_ALLOWLIST: str = "docs/**,**/*.md,**/*.rst"
+    AUTO_MERGE_METHOD: str = "squash"
+
     SUPPORTED_LANGUAGES: List[str] = ["python", "javascript", "typescript", "php"]
 
     OAUTH_ENABLED: bool = False

--- a/collegue/pilot/__init__.py
+++ b/collegue/pilot/__init__.py
@@ -17,6 +17,14 @@ from collegue.pilot.audit import (
     export_run_audit,
     run_cost_summary,
 )
+from collegue.pilot.automerge import (
+    AutoMergeDecision,
+    AutoMergeOutcome,
+    RiskPolicy,
+    evaluate_automerge,
+    is_sensitive,
+    maybe_auto_merge,
+)
 from collegue.pilot.budget import (
     ACTION_CONTINUE,
     ACTION_DEADLINE,
@@ -66,4 +74,11 @@ __all__ = [
     # H5 (Phase 5) — reprise après crash (deadline absolue)
     "persist_run_start",
     "load_run_start",
+    # H2 (Phase 5) — politique d'auto-merge (opt-in, off par défaut)
+    "RiskPolicy",
+    "AutoMergeDecision",
+    "AutoMergeOutcome",
+    "evaluate_automerge",
+    "maybe_auto_merge",
+    "is_sensitive",
 ]

--- a/collegue/pilot/automerge.py
+++ b/collegue/pilot/automerge.py
@@ -1,0 +1,276 @@
+"""Moteur de politique d'auto-merge (H2, epic #391, Phase 5).
+
+§6 reste le **défaut** : approbation humaine avant chaque merge dans ``main``.
+L'auto-merge ne s'active **que** si ``AUTO_MERGE_ENABLED`` est vrai **et** le diff
+passe une allowlist **stricte** de faible risque. Sinon : « propose seulement » (la
+PR reste pour un humain). **Fail-closed** : tout doute / information manquante (pas
+de fichiers, CI inconnue/en attente) → pas d'auto-merge.
+
+Module **isolé** : ne déclenche rien tout seul — c'est l'appelant (pilote / garde H3)
+qui décide quand l'invoquer. ``maybe_auto_merge`` est ``dry_run`` par défaut et
+n'effectue le merge réel (via H1 ``merge_pr``) que sur autorisation explicite.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+
+# Faible risque = **données / balisage non exécutable** uniquement. On exclut
+# volontairement ``tests/**`` du défaut : du code de test est exécuté en CI (avec des
+# identifiants) — ``conftest.py`` est même importé automatiquement par pytest → RCE.
+DEFAULT_PATH_ALLOWLIST: Tuple[str, ...] = ("**/*.md", "**/*.rst", "docs/**")
+DEFAULT_MAX_LOC = 50
+_GREEN = "success"
+
+# Extensions de **code/exécutable/config** : toujours bloquées (même si un opérateur
+# les met dans l'allowlist). « Faible risque » exclut tout ce qui s'exécute.
+_BLOCKED_EXTENSIONS = frozenset(
+    {
+        ".py",
+        ".pyi",
+        ".sh",
+        ".bash",
+        ".zsh",
+        ".js",
+        ".mjs",
+        ".cjs",
+        ".ts",
+        ".tsx",
+        ".jsx",
+        ".rb",
+        ".go",
+        ".rs",
+        ".php",
+        ".pl",
+        ".ps1",
+        ".bat",
+        ".cmd",
+        ".lua",
+        ".java",
+        ".c",
+        ".cpp",
+        ".cc",
+        ".h",
+        ".hpp",
+        ".yml",
+        ".yaml",
+        ".toml",
+        ".cfg",
+        ".ini",
+        ".tf",
+        ".sql",
+    }
+)
+# Basenames exécutés/sensibles indépendamment de l'extension.
+_BLOCKED_BASENAMES = frozenset({"dockerfile", "makefile", "conftest.py", "setup.py", "setup.cfg", "pyproject.toml"})
+
+
+@dataclass(frozen=True)
+class AutoMergeDecision:
+    """Verdict d'auto-merge pour une PR (toujours accompagné d'une raison)."""
+
+    allowed: bool
+    reason: str
+
+
+@dataclass(frozen=True)
+class RiskPolicy:
+    """Politique de risque de l'auto-merge (configurable via settings, off par défaut)."""
+
+    enabled: bool = False
+    max_loc: int = DEFAULT_MAX_LOC
+    path_allowlist: Tuple[str, ...] = DEFAULT_PATH_ALLOWLIST
+    method: str = "squash"
+
+    @classmethod
+    def from_settings(cls, settings: object) -> "RiskPolicy":
+        allowlist = _parse_allowlist(getattr(settings, "AUTO_MERGE_PATH_ALLOWLIST", None))
+        raw_loc = int(getattr(settings, "AUTO_MERGE_MAX_LOC", DEFAULT_MAX_LOC) or 0)
+        # ``<= 0`` ne signifie PAS « illimité » : un opérateur qui laisse le champ vide
+        # (ou met 0) croit RESSERRER la politique — on retombe sur le défaut, jamais sur
+        # « pas de plafond ».
+        return cls(
+            enabled=bool(getattr(settings, "AUTO_MERGE_ENABLED", False)),
+            max_loc=raw_loc if raw_loc > 0 else DEFAULT_MAX_LOC,
+            path_allowlist=allowlist or DEFAULT_PATH_ALLOWLIST,
+            method=str(getattr(settings, "AUTO_MERGE_METHOD", "squash") or "squash"),
+        )
+
+
+def _parse_allowlist(raw: object) -> Tuple[str, ...]:
+    if raw is None:
+        return DEFAULT_PATH_ALLOWLIST
+    items = (
+        [str(x).strip() for x in raw] if isinstance(raw, (list, tuple)) else [p.strip() for p in str(raw).split(",")]
+    )
+    return tuple(p for p in items if p)
+
+
+def _norm(path: str) -> str:
+    return str(path).replace("\\", "/").lstrip("/")
+
+
+def _seg_match(path_segs: List[str], pat_segs: List[str]) -> bool:
+    """Match glob **segment par segment** : ``**`` = 0+ segments, ``*`` reste dans un
+    segment (ne traverse PAS ``/``). Évite qu'un ``*`` global déborde de la portée."""
+    if not pat_segs:
+        return not path_segs
+    head, rest = pat_segs[0], pat_segs[1:]
+    if head == "**":
+        # zéro segment consommé, ou un de plus en gardant le '**'.
+        if _seg_match(path_segs, rest):
+            return True
+        return bool(path_segs) and _seg_match(path_segs[1:], pat_segs)
+    if not path_segs:
+        return False
+    # fnmatch sur UN segment : '*' n'y rencontre pas de '/'.
+    if fnmatch.fnmatch(path_segs[0], head):
+        return _seg_match(path_segs[1:], rest)
+    return False
+
+
+def _match_allowlist(path: str, patterns: Sequence[str]) -> bool:
+    segs = [s for s in _norm(path).split("/") if s]
+    for pattern in patterns:
+        if _seg_match(segs, [s for s in str(pattern).split("/") if s]):
+            return True
+    return False
+
+
+def is_sensitive(path: str) -> bool:
+    """Fichiers **toujours** bloqués (même dans l'allowlist) : garde dure, non configurable.
+
+    Insensible à la casse. Bloque : traversée (``..``), secrets (``.env*``), lockfiles
+    (``*.lock``), config/CI (``.github/`` à n'importe quelle profondeur), migrations
+    (``migrations/`` ou ``alembic/versions/``), et tout **code/exécutable/config**
+    (extension dans ``_BLOCKED_EXTENSIONS`` ou basename dans ``_BLOCKED_BASENAMES``) —
+    « faible risque » exclut tout ce qui s'exécute (ex. ``tests/conftest.py`` = RCE CI).
+    """
+    p = _norm(path).lower()
+    segments = [s for s in p.split("/") if s]
+    if ".." in segments:
+        return True
+    base = segments[-1] if segments else ""
+    if base.startswith(".env") or base.endswith(".lock"):
+        return True
+    if ".github" in segments:
+        return True
+    if "migrations" in segments:
+        return True
+    if "alembic" in segments and "versions" in segments:
+        return True
+    if base in _BLOCKED_BASENAMES:
+        return True
+    dot = base.rfind(".")
+    if dot > 0 and base[dot:] in _BLOCKED_EXTENSIONS:
+        return True
+    return False
+
+
+def _checks_all_green(checks: Optional[Sequence[str]]) -> bool:
+    # None / vide → état inconnu → fail-closed. Tout doit valoir "success" (refuse
+    # "pending"/"failure"/conclusion manquante).
+    if not checks:
+        return False
+    return all(str(c).strip().lower() == _GREEN for c in checks)
+
+
+def evaluate_automerge(
+    files_changed: Sequence[str],
+    *,
+    additions: int = 0,
+    deletions: int = 0,
+    checks: Optional[Sequence[str]] = None,
+    policy: RiskPolicy,
+    files_complete: bool = True,
+) -> AutoMergeDecision:
+    """Décide si une PR peut être auto-mergée. **Toutes** les conditions sont requises.
+
+    Ordre (fail-closed) : flag activé → plafond LOC configuré → liste de fichiers
+    complète → diff non vide → aucun fichier sensible → tous dans l'allowlist → LOC
+    valide et sous plafond → toutes les vérifs CI vertes.
+
+    ``files_complete=False`` (l'appelant n'a pas pu récupérer TOUS les fichiers, ex.
+    PR > 100 fichiers non paginée) → refus : on ne juge pas faible-risque un diff
+    partiellement vu. ``checks`` doit être l'ensemble **complet** des vérifs requises
+    (la complétude est de la responsabilité de l'appelant — cf. branch protection).
+    """
+    if not policy.enabled:
+        return AutoMergeDecision(False, "auto-merge désactivé (AUTO_MERGE_ENABLED off) — merge humain (§6)")
+    if policy.max_loc <= 0:
+        return AutoMergeDecision(False, "plafond LOC non configuré (<= 0) — fail-closed")
+    if not files_complete:
+        return AutoMergeDecision(False, "liste de fichiers incomplète (diff tronqué) — fail-closed")
+    files = [f for f in (files_changed or []) if f and str(f).strip()]
+    if not files:
+        return AutoMergeDecision(False, "aucun fichier au diff (état inconnu) — fail-closed")
+    for f in files:
+        if is_sensitive(f):
+            return AutoMergeDecision(False, f"fichier sensible interdit à l'auto-merge: {f}")
+    outside = [f for f in files if not _match_allowlist(f, policy.path_allowlist)]
+    if outside:
+        return AutoMergeDecision(False, f"hors allowlist de faible risque: {', '.join(outside[:3])}")
+    add, dele = int(additions or 0), int(deletions or 0)
+    if add < 0 or dele < 0:
+        return AutoMergeDecision(False, "compte de lignes négatif (malformé) — fail-closed")
+    loc = add + dele
+    if loc > policy.max_loc:
+        return AutoMergeDecision(False, f"trop volumineux: {loc} LOC > plafond {policy.max_loc}")
+    if not _checks_all_green(checks):
+        return AutoMergeDecision(False, "vérifications CI non toutes vertes (ou en attente/inconnues) — fail-closed")
+    return AutoMergeDecision(True, f"faible risque: {len(files)} fichier(s), {loc} LOC, CI verte")
+
+
+@dataclass(frozen=True)
+class AutoMergeOutcome:
+    """Résultat d'une tentative d'auto-merge (décision + effet éventuel)."""
+
+    decision: AutoMergeDecision
+    merged: bool = False
+    dry_run: bool = False
+    merge_result: Optional[object] = None
+
+
+def maybe_auto_merge(
+    pr: object,
+    files_changed: Sequence[str],
+    *,
+    additions: int = 0,
+    deletions: int = 0,
+    checks: Optional[Sequence[str]] = None,
+    policy: RiskPolicy,
+    clients: object,
+    owner: str,
+    repo: str,
+    dry_run: bool = True,
+    files_complete: bool = True,
+) -> AutoMergeOutcome:
+    """Évalue puis (si autorisé **et** pas ``dry_run``) merge via H1 ``merge_pr``.
+
+    Refusé ou ``dry_run`` → **aucun** merge (la PR reste ouverte pour un humain). Le
+    merge réel **exige** un SHA de tête connu (``pr.head_sha``/``pr.sha``) : la garde
+    anti-course de H1 est précisément ce qui justifie d'automatiser le merge — sans
+    elle, un commit poussé entre l'évaluation et le merge passerait inaperçu → refus.
+    """
+    decision = evaluate_automerge(
+        files_changed,
+        additions=additions,
+        deletions=deletions,
+        checks=checks,
+        policy=policy,
+        files_complete=files_complete,
+    )
+    if not decision.allowed:
+        return AutoMergeOutcome(decision=decision, merged=False)
+    if dry_run:
+        return AutoMergeOutcome(decision=decision, merged=False, dry_run=True)
+    expected = getattr(pr, "head_sha", None) or getattr(pr, "sha", None)
+    if not expected:
+        return AutoMergeOutcome(
+            decision=AutoMergeDecision(False, "SHA de tête inconnu — garde anti-course requise pour l'auto-merge"),
+            merged=False,
+        )
+    result = clients.prs.merge_pr(owner, repo, pr.number, method=policy.method, expected_head_sha=expected)
+    return AutoMergeOutcome(decision=decision, merged=bool(getattr(result, "merged", False)), merge_result=result)

--- a/tests/test_pilot_automerge.py
+++ b/tests/test_pilot_automerge.py
@@ -1,0 +1,271 @@
+"""Tests H2 (#393) : moteur de politique d'auto-merge (opt-in, off par défaut, fail-closed).
+
+Inclut les régressions des contournements trouvés en revue adversariale : code
+exécutable sous tests/docs (RCE CI), variantes de casse des fichiers sensibles, débordement
+de glob au-delà du segment, plafond LOC à 0 = illimité, liste/CI incomplètes, merge sans SHA.
+"""
+
+from types import SimpleNamespace
+
+from collegue.pilot.automerge import (
+    DEFAULT_PATH_ALLOWLIST,
+    AutoMergeDecision,
+    RiskPolicy,
+    evaluate_automerge,
+    is_sensitive,
+    maybe_auto_merge,
+)
+
+GREEN = ["success", "success"]
+
+
+def _policy(**kw):
+    base = dict(enabled=True, max_loc=50, path_allowlist=DEFAULT_PATH_ALLOWLIST, method="squash")
+    base.update(kw)
+    return RiskPolicy(**base)
+
+
+# --- §6 : off par défaut --------------------------------------------------------
+
+
+def test_disabled_by_default_never_allows():
+    decision = evaluate_automerge(["docs/x.md"], additions=1, deletions=0, checks=["success"], policy=RiskPolicy())
+    assert decision.allowed is False and "§6" in decision.reason
+
+
+# --- allowlist faible risque (balisage non exécutable) --------------------------
+
+
+def test_allows_low_risk_markup():
+    d = evaluate_automerge(
+        ["docs/guide.md", "README.md", "docs/sub/page.rst"], additions=20, deletions=5, checks=GREEN, policy=_policy()
+    )
+    assert d.allowed is True
+
+
+def test_rejects_app_code_outside_allowlist():
+    d = evaluate_automerge(["collegue/app.py"], additions=3, deletions=0, checks=GREEN, policy=_policy())
+    assert d.allowed is False
+
+
+def test_rejects_when_any_file_outside_allowlist():
+    d = evaluate_automerge(["docs/ok.md", "collegue/x.py"], additions=2, deletions=0, checks=GREEN, policy=_policy())
+    assert d.allowed is False
+
+
+# --- CRITICAL-1 : code exécutable jamais auto-mergé (RCE CI) ---------------------
+
+
+def test_executable_test_infra_blocked():
+    # conftest.py est importé par pytest → RCE. Tout .py est du code exécutable.
+    for path in ("tests/conftest.py", "tests/__init__.py", "tests/test_x.py", "docs/conf.py", "setup.py"):
+        assert is_sensitive(path) is True, path
+    # Même si un opérateur ajoute tests/** à l'allowlist, le code reste bloqué (garde dure).
+    d = evaluate_automerge(
+        ["tests/conftest.py"], additions=1, checks=GREEN, policy=_policy(path_allowlist=("tests/**",))
+    )
+    assert d.allowed is False and "sensible" in d.reason
+
+
+# --- CRITICAL-2 : variantes de casse + .github imbriqué -------------------------
+
+
+def test_sensitive_case_insensitive():
+    for path in (".ENV", "config/.Env.local", "Poetry.LOCK", "X.Lock", ".GitHub/workflows/x.yml"):
+        assert is_sensitive(path) is True, path
+
+
+def test_github_blocked_at_any_depth():
+    assert is_sensitive("foo/.github/workflows/ci.yml") is True
+    # Un .md sous un .GitHub (casse) ne doit pas passer via **/*.md.
+    d = evaluate_automerge([".GitHub/workflows/x.md"], additions=1, checks=GREEN, policy=_policy())
+    assert d.allowed is False and "sensible" in d.reason
+
+
+def test_alembic_versions_and_migrations_blocked():
+    assert is_sensitive("collegue/state/alembic/Versions/0006_x.py") is True
+    assert is_sensitive("app/migrations/0001.py") is True
+
+
+def test_traversal_blocked():
+    assert is_sensitive("../etc/passwd") is True
+    assert evaluate_automerge(["docs/../collegue/app.py"], checks=GREEN, policy=_policy()).allowed is False
+
+
+# --- CRITICAL-3 : le glob ne déborde pas du segment -----------------------------
+
+
+def test_glob_star_does_not_cross_slash():
+    # "docs/*" ne doit PAS matcher un sous-dossier (le '*' reste dans un segment).
+    assert (
+        evaluate_automerge(["docs/sub/app.py"], checks=GREEN, policy=_policy(path_allowlist=("docs/*",))).allowed
+        is False
+    )
+    # "**/*.md" matche bien le markdown à toute profondeur (cas légitime).
+    assert evaluate_automerge(["a/b/c.md"], additions=1, checks=GREEN, policy=_policy()).allowed is True
+    # Pas de faux positif de préfixe : "docs-evil/" ne matche PAS "docs/**".
+    assert is_sensitive("docs-evil/notes.md") is False  # pas sensible (markdown)…
+    assert (
+        evaluate_automerge(["docs-evil/notes.md"], checks=GREEN, policy=_policy(path_allowlist=("docs/**",))).allowed
+        is False  # …mais hors de l'allowlist "docs/**" → refusé
+    )
+
+
+# --- HIGH-1 : plafond LOC à 0 = fail-closed, pas illimité ------------------------
+
+
+def test_max_loc_zero_fails_closed():
+    d = evaluate_automerge(["docs/x.md"], additions=100000, checks=GREEN, policy=_policy(max_loc=0))
+    assert d.allowed is False and "plafond" in d.reason
+
+
+def test_from_settings_zero_loc_falls_back_to_default():
+    for raw in (0, None, "", "0", False):
+        policy = RiskPolicy.from_settings(SimpleNamespace(AUTO_MERGE_ENABLED=True, AUTO_MERGE_MAX_LOC=raw))
+        assert policy.max_loc == 50, raw
+
+
+# --- HIGH-3 / fail-closed sur diff incomplet ------------------------------------
+
+
+def test_incomplete_file_list_fails_closed():
+    d = evaluate_automerge(["docs/x.md"], additions=1, checks=GREEN, policy=_policy(), files_complete=False)
+    assert d.allowed is False and "incomplète" in d.reason
+
+
+# --- plafond LOC ----------------------------------------------------------------
+
+
+def test_rejects_over_loc_cap():
+    d = evaluate_automerge(["docs/big.md"], additions=40, deletions=20, checks=GREEN, policy=_policy(max_loc=50))
+    assert d.allowed is False and "LOC" in d.reason
+
+
+def test_loc_at_cap_allowed():
+    d = evaluate_automerge(["docs/x.md"], additions=25, deletions=25, checks=GREEN, policy=_policy(max_loc=50))
+    assert d.allowed is True
+
+
+def test_negative_loc_fails_closed():
+    d = evaluate_automerge(["docs/x.md"], additions=-1000, deletions=0, checks=GREEN, policy=_policy())
+    assert d.allowed is False and "négatif" in d.reason
+
+
+# --- vérifs CI (fail-closed) ----------------------------------------------------
+
+
+def test_rejects_when_checks_pending_or_unknown():
+    for checks in (None, [], ["success", "pending"], ["failure"], ["skipped"]):
+        d = evaluate_automerge(["docs/x.md"], additions=1, checks=checks, policy=_policy())
+        assert d.allowed is False, checks
+
+
+# --- from_settings --------------------------------------------------------------
+
+
+def test_from_settings_parses_csv_allowlist_and_flag():
+    settings = SimpleNamespace(
+        AUTO_MERGE_ENABLED=True,
+        AUTO_MERGE_MAX_LOC=30,
+        AUTO_MERGE_PATH_ALLOWLIST="docs/**, **/*.md , src/**",
+        AUTO_MERGE_METHOD="merge",
+    )
+    policy = RiskPolicy.from_settings(settings)
+    assert policy.enabled is True and policy.max_loc == 30 and policy.method == "merge"
+    assert policy.path_allowlist == ("docs/**", "**/*.md", "src/**")
+
+
+def test_from_settings_defaults_when_absent():
+    policy = RiskPolicy.from_settings(SimpleNamespace())
+    assert policy.enabled is False and policy.path_allowlist == DEFAULT_PATH_ALLOWLIST
+
+
+# --- maybe_auto_merge (wiring vers H1) ------------------------------------------
+
+
+class _PRs:
+    def __init__(self):
+        self.merged_calls = []
+
+    def merge_pr(
+        self, owner, repo, number, *, method="squash", commit_title=None, commit_message=None, expected_head_sha=None
+    ):
+        self.merged_calls.append({"number": number, "method": method, "sha": expected_head_sha})
+        return SimpleNamespace(merged=True, sha="merged-sha", already_merged=False)
+
+
+def _clients(prs):
+    return SimpleNamespace(prs=prs)
+
+
+def test_maybe_auto_merge_disabled_does_not_merge():
+    prs = _PRs()
+    out = maybe_auto_merge(
+        SimpleNamespace(number=7, head_sha="abc"),
+        ["docs/x.md"],
+        additions=1,
+        checks=["success"],
+        policy=RiskPolicy(),  # off
+        clients=_clients(prs),
+        owner="o",
+        repo="r",
+        dry_run=False,
+    )
+    assert out.merged is False and prs.merged_calls == []
+
+
+def test_maybe_auto_merge_dry_run_does_not_merge():
+    prs = _PRs()
+    out = maybe_auto_merge(
+        SimpleNamespace(number=7, head_sha="abc"),
+        ["docs/x.md"],
+        additions=1,
+        checks=["success"],
+        policy=_policy(),
+        clients=_clients(prs),
+        owner="o",
+        repo="r",
+        dry_run=True,
+    )
+    assert out.decision.allowed is True and out.merged is False and out.dry_run is True
+    assert prs.merged_calls == []
+
+
+def test_maybe_auto_merge_requires_head_sha():
+    # MEDIUM-1 : sans SHA de tête, pas de garde anti-course → on refuse de merger.
+    prs = _PRs()
+    out = maybe_auto_merge(
+        SimpleNamespace(number=7),  # ni head_sha ni sha
+        ["docs/x.md"],
+        additions=1,
+        checks=["success"],
+        policy=_policy(),
+        clients=_clients(prs),
+        owner="o",
+        repo="r",
+        dry_run=False,
+    )
+    assert out.merged is False and prs.merged_calls == []
+    assert "SHA" in out.decision.reason
+
+
+def test_maybe_auto_merge_real_calls_merge_pr():
+    prs = _PRs()
+    out = maybe_auto_merge(
+        SimpleNamespace(number=42, head_sha="abc123"),
+        ["docs/x.md", "docs/sub/page.md"],
+        additions=10,
+        deletions=2,
+        checks=["success"],
+        policy=_policy(method="squash"),
+        clients=_clients(prs),
+        owner="o",
+        repo="r",
+        dry_run=False,
+    )
+    assert out.merged is True
+    assert prs.merged_calls == [{"number": 42, "method": "squash", "sha": "abc123"}]
+
+
+def test_evaluate_returns_decision_type():
+    assert isinstance(evaluate_automerge(["docs/x.md"], checks=["success"], policy=_policy()), AutoMergeDecision)


### PR DESCRIPTION
## H2 — Moteur de politique d'auto-merge (Phase 5, epic #391)

Décide si une PR peut être mergée **sans humain**. **§6 reste le défaut** : `AUTO_MERGE_ENABLED` est **off**, et même activé l'auto-merge ne se déclenche que pour du **faible risque strict**. Sinon : « propose seulement » (la PR reste pour un humain). Dépend de H1 (`merge_pr`).

### `evaluate_automerge` — toutes les conditions requises (fail-closed)
1. `AUTO_MERGE_ENABLED` vrai (défaut off → toujours refusé).
2. Plafond LOC configuré (`<= 0` → refus, **jamais** « illimité »).
3. Liste de fichiers **complète** (diff tronqué → refus).
4. Aucun **fichier sensible** (garde dure, **insensible à la casse**) : `.env*`, `*.lock`, `.github/` (toute profondeur), `migrations/`, `alembic/versions/`, traversée `..`, et **tout code/exécutable/config** (`.py/.sh/.yml/.toml/…`, `conftest.py`, `setup.py`, `Dockerfile`…).
5. Tous les fichiers dans l'**allowlist** (matching segment par segment — `*` ne traverse pas `/`). Défaut = balisage non exécutable : `docs/**`, `**/*.md`, `**/*.rst`.
6. LOC valide et sous plafond.
7. **Toutes** les vérifs CI vertes (`pending`/`failure`/inconnu → refus).

`maybe_auto_merge` exige un **SHA de tête** (garde anti-course H1) avant un merge réel ; `dry_run` par défaut.

### Revue
Revue adversariale (red-team) avant ship — **6 contournements réels corrigés** :
- **CRITICAL** `tests/**`/`docs/**` laissaient passer du code exécutable (`conftest.py` importé par pytest → **RCE en CI**) → « faible risque » redéfini comme balisage non exécutable + garde dure sur toute extension de code.
- **CRITICAL** `is_sensitive` sensible à la casse (`.GitHub/`, `.ENV`, `Poetry.LOCK` contournaient) + `.github` non détecté en sous-dossier → comparaison en minuscules + appartenance par segment.
- **CRITICAL** `**`→`*` laissait `*` traverser `/` (évasion de portée) → matching glob segment par segment.
- **HIGH** `max_loc=0` désactivait silencieusement le plafond → `<= 0` = fail-closed ; `from_settings` retombe sur le défaut.
- **HIGH** complétude des fichiers/CI = responsabilité de l'appelant → `files_complete` (fail-closed) + doc.
- **MEDIUM** merge sans SHA de tête + LOC négatif → refus explicite.

### Tests
- `tests/test_pilot_automerge.py` (24 tests) : off-par-défaut, allowlist, **régressions des 6 contournements** (RCE test-infra, casse, glob, LOC=0, diff incomplet, merge sans SHA), CI fail-closed, `from_settings`, wiring vers H1.
- **Suite complète verte** hors `integration` : 1355 tests, 0 échec. `ruff check` + `ruff format --check` clean.

Avance #393. Le filet post-merge (auto-revert si `main` casse) = **H3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)