### PR TITLE
fix(core): COLLEGUE_HOME ancré en chemin absolu + warning de durabilité du budget (issue #406)

### DIFF
--- a/collegue/core/paths.py
+++ b/collegue/core/paths.py
@@ -8,8 +8,15 @@ from pathlib import Path
 
 
 def collegue_home() -> Path:
-    """Répertoire racine des données persistantes (``$COLLEGUE_HOME`` ou ``.collegue``)."""
-    return Path(os.environ.get("COLLEGUE_HOME", ".collegue"))
+    """Répertoire racine des données persistantes (``$COLLEGUE_HOME`` ou ``.collegue``).
+
+    Résolu en chemin **absolu** dès l'appel (#406) : des consommateurs capturent ce
+    chemin tôt et une seule fois (ex. ``MetricsCollector._PERSIST_DIR`` à l'import) —
+    un chemin relatif dépendrait alors du cwd courant, et un ``chdir`` ultérieur du
+    process déplacerait silencieusement la persistance (le cumul coût/tokens du
+    plafond budget C4 repartirait de zéro). ``~`` est développé.
+    """
+    return Path(os.environ.get("COLLEGUE_HOME", ".collegue")).expanduser().resolve()
 
 
 def memory_dir() -> Path:

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -20,6 +20,7 @@ l'activerait au démarrage, et le serveur tourne ``OAUTH_ENABLED=false`` par dé
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import List, Optional
 
@@ -28,11 +29,39 @@ from collegue.pilot.driver import ProjectRunResult, run_project
 
 GITHUB_TOKEN_ENV = "GITHUB_TOKEN"
 
+logger = logging.getLogger(__name__)
+
 
 def _settings():
     from collegue.config import settings
 
     return settings
+
+
+def collegue_home_durability_warning(settings_obj=None) -> Optional[str]:
+    """Avertissement si le plafond ``$``/tokens n'est pas durable (#406), sinon ``None``.
+
+    Le cumul coût/tokens du ``MetricsCollector`` survit aux redémarrages via
+    ``$COLLEGUE_HOME/monitoring/metrics.json``. Si ``COLLEGUE_HOME`` n'est pas
+    défini en chemin **absolu** (défaut : ``.collegue`` relatif au cwd), un
+    redémarrage depuis un autre répertoire relit un cumul **vide** : le plafond
+    dur (``MAX_COST_USD``/``MAX_TOKENS_BUDGET``) se réinitialise silencieusement.
+    On n'avertit que si un plafond dur est configuré (sinon rien à perdre).
+    """
+    settings_obj = settings_obj or _settings()
+    max_cost = float(getattr(settings_obj, "MAX_COST_USD", 0) or 0)
+    max_tokens = int(getattr(settings_obj, "MAX_TOKENS_BUDGET", 0) or 0)
+    if max_cost <= 0 and max_tokens <= 0:
+        return None
+    raw = os.environ.get("COLLEGUE_HOME", "")
+    if raw and os.path.isabs(os.path.expanduser(raw)):
+        return None
+    return (
+        "Budget dur configuré (MAX_COST_USD/MAX_TOKENS_BUDGET) mais COLLEGUE_HOME "
+        f"{'non défini' if not raw else f'relatif ({raw!r})'} : le cumul coût/tokens est ancré sur le cwd "
+        "du process — un redémarrage depuis un autre répertoire réinitialiserait le plafond. "
+        "Définir COLLEGUE_HOME en chemin ABSOLU et stable pour un run long (cf. #406)."
+    )
 
 
 # ── construction des dépendances réelles (integration) ─────────────────────────
@@ -107,6 +136,9 @@ async def run_project_from_settings(
     restant une fois le MVP construit (off par défaut ; activable via ``--improve``).
     """
     settings_obj = settings_obj or _settings()
+    durability = collegue_home_durability_warning(settings_obj)
+    if durability:
+        logger.warning(durability)
     manager = manager or _build_manager(settings_obj)
     sandbox = sandbox or _build_sandbox(settings_obj)
     agent = agent or _build_agent(sandbox, settings_obj)

--- a/docs/moteur_autonome.md
+++ b/docs/moteur_autonome.md
@@ -102,8 +102,13 @@ Un run de plusieurs jours peut **reprendre après un crash sans perte d'état** 
   mur reste **fixe** au lieu de glisser à chaque redémarrage.
 
 > Pour que le plafond `$`/tokens survive aussi aux redémarrages, `COLLEGUE_HOME` doit
-> pointer vers un chemin **absolu et stable** (le cumul est persisté dans
-> `$COLLEGUE_HOME/monitoring/`).
+> pointer vers un chemin **absolu et stable**, identique d'un redémarrage à l'autre
+> (le cumul est persisté dans `$COLLEGUE_HOME/monitoring/`). Le chemin est résolu en
+> absolu dès l'import (#406) — un `chdir` du process en cours de run ne déplace donc
+> plus la persistance — mais si la variable est laissée relative (défaut `.collegue`),
+> deux redémarrages depuis des répertoires différents liront deux cumuls distincts :
+> le pilote **avertit** au lancement quand un budget dur est configuré avec un
+> `COLLEGUE_HOME` non absolu.
 
 ---
 

--- a/tests/test_core_paths.py
+++ b/tests/test_core_paths.py
@@ -1,0 +1,50 @@
+"""Tests #406 : ``COLLEGUE_HOME`` ancré en chemin absolu (durabilité du plafond budget).
+
+Le cumul coût/tokens (``MetricsCollector``) est persisté sous
+``$COLLEGUE_HOME/monitoring/`` et le chemin est capturé TÔT (attribut de classe à
+l'import) : s'il restait relatif, un ``chdir`` du process déplacerait la
+persistance et le plafond dur repartirait de zéro, silencieusement.
+"""
+
+from pathlib import Path
+
+from collegue.core.paths import collegue_home, memory_dir, monitoring_dir
+
+
+def test_collegue_home_default_is_absolute(monkeypatch, tmp_path):
+    monkeypatch.delenv("COLLEGUE_HOME", raising=False)
+    monkeypatch.chdir(tmp_path)
+    home = collegue_home()
+    assert home.is_absolute()
+    assert home == tmp_path / ".collegue"
+
+
+def test_collegue_home_relative_env_resolved_against_cwd(monkeypatch, tmp_path):
+    monkeypatch.setenv("COLLEGUE_HOME", "data/colhome")
+    monkeypatch.chdir(tmp_path)
+    assert collegue_home() == (tmp_path / "data" / "colhome").resolve()
+
+
+def test_collegue_home_expanduser(monkeypatch):
+    monkeypatch.setenv("COLLEGUE_HOME", "~/colhome-406")
+    assert collegue_home() == Path.home() / "colhome-406"
+
+
+def test_subdirs_under_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("COLLEGUE_HOME", str(tmp_path))
+    assert monitoring_dir() == tmp_path / "monitoring"
+    assert memory_dir() == tmp_path / "memory"
+
+
+def test_captured_path_survives_cwd_change(monkeypatch, tmp_path):
+    """#406 (critère d'acceptation) : un consommateur qui capture le chemin une
+    fois (façon ``MetricsCollector._PERSIST_DIR`` à l'import) obtient un chemin
+    absolu — un ``chdir`` ultérieur du process ne déplace plus la persistance."""
+    monkeypatch.delenv("COLLEGUE_HOME", raising=False)
+    monkeypatch.chdir(tmp_path)
+    captured = monitoring_dir()  # capture précoce, comme à l'import
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+    assert captured == tmp_path / ".collegue" / "monitoring"
+    assert monitoring_dir() == elsewhere / ".collegue" / "monitoring"  # nouvel appel = nouveau cwd

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -10,6 +10,7 @@ import pytest
 from collegue.executor import FakeCodeAgent, FakeReviewer, PrClients
 from collegue.pilot import ProjectRunResult, TaskOutcome, format_run_report, run_project_from_settings
 from collegue.pilot.__main__ import build_parser
+from collegue.pilot.runtime import collegue_home_durability_warning
 from collegue.sandbox import SandboxResult
 from collegue.state import ProjectStateManager
 
@@ -145,6 +146,31 @@ def test_format_run_report_no_prs_and_no_budget():
     assert "PRs ouvertes : (aucune)" in report
     assert "Statut projet : (inchangé)" in report
     assert "Budget-temps restant : n/a" in report
+
+
+# --- durabilité du plafond budget (#406) ------------------------------------------
+
+
+def test_home_durability_warns_on_relative_home_with_hard_budget(monkeypatch):
+    monkeypatch.delenv("COLLEGUE_HOME", raising=False)
+    s = SimpleNamespace(MAX_COST_USD=5.0, MAX_TOKENS_BUDGET=0)
+    msg = collegue_home_durability_warning(s)
+    assert msg is not None and "COLLEGUE_HOME" in msg
+    monkeypatch.setenv("COLLEGUE_HOME", "rel/.collegue")  # relatif explicite → idem
+    assert collegue_home_durability_warning(s) is not None
+
+
+def test_home_durability_silent_when_absolute_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("COLLEGUE_HOME", str(tmp_path))
+    s = SimpleNamespace(MAX_COST_USD=0.0, MAX_TOKENS_BUDGET=100_000)
+    assert collegue_home_durability_warning(s) is None
+
+
+def test_home_durability_silent_without_hard_budget(monkeypatch):
+    # Pas de plafond dur configuré → rien à perdre, pas de bruit.
+    monkeypatch.delenv("COLLEGUE_HOME", raising=False)
+    s = SimpleNamespace(MAX_COST_USD=0.0, MAX_TOKENS_BUDGET=0)
+    assert collegue_home_durability_warning(s) is None
 
 
 # --- CLI parser -----------------------------------------------------------------


### PR DESCRIPTION
## Problème (#406)

Le plafond budget dur (`MAX_COST_USD`/`MAX_TOKENS_BUDGET`) survit aux redémarrages **uniquement** via `$COLLEGUE_HOME/monitoring/metrics.json`. Or `COLLEGUE_HOME` était résolu **relatif** (`.collegue` par défaut) et capturé à l'import (`MetricsCollector._PERSIST_DIR`) : un process repris avec un cwd différent repartait d'un cumul **vide** → plafond dur silencieusement réinitialisé sur un run de plusieurs jours.

## Correctif

- `collegue_home()` retourne un chemin **absolu** (`expanduser().resolve()`) dès l'appel → la capture précoce à l'import est stable, un `chdir` du process ne déplace plus la persistance.
- `collegue_home_durability_warning()` (runtime pilote) : **avertissement explicite** au lancement d'un run si un budget dur est configuré avec `COLLEGUE_HOME` absent/relatif (deux redémarrages depuis des cwd différents = deux cumuls distincts). Appelé par `run_project_from_settings`.
- Doc exploitation (`docs/moteur_autonome.md`) mise à jour.

## Critères d'acceptation de l'issue

- [x] Chemin résolu en absolu ; test `test_captured_path_survives_cwd_change` (capture → `chdir` → chemin inchangé).
- [x] Avertissement clair si `COLLEGUE_HOME` relatif + budget dur actif (3 tests : warn relatif/absent, silencieux si absolu, silencieux sans budget).
- [x] Doc exploitation mise à jour ; défaut dev local inchangé (`.collegue` ancré au cwd de démarrage).

Tests impactés vérifiés en local : `test_monitoring_metrics`, `test_project_memory`, `test_pilot_budget/resume/runtime` + nouveaux `tests/test_core_paths.py` — tous verts ; `ruff check`/`format` OK.

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)