### PR TITLE
fix(executor): open_pr saute les fichiers binaires au lieu de planter — #410

### DIFF
--- a/collegue/executor/pr.py
+++ b/collegue/executor/pr.py
@@ -81,6 +81,7 @@ class PrResult:
     number: Optional[int] = None
     html_url: Optional[str] = None
     skipped: bool = False  # PR déjà existante (idempotence)
+    skipped_binaries: Tuple[str, ...] = ()  # fichiers binaires non poussés (cf. #410)
 
 
 def build_pr_body(quality_report: QualityReport, issue: IssueSpec, *, closes_issue: bool = True) -> str:
@@ -153,17 +154,31 @@ def open_pr(
 
     clients.branches.ensure_branch(owner, repo, head, from_branch=base)
 
+    skipped_binaries: list[str] = []
     for path in files_changed:
         rel = _safe_rel_path(path)
         full = _resolve_in_workspace(workspace.path, rel)
         message = f"collegue: issue #{int(issue.number)} — {rel}"
         if os.path.isfile(full):
-            with open(full, "r", encoding="utf-8") as handle:
-                content = handle.read()
+            try:
+                with open(full, "r", encoding="utf-8") as handle:
+                    content = handle.read()
+            except UnicodeDecodeError:
+                # Fichier binaire (PNG/PDF/…) : la Contents API n'est câblée qu'en
+                # texte UTF-8 (limite §MVP). On le SAUTE plutôt que de faire échouer
+                # toute la tâche sur un asset — la PR porte le reste du diff. [#410]
+                skipped_binaries.append(rel)
+                continue
             clients.files.update_file(owner, repo, rel, message, content, branch=head)
         else:
             # Fichier supprimé par l'agent : on le retire aussi sur la branche.
             clients.files.delete_file(owner, repo, rel, message, branch=head)
+
+    if skipped_binaries:
+        # Trace visible pour le relecteur (la PR ne contient pas ces binaires).
+        body += "\n\n> ⚠️ Fichiers binaires non poussés (non supportés) : " + ", ".join(
+            f"`{p}`" for p in skipped_binaries
+        )
 
     pr = clients.prs.create_pr(owner, repo, title, head, base, body)
     number = getattr(pr, "number", None)
@@ -176,7 +191,16 @@ def open_pr(
             rationale=html_url,
         )
 
-    return PrResult(dry_run=False, title=title, head=head, base=base, body=body, number=number, html_url=html_url)
+    return PrResult(
+        dry_run=False,
+        title=title,
+        head=head,
+        base=base,
+        body=body,
+        number=number,
+        html_url=html_url,
+        skipped_binaries=tuple(skipped_binaries),
+    )
 
 
 def _default_clients(token: Optional[str] = None) -> PrClients:  # pragma: no cover - chemin réel (integration)

--- a/tests/test_executor_pr.py
+++ b/tests/test_executor_pr.py
@@ -124,6 +124,24 @@ def test_real_creates_branch_files_and_pr(tmp_path):
     assert "Closes #5" in body and "## Gate qualité" in body and exec_marker(5) in body
 
 
+def test_binary_file_is_skipped_not_crashed(tmp_path):
+    """#410 : un fichier binaire (PNG/PDF/…) est SAUTÉ au lieu de faire planter
+    l'ouverture de PR (la Contents API n'est câblée qu'en texte UTF-8) ; le reste
+    du diff (texte) est bien poussé, et le binaire sauté est tracé."""
+    ws_dir = tmp_path / "ws"
+    ws_dir.mkdir()
+    (ws_dir / "code.py").write_text("print('ok')\n", encoding="utf-8")
+    (ws_dir / "logo.png").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\xcbbinaire")  # octets non-UTF-8
+    ws = Workspace(path=str(ws_dir), branch="collegue/issue-5", base_commit="basesha123")
+    clients = _clients()
+    result = open_pr(ws, REPORT, ISSUE, "o", "r", files_changed=("code.py", "logo.png"), clients=clients, dry_run=False)
+    # le code texte est poussé, le binaire est sauté (aucune exception)
+    assert {p for p, _c, _b in clients.files.updated} == {"code.py"}
+    assert result.skipped_binaries == ("logo.png",)
+    # trace visible pour le relecteur dans le corps de PR
+    assert "logo.png" in clients.prs.created[0]["body"]
+
+
 def test_idempotent_when_pr_already_open(tmp_path):
     ws = _workspace(tmp_path)
     existing = SimpleNamespace(number=77, html_url="https://gh/pull/77", head_branch="collegue/issue-5")


### PR DESCRIPTION
## Problème (#410)
`open_pr` lit chaque fichier modifié en **UTF-8** (`open(full, "r", encoding="utf-8")`) pour le pousser via la Contents API (texte-only). Un **binaire** produit par l'agent (PNG, PDF, asset frontend, `.ico`…) lève `UnicodeDecodeError`, **non rattrapé** → `task_exception` → la tâche échoue en dur et tout son travail est perdu.

## Correctif
Un fichier non décodable en UTF-8 est désormais **sauté** (la PR porte le reste du diff texte) au lieu de faire planter l'ouverture de PR :
- nouveau champ `PrResult.skipped_binaries: Tuple[str, ...]` (rétro-compatible, défaut `()`),
- note dans le corps de PR listant les binaires non poussés (visibilité pour le relecteur).

Le support binaire **complet** (lecture `rb` + base64 via la Contents API, qui nécessite d'étendre `FileCommands`) reste un follow-up volontaire — ici on supprime le crash, ce que l'issue proposait comme correctif minimal.

## Preuve
Découvert pendant le **run autonome réel sur FacNor** : une tâche frontend a généré un PNG → `'utf-8' codec can't decode byte 0x89 in position 0` → tâche `failed`, run bloqué.

## Tests
- Nouveau `test_binary_file_is_skipped_not_crashed` : code texte poussé, binaire sauté, `skipped_binaries == ("logo.png",)`, trace dans le corps.
- `tests/test_executor_pr.py` vert (14 tests). `ruff check` + `ruff format --check` OK.

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)