### PR TITLE
fix(executor): ExpertReviewer détecte le langage du diff (plus de python codé en dur) — #409

### DIFF
--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -20,6 +20,7 @@ qu'il ne puisse pas forger de fausse bannière/section (cf. P5).
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import List, Optional, Protocol, Tuple, runtime_checkable
 
@@ -234,6 +235,50 @@ def outcome_from_review(response, *, min_quality: float = DEFAULT_MIN_QUALITY) -
     )
 
 
+# Extensions → langage supporté par l'outil ``code_review`` (python/js/ts/php).
+_REVIEW_LANG_BY_EXT = {
+    ".py": "python",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".php": "php",
+}
+
+
+def _detect_review_language(diff: str) -> Optional[str]:
+    """Langage dominant d'un diff parmi ceux que ``code_review`` sait reviewer.
+
+    Parse les chemins de fichiers du diff (lignes ``+++ b/…`` / ``diff --git a/… b/…``)
+    et compte les extensions reconnues. Retourne le langage le plus représenté, ou
+    ``None`` si le diff ne contient **aucun** fichier de code supporté (que du SQL,
+    Markdown, config…). Sans ça, l'``ExpertReviewer`` envoyait tout en ``python`` →
+    un diff SQL/JS était jugé « Python cassé » (score 0.00) et bloquait à tort. [#409]
+    """
+    counts: dict[str, int] = {}
+    seen: set[str] = set()
+    for line in diff.splitlines():
+        path = None
+        if line.startswith("+++ b/"):
+            path = line[len("+++ b/") :].strip()
+        elif line.startswith("diff --git "):
+            parts = line.split(" b/", 1)  # `diff --git a/x b/y` → chemin `b/`
+            if len(parts) == 2:
+                path = parts[1].strip()
+        if not path or path == "/dev/null" or path in seen:
+            continue
+        seen.add(path)
+        _root, ext = os.path.splitext(path)
+        lang = _REVIEW_LANG_BY_EXT.get(ext.lower())
+        if lang:
+            counts[lang] = counts.get(lang, 0) + 1
+    if not counts:
+        return None
+    return sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))[0][0]  # dominant, déterministe
+
+
 class ExpertReviewer:
     """Adaptateur :class:`Reviewer` vers l'outil expert ``code_review`` (réel).
 
@@ -251,10 +296,23 @@ class ExpertReviewer:
     async def review(self, diff: str, ctx, *, issue: Optional[IssueSpec] = None) -> ReviewOutcome:
         from collegue.tools.code_review.models import CodeReviewRequest
 
+        language = _detect_review_language(diff)
+        if language is None:
+            # Aucun fichier de code supporté (python/js/ts/php) dans le diff → la revue
+            # experte, calibrée pour ces langages, n'a rien à juger. On NE la lance PAS
+            # (sinon du SQL/Markdown/config serait noté comme du Python cassé → 0.00 →
+            # blocage à tort). Outcome neutre, NON bloquant. [#409]
+            return ReviewOutcome(
+                summary="revue experte ignorée : aucun fichier de code supporté (python/js/ts/php) dans le diff",
+                quality_score=1.0,
+                findings=(),
+                blocking=False,
+            )
+
         tool = self._tool or self._build_tool()
         request = CodeReviewRequest(
             code=diff or "(diff vide)",
-            language="python",
+            language=language,
             context=issue.to_prompt() if issue is not None else None,
         )
         response = await tool.execute_async(request, ctx=ctx)

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -21,7 +21,7 @@ from collegue.tools.code_review.models import CodeReviewResponse, ReviewFinding
 from collegue.tools.quotas import BudgetExceeded
 
 ISSUE = IssueSpec(number=5, title="T")
-DIFF = "diff --git a/x b/x\n+print('x')\n"
+DIFF = "diff --git a/x.py b/x.py\n+print('x')\n"
 
 
 class _FakeSandbox:
@@ -201,6 +201,28 @@ async def test_expert_reviewer_maps_tool_response():
     request = tool.calls[0][0]
     assert request.code == DIFF
     assert request.context == ISSUE.to_prompt()
+    # Langage détecté depuis l'extension du diff (#409), pas codé en dur.
+    assert request.language == "python"
+
+
+async def test_review_skipped_for_unsupported_language_diff():
+    """#409 : un diff sans fichier de code supporté (SQL seul) → revue IGNORÉE et
+    NON bloquante ; l'outil n'est PAS appelé (plus de faux 0.00 sur du non-code)."""
+    sql_diff = "diff --git a/schema.sql b/schema.sql\n+CREATE TABLE t (id INT);\n"
+    tool = _FakeTool(_response(0.0))  # bloquerait s'il était appelé
+    reviewer = ExpertReviewer(tool=tool)
+    outcome = await reviewer.review(sql_diff, ctx=None, issue=ISSUE)
+    assert outcome.blocking is False
+    assert tool.calls == []  # outil non sollicité
+
+
+async def test_review_detects_language_from_diff():
+    """#409 : le langage envoyé à code_review est détecté depuis les extensions du diff."""
+    ts_diff = "diff --git a/app/x.ts b/app/x.ts\n+export const a = 1;\n"
+    tool = _FakeTool(_response(0.9))
+    reviewer = ExpertReviewer(tool=tool)
+    await reviewer.review(ts_diff, ctx=None, issue=ISSUE)
+    assert tool.calls[0][0].language == "typescript"
 
 
 # --- protocole ------------------------------------------------------------------


### PR DESCRIPTION
## Problème (#409)
`ExpertReviewer.review` envoyait **tout** diff à `code_review` avec `language="python"` codé en dur. Un diff non-Python (SQL, JS/TS, config) était alors analysé comme du **Python cassé** → `quality_score = 0.00` → revue **bloquante** → aucune PR ouverte en greenfield non-Python.

## Correctif
- Nouveau `_detect_review_language(diff)` : détecte le langage **dominant** depuis les extensions des fichiers du diff, parmi les 4 que `code_review` sait reviewer (`python`/`javascript`/`typescript`/`php`).
- `ExpertReviewer.review` passe ce langage détecté (plus de `"python"` en dur).
- Si le diff ne contient **aucun** fichier de code supporté (que du SQL/Markdown/config), la revue experte est **ignorée** et **non bloquante** (l'outil n'a rien à juger) — au lieu de produire un faux 0.00.

## Preuve
Découvert pendant le **run autonome réel sur FacNor** : la tâche #1 (`schema.sql`) était notée **0.00/1.0** avec « 12 problèmes » — du **SQL lu comme du Python**.

## Limite assumée / follow-up
La revue porte toujours sur le **diff brut** (avec marqueurs `+/-`) et avec un seul langage dominant. La revue **fichier-par-fichier** (langage propre à chaque fichier, lignes ajoutées seules) reste un follow-up.

## Tests
- `test_review_skipped_for_unsupported_language_diff` (diff SQL → non bloquant, outil non appelé),
- `test_review_detects_language_from_diff` (diff `.ts` → `typescript`),
- `test_expert_reviewer_maps_tool_response` étendu (langage détecté = `python`).
- `tests/test_executor_quality_gate.py` vert (17 tests). `ruff check` + `ruff format --check` OK.

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)