### PR TITLE
feat(pilot): retry au niveau tâche avec backoff + attempt_count persisté (issue #420)

### DIFF
--- a/alembic/versions/0005_task_attempts.py
+++ b/alembic/versions/0005_task_attempts.py
@@ -1,0 +1,34 @@
+"""compteur de tentatives + dernier échec sur tasks (retry niveau tâche)
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-06-10
+
+Ajoute ``tasks.attempt_count`` (plafond de retries persistant entre redémarrages)
+et ``tasks.last_error`` (motif du dernier échec, diagnostic + feedback) — #420.
+batch_alter_table pour rester portable SQLite/PostgreSQL.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0005"
+down_revision: Union[str, None] = "0004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("tasks") as batch_op:
+        batch_op.add_column(sa.Column("attempt_count", sa.Integer(), nullable=False, server_default="0"))
+        batch_op.add_column(sa.Column("last_error", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("tasks") as batch_op:
+        batch_op.drop_column("last_error")
+        batch_op.drop_column("attempt_count")

--- a/collegue/config.py
+++ b/collegue/config.py
@@ -75,6 +75,12 @@ class Settings(BaseSettings):
             return 0.0
         return f if math.isfinite(f) and f > 0 else 0.0
 
+    # Retry au niveau tâche du pilote (#420) : nombre max de tentatives par tâche
+    # (1 = pas de retry) et base du backoff linéaire entre tentatives (s, plafonné
+    # côté driver). Un échec transitoire (503, no-op) ne fige plus tout le DAG.
+    TASK_MAX_ATTEMPTS: int = 3
+    TASK_RETRY_BACKOFF_SECONDS: float = 15.0
+
     ENGINE_INIT_TIMEOUT: float = 10.0
     ENGINE_WAIT_TIMEOUT: float = 30.0
     MAX_HISTORY_LENGTH: int = 20

--- a/collegue/pilot/audit.py
+++ b/collegue/pilot/audit.py
@@ -25,7 +25,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 CostSource = Callable[[], Tuple[float, int]]
 
 TASK_STARTED = "task_started"
-TASK_FAILED = "task_failed"  # échec d'une tâche, avec raison + extrait de logs (#421)
+TASK_RETRY = "task_retry"  # tâche re-filée `todo` après un échec retentable (#420)
+TASK_FAILED = "task_failed"  # échec TERMINAL d'une tâche, raison + extrait de logs (#421)
 DIFF_PRODUCED = "diff_produced"
 GATE_DECISION = "gate_decision"
 PR_OPENED = "pr_opened"

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -6,8 +6,10 @@ tâches prêtes, exécuter la prochaine, checkpointer, et basculer en mode
 amélioration quand le MVP est atteint.
 
 Boucle **séquentielle et bornée** : chaque itération traite une tâche ``todo`` et
-la marque ``in_review`` (succès) ou ``failed`` (fail-closed). Le todo-set décroît
-strictement → terminaison garantie (backstop ``max_iterations`` par sécurité).
+la marque ``in_review`` (succès), la **re-file** ``todo`` avec backoff si l'échec
+est encore retentable (``max_task_attempts``, #420), ou la marque ``failed``
+(terminal). La terminaison reste garantie : chaque tâche consomme au plus
+``max_task_attempts`` itérations (backstop ``max_iterations`` par sécurité).
 
 ``dry_run`` (défaut) : pipeline complet jusqu'aux **aperçus** de PR, **sans aucune
 écriture** (ni GitHub ni état) ; la progression est simulée via un *overlay* en
@@ -22,6 +24,7 @@ Module **isolé** : non importé par ``app.py`` (F4 câblera).
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass, field
 from typing import List, Optional
@@ -35,6 +38,7 @@ from collegue.pilot.audit import (
     PR_OPENED,
     RUN_STOP,
     TASK_FAILED,
+    TASK_RETRY,
     TASK_STARTED,
     CostSource,
     NullAuditLog,
@@ -57,6 +61,14 @@ STOP_PAUSED_BUDGET = "paused_budget"
 STOP_DEADLINE = "deadline_reached"
 STOP_BLOCKED = "blocked"  # graphe coincé (dépendance échouée)
 STOP_SAFETY_CAP = "safety_cap"  # garde-fou anti-boucle
+
+# Retry au niveau tâche (#420). Le défaut du MODULE reste 1 (= pas de retry,
+# comportement historique — module isolé, aucun changement sans opt-in) ; le
+# runtime assemblé (F4) passe ``TASK_MAX_ATTEMPTS`` (défaut config : 3) pour que
+# le chemin autonome réel soit, lui, résilient aux échecs transitoires.
+DEFAULT_MAX_TASK_ATTEMPTS = 1
+DEFAULT_RETRY_BACKOFF_SECONDS = 15.0
+RETRY_BACKOFF_CAP_SECONDS = 90.0
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +148,9 @@ async def run_project(
     cost_source: Optional[CostSource] = None,
     improve: bool = False,
     run_improvement_fn=None,
+    max_task_attempts: int = DEFAULT_MAX_TASK_ATTEMPTS,
+    retry_backoff_seconds: float = DEFAULT_RETRY_BACKOFF_SECONDS,
+    sleep_fn=None,
 ) -> ProjectRunResult:
     """Pilote un projet : chaîne ``execute_issue`` sur les tâches prêtes sous budget.
 
@@ -154,9 +169,28 @@ async def run_project(
     d'amélioration (Phase 4) **sous le budget restant** et attache l'``ImprovementResult``
     à ``result.improvement``. Défaut faux → comportement inchangé.
     ``run_improvement_fn`` : injection de test ; défaut = ``collegue.improve.run_improvement``.
+
+    ``max_task_attempts`` (#420) : tentatives max par tâche. À 1 (défaut du module),
+    tout échec est terminal (comportement historique). Au-delà, un échec re-file la
+    tâche ``todo`` avec un backoff linéaire ``retry_backoff_seconds × tentative``
+    (plafonné à ``RETRY_BACKOFF_CAP_SECONDS``) tant que le plafond n'est pas
+    atteint — un aléa transitoire (503, no-op) ne fige plus tout le DAG. Le compteur
+    est persisté (``tasks.attempt_count``) → le plafond survit aux redémarrages.
+    ``sleep_fn`` : injection de test (défaut ``asyncio.sleep``).
     """
     budget = budget or BudgetTimeController()
     audit = audit or NullAuditLog()
+    try:
+        max_task_attempts = max(1, int(max_task_attempts))
+    except (TypeError, ValueError):
+        max_task_attempts = DEFAULT_MAX_TASK_ATTEMPTS
+    try:
+        backoff = float(retry_backoff_seconds)
+    except (TypeError, ValueError):
+        backoff = DEFAULT_RETRY_BACKOFF_SECONDS
+    if not (backoff > 0 and backoff < float("inf")):  # nan/inf/négatif → pas d'attente
+        backoff = 0.0
+    sleep = sleep_fn or asyncio.sleep
     tasks = manager.get_tasks(project_id)  # objets détachés : overlay mutable en mémoire
     tasks_by_id = {t.id: t for t in tasks}  # pour le contexte inter-tâches (#412)
 
@@ -184,7 +218,8 @@ async def run_project(
             if not dry_run:
                 manager.update_task_status(task.id, TASK_STATUS_TODO)
 
-    cap = max_iterations if max_iterations is not None else len(tasks) * 2 + 5
+    # Avec retries, chaque tâche peut consommer jusqu'à max_task_attempts itérations.
+    cap = max_iterations if max_iterations is not None else len(tasks) * max(2, max_task_attempts) + 5
 
     # Reprise : repartir du numéro d'itération du dernier checkpoint (l'état des
     # tâches en DB fournit la vraie reprise — les tâches terminées sont ignorées).
@@ -248,24 +283,6 @@ async def run_project(
             stage=outcome.stage,
             reason=outcome.reason,
         )
-        if not outcome.success:
-            # #421 : la cause doit SURVIVRE à l'échec — raison différenciée
-            # (no_op/agent_error/gate_failed) + extraits bornés des logs agent et de
-            # la sortie des tests, journalisés ET audités (persistés via decisions).
-            detail = {"task_id": task.id, "stage": outcome.stage, "reason": outcome.reason}
-            agent_tail = log_tail(outcome.execution.agent_result.logs)
-            if agent_tail:
-                detail["agent_log_tail"] = agent_tail
-            if outcome.quality_report is not None and outcome.quality_report.test_output:
-                detail["test_output_tail"] = log_tail(outcome.quality_report.test_output, 1000)
-            audit.record(TASK_FAILED, iteration=iteration, **detail)
-            logger.warning(
-                "tâche %s « %s » en échec (stage=%s, reason=%s)",
-                task.id,
-                task.title,
-                outcome.stage,
-                outcome.reason,
-            )
         if pr_number is not None:
             audit.record(PR_OPENED, iteration=iteration, task_id=task.id, pr_number=pr_number, dry_run=dry_run)
         processed.append(
@@ -278,14 +295,75 @@ async def run_project(
             )
         )
 
-        # Overlay en mémoire : avance le statut de la tâche pour l'ordonnancement.
-        # En réel, le succès est déjà persisté par execute_issue (→ in_review) ; on
-        # ne persiste donc que l'échec (fail-closed) pour ne pas re-sélectionner la
-        # tâche et débloquer la détection de blocage.
-        task.status = TASK_STATUS_IN_REVIEW if outcome.success else TASK_STATUS_FAILED
+        # Overlay en mémoire (+ persistance en réel). Succès → in_review (déjà
+        # persisté par execute_issue). Échec : tant qu'il reste des tentatives
+        # (#420), la tâche est RE-FILÉE `todo` avec backoff — un aléa transitoire
+        # (503, no-op) ne fige plus le DAG ; sinon `failed` (terminal, fail-closed).
+        # Dans les deux cas la cause SURVIT (#421) : raison différenciée + extraits
+        # bornés des logs agent / sortie des tests, audités (persistés via decisions)
+        # et stockés dans tasks.last_error.
+        if outcome.success:
+            task.status = TASK_STATUS_IN_REVIEW
+        else:
+            detail = {"task_id": task.id, "stage": outcome.stage, "reason": outcome.reason}
+            agent_tail = log_tail(outcome.execution.agent_result.logs)
+            if agent_tail:
+                detail["agent_log_tail"] = agent_tail
+            if outcome.quality_report is not None and outcome.quality_report.test_output:
+                detail["test_output_tail"] = log_tail(outcome.quality_report.test_output, 1000)
+
+            attempts = int(getattr(task, "attempt_count", 0) or 0) + 1
+            task.attempt_count = attempts
+            last_error = f"[{outcome.stage}/{outcome.reason}] tentative {attempts}/{max_task_attempts}"
+            diagnostic = detail.get("test_output_tail") or detail.get("agent_log_tail") or ""
+            if diagnostic:
+                last_error += " — " + diagnostic[-700:]
+            task.last_error = last_error
+
+            if attempts < max_task_attempts:
+                task.status = TASK_STATUS_TODO
+                if not dry_run:
+                    manager.update_task(task.id, status=TASK_STATUS_TODO, attempt_count=attempts, last_error=last_error)
+                delay = min(backoff * attempts, RETRY_BACKOFF_CAP_SECONDS) if backoff > 0 else 0.0
+                audit.record(
+                    TASK_RETRY,
+                    iteration=iteration,
+                    attempt=attempts,
+                    max_attempts=max_task_attempts,
+                    backoff_seconds=delay,
+                    **detail,
+                )
+                logger.warning(
+                    "tâche %s « %s » re-tentée (%d/%d, stage=%s, reason=%s, backoff=%.0fs)",
+                    task.id,
+                    task.title,
+                    attempts,
+                    max_task_attempts,
+                    outcome.stage,
+                    outcome.reason,
+                    delay,
+                )
+                if delay > 0 and not dry_run:  # l'aperçu (dry_run) n'attend pas
+                    await sleep(delay)
+            else:
+                task.status = TASK_STATUS_FAILED
+                if not dry_run:
+                    manager.update_task(
+                        task.id, status=TASK_STATUS_FAILED, attempt_count=attempts, last_error=last_error
+                    )
+                audit.record(
+                    TASK_FAILED, iteration=iteration, attempt=attempts, max_attempts=max_task_attempts, **detail
+                )
+                logger.warning(
+                    "tâche %s « %s » en échec TERMINAL (%d/%d, stage=%s, reason=%s)",
+                    task.id,
+                    task.title,
+                    attempts,
+                    max_task_attempts,
+                    outcome.stage,
+                    outcome.reason,
+                )
         if not dry_run:
-            if not outcome.success:
-                manager.update_task_status(task.id, TASK_STATUS_FAILED)
             # Checkpoint C7 : le numéro d'itération sert à la reprise ; ``state_json``
             # est un instantané d'audit (la reprise effective lit les statuts en DB).
             manager.save_checkpoint(

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -170,6 +170,10 @@ async def run_project_from_settings(
         max_iterations=max_iterations,
         improve=improve,
         run_improvement_fn=run_improvement_fn,
+        # Retry au niveau tâche (#420) : le chemin assemblé est résilient par défaut
+        # (TASK_MAX_ATTEMPTS=3 en config) ; le module driver isolé reste, lui, à 1.
+        max_task_attempts=getattr(settings_obj, "TASK_MAX_ATTEMPTS", 3),
+        retry_backoff_seconds=getattr(settings_obj, "TASK_RETRY_BACKOFF_SECONDS", 15.0),
     )
 
     # Reporting (journal de décisions) — réel uniquement (dry_run n'écrit rien).

--- a/collegue/state/models.py
+++ b/collegue/state/models.py
@@ -105,6 +105,12 @@ class Task(Base):
     # Numéro d'issue GitHub une fois la tâche synchronisée (P4) ; NULL sinon.
     # Sert de mapping task↔issue et de garde d'idempotence (ne pas recréer).
     issue_number: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    # Tentatives d'exécution déjà consommées (retry au niveau tâche, #420) :
+    # persistées pour que le plafond max_attempts survive aux redémarrages.
+    attempt_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    # Dernier motif d'échec connu (stage/raison + extrait) — diagnostic post-mortem
+    # et ré-injection de feedback à la tentative suivante (#420/#424).
+    last_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         UTCDateTime, nullable=False, default=_utcnow, server_default=func.now()
     )

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from collegue.executor import FakeCodeAgent, FakeReviewer, PrClients
+from collegue.executor import AgentResult, FakeCodeAgent, FakeReviewer, PrClients
 from collegue.pilot import (
     ACTION_CONTINUE,
     ACTION_DEADLINE,
@@ -217,6 +217,111 @@ async def test_failed_task_blocks_dependents(repo, manager):
     statuses = {t.title: t.status for t in manager.get_tasks(pid)}
     assert statuses["T0"] == "failed"
     assert statuses["T1"] == "todo"  # jamais lancée
+
+
+# --- retry au niveau tâche (#420) -------------------------------------------------
+
+
+class _FlakyAgent:
+    """Agent qui échoue N fois (process en erreur) puis réussit — simule un 503."""
+
+    def __init__(self, fail_times=1):
+        self.calls = 0
+        self._fail_times = fail_times
+        self._ok = FakeCodeAgent()
+
+    def implement_issue(self, workspace, issue):
+        self.calls += 1
+        if self.calls <= self._fail_times:
+            return AgentResult(success=False, logs="503 transitoire simulé")
+        return self._ok.implement_issue(workspace, issue)
+
+
+async def test_transient_failure_retried_then_recovers(repo, manager):
+    """#420 : un échec transitoire ne fige plus le DAG — la tâche est re-filée
+    `todo` avec backoff, réussit à la tentative suivante, et les dépendants
+    s'enchaînent jusqu'au MVP (avant : `failed` terminal → run `blocked` à 0%)."""
+    from collegue.pilot.audit import RunAuditLog
+
+    pid = _linear_project(manager, 2)
+    agent = _FlakyAgent(fail_times=1)
+    sleeps = []
+
+    async def _sleep(d):
+        sleeps.append(d)
+
+    audit = RunAuditLog(pid)
+    result = await _run(
+        manager, repo, pid, dry_run=False, agent=agent, audit=audit, max_task_attempts=3, sleep_fn=_sleep
+    )
+    assert result.stop_reason == "completed"
+    statuses = {t.title: t.status for t in manager.get_tasks(pid)}
+    assert statuses == {"T0": "in_review", "T1": "in_review"}
+    assert sleeps == [15.0]  # backoff linéaire : 15 × tentative 1
+    retries = [e for e in audit.events if e.kind == "task_retry"]
+    assert len(retries) == 1
+    assert retries[0].detail["reason"] == "agent_error"
+    assert retries[0].detail["attempt"] == 1
+    # Compteur + motif persistés (le plafond survit aux redémarrages).
+    t0 = manager.get_tasks(pid)[0]
+    assert t0.attempt_count == 1
+    assert "agent_error" in t0.last_error and "503 transitoire" in t0.last_error
+
+
+async def test_attempts_exhausted_marks_failed_and_blocks(repo, manager):
+    pid = _linear_project(manager, 2)
+    sleeps = []
+
+    async def _sleep(d):
+        sleeps.append(d)
+
+    result = await _run(
+        manager, repo, pid, dry_run=False, agent=FakeCodeAgent(files={}), max_task_attempts=3, sleep_fn=_sleep
+    )
+    assert result.stop_reason == "blocked"
+    t0, t1 = manager.get_tasks(pid)
+    assert t0.status == "failed"  # terminal après épuisement
+    assert t0.attempt_count == 3
+    assert "no_op" in t0.last_error
+    assert sleeps == [15.0, 30.0]  # 15×1 puis 15×2 (plafonné à 90)
+    assert t1.status == "todo"  # dépendant jamais lancé
+
+
+async def test_default_module_behavior_is_no_retry(repo, manager):
+    # Défaut du MODULE isolé (max_task_attempts=1) : comportement historique —
+    # tout échec est terminal, aucun retry (le runtime, lui, passe la config).
+    pid = _linear_project(manager, 1)
+    result = await _run(manager, repo, pid, dry_run=False, agent=FakeCodeAgent(files={}))
+    assert result.iterations == 1
+    assert manager.get_tasks(pid)[0].status == "failed"
+
+
+async def test_dry_run_retry_simulates_without_persisting_or_sleeping(repo, manager):
+    pid = _linear_project(manager, 1)
+    sleeps = []
+
+    async def _sleep(d):
+        sleeps.append(d)
+
+    result = await _run(
+        manager, repo, pid, dry_run=True, agent=_FlakyAgent(fail_times=1), max_task_attempts=3, sleep_fn=_sleep
+    )
+    assert result.stop_reason == "completed"  # la simulation retente et aboutit
+    assert sleeps == []  # l'aperçu n'attend jamais
+    t = manager.get_tasks(pid)[0]
+    assert t.status == "todo" and t.attempt_count == 0 and t.last_error is None  # rien persisté
+
+
+async def test_attempt_budget_survives_restart(repo, manager):
+    # attempt_count est lu depuis la DB : 2 tentatives déjà consommées avant un
+    # redémarrage → la 3e (dernière) échoue TERMINAL sans re-queue infinie.
+    pid = _linear_project(manager, 1)
+    tid = manager.get_tasks(pid)[0].id
+    manager.update_task(tid, attempt_count=2)
+    result = await _run(manager, repo, pid, dry_run=False, agent=FakeCodeAgent(files={}), max_task_attempts=3)
+    t = manager.get_tasks(pid)[0]
+    assert result.iterations == 1
+    assert t.status == "failed" and t.attempt_count == 3
 
 
 async def test_failure_is_audited_with_reason_and_log_tails(repo, manager):


### PR DESCRIPTION
## Problème (#420 — CRITIQUE)

Un échec transitoire (fenêtre 503 « high demand », no-op de l'agent) marquait la tâche `failed` **terminal** (`driver.py:256`) ; `failed` ne satisfaisant pas une dépendance, **tout le DAG dépendant devenait inatteignable** → run `blocked`. Preuve FacNor : blocage à 2/14 tâches alors qu'une reproduction du même prompt **3 minutes plus tard réussissait**. Récupération uniquement par reset manuel `failed→todo` (4 rounds opérateur).

## Correctif

- **`run_project(max_task_attempts=…, retry_backoff_seconds=…, sleep_fn=…)`** : un échec encore retentable **re-file la tâche `todo`** avec backoff linéaire `15s × tentative` (plafonné 90s) ; l'épuisement du plafond reste **fail-closed** (`failed` terminal, dépendants bloqués → `blocked`).
- **Persistance** : `tasks.attempt_count` + `tasks.last_error` (modèle + **migration Alembic 0005**) → le plafond de tentatives **survit aux redémarrages** (reprise H5) ; le motif d'échec (stage/raison + extrait borné tests/logs agent) est stocké — base de la ré-injection de feedback (#424, PR suivante).
- **Audit** : `task_retry` (re-queue, avec attempt/max/backoff + diagnostic #421) vs `task_failed` (terminal uniquement désormais).
- **Défauts en deux étages (volontaire)** : le **module** driver isolé reste à `max_task_attempts=1` → comportement historique strictement inchangé pour tout appelant existant ; le **runtime assemblé** (`run_project_from_settings`, le chemin autonome réel) passe `TASK_MAX_ATTEMPTS` (config, **défaut 3**) + `TASK_RETRY_BACKOFF_SECONDS` (15s).
- `dry_run` : la simulation retente (overlay) mais **ne dort pas et ne persiste rien** ; cap d'itérations recalculé `len(tasks) × max(2, attempts) + 5`.

## Tests (6 nouveaux)

- `test_transient_failure_retried_then_recovers` — la repro exacte du scénario FacNor : échec transitoire → retry (sleep 15s capturé) → MVP `completed`, `attempt_count`/`last_error` persistés, événement `task_retry` audité.
- `test_attempts_exhausted_marks_failed_and_blocks` — épuisement → `failed` terminal + `blocked` (fail-closed conservé), backoffs `[15, 30]`.
- `test_default_module_behavior_is_no_retry` — défaut module inchangé (1 tentative).
- `test_dry_run_retry_simulates_without_persisting_or_sleeping`.
- `test_attempt_budget_survives_restart` — compteur lu depuis la DB après « redémarrage ».
- Anti-drift : `test_crud_on_migrated_schema` exerce la migration 0005 (roundtrip CRUD sur schéma migré) ; suites `pilot_driver`/`pilot_runtime`/`project_state`/`executor_pipeline` vertes ; `ruff check`/`format` OK.

S'appuie sur #421 (raison d'échec différenciée, mergée). Complété par #424 (feedback au retry, PR suivante).

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)