### PR TITLE
feat(pilot): garde post-merge — auto-revert si main régresse (H3)

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -130,6 +130,15 @@ class Settings(BaseSettings):
     AUTO_MERGE_PATH_ALLOWLIST: str = "docs/**,**/*.md,**/*.rst"
     AUTO_MERGE_METHOD: str = "squash"
 
+    # ── Auto-revert post-merge (Phase 5, H3) ─────────────────────────────────
+    # Filet de sécurité de l'auto-merge : après un auto-merge, si `main` devient
+    # rouge (tests en sandbox), on prépare un revert automatique. N'a d'effet que
+    # si AUTO_MERGE_ENABLED. Activé par défaut QUAND l'auto-merge l'est (le mettre
+    # à false = renoncer au filet de sécurité, risqué). Fail-closed : santé non
+    # concluante (sandbox indispo) = traité comme rouge → revert.
+    AUTO_REVERT_ENABLED: bool = True
+    AUTO_REVERT_HEALTH_COMMAND: str = "pytest -q"
+
     SUPPORTED_LANGUAGES: List[str] = ["python", "javascript", "typescript", "php"]
 
     OAUTH_ENABLED: bool = False

--- a/collegue/pilot/__init__.py
+++ b/collegue/pilot/__init__.py
@@ -32,6 +32,7 @@ from collegue.pilot.budget import (
     BudgetTimeController,
     ContinueDecision,
 )
