### PR TITLE
ci: workflow nightly « integration » — Postgres + DockerSandbox réels, LLM gaté par secrets (issue #404)

### DIFF
--- a/.github/workflows/integration-nightly.yml
+++ b/.github/workflows/integration-nightly.yml
@@ -1,0 +1,153 @@
+# CI nightly « integration » (#404) : exécute les chemins RÉELS exclus de la CI PR
+# (pytest est configuré avec addopts `-m 'not integration'` → on l'override ici).
+#
+# Ce que ce workflow exerce réellement, sans secret :
+#   - les variantes PostgreSQL de l'état durable (service container, STATE_DATABASE_URL)
+#   - le DockerSandbox réel (isolation FS hôte, persistance) sur python:3.12-slim
+# Et avec secrets (chiffrés, jamais en clair dans le dépôt) :
+#   - les tests LLM réels (INTEGRATION_LLM_API_KEY), sous budget DUR borné
+#   - Sentry/GitHub réels si fournis (sinon les tests se skippent proprement)
+#
+# Les tests `integration` skippent quand un prérequis manque : le rapport liste
+# les skips (-rs) et l'étape « Bilan » échoue si TOUT a été skippé (un nightly
+# vert par vacuité serait une fausse assurance).
+
+name: Integration (nightly)
+
+on:
+  schedule:
+    - cron: "17 3 * * *" # 03:17 UTC chaque nuit (heure creuse, évite :00 surchargés)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write # notification d'échec (issue de suivi)
+
+concurrency:
+  group: integration-nightly
+  cancel-in-progress: false
+
+jobs:
+  integration:
+    name: Pytest -m integration (réel)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: collegue
+          POSTGRES_PASSWORD: collegue
+          POSTGRES_DB: collegue_state
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U collegue"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    env:
+      # État durable : variante PostgreSQL réelle (test_project_state / test_checkpoints).
+      STATE_DATABASE_URL: postgresql+psycopg2://collegue:collegue@localhost:5432/collegue_state
+      # Sandbox Docker réel : image légère publique (pullée ci-dessous).
+      SANDBOX_TEST_IMAGE: python:3.12-slim
+      # Secrets chiffrés (Settings → Secrets and variables → Actions). Absent = les
+      # tests correspondants se skippent — JAMAIS de clé en clair dans le dépôt.
+      LLM_API_KEY: ${{ secrets.INTEGRATION_LLM_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.INTEGRATION_LLM_API_KEY }}
+      GITHUB_TOKEN: ${{ secrets.INTEGRATION_GITHUB_TOKEN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.INTEGRATION_SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.INTEGRATION_SENTRY_ORG }}
+      # Budget DUR : borne le coût d'un nightly même si un test LLM s'emballe.
+      MAX_COST_USD: "2.0"
+      MAX_TOKENS_BUDGET: "2000000"
+      COLLEGUE_RUN_DEADLINE_SECONDS: "1800"
+      # Persistance ancrée (cf. #406) : chemin absolu et stable pour le job.
+      COLLEGUE_HOME: /tmp/collegue-home
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Pull sandbox test image
+        run: docker pull "$SANDBOX_TEST_IMAGE"
+
+      - name: Run integration suite
+        id: pytest
+        env:
+          PYTHONPATH: .
+        # --override-ini neutralise l'addopts `-m 'not integration'` du pyproject ;
+        # -rs liste chaque skip avec sa raison (lisible dans le log du run).
+        run: |
+          pytest tests/ -m integration --override-ini="addopts=" -rs -v \
+            --junitxml=integration-report.xml | tee pytest-integration.log
+
+      - name: Bilan — refuser un nightly « vert par vacuité »
+        if: always()
+        run: |
+          if [ ! -f pytest-integration.log ]; then
+            echo "::error::Aucun log pytest — le run n'a pas démarré."; exit 1
+          fi
+          summary=$(tail -n 3 pytest-integration.log)
+          echo "Résumé : $summary"
+          if echo "$summary" | grep -qE "[1-9][0-9]* (passed|failed|error)"; then
+            echo "Au moins un test integration a tourné."
+          else
+            echo "::error::Tous les tests integration ont été skippés (aucun exercé) — vérifier services/secrets."
+            exit 1
+          fi
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-report
+          path: |
+            integration-report.xml
+            pytest-integration.log
+
+      - name: Notifier l'échec (issue de suivi)
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = "CI nightly integration en échec";
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `Le run nightly integration a échoué : ${runUrl}\n\n_(notification automatique du workflow integration-nightly — #404)_`;
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              per_page: 100,
+            });
+            const existing = issues.find((i) => i.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+              });
+            }

