### PR TITLE
fix(executor): gate lance `python -m pytest` (imports src/app) — #413

### DIFF
--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -27,7 +27,12 @@ from collegue.executor.agent import IssueSpec
 from collegue.sandbox.executor import DockerSandbox
 from collegue.textnorm import inline
 
-DEFAULT_TEST_COMMAND = "pytest -q"
+# `python -m pytest` (et non le script `pytest`) ajoute le répertoire de travail
+# (la racine du workspace, montée sur `/workspace`) à `sys.path`. Sans ça, les tests
+# d'un projet en layout `src/`/`app/` qui importent par package (`from app.x import …`,
+# `from src.x import …`) lèvent `ModuleNotFoundError` à la collecte → le gate échoue
+# à tort (tests verts vus comme rouges). Voir issue #413.
+DEFAULT_TEST_COMMAND = "python -m pytest -q"
 # Triple-backtick de remplacement : neutralise les fences pour qu'un texte non
 # fiable ne puisse pas refermer le bloc de code et forger une fausse section.
 _FENCE = "```"

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -69,6 +69,20 @@ async def test_failed_when_review_blocks():
     assert report.passed is False
 
 
+async def test_default_test_command_invokes_pytest_as_module():
+    """Régression #413 : le gate lance `python -m pytest` (PAS le script `pytest`).
+
+    Le script `pytest` n'ajoute pas le répertoire de travail à ``sys.path`` ; un projet
+    en layout ``src/``/``app/`` qui importe par package échouerait alors à la collecte.
+    ``python -m pytest`` ajoute le cwd (la racine du workspace) → imports résolus.
+    """
+    sandbox = _green()
+    await run_quality_gate("/ws", DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    assert sandbox.calls, "le gate doit exécuter les tests"
+    _ws, command = sandbox.calls[0]
+    assert command.startswith("python -m pytest"), f"commande de test inattendue: {command!r}"
+
+
 # --- fail-closed ----------------------------------------------------------------
 
 


### PR DESCRIPTION
## Problème (#413)
Le gate qualité exécutait les tests via le **script** `pytest -q`. Or `pytest` (script) n'ajoute **pas** le répertoire de travail à `sys.path`. Un projet généré en layout `src/` ou `app/` dont les tests importent par package (`from app.x import …`, `from src.x import …`) lève alors `ModuleNotFoundError` **à la collecte** → le gate voit des tests **verts comme rouges**, fail-closed, et n'ouvre aucune PR.

## Correctif
`DEFAULT_TEST_COMMAND` passe de `pytest -q` à **`python -m pytest -q`**. `python -m pytest` ajoute le cwd (la racine du workspace, montée sur `/workspace` par le sandbox via `-w`) en tête de `sys.path` → les imports par package se résolvent. Changement **minimal** (une constante) ; aucun comportement du verdict (fail-closed) modifié.

## Preuve
Découvert pendant le **run autonome réel sur FacNor** : des tâches dont la suite de tests **passe** avec `python -m pytest` **échouaient** avec `pytest` (collecte interrompue : `No module named 'src'`/`'app'`). Vérifié sur les workspaces réels (ex. 5 passed vs collecte interrompue).

## Tests
- Nouveau test de régression `test_default_test_command_invokes_pytest_as_module` (le gate doit lancer `python -m pytest`).
- `tests/test_executor_quality_gate.py`, `test_executor_pipeline.py`, `test_pilot_driver.py`, `test_pilot_runtime.py` : verts (46 tests). `ruff check` + `ruff format --check` OK.

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)