### PR TITLE
feat(dashboard): vue « Run autonome » — timeline d'audit + ledger de coût (#405)

### DIFF
--- a/collegue/dashboard/app.py
+++ b/collegue/dashboard/app.py
@@ -12,6 +12,7 @@ All data is read from disk-backed stores so the dashboard
 (separate process) sees updates from the MCP server in real-time.
 """
 
+import json
 import sys
 from pathlib import Path
 
@@ -24,6 +25,7 @@ if str(_project_root) not in sys.path:
 
 from collegue.dashboard.data import (
     get_activity_data,
+    get_autonomous_runs_data,
     get_dashboard_data,
     get_delegation_data,
     get_memory_stats,
@@ -101,8 +103,8 @@ def _escape_html(text: str) -> str:
 st.title("Dashboard Monitoring")
 
 # Tabs
-tab_overview, tab_activity, tab_metrics, tab_delegation, tab_memory = st.tabs(
-    ["Vue d'ensemble", "Activite LLM", "Metriques", "Delegation", "Memoire"]
+tab_overview, tab_activity, tab_metrics, tab_delegation, tab_memory, tab_runs = st.tabs(
+    ["Vue d'ensemble", "Activite LLM", "Metriques", "Delegation", "Memoire", "Run autonome"]
 )
 
 # ==============================================================================
@@ -456,6 +458,80 @@ with tab_memory:
                     st.json(entry["data"])
     else:
         st.info("Aucune entree recente en memoire.")
+
+# ==============================================================================
+# TAB 6: Autonomous run (pilote) — audit timeline + cost ledger (#405)
+# ==============================================================================
+
+with tab_runs:
+    st.subheader("Runs autonomes (pilote)")
+    runs_data = get_autonomous_runs_data()
+
+    if not runs_data.get("configured"):
+        st.info(
+            "Etat durable non configure (STATE_DATABASE_URL absent) — aucun run autonome a afficher. "
+            "Le pilote (`python -m collegue.pilot`) ecrit son audit dans l'etat durable."
+        )
+    else:
+        runs = runs_data.get("runs", [])
+        if not runs:
+            st.info("Aucun run autonome enregistre pour l'instant.")
+        else:
+            by_id = {r["project_id"]: r for r in runs}
+            label_by_id = {
+                r["project_id"]: f"#{r['project_id']} {r['project_name']}"
+                + (" [!]" if r.get("needs_attention") else "")
+                for r in runs
+            }
+            # Clé par project_id (et non par index positionnel) : le tri peut changer à
+            # l'auto-refresh (un nouvel echec d'auto-revert remonte le projet en tete) ;
+            # garder l'id evite de pointer silencieusement sur un autre projet.
+            selected_id = st.selectbox(
+                "Projet", [r["project_id"] for r in runs], format_func=lambda i: label_by_id[i], key="run_select"
+            )
+            run = by_id[selected_id]
+
+            if run.get("needs_attention"):
+                st.error(
+                    "Intervention humaine requise : un auto-revert a echoue (`auto_revert_failed`) — "
+                    "`main` peut etre rouge sans avoir pu etre annule."
+                )
+
+            cost = run.get("cost", {})
+            counts = run.get("counts", {})
+            col1, col2, col3, col4 = st.columns(4)
+            col1.metric("Statut", run.get("status") or "--")
+            latest_iter = run.get("latest_iteration")
+            col2.metric("Iteration (checkpoint)", latest_iter if latest_iter is not None else "--")
+            col3.metric("Cout ($)", f"{cost.get('usd', 0):.4f}")
+            col4.metric("Tokens", cost.get("tokens", 0))
+
+            st.caption(
+                f"PR ouvertes: {counts.get('pr_opened', 0)} · "
+                f"auto-merge: {counts.get('automerge_decision', 0)} · "
+                f"auto-revert: {counts.get('auto_revert', 0)} · "
+                f"revert echoue: {counts.get('auto_revert_failed', 0)}"
+            )
+
+            st.divider()
+            st.subheader("Timeline d'audit")
+            events = run.get("events", [])
+            if events:
+                for event in reversed(events[-50:]):
+                    kind = event.get("kind", "?")
+                    if kind == "auto_revert_failed":
+                        icon = "🔴"
+                    elif kind in ("auto_revert", "budget_event", "run_stop"):
+                        icon = "🟠"
+                    else:
+                        icon = "•"
+                    detail = event.get("detail") or {}
+                    detail_str = json.dumps(detail, ensure_ascii=False) if detail else ""
+                    st.text(f"{icon} [{event.get('ts', '?')}] {kind} {detail_str}".rstrip())
+            else:
+                st.info(
+                    "Aucun evenement d'audit pour ce projet (le run n'a pas utilise de journal d'audit persistant)."
+                )
 
 
 # -- Auto-refresh at the end (after all data is loaded) ------------------------

--- a/collegue/dashboard/data.py
+++ b/collegue/dashboard/data.py
@@ -226,6 +226,30 @@ def get_memory_stats() -> Dict[str, Any]:
         }
 
 
+def get_autonomous_runs_data() -> Dict[str, Any]:
+    """Vue des runs autonomes (pilote) depuis l'état durable (``STATE_DATABASE_URL``).
+
+    Lecture seule via ``ProjectStateManager`` ; ``configured=False`` si l'état durable
+    n'est pas configuré (cas dev local sans Postgres/SQLite). Tolérant aux pannes.
+    """
+    try:
+        from collegue.config import settings
+
+        url = getattr(settings, "STATE_DATABASE_URL", None)
+        if not url:
+            return {"configured": False, "runs": []}
+
+        from collegue.dashboard.run_view import build_all_runs
+        from collegue.state import ProjectStateManager
+
+        manager = ProjectStateManager.from_url(url)
+        runs = [view.to_dict() for view in build_all_runs(manager)]
+        return {"configured": True, "runs": runs}
+    except Exception as exc:
+        logger.warning("Cannot load autonomous runs: %s", exc)
+        return {"configured": False, "runs": [], "error": str(exc)}
+
+
 def get_activity_data() -> Dict[str, Any]:
     """Get activity log data (LLM calls, expert results, delegations, memory writes)."""
     try:

--- a/collegue/dashboard/run_view.py
+++ b/collegue/dashboard/run_view.py
@@ -1,0 +1,153 @@
+"""Vue « Run autonome » pour le dashboard (#405).
+
+Reconstruit, depuis l'**état durable** (table des décisions « [run] … » + métriques,
+écrites par :class:`collegue.pilot.audit.RunAuditLog`), une vue lisible d'un run
+autonome : timeline d'audit, ledger de coût par run, décisions auto-merge/revert,
+statut et reprise (checkpoints C7).
+
+Lecture seule, **sans dépendre du process du pilote** ni de Streamlit (donc testable).
+Ne tire **pas** le package ``collegue.pilot`` (le dashboard reste découplé) : les noms
+de métriques sont dupliqués localement (miroir de ``collegue.pilot.audit``).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+# Préfixe des décisions émises par RunAuditLog (``record_decision("[run] <kind>", ...)``).
+RUN_PREFIX = "[run] "
+# Événements qui exigent une intervention humaine (mis en avant dans le dashboard).
+ATTENTION_KINDS = frozenset({"auto_revert_failed"})
+# Miroir de ``collegue.pilot.audit.METRIC_*`` — dupliqué pour ne pas importer le pilote ici.
+_METRIC_RUN_COST_USD = "run_cost_usd"
+_METRIC_RUN_TOKENS = "run_tokens"
+
+
+@dataclass
+class RunAuditEntry:
+    """Un événement d'audit du run, reconstruit depuis une décision « [run] … »."""
+
+    kind: str
+    ts: str
+    detail: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"kind": self.kind, "ts": self.ts, "detail": self.detail}
+
+
+@dataclass
+class RunView:
+    """Vue agrégée d'un run autonome (lecture seule)."""
+
+    project_id: int
+    project_name: str
+    status: Optional[str]
+    cost: Dict[str, Any]
+    events: List[RunAuditEntry] = field(default_factory=list)
+    latest_iteration: Optional[int] = None
+    counts: Dict[str, int] = field(default_factory=dict)
+    needs_attention: bool = False
+
+    @property
+    def has_run_data(self) -> bool:
+        """Le projet a-t-il une trace de run autonome (événements ou coût enregistré) ?"""
+        return bool(self.events) or bool(self.cost.get("usd")) or bool(self.cost.get("tokens"))
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "project_id": self.project_id,
+            "project_name": self.project_name,
+            "status": self.status,
+            "cost": self.cost,
+            "events": [e.to_dict() for e in self.events],
+            "latest_iteration": self.latest_iteration,
+            "counts": self.counts,
+            "needs_attention": self.needs_attention,
+            "has_run_data": self.has_run_data,
+        }
+
+
+def _parse_detail(rationale: Optional[str]) -> Dict[str, Any]:
+    """Détail d'un événement depuis le ``rationale`` JSON (best-effort, jamais levant)."""
+    if not rationale:
+        return {}
+    try:
+        data = json.loads(rationale)
+    except (ValueError, TypeError):
+        return {"raw": rationale}
+    return data if isinstance(data, dict) else {"value": data}
+
+
+def _finite(value: object, default: float = 0.0) -> float:
+    """Float fini sûr (NaN/inf/non numérique → ``default``) — best-effort, jamais levant."""
+    try:
+        number = float(value)
+    except (ValueError, TypeError):
+        return default
+    return number if math.isfinite(number) else default
+
+
+def _run_cost(manager: object, project_id: int) -> Dict[str, Any]:
+    """Coût/tokens du run depuis les métriques persistées (dernier total cumulé).
+
+    Défensif : une valeur non finie (NaN/inf) ne doit pas faire planter la lecture du
+    dashboard (le writer les rejette déjà ; ceinture + bretelles).
+    """
+    usd: float = 0.0
+    tokens: int = 0
+    for metric in manager.get_metrics(project_id):
+        if metric.name == _METRIC_RUN_COST_USD:
+            usd = _finite(metric.value)
+        elif metric.name == _METRIC_RUN_TOKENS:
+            tokens = int(_finite(metric.value))
+    return {"usd": round(usd, 6), "tokens": tokens}
+
+
+def build_run_view(manager: object, project_id: int, project_name: str = "") -> RunView:
+    """Construit la :class:`RunView` d'un projet depuis l'état durable."""
+    events: List[RunAuditEntry] = []
+    counts: Dict[str, int] = {}
+    needs_attention = False
+    for decision in manager.get_decisions(project_id):  # ordonné par id (chronologique)
+        summary = decision.summary or ""
+        if not summary.startswith(RUN_PREFIX):
+            continue
+        kind = summary[len(RUN_PREFIX) :].strip()
+        ts = decision.ts.isoformat() if getattr(decision, "ts", None) else ""
+        events.append(RunAuditEntry(kind=kind, ts=ts, detail=_parse_detail(decision.rationale)))
+        counts[kind] = counts.get(kind, 0) + 1
+        if kind in ATTENTION_KINDS:
+            needs_attention = True
+
+    project = manager.get_project(project_id)
+    status = getattr(project, "status", None) if project is not None else None
+    if not project_name and project is not None:
+        project_name = project.name
+    checkpoint = manager.get_latest_checkpoint(project_id)
+    latest_iteration = checkpoint.iteration if checkpoint is not None else None
+
+    return RunView(
+        project_id=project_id,
+        project_name=project_name,
+        status=status,
+        cost=_run_cost(manager, project_id),
+        events=events,
+        latest_iteration=latest_iteration,
+        counts=counts,
+        needs_attention=needs_attention,
+    )
+
+
+def build_all_runs(manager: object) -> List[RunView]:
+    """Vues de tous les projets **ayant une trace de run autonome**.
+
+    Tri : ceux nécessitant une intervention (``needs_attention``) d'abord, puis les
+    plus récents (id décroissant).
+    """
+    views = [build_run_view(manager, project.id, project.name) for project in manager.list_projects()]
+    runs = [view for view in views if view.has_run_data]
+    runs.sort(key=lambda v: (not v.needs_attention, -v.project_id))
+    return runs