--- a/docs/moteur_autonome.md
+++ b/docs/moteur_autonome.md
@@ -177,3 +177,31 @@ lit :
 python -m pytest -m "not integration" -q   # CI (par défaut)
 python -m pytest -m integration -q          # chemins réels (credentials requis)
 ```
+
+### CI nightly « integration » (#404)
+
+Le workflow [`integration-nightly.yml`](../.github/workflows/integration-nightly.yml)
+exécute chaque nuit (03:17 UTC, ou à la demande via *Run workflow*) la suite
+`pytest -m integration` que la CI PR exclut :
+
+| Chemin réel exercé | Pré-requis | Fourni par |
+|--------------------|------------|------------|
+| État durable **PostgreSQL** (checkpoints, reprise) | `STATE_DATABASE_URL` | service container `postgres:16` (aucun secret) |
+| **DockerSandbox** réel (isolation FS, persistance, kill au timeout) | Docker + image | runner GitHub + `python:3.12-slim` |
+| Appels **LLM réels** (chaînes de délégation…) | clé API | secret `INTEGRATION_LLM_API_KEY` |
+| Sentry / GitHub réels | tokens | secrets `INTEGRATION_SENTRY_AUTH_TOKEN`, `INTEGRATION_SENTRY_ORG`, `INTEGRATION_GITHUB_TOKEN` |
+
+**Secrets** (Settings → Secrets and variables → Actions) — tous **optionnels** : un
+test dont le pré-requis manque se **skippe** avec sa raison (`-rs`). Garde-fou
+anti-vacuité : si *tous* les tests ont été skippés, le job **échoue** (un nightly
+vert qui n'a rien exercé serait une fausse assurance). Les coûts LLM sont bornés
+par le budget dur (`MAX_COST_USD=2`, `MAX_TOKENS_BUDGET=2M`, deadline 30 min) —
+coût attendu par run : ~0 à 2 $ selon les secrets fournis.
+
+En cas d'échec, le workflow ouvre (ou commente) une issue **« CI nightly
+integration en échec »** avec le lien du run — la CI PR normale n'est jamais
+bloquée par le nightly.
+
+> Étape suivante (suivi #404) : un smoke **end-to-end** réel (plan → `--execute`
+> sur un dépôt fixture → PR ouverte puis nettoyée). Il exige une image sandbox
+> embarquant OpenHands, que le dépôt ne fournit pas encore.


### PR DESCRIPTION
## Problème (#404)

Toute la suite `integration` est exclue de la CI (`addopts -m 'not integration'`) : les chemins **réels** (Docker, Postgres, LLM, GitHub) ne sont jamais vérifiés — les régressions d'intégration passeraient inaperçues.

## Livré

`.github/workflows/integration-nightly.yml` — `schedule` (03:17 UTC) + `workflow_dispatch` :

- **Postgres réel** via service container `postgres:16` → exerce `test_project_state`/`test_checkpoints` (variantes PG de l'état durable) **sans aucun secret**.
- **DockerSandbox réel** sur `python:3.12-slim` (`SANDBOX_TEST_IMAGE`) → isolation FS hôte, persistance, kill au timeout.
- **LLM/Sentry/GitHub réels** si les secrets `INTEGRATION_LLM_API_KEY` / `INTEGRATION_SENTRY_*` / `INTEGRATION_GITHUB_TOKEN` sont configurés (jamais en clair — critère d'acceptation de l'issue) ; sinon les tests se **skippent** avec raison visible (`-rs`).
- **Budget borné** : `MAX_COST_USD=2`, `MAX_TOKENS_BUDGET=2M`, deadline 30 min, job timeout 45 min, `COLLEGUE_HOME` absolu (cf. #406).
- **Garde anti-vacuité** : si *tous* les tests ont été skippés, le job **échoue** — un nightly « vert » qui n'a rien exercé est une fausse assurance.
- **Notification** : en échec, ouvre/commente l'issue « CI nightly integration en échec » avec le lien du run ; la CI PR normale n'est jamais bloquée.
- **Artefacts** : rapport JUnit + log pytest. **Doc** : section dédiée dans `docs/moteur_autonome.md` (secrets, coût attendu ~0–2 $/run).

## Critères d'acceptation

- [x] Workflow nightly `pytest -m integration` avec credentials chiffrés (jamais en clair)
- [x] Budget/quotas bornés ; échec → notification (issue), pas de blocage de la CI PR
- [x] Doc : comment fournir les secrets, coût attendu par run
- [ ] Smoke end-to-end réel (plan→`--execute`→PR sur dépôt fixture, auto-nettoyant) — **suivi** : exige une image sandbox embarquant OpenHands, que le dépôt ne fournit pas encore (commenté sur l'issue).

Refs #404 (je laisse l'issue ouverte pour le smoke e2e restant — commentaire posté)

🤖 Generated with [Claude Code](https://claude.com/claude-code)