### PR TITLE
feat(sandbox): DockerSandbox injecte des env + ressources configurables (support #404)

### DIFF
--- a/collegue/sandbox/executor.py
+++ b/collegue/sandbox/executor.py
@@ -36,7 +36,7 @@ import subprocess
 import tempfile
 import uuid
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import List, Mapping, Optional, Tuple, Union
 
 DEFAULT_SANDBOX_IMAGE = "collegue-sandbox:latest"
 
@@ -83,6 +83,9 @@ class DockerSandbox:
         workspace_root: Optional[str] = None,
         allow_root: bool = False,
         docker_bin: str = "docker",
+        env: Optional[Mapping[str, str]] = None,
+        env_passthrough: Tuple[str, ...] = (),
+        read_only: bool = True,
     ):
         self.image = image
         self.network = network
@@ -94,6 +97,16 @@ class DockerSandbox:
         self.workspace_root = workspace_root
         self.allow_root = allow_root
         self.docker_bin = docker_bin
+        # Injection d'environnement (ex. worker OpenHands) :
+        # - ``env`` : couples explicites (-e K=V) — pour les valeurs NON secrètes.
+        # - ``env_passthrough`` : noms passés par référence (-e NAME, sans valeur) —
+        #   docker hérite la valeur de l'environnement du process appelant, donc le
+        #   secret (ex. LLM_API_KEY) n'apparaît JAMAIS dans l'argv (ni dans `ps`).
+        # ``read_only`` : root FS en lecture seule (durci) ; désactivable pour les
+        #   workers qui écrivent hors workspace/tmp (au prix d'un durcissement moindre).
+        self.env = dict(env) if env else {}
+        self.env_passthrough = tuple(env_passthrough)
+        self.read_only = bool(read_only)
 
     # ── validation / construction (pur, testable sans Docker) ─────────────────────
 
@@ -137,12 +150,23 @@ class DockerSandbox:
             self.cpus,
             "--stop-timeout",
             "5",
-            "--read-only",  # root FS en lecture seule
+        ]
+        if self.read_only:
+            argv += ["--read-only"]  # root FS en lecture seule
+        argv += [
             "--tmpfs",
             "/tmp",  # scratch éphémère écrivable
             "-e",
             "HOME=/tmp",
         ]
+        # Injection d'environnement (ordre déterministe : passthrough triés, puis
+        # couples explicites triés) — pour le worker OpenHands (clé API par réf.,
+        # modèle/flags en clair). Vide par défaut → argv identique au comportement
+        # historique (tests inchangés).
+        for name in sorted(self.env_passthrough):
+            argv += ["-e", name]
+        for key in sorted(self.env):
+            argv += ["-e", f"{key}={self.env[key]}"]
         # Exécuter en tant qu'utilisateur hôte non-root : le workspace (dir hôte)
         # reste écrivable/persisté, et le conteneur ne tourne jamais en root
         # (run_command refuse uid 0 sauf allow_root explicite).

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -49,6 +49,30 @@ def test_build_argv_mounts_only_workspace(tmp_path):
     assert _mounts(argv) == [f"{tmp_path}:/workspace"]
 
 
+def test_build_argv_env_injection_secret_by_reference(tmp_path):
+    # Worker (ex. OpenHands) : la clé API est passée par RÉFÉRENCE (`-e NAME`, sans
+    # valeur → docker l'hérite du process appelant) → le secret n'apparaît JAMAIS
+    # dans l'argv (ni dans `ps`). Les valeurs non secrètes vont en clair (`-e K=V`).
+    sb = DockerSandbox(image="img", env={"LLM_MODEL": "gemini/x"}, env_passthrough=("LLM_API_KEY",))
+    argv = sb._build_run_argv("echo hi", str(tmp_path))
+    joined = " ".join(argv)
+    assert "-e LLM_API_KEY" in joined  # par référence
+    assert "LLM_API_KEY=" not in joined  # jamais la valeur du secret
+    assert "-e LLM_MODEL=gemini/x" in joined  # valeur non secrète en clair
+
+
+def test_build_argv_no_env_by_default(tmp_path):
+    # Défaut : aucun `-e` hormis HOME=/tmp → argv identique au comportement historique.
+    sb = DockerSandbox(image="img")
+    argv = sb._build_run_argv("echo hi", str(tmp_path))
+    assert [argv[i + 1] for i, a in enumerate(argv) if a == "-e"] == ["HOME=/tmp"]
+
+
+def test_build_argv_read_only_toggle(tmp_path):
+    assert "--read-only" in DockerSandbox(image="img")._build_run_argv("x", str(tmp_path))
+    assert "--read-only" not in DockerSandbox(image="img", read_only=False)._build_run_argv("x", str(tmp_path))
+
+
 def test_build_argv_runs_non_root(tmp_path):
     sb = DockerSandbox(image="img")
     argv = sb._build_run_argv("echo hi", str(tmp_path))


### PR DESCRIPTION
## Contexte (support #404)
Le chemin d'exécution réel (worker OpenHands dans le sandbox) a besoin de passer des variables d'environnement au conteneur — notamment la **clé API LLM** — ce que `DockerSandbox` ne permettait pas (seul `HOME=/tmp` était injecté). De plus, ses ressources (`--read-only`, mémoire, timeout) n'étaient pas adaptables à un worker agentique (long, écrivant son état).

## Ajouts (rétro-compatibles)
- **`env`** : couples explicites `-e K=V` — pour les valeurs **non secrètes** (ex. nom du modèle LiteLLM).
- **`env_passthrough`** : noms passés **par référence** (`-e NAME`, sans valeur) → docker hérite la valeur de l'environnement du process appelant, donc **un secret (ex. `LLM_API_KEY`) n'apparaît jamais dans l'argv** (ni dans `ps`).
- **`read_only`** : toggle du root FS read-only (un worker écrit son état hors `/tmp`).

Les **défauts préservent le comportement historique** : sans `env`, l'argv est identique (seul `HOME=/tmp`) ; `read_only=True` par défaut. Aucun test existant impacté.

## Tests
- `test_build_argv_env_injection_secret_by_reference` (secret par référence, jamais sa valeur dans l'argv ; valeur non secrète en clair),
- `test_build_argv_no_env_by_default` (argv inchangé sans env),
- `test_build_argv_read_only_toggle`.
- `tests/test_sandbox.py` vert (22 tests, `-m "not integration"`). `ruff check` + `ruff format --check` OK.

Découvert nécessaire pendant le **run autonome réel sur FacNor** (sans injection d'env, la clé API ne pouvait pas atteindre le worker OpenHands). Brique de l'umbrella #404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)