### PR TITLE
fix(executor): le gate qualité installe les deps du projet avant pytest (issue #414)

### DIFF
--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -3,7 +3,9 @@
 Deux vérifications, **fail-closed** :
 
 1. **Tests** dans le :class:`~collegue.sandbox.executor.DockerSandbox` (C8) sur
-   l'arbre patché — du code non fiable ne tourne donc jamais sur l'hôte.
+   l'arbre patché — du code non fiable ne tourne donc jamais sur l'hôte. Les
+   dépendances déclarées du projet (``requirements.txt`` / ``pyproject.toml``)
+   sont installées dans le **même** conteneur avant ``pytest`` (#414).
 2. **Revue experte** via l'outil ``code_review`` existant (rôle LLM ``REVIEWER``),
    derrière un :class:`Reviewer` injectable (mocké en CI, réel en ``integration``).
 
@@ -34,6 +36,37 @@ from collegue.textnorm import inline
 # `from src.x import …`) lèvent `ModuleNotFoundError` à la collecte → le gate échoue
 # à tort (tests verts vus comme rouges). Voir issue #413.
 DEFAULT_TEST_COMMAND = "python -m pytest -q"
+# Note visible dans la sortie du gate quand l'installation des deps échoue (#414).
+_INSTALL_FAILED_NOTE = "[gate] installation des dépendances en échec — tests lancés quand même (#414)"
+
+
+def deps_install_prelude(workspace: str) -> Optional[str]:
+    """Préambule shell installant les dépendances du projet avant les tests (#414).
+
+    Le conteneur de tests est **éphémère** et distinct de celui où l'agent a
+    travaillé : sans installation, tout projet à dépendance tierce échoue en
+    ``ModuleNotFoundError`` (environnement incomplet, pas code faux) et le gate
+    refuse la PR à tort (cas réel FacNor : ``No module named 'jose'``).
+
+    Contraintes de conception :
+    - install et tests partagent le **même** conteneur : ``pip install --user``
+      écrit sous ``HOME=/tmp`` (tmpfs compatible rootfs read-only) qui **meurt avec
+      le conteneur** → on PRÉFIXE la commande de tests au lieu d'un run séparé ;
+    - échec d'install **toléré** (``|| echo``) : les tests tournent quand même
+      (comportement historique préservé, ex. sandbox sans réseau), mais la cause
+      reste visible dans la sortie du gate ;
+    - ``None`` si le workspace ne déclare aucune dépendance installable.
+    """
+    parts: List[str] = []
+    if os.path.isfile(os.path.join(workspace, "requirements.txt")):
+        parts.append("python -m pip install --user --no-cache-dir -q -r requirements.txt")
+    if os.path.isfile(os.path.join(workspace, "pyproject.toml")) or os.path.isfile(os.path.join(workspace, "setup.py")):
+        parts.append("python -m pip install --user --no-cache-dir -q -e .")
+    if not parts:
+        return None
+    return "; ".join(f"({part} || echo '{_INSTALL_FAILED_NOTE}')" for part in parts)
+
+
 # Triple-backtick de remplacement : neutralise les fences pour qu'un texte non
 # fiable ne puisse pas refermer le bloc de code et forger une fausse section.
 _FENCE = "```"
@@ -165,11 +198,14 @@ async def run_quality_gate(
     reviewer: Optional[Reviewer] = None,
     issue: Optional[IssueSpec] = None,
     test_command: str = DEFAULT_TEST_COMMAND,
+    install_deps: bool = True,
 ) -> QualityReport:
     """Exécute les tests (sandbox) + la revue (reviewer) sur un diff. Fail-closed.
 
     ``sandbox``/``reviewer`` sont injectables (mockés en CI). Tout échec ou
     indisponibilité ⇒ ``passed=False``. Les ``BaseException`` remontent.
+    ``install_deps`` (défaut vrai) : préfixe la commande de tests par l'installation
+    des dépendances déclarées du projet (cf. :func:`deps_install_prelude`, #414).
     """
     sandbox = sandbox or DockerSandbox()
     reviewer = reviewer or _default_reviewer()
@@ -177,7 +213,12 @@ async def run_quality_gate(
     # 1. Tests dans le sandbox. Une incapacité à les exécuter = non passé
     #    (fail-closed), pas une exception qui remonterait.
     try:
-        test_res = sandbox.run_tests(workspace, test_command)
+        command = test_command
+        if install_deps:
+            prelude = deps_install_prelude(workspace)
+            if prelude is not None:
+                command = f"{prelude}; {test_command}"
+        test_res = sandbox.run_tests(workspace, command)
         tests_passed = test_res.ok
         test_exit_code = test_res.exit_code
         test_output = "\n".join(part for part in (test_res.stdout, test_res.stderr) if part).strip()

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -83,6 +83,55 @@ async def test_default_test_command_invokes_pytest_as_module():
     assert command.startswith("python -m pytest"), f"commande de test inattendue: {command!r}"
 
 
+# --- installation des deps du projet (#414) --------------------------------------
+
+
+async def test_gate_installs_project_deps_before_tests(tmp_path):
+    """#414 : le conteneur de tests est éphémère → les deps déclarées du projet
+    sont installées AVANT pytest, dans la MÊME commande (même conteneur — un run
+    séparé perdrait l'install, `pip --user` écrivant sous /tmp tmpfs)."""
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    sandbox = _green()
+    await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    _ws, command = sandbox.calls[0]
+    assert "pip install --user --no-cache-dir -q -r requirements.txt" in command
+    assert command.index("pip install") < command.index("python -m pytest")
+
+
+async def test_gate_installs_editable_project_when_pyproject(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'x'\n", encoding="utf-8")
+    sandbox = _green()
+    await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    _ws, command = sandbox.calls[0]
+    assert "pip install --user --no-cache-dir -q -e ." in command
+
+
+async def test_gate_no_install_when_no_deps_declared(tmp_path):
+    sandbox = _green()
+    await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    _ws, command = sandbox.calls[0]
+    assert command == "python -m pytest -q"
+
+
+async def test_gate_install_failure_is_tolerated_in_command(tmp_path):
+    # L'échec d'install ne court-circuite pas les tests : chaque étape est
+    # encapsulée en `(... || echo ...)` — les tests tournent quand même et la
+    # cause reste visible dans la sortie du gate.
+    (tmp_path / "requirements.txt").write_text("x\n", encoding="utf-8")
+    sandbox = _green()
+    await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    _ws, command = sandbox.calls[0]
+    assert "|| echo" in command
+
+
+async def test_gate_install_deps_opt_out(tmp_path):
+    (tmp_path / "requirements.txt").write_text("x\n", encoding="utf-8")
+    sandbox = _green()
+    await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer(), install_deps=False)
+    _ws, command = sandbox.calls[0]
+    assert "pip install" not in command
+
+
 # --- fail-closed ----------------------------------------------------------------
 
 


### PR DESCRIPTION
## Problème (#414)

Le gate exécute les tests dans un conteneur **éphémère** (`docker run --rm`), séparé de celui où l'agent a travaillé : aucune étape n'installait les dépendances du projet. Tout projet à dépendance tierce échouait en `ModuleNotFoundError` (cas réel FacNor : `No module named 'jose'`) → `passed=False` → **aucune PR**, travail correct perdu.

## Correctif

`deps_install_prelude(workspace)` préfixe la commande de tests :

- `requirements.txt` présent → `python -m pip install --user --no-cache-dir -q -r requirements.txt`
- `pyproject.toml`/`setup.py` présent → `python -m pip install --user --no-cache-dir -q -e .`

Choix de conception (appris du run réel) :
- **Même conteneur** que les tests : `pip --user` écrit sous `HOME=/tmp` (tmpfs, compatible rootfs `--read-only`) qui **meurt avec le conteneur** — un `run_command` d'install séparé serait perdu. D'où le préfixe `install; pytest` plutôt que deux runs.
- **Échec d'install toléré** (`(… || echo '[gate] installation des dépendances en échec…')`) : sandbox sans réseau (`network="none"`) ou image sans pip → comportement historique préservé, et la cause survit dans `QualityReport.test_output` (visible dans le corps de PR).
- Opt-out : `run_quality_gate(..., install_deps=False)`.

Pré-requis réseau documenté : en run réel le runtime construit déjà `DockerSandbox(network="bridge")` (nécessaire à OpenHands) — l'install fonctionne donc sur le chemin réel.

## Tests

5 nouveaux tests (commande composée, ordre install→pytest, `-e .`, tolérance `|| echo`, opt-out, aucun préfixe sans deps déclarées) + suite locale verte, `ruff check`/`format --check` OK.

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)