### PR TITLE
fix(executor): open_pr saute les symlinks au lieu de lever (issue #423)

### DIFF
--- a/collegue/executor/pr.py
+++ b/collegue/executor/pr.py
@@ -43,16 +43,16 @@ def _safe_rel_path(path: str) -> str:
 
 
 def _resolve_in_workspace(workspace_path: str, rel: str) -> str:
-    """Résout ``rel`` dans le workspace en **refusant toute évasion** (symlink inclus).
+    """Résout ``rel`` dans le workspace en **refusant toute évasion**.
 
-    L'agent est **non fiable** : sans cette garde, un symlink ``x.py`` pointant vers
-    un secret de l'hôte (``~/.ssh/id_rsa``, ``.env``…) serait lu sur l'hôte et poussé
-    dans la PR. On refuse donc tout symlink et on vérifie le confinement via
-    ``realpath`` (déjoue aussi un répertoire intermédiaire symlinké).
+    L'agent est **non fiable** : sans cette garde, un chemin passant par un
+    répertoire intermédiaire symlinké vers l'hôte (``dir → ~/.ssh``) serait lu sur
+    l'hôte et poussé dans la PR. Le confinement est vérifié via ``realpath``.
+    Les **fichiers** symlinks, eux, sont sautés en amont par :func:`open_pr` sans
+    jamais être lus (même politique que les binaires, cf. #423) — ils ne passent
+    donc pas par cette résolution.
     """
     full = os.path.join(workspace_path, rel)
-    if os.path.islink(full):
-        raise ValueError(f"symlink refusé dans le workspace: {rel!r}")
     root = os.path.realpath(workspace_path)
     real = os.path.realpath(full)
     if real != root and os.path.commonpath([real, root]) != root:
@@ -82,6 +82,7 @@ class PrResult:
     html_url: Optional[str] = None
     skipped: bool = False  # PR déjà existante (idempotence)
     skipped_binaries: Tuple[str, ...] = ()  # fichiers binaires non poussés (cf. #410)
+    skipped_symlinks: Tuple[str, ...] = ()  # liens symboliques non poussés (cf. #423)
 
 
 def build_pr_body(quality_report: QualityReport, issue: IssueSpec, *, closes_issue: bool = True) -> str:
@@ -155,8 +156,16 @@ def open_pr(
     clients.branches.ensure_branch(owner, repo, head, from_branch=base)
 
     skipped_binaries: list[str] = []
+    skipped_symlinks: list[str] = []
     for path in files_changed:
         rel = _safe_rel_path(path)
+        if os.path.islink(os.path.join(workspace.path, rel)):
+            # Lien symbolique (ex. `node_modules/.bin/*` après un `npm install`) :
+            # la Contents API ne représente pas les symlinks, et un lien peut viser
+            # un secret hôte — on ne le LIT jamais. Même politique que les binaires :
+            # SAUTER + tracer, plutôt que faire échouer toute la tâche. [#423]
+            skipped_symlinks.append(rel)
+            continue
         full = _resolve_in_workspace(workspace.path, rel)
         message = f"collegue: issue #{int(issue.number)} — {rel}"
         if os.path.isfile(full):
@@ -179,6 +188,10 @@ def open_pr(
         body += "\n\n> ⚠️ Fichiers binaires non poussés (non supportés) : " + ", ".join(
             f"`{p}`" for p in skipped_binaries
         )
+    if skipped_symlinks:
+        body += "\n\n> ⚠️ Liens symboliques non poussés (jamais lus, non supportés) : " + ", ".join(
+            f"`{p}`" for p in skipped_symlinks
+        )
 
     pr = clients.prs.create_pr(owner, repo, title, head, base, body)
     number = getattr(pr, "number", None)
@@ -200,6 +213,7 @@ def open_pr(
         number=number,
         html_url=html_url,
         skipped_binaries=tuple(skipped_binaries),
+        skipped_symlinks=tuple(skipped_symlinks),
     )
 
 

--- a/tests/test_executor_pr.py
+++ b/tests/test_executor_pr.py
@@ -196,18 +196,58 @@ def test_dot_and_empty_segments_rejected(tmp_path):
             open_pr(ws, REPORT, ISSUE, "o", "r", files_changed=(bad,), clients=_clients(), dry_run=False)
 
 
-def test_symlink_escape_is_rejected_not_exfiltrated(tmp_path):
+def test_symlink_is_skipped_not_crashed(tmp_path):
+    """#423 : un symlink légitime du diff (ex. `node_modules/.bin/*` après un
+    `npm install`) est SAUTÉ au lieu de faire planter toute la tâche ; le reste
+    du diff est poussé et le lien sauté est tracé (résultat + corps de PR)."""
+    ws = _workspace(tmp_path, {"code.py": "x = 1\n", "node_modules/acorn/bin/acorn": "#!/usr/bin/env node\n"})
+    bin_dir = Path(ws.path) / "node_modules" / ".bin"
+    bin_dir.mkdir(parents=True)
+    os.symlink(Path(ws.path) / "node_modules" / "acorn" / "bin" / "acorn", bin_dir / "acorn")
+    clients = _clients()
+    result = open_pr(
+        ws,
+        REPORT,
+        ISSUE,
+        "o",
+        "r",
+        files_changed=("code.py", "node_modules/.bin/acorn"),
+        clients=clients,
+        dry_run=False,
+    )
+    assert {p for p, _c, _b in clients.files.updated} == {"code.py"}
+    assert result.skipped_symlinks == ("node_modules/.bin/acorn",)
+    assert "node_modules/.bin/acorn" in clients.prs.created[0]["body"]
+
+
+def test_symlink_escape_is_skipped_never_read(tmp_path):
     # Un agent non fiable crée un symlink pointant un secret hôte hors workspace.
-    # open_pr doit REFUSER (ValueError) et ne jamais lire/pousser le secret.
+    # open_pr ne doit JAMAIS lire/pousser le secret : le lien est sauté (et la
+    # tâche n'échoue plus pour autant, cf. #423 — même politique que les binaires).
     secret = tmp_path / "host_secret.txt"
     secret.write_text("HOST PRIVATE KEY", encoding="utf-8")
     ws = _workspace(tmp_path, {"real.py": "x = 1\n"})
     os.symlink(secret, Path(ws.path) / "evil.py")
     clients = _clients()
-    with pytest.raises(ValueError):
-        open_pr(ws, REPORT, ISSUE, "o", "r", files_changed=("evil.py",), clients=clients, dry_run=False)
-    # le contenu du secret n'a JAMAIS été poussé
+    result = open_pr(ws, REPORT, ISSUE, "o", "r", files_changed=("real.py", "evil.py"), clients=clients, dry_run=False)
+    # le contenu du secret n'a JAMAIS été poussé ; le vrai code l'est.
     assert all("HOST PRIVATE KEY" not in content for _p, content, _b in clients.files.updated)
+    assert {p for p, _c, _b in clients.files.updated} == {"real.py"}
+    assert result.skipped_symlinks == ("evil.py",)
+
+
+def test_symlinked_dir_escape_still_rejected(tmp_path):
+    # Garde de confinement conservée : un répertoire INTERMÉDIAIRE symlinké vers
+    # l'hôte (le fichier terminal n'est pas un lien) reste une évasion → refus.
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("HOST PRIVATE KEY", encoding="utf-8")
+    ws = _workspace(tmp_path, {"real.py": "x = 1\n"})
+    os.symlink(outside, Path(ws.path) / "leak")
+    clients = _clients()
+    with pytest.raises(ValueError):
+        open_pr(ws, REPORT, ISSUE, "o", "r", files_changed=("leak/secret.txt",), clients=clients, dry_run=False)
+    assert clients.files.updated == []
 
 
 def test_title_is_inlined(tmp_path):


### PR DESCRIPTION
## Problème (#423)

`_resolve_in_workspace` levait `ValueError("symlink refusé…")` dès qu'un **fichier** du diff était un lien symbolique. Or un diff frontend parfaitement légitime en contient (`frontend/node_modules/.bin/acorn` après un `npm install`) → **toute la tâche échouait** et son code était perdu. Observé en run réel FacNor (round C, event `task_exception`).

## Correctif

Même politique que les binaires (#410/#416) : **sauter, ne pas planter**.

- `open_pr` saute tout fichier symlink **avant** résolution/lecture (le lien n'est **jamais lu**, donc jamais exfiltrable) ; tracé via `PrResult.skipped_symlinks` + note `> ⚠️` dans le corps de PR.
- `_resolve_in_workspace` conserve la garde de confinement `realpath` : un **répertoire intermédiaire** symlinké vers l'hôte (`dir → ~/.ssh`) reste refusé fail-closed (`ValueError`).

## Sécurité

- Avant : symlink → exception (rien poussé). Après : symlink → sauté (rien lu, rien poussé). La propriété « aucun contenu hors workspace ne part dans la PR » est préservée, testée par `test_symlink_escape_is_skipped_never_read` et `test_symlinked_dir_escape_still_rejected`.

## Tests

- `test_symlink_is_skipped_not_crashed` — cas réel node_modules/.bin : le code est poussé, le lien est sauté + tracé.
- `test_symlink_escape_is_skipped_never_read` — symlink vers un secret hôte : jamais lu/poussé.
- `test_symlinked_dir_escape_still_rejected` — l'évasion par répertoire symlinké lève toujours.
- Suite complète locale : verte (`pytest tests/`), `ruff check` + `ruff format --check` OK.

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)