### PR TITLE
feat(executor): régulation du canal coder OpenHands — retries propagés + back-pressure (issue #422)

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -90,6 +90,19 @@ class Settings(BaseSettings):
     LLM_RATE_LIMIT_PER_MINUTE: int = 15
     LLM_RATE_LIMIT_PER_DAY: int = 500
 
+    # --- Canal LLM du coder OpenHands (#422) ---
+    # Le coder appelle le modèle DIRECTEMENT (LiteLLM dans le sandbox), hors de
+    # portée du rate-limiter et des retries des clients du moteur. À défaut d'un
+    # proxy partagé, le moteur (1) PROPAGE une politique retries/backoff au worker
+    # (env LLM_NUM_RETRIES / LLM_RETRY_MIN_WAIT / LLM_RETRY_MAX_WAIT, lus par la
+    # config OpenHands) pour absorber les fenêtres 503 « high demand », et
+    # (2) peut ESPACER les lancements coder (back-pressure start-to-start) pour
+    # lisser le débit sur le quota fournisseur partagé. 0 = pas d'espacement.
+    CODER_LLM_NUM_RETRIES: int = 8
+    CODER_LLM_RETRY_MIN_WAIT: int = 8
+    CODER_LLM_RETRY_MAX_WAIT: int = 90
+    CODER_MIN_INTERVAL_SECONDS: float = 0.0
+
     # --- Budget DUR global (coût $ / tokens) + auto-pause (garde-fou brief §6) ---
     # Plafond DUR sur la dépense cumulée, distinct du rate limiter (fréquence) et
     # des quotas per-session (collegue.tools.quotas). Quand le coût cumulé atteint

--- a/collegue/executor/openhands_agent.py
+++ b/collegue/executor/openhands_agent.py
@@ -23,6 +23,8 @@ Pré-requis d'une exécution réelle (différés, integration) :
 
 from __future__ import annotations
 
+import math
+import time
 from typing import List, Optional, Tuple
 
 from collegue.core.llm.roles import LLMRole, resolve_role
@@ -30,6 +32,21 @@ from collegue.executor.agent import AgentResult, IssueSpec
 
 # Point d'entrée headless d'OpenHands (module exécuté dans le conteneur sandbox).
 OPENHANDS_ENTRYPOINT = "openhands.core.main"
+
+# Politique retries/backoff par défaut du canal coder (#422) — alignée sur les
+# settings ``CODER_LLM_*`` de ``collegue.config``.
+DEFAULT_CODER_NUM_RETRIES = 8
+DEFAULT_CODER_RETRY_MIN_WAIT = 8
+DEFAULT_CODER_RETRY_MAX_WAIT = 90
+
+
+def _int_setting(settings_obj, name: str, default: int) -> int:
+    """Lit un entier de settings, robuste (None/str/invalide/négatif → défaut)."""
+    try:
+        value = int(getattr(settings_obj, name, default))
+    except (TypeError, ValueError):
+        return default
+    return value if value >= 0 else default
 
 
 class OpenHandsAgent:
@@ -48,12 +65,62 @@ class OpenHandsAgent:
         settings_obj: Optional[object] = None,
         entrypoint: str = OPENHANDS_ENTRYPOINT,
         python_bin: str = "python",
+        clock=time.monotonic,
+        sleep=time.sleep,
     ):
         self._sandbox = sandbox
         self._role = role
         self._settings = settings_obj
         self._entrypoint = entrypoint
         self._python_bin = python_bin