+from collegue.pilot.driver import ProjectRunResult, TaskOutcome, run_project
 from collegue.pilot.guard import (
     GuardOutcome,
     HealthResult,
@@ -39,7 +40,6 @@ from collegue.pilot.guard import (
     check_main_health,
     guard_post_merge,
 )
-from collegue.pilot.driver import ProjectRunResult, TaskOutcome, run_project
 from collegue.pilot.resume import load_run_start, persist_run_start
 from collegue.pilot.runtime import format_run_report, run_project_from_settings
 from collegue.pilot.scheduler import (

--- a/collegue/pilot/__init__.py
+++ b/collegue/pilot/__init__.py
@@ -32,6 +32,13 @@ from collegue.pilot.budget import (
     BudgetTimeController,
     ContinueDecision,
 )
+from collegue.pilot.guard import (
+    GuardOutcome,
+    HealthResult,
+    RevertPolicy,
+    check_main_health,
+    guard_post_merge,
+)
 from collegue.pilot.driver import ProjectRunResult, TaskOutcome, run_project
 from collegue.pilot.resume import load_run_start, persist_run_start
 from collegue.pilot.runtime import format_run_report, run_project_from_settings
@@ -81,4 +88,10 @@ __all__ = [
     "evaluate_automerge",
     "maybe_auto_merge",
     "is_sensitive",
+    # H3 (Phase 5) — garde post-merge (auto-revert)
+    "RevertPolicy",
+    "HealthResult",
+    "GuardOutcome",
+    "check_main_health",
+    "guard_post_merge",
 ]

--- a/collegue/pilot/guard.py
+++ b/collegue/pilot/guard.py
@@ -1,0 +1,203 @@
+"""Garde post-merge : auto-revert si ``main`` régresse (H3, epic #391, Phase 5).
+
+Filet de sécurité de l'auto-merge (H2) : après un auto-merge, on vérifie la **santé
+de ``main``** (tests en sandbox, C8) ; si elle est rouge, on **prépare un revert**
+automatique (réutilise H1) et on journalise la décision. Borne le risque de
+l'auto-merge — un changement « faible risque » qui casse quand même ``main`` est
+annulé sans attendre.
+
+**Fail-closed** : si la mesure de santé est **non concluante** (clone/sandbox
+indisponible), on considère ``main`` **non sain** → revert (sécurité > disponibilité).
+N'a d'effet que si la politique est active (suit l'auto-merge). Le revert produit est
+**local** (branche + commit d'annulation) ; le push + l'ouverture de la PR de revert
+relèvent de ``integration`` (comme H1), le merge restant humain (§6).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+from typing import Optional
+
+from collegue.executor.command import CommandRunner, LocalCommandRunner
+from collegue.executor.revert import RevertError, RevertResult, prepare_revert
+
+DEFAULT_HEALTH_COMMAND = "pytest -q"
+# Sorties signalant qu'AUCUN test n'a réellement tourné (exit 0 trompeur).
+_NO_TEST_MARKERS = ("no tests ran", "collected 0 items", "no tests collected")
+# Opérateurs shell qui pourraient masquer un échec (ex. ``pytest || true``) → on refuse.
+_SHELL_OPERATORS = (";", "|", "&", "`", "$(", ">", "<", "\n")
+
+
+@dataclass(frozen=True)
+class RevertPolicy:
+    """Politique d'auto-revert (suit l'auto-merge ; off si l'auto-merge est off)."""
+
+    enabled: bool = False
+    health_command: str = DEFAULT_HEALTH_COMMAND
+
+    @classmethod
+    def from_settings(cls, settings: object) -> "RevertPolicy":
+        # Le filet n'a de sens que si l'auto-merge est actif ; activé par défaut quand
+        # il l'est (AUTO_REVERT_ENABLED défaut True → désactivable explicitement).
+        auto_merge = bool(getattr(settings, "AUTO_MERGE_ENABLED", False))
+        auto_revert = bool(getattr(settings, "AUTO_REVERT_ENABLED", True))
+        return cls(
+            enabled=auto_merge and auto_revert,
+            health_command=str(
+                getattr(settings, "AUTO_REVERT_HEALTH_COMMAND", DEFAULT_HEALTH_COMMAND) or DEFAULT_HEALTH_COMMAND
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class HealthResult:
+    """Santé de ``main`` après un merge."""
+
+    healthy: bool
+    reason: str
+    exit_code: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class GuardOutcome:
+    """Résultat de la garde post-merge."""
+
+    checked: bool
+    healthy: Optional[bool] = None
+    reverted: bool = False
+    revert_failed: bool = False  # main rouge MAIS revert impossible → intervention humaine
+    health: Optional[HealthResult] = None
+    revert: Optional[RevertResult] = None
+    reason: str = ""
+
+
+def _clone_main(repo_source: str, *, runner: CommandRunner, git_bin: str) -> str:
+    source = os.path.realpath(os.path.abspath(repo_source))
+    if not os.path.isdir(os.path.join(source, ".git")):
+        raise RuntimeError(f"repo_source n'est pas un dépôt git: {repo_source}")
+    parent = tempfile.mkdtemp(prefix="collegue-health-")
+    dest = os.path.join(parent, "workspace")
+    clone = runner.run_command([git_bin, "clone", "--quiet", source, dest], parent)
+    if not clone.ok:
+        raise RuntimeError(f"git clone a échoué: {clone.stderr.strip() or clone.stdout.strip()}")
+    return dest
+
+
+def check_main_health(
+    repo_source: str,
+    *,
+    sandbox: object,
+    command: str = DEFAULT_HEALTH_COMMAND,
+    merge_sha: Optional[str] = None,
+    runner: Optional[CommandRunner] = None,
+    git_bin: str = "git",
+) -> HealthResult:
+    """Clone ``main`` et lance les tests en sandbox. **Fail-closed** : tout résultat
+    non concluant → ``healthy=False``.
+
+    Non concluant inclut : commande de santé non sûre (opérateurs shell pouvant masquer
+    un échec), clone/sandbox en erreur, pas de résultat, clone ne contenant pas
+    ``merge_sha`` (on testerait le mauvais arbre), et **sortie sans test exécuté**
+    (exit 0 trompeur : « collected 0 items »…). Le clone est toujours nettoyé.
+    """
+    runner = runner or LocalCommandRunner()
+    if not command or any(op in command for op in _SHELL_OPERATORS):
+        return HealthResult(False, "commande de santé non sûre (opérateurs shell) — non concluant")
+    try:
+        workspace = _clone_main(repo_source, runner=runner, git_bin=git_bin)
+    except Exception as exc:  # clone impossible → on ne peut pas affirmer la santé
+        return HealthResult(False, f"clone de main impossible: {exc}")
+    parent = os.path.dirname(workspace)
+    try:
+        # Le clone DOIT contenir le commit mergé, sinon on testerait un arbre périmé
+        # (source pré-merge) et un « vert » ne dirait rien de la vraie main.
+        if merge_sha is not None:
+            present = runner.run_command([git_bin, "cat-file", "-e", f"{merge_sha}^{{commit}}"], workspace)
+            if not present.ok:
+                return HealthResult(False, "le clone ne contient pas le commit mergé — non concluant")
+        try:
+            result = sandbox.run_tests(workspace, command)
+        except Exception as exc:  # sandbox indisponible → non concluant → non sain
+            return HealthResult(False, f"sandbox indisponible: {exc}")
+        if result is None:
+            return HealthResult(False, "résultat de test indisponible — non concluant")
+        exit_code = getattr(result, "exit_code", None)
+        if not bool(getattr(result, "ok", False)):
+            return HealthResult(False, "tests rouges sur main", exit_code)
+        # Exit 0 mais aucun test réellement exécuté → on ne déclare PAS la main saine.
+        output = f"{getattr(result, 'stdout', '')}\n{getattr(result, 'stderr', '')}".lower()
+        if any(marker in output for marker in _NO_TEST_MARKERS):
+            return HealthResult(False, "aucun test exécuté (exit 0 trompeur) — non concluant", exit_code)
+        return HealthResult(True, "main vert", exit_code)
+    finally:
+        shutil.rmtree(parent, ignore_errors=True)  # pas de fuite de clones en boucle longue
+
+
+def guard_post_merge(
+    repo_source: str,
+    merge_sha: str,
+    *,
+    sandbox: object,
+    policy: RevertPolicy,
+    merge_parent: Optional[int] = None,
+    manager: Optional[object] = None,
+    project_id: Optional[int] = None,
+    audit: Optional[object] = None,
+    runner: Optional[CommandRunner] = None,
+    git_bin: str = "git",
+) -> GuardOutcome:
+    """Vérifie la santé de ``main`` après un merge et prépare un revert si elle est rouge.
+
+    Désactivé (politique off) → ``checked=False`` (rien). Sain → aucun revert. Rouge
+    ou **non concluant** (fail-closed) → ``prepare_revert`` (H1, local), décision
+    journalisée + événement d'audit (H4). Le push + la PR de revert sont ``integration``.
+    """
+    if not policy.enabled:
+        return GuardOutcome(checked=False, reason="auto-revert désactivé (politique off)")
+
+    health = check_main_health(
+        repo_source, sandbox=sandbox, command=policy.health_command, merge_sha=merge_sha, runner=runner, git_bin=git_bin
+    )
+    if health.healthy:
+        return GuardOutcome(checked=True, healthy=True, health=health, reason="main sain — aucun revert")
+
+    # Rouge / non concluant → revert (fail-closed). Le revert lui-même peut échouer
+    # (SHA invalide, commit de merge sans ``merge_parent``, source sans le commit) :
+    # ce cas — main rouge ET revert impossible — est le plus critique et doit
+    # ESCALADER vers un humain, pas passer pour un succès.
+    revert: Optional[RevertResult] = None
+    try:
+        revert = prepare_revert(repo_source, merge_sha, merge_parent=merge_parent, runner=runner, git_bin=git_bin)
+    except RevertError:
+        revert = None
+    reverted = bool(revert and revert.reverted)
+    revert_failed = not reverted
+    branch = getattr(revert, "branch", None)
+    if revert_failed:
+        summary = f"ÉCHEC du revert de {merge_sha[:12]} — intervention humaine requise ({health.reason})"
+        audit_kind = "auto_revert_failed"
+    else:
+        summary = f"Auto-revert: main rouge après merge {merge_sha[:12]} ({health.reason})"
+        audit_kind = "auto_revert"
+    if manager is not None and project_id is not None:
+        try:
+            manager.record_decision(project_id, summary, rationale=f"branche de revert: {branch}")
+        except Exception:
+            pass  # journalisation best-effort, ne bloque pas la garde
+    if audit is not None:
+        try:
+            audit.record(audit_kind, merge_sha=merge_sha, reason=health.reason, reverted=reverted, branch=branch)
+        except Exception:
+            pass
+    return GuardOutcome(
+        checked=True,
+        healthy=False,
+        reverted=reverted,
+        revert_failed=revert_failed,
+        health=health,
+        revert=revert,
+        reason=summary,
+    )

--- a/tests/test_pilot_guard.py
+++ b/tests/test_pilot_guard.py
@@ -1,0 +1,188 @@
+"""Tests H3 (#394) : garde post-merge (santé de main → auto-revert si rouge)."""
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from collegue.pilot.guard import (
+    RevertPolicy,
+    check_main_health,
+    guard_post_merge,
+)
+from collegue.sandbox import SandboxResult
+
+
+class _Sandbox:
+    def __init__(self, exit_code=0, raises=False, stdout="2 passed in 0.1s"):
+        self._exit = exit_code
+        self._raises = raises
+        self._stdout = stdout
+
+    def run_tests(self, workspace, command="pytest -q"):
+        if self._raises:
+            raise RuntimeError("docker indisponible")
+        return SandboxResult(exit_code=self._exit, stdout=self._stdout, stderr="")
+
+
+class _Manager:
+    def __init__(self):
+        self.decisions = []
+
+    def record_decision(self, project_id, summary, rationale=None):
+        self.decisions.append((summary, rationale))
+
+
+class _Audit:
+    def __init__(self):
+        self.events = []
+
+    def record(self, kind, **detail):
+        self.events.append((kind, detail))
+
+
+def _git(cwd, *args):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """Dépôt avec 2 commits ; renvoie (chemin, sha_du_dernier_commit_à_réverter)."""
+    src = tmp_path / "main"
+    src.mkdir()
+    _git(src, "init", "-q")
+    _git(src, "config", "user.email", "t@example.com")
+    _git(src, "config", "user.name", "Test")
+    (src / "f.txt").write_text("v1\n")
+    _git(src, "add", "-A")
+    _git(src, "commit", "-q", "-m", "v1")
+    (src / "f.txt").write_text("v2\n")
+    _git(src, "add", "-A")
+    _git(src, "commit", "-q", "-m", "merge bad change")
+    sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=src, capture_output=True, text=True).stdout.strip()
+    return str(src), sha
+
+
+def _policy(enabled=True):
+    return RevertPolicy(enabled=enabled, health_command="pytest -q")
+
+
+# --- check_main_health ----------------------------------------------------------
+
+
+def test_health_green(repo):
+    src, _ = repo
+    res = check_main_health(src, sandbox=_Sandbox(exit_code=0))
+    assert res.healthy is True and res.exit_code == 0
+
+
+def test_health_red(repo):
+    src, _ = repo
+    res = check_main_health(src, sandbox=_Sandbox(exit_code=1))
+    assert res.healthy is False
+
+
+def test_health_sandbox_unavailable_is_failclosed(repo):
+    src, _ = repo
+    res = check_main_health(src, sandbox=_Sandbox(raises=True))
+    assert res.healthy is False and "sandbox" in res.reason
+
+
+def test_health_bad_repo_is_failclosed(tmp_path):
+    res = check_main_health(str(tmp_path / "nope"), sandbox=_Sandbox(exit_code=0))
+    assert res.healthy is False and "clone" in res.reason
+
+
+def test_health_no_tests_marker_is_failclosed(repo):
+    # Exit 0 mais aucun test exécuté (« collected 0 items ») → non concluant.
+    src, _ = repo
+    res = check_main_health(src, sandbox=_Sandbox(exit_code=0, stdout="collected 0 items"))
+    assert res.healthy is False and "aucun test" in res.reason
+
+
+def test_health_unsafe_command_is_failclosed(repo):
+    # Une commande qui pourrait masquer un échec (|| true) est refusée (fail-closed).
+    src, _ = repo
+    res = check_main_health(src, sandbox=_Sandbox(exit_code=0), command="pytest -q || true")
+    assert res.healthy is False and "non sûre" in res.reason
+
+
+def test_health_clone_missing_commit_is_failclosed(repo):
+    # Le clone (source périmée) ne contient pas le commit mergé → non concluant.
+    src, _ = repo
+    absent = "0123456789abcdef0123456789abcdef01234567"
+    res = check_main_health(src, sandbox=_Sandbox(exit_code=0), merge_sha=absent)
+    assert res.healthy is False and "ne contient pas" in res.reason
+
+
+# --- guard_post_merge -----------------------------------------------------------
+
+
+def test_guard_disabled_does_nothing(repo):
+    src, sha = repo
+    out = guard_post_merge(src, sha, sandbox=_Sandbox(exit_code=1), policy=_policy(enabled=False))
+    assert out.checked is False and out.reverted is False
+
+
+def test_guard_healthy_no_revert(repo):
+    src, sha = repo
+    out = guard_post_merge(src, sha, sandbox=_Sandbox(exit_code=0), policy=_policy())
+    assert out.checked is True and out.healthy is True and out.reverted is False
+
+
+def test_guard_red_prepares_revert_and_logs(repo):
+    src, sha = repo
+    manager, audit = _Manager(), _Audit()
+    out = guard_post_merge(
+        src, sha, sandbox=_Sandbox(exit_code=1), policy=_policy(), manager=manager, project_id=1, audit=audit
+    )
+    assert out.checked is True and out.healthy is False and out.reverted is True
+    assert out.revert.branch and out.revert.branch.startswith("collegue/revert-")
+    assert manager.decisions and "Auto-revert" in manager.decisions[0][0]
+    assert audit.events and audit.events[0][0] == "auto_revert"
+
+
+def test_guard_inconclusive_health_reverts_failclosed(repo):
+    # Santé non concluante (sandbox indispo) → traité comme rouge → revert.
+    src, sha = repo
+    out = guard_post_merge(src, sha, sandbox=_Sandbox(raises=True), policy=_policy())
+    assert out.healthy is False and out.reverted is True
+
+
+def test_guard_revert_failure_escalates(repo):
+    # Main rouge ET revert impossible (commit absent) → escalade, pas un faux succès.
+    src, _ = repo
+    absent = "0123456789abcdef0123456789abcdef01234567"
+    manager, audit = _Manager(), _Audit()
+    out = guard_post_merge(
+        src, absent, sandbox=_Sandbox(exit_code=1), policy=_policy(), manager=manager, project_id=1, audit=audit
+    )
+    assert out.healthy is False and out.reverted is False and out.revert_failed is True
+    assert audit.events and audit.events[0][0] == "auto_revert_failed"
+    assert manager.decisions and "ÉCHEC" in manager.decisions[0][0]
+
+
+def test_guard_invalid_sha_escalates_without_raising(repo):
+    # Un SHA malformé fait lever prepare_revert (RevertError) : la garde l'attrape et
+    # escalade (ne propage pas l'exception au-delà du filet de sécurité).
+    src, _ = repo
+    out = guard_post_merge(src, "not-a-sha", sandbox=_Sandbox(exit_code=1), policy=_policy())
+    assert out.revert_failed is True and out.reverted is False
+
+
+# --- RevertPolicy.from_settings -------------------------------------------------
+
+
+def test_policy_off_when_automerge_off():
+    p = RevertPolicy.from_settings(SimpleNamespace(AUTO_MERGE_ENABLED=False, AUTO_REVERT_ENABLED=True))
+    assert p.enabled is False  # rien n'est auto-mergé → rien à réverter
+
+
+def test_policy_on_follows_automerge_by_default():
+    p = RevertPolicy.from_settings(SimpleNamespace(AUTO_MERGE_ENABLED=True))  # AUTO_REVERT_ENABLED défaut True
+    assert p.enabled is True
+
+
+def test_policy_can_be_disabled_explicitly():
+    p = RevertPolicy.from_settings(SimpleNamespace(AUTO_MERGE_ENABLED=True, AUTO_REVERT_ENABLED=False))
+    assert p.enabled is False  # filet désactivé explicitement (risqué)


### PR DESCRIPTION
## H3 — Garde post-merge : auto-revert si `main` régresse (Phase 5, epic #391)

Filet de sécurité de l'auto-merge (H2) : après un auto-merge, vérifier la **santé de `main`** ; si elle casse, **réverter** (H1). Borne le risque — un changement « faible risque » qui casse quand même `main` est annulé. Dépend de H1 (revert) + H2 (auto-merge).

### `check_main_health` (fail-closed strict)
Clone `main`, lance les tests en sandbox (C8). Déclaré **non sain** (→ revert) dès qu'il y a le moindre doute :
- tests rouges (`exit != 0`) ;
- sandbox indisponible / pas de résultat ;
- **commande de santé non sûre** (opérateurs shell type `|| true` qui masqueraient un échec) ;
- **clone ne contenant pas le commit mergé** (source périmée → on testerait le mauvais arbre) ;
- **exit 0 trompeur** sans test exécuté (« collected 0 items »…).

Le clone est **toujours nettoyé** (pas de fuite en boucle longue).

### `guard_post_merge`
Désactivé (politique off) → rien. Sain → aucun revert. Rouge/non concluant → `prepare_revert` (H1) + décision journalisée + audit (H4). 
- **Escalade** : si le revert lui-même échoue (commit de merge sans `merge_parent`, SHA invalide, source sans le commit), on **ne fait pas passer ça pour un succès** : `revert_failed=True`, raison « ÉCHEC … intervention humaine requise », événement d'audit distinct `auto_revert_failed`.
- La garde **n'émet jamais d'exception** (RevertError attrapée) — un filet de sécurité ne doit pas tomber.

`RevertPolicy` suit l'auto-merge : `enabled = AUTO_MERGE_ENABLED AND AUTO_REVERT_ENABLED` (off si l'auto-merge est off ; activable/désactivable par `AUTO_REVERT_ENABLED`, défaut True).

### Revue
Revue adversariale (red-team) avant ship — **4 chemins fail-open/silencieux corrigés** :
- **HIGH** exit-0-sans-test (no-tests / `|| true`) déclaré sain → main cassée non revertée → détection des marqueurs « collected 0 items » + refus des commandes à opérateurs shell.
- **HIGH** revert d'un commit de merge échouait silencieusement (indistinct d'un succès) → signal `revert_failed` + audit `auto_revert_failed`.
- **MEDIUM** `RevertError` (SHA/source invalide) s'échappait avant l'audit → attrapée, escalade + trace.
- **MEDIUM** santé testée sur une source non vérifiée → contrôle que le clone contient `merge_sha` (sinon non concluant).
- **LOW** fuite de répertoires temporaires → nettoyage systématique.

### Tests
- `tests/test_pilot_guard.py` (16 tests) : santé verte/rouge/sandbox-indispo/repo-invalide, **régressions** (marqueur no-test, commande non sûre, clone sans le commit, échec de revert → escalade, SHA invalide sans exception), politique (suit l'auto-merge).
- **Suite complète verte** hors `integration` : 1371 tests, 0 échec. `ruff check` + `ruff format --check` clean.

Clôt #394. Reste H6 (#397) pour terminer la Phase 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)