### PR TITLE
feat(executor): IssueSpec porte un contexte inter-tâches (cohérence) — #412

### DIFF
--- a/collegue/executor/agent.py
+++ b/collegue/executor/agent.py
@@ -39,6 +39,10 @@ class IssueSpec:
     title: str
     body: str = ""
     acceptance_criteria: Tuple[str, ...] = ()
+    # Contexte inter-tâches (dépendances déjà construites, état du dépôt, conventions)
+    # injecté par le pilote pour que l'agent BÂTISSE sur l'existant au lieu de coder
+    # depuis une consigne d'une ligne → cohérence inter-tâches. Voir issue #412.
+    context: str = ""
 
     def to_prompt(self) -> str:
         """Construit la consigne (sanitizée) donnée à l'agent.
@@ -48,6 +52,9 @@ class IssueSpec:
         ne peut forger une nouvelle ligne/section dans la consigne rendue.
         """
         lines = [f"Issue #{self.number}: {inline(self.title)}"]
+        context = inline(self.context)
+        if context:
+            lines += ["", f"Contexte : {context}"]
         body = inline(self.body)
         if body:
             lines += ["", body]

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -83,16 +83,31 @@ class ProjectRunResult:
         return [t.pr_number for t in self.processed if t.pr_number is not None]
 
 
-def _issue_from_task(task) -> IssueSpec:
+def _issue_from_task(task, by_id=None) -> IssueSpec:
     """Construit l'``IssueSpec`` exécutable depuis une tâche persistée.
 
     Le numéro est celui de l'issue GitHub si la tâche est synchronisée
     (``issue_number``), sinon l'id de tâche (branche/``Closes`` cohérents).
+
+    ``by_id`` (id → tâche) permet d'injecter un **contexte inter-tâches** (#412) :
+    on liste les **dépendances déjà construites** pour que l'agent bâtisse sur
+    l'existant (le code des dépendances est dans le dépôt) au lieu de coder depuis
+    la seule consigne de l'issue → cohérence entre tâches.
     """
+    context = ""
+    deps = [by_id[d] for d in (task.depends_on or []) if by_id and d in by_id]
+    if deps:
+        titres = ", ".join(f"« {d.title} »" for d in deps)
+        context = (
+            f"Cette tâche dépend de tâches déjà construites : {titres}. "
+            "Inspecte le dépôt existant et réutilise leur code, modèles et conventions "
+            "(ne recrée pas ce qui existe)."
+        )
     return IssueSpec(
         number=task.issue_number or task.id,
         title=task.title,
         body=task.acceptance or "",
+        context=context,
     )
 
 
@@ -139,6 +154,7 @@ async def run_project(
     budget = budget or BudgetTimeController()
     audit = audit or NullAuditLog()
     tasks = manager.get_tasks(project_id)  # objets détachés : overlay mutable en mémoire
+    tasks_by_id = {t.id: t for t in tasks}  # pour le contexte inter-tâches (#412)
 
     # Ancrage du début de run (réel) : persiste le ``started_at`` pour qu'une reprise
     # reconstruise une deadline ABSOLUE (sinon elle glisse à chaque redémarrage). La
@@ -198,7 +214,7 @@ async def run_project(
 
         audit.record(TASK_STARTED, iteration=iteration + 1, task_id=task.id, title=task.title)
         outcome = await execute_issue(
-            _issue_from_task(task),
+            _issue_from_task(task, tasks_by_id),
             repo_source,
             ctx,
             agent=agent,

--- a/tests/test_executor_agent.py
+++ b/tests/test_executor_agent.py
@@ -40,6 +40,18 @@ def test_issue_to_prompt_drops_blank_criteria():
     assert prompt.count("- ") == 1  # les critères vides sont ignorés
 
 
+def test_issue_to_prompt_includes_context():
+    # #412 : le contexte inter-tâches est rendu (et inline-isé : pas d'injection).
+    issue = IssueSpec(number=2, title="T", context="Dépend de « Schéma »\n## faux titre")
+    prompt = issue.to_prompt()
+    assert "Contexte : Dépend de « Schéma »" in prompt
+    assert "\n## faux titre" not in prompt  # multi-ligne aplati (anti-injection)
+
+
+def test_issue_to_prompt_no_context_by_default():
+    assert "Contexte" not in IssueSpec(number=1, title="Titre").to_prompt()
+
+
 # --- FakeCodeAgent --------------------------------------------------------------
 
 

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -123,6 +123,22 @@ async def _run(manager, repo, pid, *, budget=None, dry_run=True, sandbox=None, *
     )
 
 
+# --- contexte inter-tâches (#412) -----------------------------------------------
+
+
+def test_issue_from_task_injects_dependency_context():
+    from collegue.pilot.driver import _issue_from_task
+
+    schema = SimpleNamespace(id=1, issue_number=1, title="Schéma DB", acceptance="", depends_on=[])
+    api = SimpleNamespace(id=2, issue_number=12, title="API clients", acceptance="CRUD", depends_on=[1])
+    by_id = {1: schema, 2: api}
+    # une tâche dépendante reçoit le titre de ses dépendances déjà construites
+    ctx = _issue_from_task(api, by_id).context
+    assert "« Schéma DB »" in ctx and "réutilise" in ctx.lower()
+    # une tâche racine (sans dépendance) n'a pas de contexte
+    assert _issue_from_task(schema, by_id).context == ""
+
+
 # --- bout en bout ---------------------------------------------------------------
 
 


### PR DESCRIPTION
## Problème (#412)
`IssueSpec` ne portait que `title` + `acceptance_criteria` → l'agent codait depuis une **consigne d'une ligne**, sans savoir que les tâches dont elle dépend ont déjà produit du code/des modèles dans le dépôt. Résultat : **incohérence inter-tâches** (ex. une tâche choisit Postgres alors que la précédente a posé du SQLite ; recrée des modèles déjà existants).

## Correctif
- **`IssueSpec.context`** : nouveau champ (défaut `""`), rendu dans `to_prompt` (inline-isé → anti-injection, comme les autres champs).
- **Le pilote (`_issue_from_task`)** le peuple à partir du graphe (`tasks_by_id`) : il liste les **titres des dépendances déjà construites** + une consigne « inspecte le dépôt existant et réutilise leur code/modèles/conventions (ne recrée pas l'existant) ».

Rétro-compatible : sans dépendances ou sans `by_id`, `context=""` et `to_prompt` est inchangé.

## Preuve
Découvert pendant le **run autonome réel sur FacNor** : faute de contexte, des tâches partaient sur des choix de stack incompatibles avec les tâches précédentes (cf. tests connectant tantôt SQLite, tantôt Postgres).

## Limite assumée / follow-up
Le contexte se limite aux **titres** des dépendances. Un résumé plus riche (fichiers/décisions clés de l'état du dépôt) est un follow-up.

## Tests
- `test_issue_to_prompt_includes_context` + `test_issue_to_prompt_no_context_by_default` (rendu + anti-injection),
- `test_issue_from_task_injects_dependency_context` (le pilote injecte les titres des dépendances ; tâche racine = pas de contexte).
- `tests/test_executor_agent.py` + `tests/test_pilot_driver.py` verts (31 tests). `ruff check` + `ruff format --check` OK.

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)