+        # Back-pressure du canal coder (#422) : horloge/sleep injectables (tests).
+        self._clock = clock
+        self._sleep = sleep
+        self._last_launch: Optional[float] = None
+
+    def _resolved_settings(self):
+        if self._settings is not None:
+            return self._settings
+        from collegue.config import settings
+
+        return settings
+
+    def retry_policy(self) -> Tuple[int, int, int]:
+        """``(num_retries, retry_min_wait, retry_max_wait)`` du canal coder (#422).
+
+        Le moteur n'intercepte pas les appels LiteLLM faits DANS le sandbox : la
+        seule régulation possible est de propager une politique de retries/backoff
+        au worker OpenHands (qui la lit via l'environnement ``LLM_*``).
+        """
+        s = self._resolved_settings()
+        return (
+            _int_setting(s, "CODER_LLM_NUM_RETRIES", DEFAULT_CODER_NUM_RETRIES),
+            _int_setting(s, "CODER_LLM_RETRY_MIN_WAIT", DEFAULT_CODER_RETRY_MIN_WAIT),
+            _int_setting(s, "CODER_LLM_RETRY_MAX_WAIT", DEFAULT_CODER_RETRY_MAX_WAIT),
+        )
+
+    def min_interval_seconds(self) -> float:
+        """Espacement minimal (s) entre deux lancements coder (0 = désactivé)."""
+        try:
+            value = float(getattr(self._resolved_settings(), "CODER_MIN_INTERVAL_SECONDS", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            return 0.0
+        return value if math.isfinite(value) and value > 0 else 0.0
+
+    def _respect_min_interval(self) -> float:
+        """Back-pressure start-to-start (#422) : attend s'il le faut, renvoie l'attente.
+
+        Protège le quota fournisseur partagé contre des lancements coder en rafale
+        (ex. retries de tâche pendant une fenêtre 503) sans toucher au sandbox.
+        """
+        interval = self.min_interval_seconds()
+        if interval <= 0 or self._last_launch is None:
+            return 0.0
+        remaining = interval - (self._clock() - self._last_launch)
+        if remaining > 0:
+            self._sleep(remaining)
+            return remaining
+        return 0.0
 
     def resolved_model(self) -> Tuple[str, str]:
         """Retourne ``(provider, model)`` pour le rôle de cet agent (défaut CODER).
@@ -70,12 +137,17 @@ class OpenHandsAgent:
         clé API reste hors argv (injectée par le sandbox à l'exécution réelle). La
         consigne est ``issue.to_prompt()`` (déjà sanitizée contre l'injection).
         On passe un **argv** (pas de ``sh -c``) : aucun risque d'injection shell via
-        le texte de l'issue.
+        le texte de l'issue. La politique retries/backoff du canal coder (#422,
+        non secrète) est propagée via l'environnement ``LLM_*`` d'OpenHands.
         """
         _provider, model = self.resolved_model()
+        num_retries, retry_min, retry_max = self.retry_policy()
         return [
             "env",
             f"LLM_MODEL={model}",
+            f"LLM_NUM_RETRIES={num_retries}",
+            f"LLM_RETRY_MIN_WAIT={retry_min}",
+            f"LLM_RETRY_MAX_WAIT={retry_max}",
             self._python_bin,
             "-m",
             self._entrypoint,
@@ -87,8 +159,11 @@ class OpenHandsAgent:
         """Lance OpenHands dans le sandbox sur ``workspace`` pour ``issue``.
 
         Le diff autoritatif est capturé par l'exécuteur (E2) ; ici on ne renvoie que
-        le statut (code de sortie du sandbox) et les logs.
+        le statut (code de sortie du sandbox) et les logs. Les lancements sont
+        espacés de ``CODER_MIN_INTERVAL_SECONDS`` (back-pressure, #422).
         """
+        self._respect_min_interval()
+        self._last_launch = self._clock()
         result = self._sandbox.run_command(self.build_command(issue), workspace)
         logs = "\n".join(part for part in (result.stdout, result.stderr) if part).strip()
         return AgentResult(

--- a/tests/test_executor_agent.py
+++ b/tests/test_executor_agent.py
@@ -145,6 +145,64 @@ def test_openhands_build_command_carries_task_and_model_not_secret():
     assert not any("API_KEY" in part for part in argv)
 
 
+def test_openhands_build_command_propagates_coder_retry_policy():
+    """#422 : le moteur ne peut pas intercepter les appels LiteLLM du sandbox —
+    il PROPAGE donc la politique retries/backoff au worker via l'env OpenHands."""
+    agent = OpenHandsAgent(
+        sandbox=object(),
+        settings_obj=_settings(CODER_LLM_NUM_RETRIES=5, CODER_LLM_RETRY_MIN_WAIT=10, CODER_LLM_RETRY_MAX_WAIT=60),
+    )
+    argv = agent.build_command(IssueSpec(number=9, title="T"))
+    assert "LLM_NUM_RETRIES=5" in argv
+    assert "LLM_RETRY_MIN_WAIT=10" in argv
+    assert "LLM_RETRY_MAX_WAIT=60" in argv
+    # L'env précède l'entrypoint python (consommé par `env`).
+    assert argv.index("LLM_NUM_RETRIES=5") < argv.index("-m")
+
+
+def test_openhands_retry_policy_defaults_and_robustness():
+    # Sans settings dédiés → défauts ; valeurs invalides/négatives → défauts.
+    assert OpenHandsAgent(sandbox=object(), settings_obj=_settings()).retry_policy() == (8, 8, 90)
+    agent = OpenHandsAgent(
+        sandbox=object(),
+        settings_obj=_settings(CODER_LLM_NUM_RETRIES="n/a", CODER_LLM_RETRY_MIN_WAIT=-3),
+    )
+    assert agent.retry_policy() == (8, 8, 90)
+
+
+def test_openhands_min_interval_paces_consecutive_launches():
+    """#422 : back-pressure start-to-start — deux lancements coder rapprochés sont
+    espacés de CODER_MIN_INTERVAL_SECONDS (lisse le débit sur le quota partagé)."""
+    sandbox = _FakeSandbox(SandboxResult(exit_code=0, stdout="ok", stderr=""))
+    waits = []
+    fake_now = [100.0]
+    agent = OpenHandsAgent(
+        sandbox=sandbox,
+        settings_obj=_settings(CODER_MIN_INTERVAL_SECONDS=30.0),
+        clock=lambda: fake_now[0],
+        sleep=waits.append,
+    )
+    issue = IssueSpec(number=1, title="T")
+    agent.implement_issue("/work", issue)
+    assert waits == []  # premier lancement : aucun délai
+    fake_now[0] = 112.0  # 12s plus tard → il manque 18s
+    agent.implement_issue("/work", issue)
+    assert waits == [18.0]
+    fake_now[0] = 200.0  # bien après l'intervalle → pas d'attente
+    agent.implement_issue("/work", issue)
+    assert waits == [18.0]
+
+
+def test_openhands_min_interval_disabled_by_default():
+    sandbox = _FakeSandbox(SandboxResult(exit_code=0, stdout="ok", stderr=""))
+    waits = []
+    agent = OpenHandsAgent(sandbox=sandbox, settings_obj=_settings(), clock=lambda: 0.0, sleep=waits.append)
+    issue = IssueSpec(number=1, title="T")
+    agent.implement_issue("/work", issue)
+    agent.implement_issue("/work", issue)
+    assert waits == []  # 0 (défaut) = pas d'espacement
+
+
 class _FakeSandbox:
     """Sandbox factice : enregistre l'argv et renvoie un SandboxResult canné."""
 


### PR DESCRIPTION
## Problème (#422)

Le coder OpenHands appelle le modèle **directement via LiteLLM depuis le sandbox**, hors de portée du rate-limiter et des retries des clients du moteur (`tools/clients/base.py` ne couvre que planner/reviewer). Une fenêtre 503 « high demand » n'était amortie par rien côté moteur — cause directe des no-op (`changed=false`) des tâches 1-2 du run réel FacNor.

## Correctif (option « à défaut » de l'issue, le proxy partagé restant différé)

1. **Propagation de la politique retries/backoff au worker** : `build_command` ajoute `LLM_NUM_RETRIES` / `LLM_RETRY_MIN_WAIT` / `LLM_RETRY_MAX_WAIT` (noms de config OpenHands) à l'env du conteneur — pilotés par les nouveaux settings `CODER_LLM_NUM_RETRIES`/`CODER_LLM_RETRY_MIN_WAIT`/`CODER_LLM_RETRY_MAX_WAIT` (défauts 8/8/90, valeurs invalides/négatives → défauts). Valeurs **non secrètes** uniquement (la clé API reste hors argv, inchangé).
2. **Back-pressure côté moteur** : `implement_issue` espace les lancements coder de `CODER_MIN_INTERVAL_SECONDS` (start-to-start, **0 = off par défaut** → aucun changement de comportement sans opt-in). Lisse le débit sur le quota fournisseur partagé, notamment quand le retry de tâche (#420) relance en rafale pendant une fenêtre 503.

Horloge/sleep injectables → tests déterministes sans temps réel.

## Tests

- `test_openhands_build_command_propagates_coder_retry_policy` (env présent, avant `-m`)
- `test_openhands_retry_policy_defaults_and_robustness` (défauts + robustesse aux valeurs invalides)
- `test_openhands_min_interval_paces_consecutive_launches` (1er lancement sans délai, 2e espacé de l'écart manquant exact, lancement tardif sans attente)
- `test_openhands_min_interval_disabled_by_default`
- Suites `test_executor_agent`/`test_pilot_runtime`/`test_executor_pipeline` vertes, `ruff check`/`format` OK.

Complète le retry au niveau tâche (#420, PR séparée) pour absorber les 503 résiduels.

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)