--- a/collegue/pilot/automerge.py
+++ b/collegue/pilot/automerge.py
@@ -17,6 +17,8 @@ import fnmatch
 from dataclasses import dataclass
 from typing import List, Optional, Sequence, Tuple
 
+from collegue.pilot.audit import AUTOMERGE_DECISION
+
 # Faible risque = **données / balisage non exécutable** uniquement. On exclut
 # volontairement ``tests/**`` du défaut : du code de test est exécuté en CI (avec des
 # identifiants) — ``conftest.py`` est même importé automatiquement par pytest → RCE.
@@ -246,6 +248,7 @@ def maybe_auto_merge(
     repo: str,
     dry_run: bool = True,
     files_complete: bool = True,
+    audit: object = None,
 ) -> AutoMergeOutcome:
     """Évalue puis (si autorisé **et** pas ``dry_run``) merge via H1 ``merge_pr``.
 
@@ -253,7 +256,18 @@ def maybe_auto_merge(
     merge réel **exige** un SHA de tête connu (``pr.head_sha``/``pr.sha``) : la garde
     anti-course de H1 est précisément ce qui justifie d'automatiser le merge — sans
     elle, un commit poussé entre l'évaluation et le merge passerait inaperçu → refus.
+
+    ``audit`` (H4) : si fourni, chaque décision émet un événement ``automerge_decision``
+    (tracé/auditable, visible au dashboard) — best-effort, ne casse jamais le flux.
     """
