### PR TITLE
feat(executor,pilot): raison d'échec différenciée (no_op/agent_error/gate_failed) + logs agent journalisés (issue #421)

### DIFF
--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -43,6 +43,21 @@ STAGE_RUN = "run"  # exécution de l'agent (diff)
 STAGE_GATE = "gate"  # gate qualité (tests + revue)
 STAGE_PR = "pr"  # ouverture de PR
 
+# Raisons d'échec portées par l'outcome (#421). Un ``success=False`` indifférencié
+# rendait le no-op de l'agent (souvent transitoire, ex. fenêtre 503 du provider)
+# indiscernable d'un vrai échec : ni retry intelligent, ni post-mortem possibles.
+REASON_NO_OP = "no_op"  # l'agent a tourné sans erreur mais n'a produit AUCUN diff
+REASON_AGENT_ERROR = "agent_error"  # le process agent a échoué (exit ≠ 0 / timeout)
+REASON_GATE_FAILED = "gate_failed"  # tests rouges ou revue bloquante
+
+
+def log_tail(text: str, limit: int = 2000) -> str:
+    """Dernier segment (borné) d'un log — journalisable sans inonder l'audit (#421)."""
+    text = (text or "").strip()
+    if len(text) <= limit:
+        return text
+    return "…" + text[-limit:]
+
 
 @dataclass
 class ExecutionOutcome:
@@ -55,6 +70,7 @@ class ExecutionOutcome:
     quality_report: Optional[QualityReport] = None
     pr: Optional[PrResult] = None
     final_status: Optional[str] = None  # statut de tâche effectivement écrit (None si dry_run / pas de manager)
+    reason: Optional[str] = None  # raison d'échec (no_op | agent_error | gate_failed), None si succès
 
 
 def _set_status(manager, task_id, status: str, *, enabled: bool) -> Optional[str]:
@@ -99,12 +115,16 @@ async def execute_issue(
     # E2 : exécution de l'agent + capture du diff (l'état est piloté ici, pas par run_issue).
     execution = run_issue(agent, workspace, issue, runner=runner)
     if not execution.changed:
+        # #421 : distinguer le no-op (agent OK, zéro diff — souvent transitoire)
+        # de l'erreur du process agent (exit ≠ 0) — la couche retry en dépend.
+        reason = REASON_NO_OP if execution.agent_result.success else REASON_AGENT_ERROR
         return ExecutionOutcome(
             success=False,
             stage=STAGE_RUN,
             workspace=workspace,
             execution=execution,
             final_status=final_status,
+            reason=reason,
         )
 
     # E3 : gate qualité (fail-closed).
@@ -119,6 +139,7 @@ async def execute_issue(
             execution=execution,
             quality_report=report,
             final_status=final_status,
+            reason=REASON_GATE_FAILED,
         )
 
     # E4 : ouverture de PR (dry_run respecté).

--- a/collegue/pilot/audit.py
+++ b/collegue/pilot/audit.py
@@ -25,6 +25,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 CostSource = Callable[[], Tuple[float, int]]
 
 TASK_STARTED = "task_started"
+TASK_FAILED = "task_failed"  # échec d'une tâche, avec raison + extrait de logs (#421)
 DIFF_PRODUCED = "diff_produced"
 GATE_DECISION = "gate_decision"
 PR_OPENED = "pr_opened"

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -22,17 +22,19 @@ Module **isolé** : non importé par ``app.py`` (F4 câblera).
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import List, Optional
 
 from collegue.executor.agent import IssueSpec
-from collegue.executor.pipeline import execute_issue
+from collegue.executor.pipeline import execute_issue, log_tail
 from collegue.pilot.audit import (
     BUDGET_EVENT,
     CHECKPOINT_SAVED,
     GATE_DECISION,
     PR_OPENED,
     RUN_STOP,
+    TASK_FAILED,
     TASK_STARTED,
     CostSource,
     NullAuditLog,
@@ -55,6 +57,8 @@ STOP_PAUSED_BUDGET = "paused_budget"
 STOP_DEADLINE = "deadline_reached"
 STOP_BLOCKED = "blocked"  # graphe coincé (dépendance échouée)
 STOP_SAFETY_CAP = "safety_cap"  # garde-fou anti-boucle
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -236,7 +240,32 @@ async def run_project(
             audit.record_cost(usd=cur_usd - last_usd, tokens=int(cur_tokens - last_tokens), iteration=iteration)
             last_usd, last_tokens = cur_usd, cur_tokens
         pr_number = outcome.pr.number if outcome.pr is not None else None
-        audit.record(GATE_DECISION, iteration=iteration, task_id=task.id, success=outcome.success, stage=outcome.stage)
+        audit.record(
+            GATE_DECISION,
+            iteration=iteration,
+            task_id=task.id,
+            success=outcome.success,
+            stage=outcome.stage,
+            reason=outcome.reason,
+        )
+        if not outcome.success:
+            # #421 : la cause doit SURVIVRE à l'échec — raison différenciée
+            # (no_op/agent_error/gate_failed) + extraits bornés des logs agent et de
+            # la sortie des tests, journalisés ET audités (persistés via decisions).
+            detail = {"task_id": task.id, "stage": outcome.stage, "reason": outcome.reason}
+            agent_tail = log_tail(outcome.execution.agent_result.logs)
+            if agent_tail:
+                detail["agent_log_tail"] = agent_tail
+            if outcome.quality_report is not None and outcome.quality_report.test_output:
+                detail["test_output_tail"] = log_tail(outcome.quality_report.test_output, 1000)
+            audit.record(TASK_FAILED, iteration=iteration, **detail)
+            logger.warning(
+                "tâche %s « %s » en échec (stage=%s, reason=%s)",
+                task.id,
+                task.title,
+                outcome.stage,
+                outcome.reason,
+            )
         if pr_number is not None:
             audit.record(PR_OPENED, iteration=iteration, task_id=task.id, pr_number=pr_number, dry_run=dry_run)
         processed.append(

--- a/tests/test_executor_pipeline.py
+++ b/tests/test_executor_pipeline.py
@@ -155,6 +155,7 @@ async def test_tests_red_stops_at_gate_no_pr(repo, tmp_path):
     )
     assert outcome.success is False
     assert outcome.stage == "gate"
+    assert outcome.reason == "gate_failed"  # raison différenciée (#421)
     assert outcome.pr is None
     assert clients.prs.created == []  # aucune PR
     # l'état ne dépasse pas in_progress
@@ -180,9 +181,38 @@ async def test_agent_noop_stops_at_run(repo):
     )
     assert outcome.success is False
     assert outcome.stage == "run"
+    assert outcome.reason == "no_op"  # agent OK mais zéro diff (#421)
     assert outcome.quality_report is None  # gate jamais atteint
     assert outcome.pr is None
     assert clients.prs.created == []
+
+
+async def test_agent_process_error_has_distinct_reason(repo):
+    """#421 : un agent dont le PROCESS échoue (exit ≠ 0) n'est pas un no-op —
+    même stage `run`, mais reason `agent_error` (la couche retry en dépend)."""
+    outcome = await execute_issue(ISSUE, repo, ctx=None, dry_run=False, **_kwargs(agent=FakeCodeAgent(succeed=False)))
+    assert outcome.success is False
+    assert outcome.stage == "run"
+    assert outcome.reason == "agent_error"
+    # Le diagnostic (logs agent) survit dans l'outcome.
+    assert "échec simulé" in outcome.execution.agent_result.logs
+
+
+async def test_success_outcome_has_no_reason(repo):
+    outcome = await execute_issue(ISSUE, repo, ctx=None, dry_run=True, **_kwargs())
+    assert outcome.success is True
+    assert outcome.reason is None
+
+
+def test_log_tail_bounds_long_text():
+    from collegue.executor.pipeline import log_tail
+
+    assert log_tail("") == ""
+    assert log_tail("court") == "court"
+    long = "x" * 5000
+    tail = log_tail(long, 2000)
+    assert len(tail) == 2001  # « … » + 2000 derniers caractères
+    assert tail.startswith("…") and tail.endswith("x")
 
 
 async def test_reviewer_error_is_contained_not_propagated(repo):

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -105,12 +105,12 @@ def _linear_project(manager, n=3):
     return pid
 
 
-async def _run(manager, repo, pid, *, budget=None, dry_run=True, sandbox=None, **kw):
+async def _run(manager, repo, pid, *, budget=None, dry_run=True, sandbox=None, agent=None, **kw):
     return await run_project(
         pid,
         repo,
         ctx=None,
-        agent=FakeCodeAgent(),
+        agent=agent or FakeCodeAgent(),
         owner="o",
         repo="r",
         manager=manager,
@@ -217,6 +217,35 @@ async def test_failed_task_blocks_dependents(repo, manager):
     statuses = {t.title: t.status for t in manager.get_tasks(pid)}
     assert statuses["T0"] == "failed"
     assert statuses["T1"] == "todo"  # jamais lancée
+
+
+async def test_failure_is_audited_with_reason_and_log_tails(repo, manager):
+    """#421 : la cause d'un échec SURVIT — l'audit porte la raison différenciée
+    (gate_failed / no_op / agent_error) + extraits bornés des logs agent et de la
+    sortie des tests (avant : seul success/stage, post-mortem impossible)."""
+    from collegue.pilot.audit import RunAuditLog
+
+    # Échec au gate (tests rouges) : raison + tails agent/tests.
+    pid = _linear_project(manager, 1)
+    audit = RunAuditLog(pid)
+    await _run(manager, repo, pid, dry_run=False, sandbox=_Sandbox(ok=False), audit=audit)
+    failed = [e for e in audit.events if e.kind == "task_failed"]
+    assert len(failed) == 1
+    detail = failed[0].detail
+    assert detail["stage"] == "gate" and detail["reason"] == "gate_failed"
+    assert "fake agent" in detail["agent_log_tail"]  # logs agent enfin journalisés
+    assert detail["test_output_tail"] == "out"  # sortie des tests rouge capturée
+    # gate_decision porte aussi la raison (None si succès).
+    gates = [e for e in audit.events if e.kind == "gate_decision"]
+    assert gates and gates[0].detail["reason"] == "gate_failed"
+
+    # No-op de l'agent (zéro diff) : raison distincte, pas de sortie de tests.
+    pid2 = _linear_project(manager, 1)
+    audit2 = RunAuditLog(pid2)
+    await _run(manager, repo, pid2, dry_run=False, agent=FakeCodeAgent(files={}), audit=audit2)
+    failed2 = [e for e in audit2.events if e.kind == "task_failed"]
+    assert failed2 and failed2[0].detail["reason"] == "no_op"
+    assert "test_output_tail" not in failed2[0].detail  # gate jamais atteint
 
 
 async def test_resume_skips_already_done(repo, manager):


### PR DESCRIPTION
## Problème (#421)

Quand l'agent ne produit aucun diff, le pipeline renvoyait le **même** `ExecutionOutcome(success=False, stage="run")` qu'un crash de plomberie, et `AgentResult.logs` (rempli par l'adaptateur OpenHands) n'était **consommé nulle part**. Sur le run réel FacNor (tâche 1, fenêtre 503), aucune information actionnable n'a survécu à l'échec — diagnostic post-mortem impossible, retry intelligent impossible.

## Correctif

- **`ExecutionOutcome.reason`** (nouveau champ, `None` si succès) :
  - `no_op` — l'agent a tourné sans erreur mais n'a produit **aucun** diff (souvent transitoire) ;
  - `agent_error` — le **process** agent a échoué (exit ≠ 0 / timeout sandbox) ;
  - `gate_failed` — tests rouges ou revue bloquante.
- **`log_tail(text, limit=2000)`** : extrait borné d'un log (anti-inondation de l'audit).
- **Driver** : sur échec, nouvel événement d'audit **`task_failed`** portant `reason` + `agent_log_tail` + `test_output_tail` (persisté en table `decisions` quand l'audit persiste — la cause **survit** au process) + `logger.warning`. `gate_decision` porte désormais aussi la raison.
- La raison est **exposée à la couche retry** (#420, PR suivante) pour décider re-queue (transitoire) vs échec dur — exactement le correctif suggéré par l'issue.

## Tests

- Pipeline : `no_op` vs `agent_error` vs `gate_failed` distingués, succès → `reason=None`, bornage `log_tail`.
- Driver : `test_failure_is_audited_with_reason_and_log_tails` — l'audit contient `task_failed` avec raison + tails (gate rouge **et** no-op), `gate_decision` porte la raison.
- Suites `test_executor_pipeline` / `test_pilot_driver` / `test_pilot_audit` / `test_pilot_runtime` / `test_improve_loop` vertes ; `ruff check`/`format` OK.

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)