+
+    def _emit(**detail):
+        if audit is not None:
+            try:
+                audit.record(AUTOMERGE_DECISION, **detail)
+            except Exception:
+                pass
+
     decision = evaluate_automerge(
         files_changed,
         additions=additions,
@@ -262,15 +276,19 @@ def maybe_auto_merge(
         policy=policy,
         files_complete=files_complete,
     )
+    pr_number = getattr(pr, "number", None)
     if not decision.allowed:
+        _emit(pr_number=pr_number, allowed=False, merged=False, reason=decision.reason)
         return AutoMergeOutcome(decision=decision, merged=False)
     if dry_run:
+        _emit(pr_number=pr_number, allowed=True, merged=False, dry_run=True, reason=decision.reason)
         return AutoMergeOutcome(decision=decision, merged=False, dry_run=True)
     expected = getattr(pr, "head_sha", None) or getattr(pr, "sha", None)
     if not expected:
-        return AutoMergeOutcome(
-            decision=AutoMergeDecision(False, "SHA de tête inconnu — garde anti-course requise pour l'auto-merge"),
-            merged=False,
-        )
+        refused = AutoMergeDecision(False, "SHA de tête inconnu — garde anti-course requise pour l'auto-merge")
+        _emit(pr_number=pr_number, allowed=False, merged=False, reason=refused.reason)
+        return AutoMergeOutcome(decision=refused, merged=False)
     result = clients.prs.merge_pr(owner, repo, pr.number, method=policy.method, expected_head_sha=expected)
-    return AutoMergeOutcome(decision=decision, merged=bool(getattr(result, "merged", False)), merge_result=result)
+    merged = bool(getattr(result, "merged", False))
+    _emit(pr_number=pr_number, allowed=True, merged=merged, reason=decision.reason)
+    return AutoMergeOutcome(decision=decision, merged=merged, merge_result=result)

--- a/tests/test_dashboard_run_view.py
+++ b/tests/test_dashboard_run_view.py
@@ -1,0 +1,122 @@
+"""Tests #405 : vue « Run autonome » du dashboard (lecture seule de l'état durable)."""
+
+import json
+
+import pytest
+
+from collegue.dashboard.data import get_autonomous_runs_data
+from collegue.dashboard.run_view import (
+    RunView,
+    _parse_detail,
+    build_all_runs,
+    build_run_view,
+)
+from collegue.state import ProjectStateManager
+
+
+@pytest.fixture
+def manager(tmp_path):
+    return ProjectStateManager.from_url(f"sqlite:///{tmp_path / 'state.db'}", create=True)
+
+
+def _seed_run(manager, name, *, failed_revert=False, status="improving"):
+    pid = manager.create_project(name=name)
+    manager.record_decision(pid, "[run] task_started", rationale=json.dumps({"task_id": 1, "title": "T"}))
+    manager.record_decision(pid, "[run] gate_decision", rationale=json.dumps({"success": True, "stage": "pr"}))
+    manager.record_decision(pid, "[run] pr_opened", rationale=json.dumps({"pr_number": 101}))
+    if failed_revert:
+        manager.record_decision(pid, "[run] auto_revert_failed", rationale=json.dumps({"merge_sha": "abc"}))
+    # Décision « humaine » non préfixée → ignorée par la timeline d'audit.
+    manager.record_decision(pid, "Run pilote: completed — 1 tâche", rationale="hors timeline")
+    manager.add_metric(pid, "run_cost_usd", 0.0123)
+    manager.add_metric(pid, "run_tokens", 4200.0)
+    manager.save_checkpoint(pid, 7, state_json={"processed_task_ids": [1]})
+    manager.update_project(pid, status=status)
+    return pid
+
+
+# --- build_run_view -------------------------------------------------------------
+
+
+def test_build_run_view_parses_events_cost_and_status(manager):
+    pid = _seed_run(manager, "demo")
+    view = build_run_view(manager, pid)
+    assert isinstance(view, RunView)
+    kinds = [e.kind for e in view.events]
+    assert kinds == ["task_started", "gate_decision", "pr_opened"]  # ordre chronologique, sans la décision humaine
+    assert view.events[2].detail == {"pr_number": 101}
+    assert view.cost == {"usd": 0.0123, "tokens": 4200}
+    assert view.status == "improving"
+    assert view.latest_iteration == 7
+    assert view.counts.get("pr_opened") == 1
+    assert view.needs_attention is False
+    assert view.has_run_data is True
+
+
+def test_build_run_view_flags_failed_revert(manager):
+    pid = _seed_run(manager, "broken", failed_revert=True)
+    view = build_run_view(manager, pid)
+    assert view.needs_attention is True
+    assert view.counts.get("auto_revert_failed") == 1
+
+
+def test_project_without_run_data_has_none(manager):
+    pid = manager.create_project(name="vide")
+    manager.record_decision(pid, "décision normale", rationale="x")  # pas « [run] »
+    view = build_run_view(manager, pid)
+    assert view.events == [] and view.cost == {"usd": 0.0, "tokens": 0}
+    assert view.has_run_data is False
+
+
+def test_to_dict_is_json_serializable(manager):
+    pid = _seed_run(manager, "demo")
+    blob = json.dumps(build_run_view(manager, pid).to_dict())  # ne lève pas
+    assert "pr_opened" in blob
+
+
+# --- build_all_runs : filtre + tri (attention d'abord) --------------------------
+
+
+def test_build_all_runs_filters_and_orders(manager):
+    _seed_run(manager, "p1")  # ok
+    manager.create_project(name="sans-run")  # aucune trace → exclu
+    pid_attn = _seed_run(manager, "p3-attn", failed_revert=True)  # attention
+
+    runs = build_all_runs(manager)
+    names = [r.project_name for r in runs]
+    assert "sans-run" not in names  # exclu (pas de run data)
+    assert runs[0].project_id == pid_attn  # needs_attention en tête
+    assert runs[0].needs_attention is True
+
+
+# --- _parse_detail robustesse ---------------------------------------------------
+
+
+def test_parse_detail_handles_bad_json_and_none():
+    assert _parse_detail(None) == {}
+    assert _parse_detail("not json") == {"raw": "not json"}
+    assert _parse_detail("[1, 2]") == {"value": [1, 2]}
+    assert _parse_detail('{"a": 1}') == {"a": 1}
+
+
+# --- get_autonomous_runs_data ---------------------------------------------------
+
+
+def test_data_unconfigured_when_no_state_url(monkeypatch):
+    import collegue.config as config_module
+
+    monkeypatch.setattr(config_module.settings, "STATE_DATABASE_URL", None, raising=False)
+    out = get_autonomous_runs_data()
+    assert out["configured"] is False and out["runs"] == []
+
+
+def test_data_configured_reads_runs(monkeypatch, tmp_path):
+    url = f"sqlite:///{tmp_path / 'state.db'}"
+    mgr = ProjectStateManager.from_url(url, create=True)
+    _seed_run(mgr, "demo")
+    import collegue.config as config_module
+
+    monkeypatch.setattr(config_module.settings, "STATE_DATABASE_URL", url, raising=False)
+    out = get_autonomous_runs_data()
+    assert out["configured"] is True
+    assert any(r["project_name"] == "demo" for r in out["runs"])

--- a/tests/test_pilot_automerge.py
+++ b/tests/test_pilot_automerge.py
@@ -269,3 +269,40 @@ def test_maybe_auto_merge_real_calls_merge_pr():
 
 def test_evaluate_returns_decision_type():
     assert isinstance(evaluate_automerge(["docs/x.md"], checks=["success"], policy=_policy()), AutoMergeDecision)
+
+
+def test_maybe_auto_merge_emits_audit_events():
+    # L'audit (H4) reçoit un événement `automerge_decision` à chaque décision → visible
+    # au dashboard (#405). Refus puis merge réel.
+    audit = SimpleNamespace(events=[])
+    audit.record = lambda kind, **d: audit.events.append((kind, d))
+    prs = _PRs()
+
+    maybe_auto_merge(  # refusé (politique off)
+        SimpleNamespace(number=7, head_sha="abc"),
+        ["docs/x.md"],
+        additions=1,
+        checks=["success"],
+        policy=RiskPolicy(),
+        clients=_clients(prs),
+        owner="o",
+        repo="r",
+        dry_run=False,
+        audit=audit,
+    )
+    assert audit.events[-1][0] == "automerge_decision" and audit.events[-1][1]["allowed"] is False
+
+    maybe_auto_merge(  # autorisé + merge réel
+        SimpleNamespace(number=42, head_sha="abc123"),
+        ["docs/x.md"],
+        additions=5,
+        checks=["success"],
+        policy=_policy(),
+        clients=_clients(prs),
+        owner="o",
+        repo="r",
+        dry_run=False,
+        audit=audit,
+    )
+    ev = audit.events[-1]
+    assert ev[0] == "automerge_decision" and ev[1]["allowed"] is True and ev[1]["merged"] is True


### PR DESCRIPTION
## Dashboard du run autonome (closes #405)

H4 a posé la **collecte** (`RunAuditLog` + ledger de coût + export) ; il manquait la **visualisation**. Cette PR ajoute un onglet **« Run autonome »** au dashboard Streamlit.

### Lecture seule, découplée (`collegue/dashboard/run_view.py`)
Reconstruit, depuis l'**état durable** (table des décisions `[run] …` + métriques `run_cost_usd`/`run_tokens`, écrites par `RunAuditLog`), une `RunView` par projet :
- **timeline d'audit** (événements `task_started`/`gate_decision`/`pr_opened`/`budget_event`/`auto_revert`/`auto_revert_failed`/`automerge_decision`/`run_stop`/`cost_observed`) ;
- **coût/tokens par run** (dernier total cumulé) ;
- **compteurs auto-merge / auto-revert** ; `auto_revert_failed` → `needs_attention` (mis en tête, alerte rouge) ;
- statut du projet + itération du dernier **checkpoint** (C7).

`build_all_runs` ne garde que les projets avec une trace de run. Volontairement **sans importer `collegue.pilot`** (le dashboard reste découplé). `data.get_autonomous_runs_data` lit `STATE_DATABASE_URL` (**fail-soft** : non configuré / DB illisible → `configured=False`, jamais d'exception vers Streamlit).

### Onglet Streamlit
Nouvel onglet « Run autonome » : sélecteur de projet (clé par `project_id`, **stable à l'auto-refresh** même si le tri change), métriques (statut/itération/coût/tokens), bandeau d'alerte si `auto_revert_failed`, timeline.

### Revue
Revue adversariale avant ship — la vue est correcte, robuste, honnête (contrat de persistance respecté, `_parse_detail` ne lève jamais, `_run_cost` « last wins » correct, fail-soft). **1 lacune d'acceptation corrigée** : l'événement `automerge_decision` n'était **jamais produit** (constante définie mais jamais émise) → le compteur auto-merge affichait toujours 0. Corrigé en amont : `maybe_auto_merge` émet désormais l'événement à l'audit (H4). + 2 durcissements (LOW) : garde des valeurs non finies dans `_run_cost`, sélecteur clé par `project_id`.

### Tests
- `tests/test_dashboard_run_view.py` (8) : parsing événements/coût/statut/checkpoint, flag `auto_revert_failed`, exclusion des projets sans run, JSON-sérialisable, tri attention-d'abord, `_parse_detail` (JSON invalide/non-dict/None), `get_autonomous_runs_data` configuré/non-configuré.
- `tests/test_pilot_automerge.py` : émission `automerge_decision` (refus + merge réel).
- **Suite complète verte** hors `integration` : 1394 tests, 0 échec. `ruff check` + `ruff format --check` (arbre entier) clean.

Suivi post-brief — voir aussi #404 (CI nightly integration) et #406 (COLLEGUE_HOME absolu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)