### PR TITLE
feat(pilot): ré-injection du feedback d'échec dans le prompt au retry (issue #424)

### DIFF
--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -59,6 +59,25 @@ def log_tail(text: str, limit: int = 2000) -> str:
     return "…" + text[-limit:]
 
 
+def failure_feedback(outcome: "ExecutionOutcome") -> str:
+    """Synthèse **courte et actionnable** d'un échec, pour la tentative suivante (#424).
+
+    Priorité aux lignes ``FAILED``/``ERROR`` de pytest : c'est exactement ce dont
+    l'agent a besoin pour corriger la cause. Un feedback verbeux (sortie brute)
+    NOIE l'agent au lieu de l'aider — constaté en run réel (FacNor, task 4 :
+    feedback bruité → time-out de 40 min ; lignes FAILED seules → convergence).
+    À défaut de lignes de tests, queue bornée de la sortie de tests puis des logs
+    agent (échec au stage ``run``).
+    """
+    if outcome.quality_report is not None and outcome.quality_report.test_output:
+        output = outcome.quality_report.test_output
+        fails = [line.strip() for line in output.splitlines() if line.strip().startswith(("FAILED", "ERROR"))]
+        if fails:
+            return " ; ".join(fails[:6])[:700]
+        return log_tail(output, 400)
+    return log_tail(outcome.execution.agent_result.logs, 400)
+
+
 @dataclass
 class ExecutionOutcome:
     """Résultat de bout en bout de l'exécution d'une issue."""

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional
 
 from collegue.executor.agent import IssueSpec
-from collegue.executor.pipeline import execute_issue, log_tail
+from collegue.executor.pipeline import execute_issue, failure_feedback, log_tail
 from collegue.pilot.audit import (
     BUDGET_EVENT,
     CHECKPOINT_SAVED,
@@ -109,21 +109,34 @@ def _issue_from_task(task, by_id=None) -> IssueSpec:
     on liste les **dépendances déjà construites** pour que l'agent bâtisse sur
     l'existant (le code des dépendances est dans le dépôt) au lieu de coder depuis
     la seule consigne de l'issue → cohérence entre tâches.
+
+    Retry (#424) : si la tâche a déjà échoué (``attempt_count`` > 0), le motif du
+    dernier échec (``last_error``, synthèse crisp de :func:`failure_feedback`) est
+    ré-injecté dans le contexte — sans lui, un retry rejoue la même consigne à
+    l'identique et reproduit le même bug (retry « aveugle », gaspillage pur).
+    Le contexte passe par ``IssueSpec.to_prompt`` → inline-isé (anti-injection).
     """
-    context = ""
+    parts = []
     deps = [by_id[d] for d in (task.depends_on or []) if by_id and d in by_id]
     if deps:
         titres = ", ".join(f"« {d.title} »" for d in deps)
-        context = (
+        parts.append(
             f"Cette tâche dépend de tâches déjà construites : {titres}. "
             "Inspecte le dépôt existant et réutilise leur code, modèles et conventions "
             "(ne recrée pas ce qui existe)."
+        )
+    last_error = getattr(task, "last_error", None)
+    if int(getattr(task, "attempt_count", 0) or 0) > 0 and last_error:
+        parts.append(
+            "ATTENTION : ta tentative précédente sur CETTE tâche a ÉCHOUÉ. "
+            f"Détail de l'échec : {last_error}. "
+            "Analyse et corrige d'abord cette cause précise au lieu de régénérer le même code."
         )
     return IssueSpec(
         number=task.issue_number or task.id,
         title=task.title,
         body=task.acceptance or "",
-        context=context,
+        context=" ".join(parts),
     )
 
 
@@ -314,10 +327,12 @@ async def run_project(
 
             attempts = int(getattr(task, "attempt_count", 0) or 0) + 1
             task.attempt_count = attempts
+            # Synthèse CRISP (#424) : lignes FAILED/ERROR de pytest en priorité —
+            # c'est ce qui sera ré-injecté dans le prompt de la tentative suivante.
             last_error = f"[{outcome.stage}/{outcome.reason}] tentative {attempts}/{max_task_attempts}"
-            diagnostic = detail.get("test_output_tail") or detail.get("agent_log_tail") or ""
+            diagnostic = failure_feedback(outcome)
             if diagnostic:
-                last_error += " — " + diagnostic[-700:]
+                last_error += " — " + diagnostic
             task.last_error = last_error
 
             if attempts < max_task_attempts:

--- a/tests/test_executor_pipeline.py
+++ b/tests/test_executor_pipeline.py
@@ -215,6 +215,60 @@ def test_log_tail_bounds_long_text():
     assert tail.startswith("…") and tail.endswith("x")
 
 
+def test_failure_feedback_is_crisp_and_actionable():
+    """#424 : la synthèse d'échec privilégie les lignes FAILED/ERROR de pytest
+    (courtes, actionnables) — la sortie brute noierait l'agent au retry."""
+    from collegue.executor import AgentResult, QualityReport, Workspace
+    from collegue.executor.pipeline import ExecutionOutcome, failure_feedback
+    from collegue.executor.runner import ExecutionResult
+
+    ws = Workspace(path="/w", branch="b", base_commit="c")
+    execution = ExecutionResult(
+        agent_result=AgentResult(success=True, logs="journal de l'agent"),
+        changed=True,
+        diff="",
+        files_changed=("a.py",),
+        success=True,
+    )
+
+    def _report(output):
+        return QualityReport(
+            tests_passed=False,
+            test_exit_code=1,
+            test_output=output,
+            review_summary="",
+            review_findings=(),
+            review_blocking=False,
+            passed=False,
+        )
+
+    # Lignes FAILED/ERROR présentes → seules elles sont retenues (jointes, bornées).
+    gate = ExecutionOutcome(
+        success=False,
+        stage="gate",
+        workspace=ws,
+        execution=execution,
+        quality_report=_report("bruit\nFAILED tests/a.py::t1 - boom\nencore du bruit\nERROR tests/b.py - setup\n"),
+        reason="gate_failed",
+    )
+    assert failure_feedback(gate) == "FAILED tests/a.py::t1 - boom ; ERROR tests/b.py - setup"
+
+    # Pas de ligne FAILED → queue bornée de la sortie de tests.
+    fuzzy = ExecutionOutcome(
+        success=False,
+        stage="gate",
+        workspace=ws,
+        execution=execution,
+        quality_report=_report("z" * 1000),
+        reason="gate_failed",
+    )
+    assert len(failure_feedback(fuzzy)) <= 401 and failure_feedback(fuzzy).endswith("z")
+
+    # Échec au stage run (aucun rapport) → logs agent.
+    run = ExecutionOutcome(success=False, stage="run", workspace=ws, execution=execution, reason="agent_error")
+    assert failure_feedback(run) == "journal de l'agent"
+
+
 async def test_reviewer_error_is_contained_not_propagated(repo):
     # Une exception « ordinaire » du reviewer est CONTENUE par le gate (fail-closed) :
     # le pipeline s'arrête proprement, sans laisser l'exception remonter.

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -219,19 +219,104 @@ async def test_failed_task_blocks_dependents(repo, manager):
     assert statuses["T1"] == "todo"  # jamais lancée
 
 
+# --- ré-injection du feedback d'échec au retry (#424) ------------------------------
+
+
+class _RecordingAgent:
+    """Enregistre le contexte de chaque issue reçue (délègue au FakeCodeAgent)."""
+
+    def __init__(self):
+        self.contexts = []
+        self._ok = FakeCodeAgent()
+
+    def implement_issue(self, workspace, issue):
+        self.contexts.append(issue.context)
+        return self._ok.implement_issue(workspace, issue)
+
+
+class _FlakySandbox:
+    """Tests rouges N fois (sortie pytest réaliste) puis verts."""
+
+    def __init__(self, fail_times=1):
+        self.calls = 0
+        self._fail_times = fail_times
+
+    def run_tests(self, workspace, command="pytest -q"):
+        self.calls += 1
+        if self.calls <= self._fail_times:
+            return SandboxResult(
+                exit_code=1,
+                stdout=(
+                    "collected 4 items\n"
+                    "bruit de collection\n"
+                    "FAILED tests/test_auth.py::test_login - sqlalchemy.exc.OperationalError: no such table\n"
+                    "1 failed, 3 passed"
+                ),
+                stderr="",
+            )
+        return SandboxResult(exit_code=0, stdout="4 passed", stderr="")
+
+
+async def test_retry_reinjects_crisp_failure_feedback(repo, manager):
+    """#424 : la tentative suivante reçoit le MOTIF de l'échec précédent (lignes
+    FAILED de pytest, pas la sortie brute) dans son contexte — sans ça, le retry
+    rejoue la même consigne à l'identique et reproduit le même bug."""
+
+    async def _sleep(d):
+        pass
+
+    pid = _linear_project(manager, 1)
+    agent = _RecordingAgent()
+    result = await _run(
+        manager,
+        repo,
+        pid,
+        dry_run=False,
+        agent=agent,
+        sandbox=_FlakySandbox(fail_times=1),
+        max_task_attempts=3,
+        sleep_fn=_sleep,
+    )
+    assert result.stop_reason == "completed"
+    assert len(agent.contexts) == 2
+    assert "ÉCHOUÉ" not in agent.contexts[0]  # 1re tentative : pas de feedback
+    ctx = agent.contexts[1]
+    assert "ÉCHOUÉ" in ctx  # la consigne signale l'échec précédent
+    assert "FAILED tests/test_auth.py::test_login" in ctx  # crisp et actionnable
+    assert "collected 4 items" not in ctx  # le bruit n'est PAS ré-injecté
+
+
+async def test_run_stage_retry_feeds_agent_logs(repo, manager):
+    # Échec au stage `run` (process agent) : le feedback vient des logs agent.
+    async def _sleep(d):
+        pass
+
+    pid = _linear_project(manager, 1)
+    agent = _FlakyAgent(fail_times=1)
+    result = await _run(manager, repo, pid, dry_run=False, agent=agent, max_task_attempts=3, sleep_fn=_sleep)
+    assert result.stop_reason == "completed"
+    assert "503 transitoire simulé" in agent.contexts[1]
+
+
 # --- retry au niveau tâche (#420) -------------------------------------------------
 
 
 class _FlakyAgent:
-    """Agent qui échoue N fois (process en erreur) puis réussit — simule un 503."""
+    """Agent qui échoue N fois (process en erreur) puis réussit — simule un 503.
+
+    Enregistre le ``context`` de chaque ``IssueSpec`` reçu (vérification de la
+    ré-injection de feedback, #424).
+    """
 
     def __init__(self, fail_times=1):
         self.calls = 0
+        self.contexts = []
         self._fail_times = fail_times
         self._ok = FakeCodeAgent()
 
     def implement_issue(self, workspace, issue):
         self.calls += 1
+        self.contexts.append(issue.context)
         if self.calls <= self._fail_times:
             return AgentResult(success=False, logs="503 transitoire simulé")
         return self._ok.implement_issue(workspace, issue)


### PR DESCRIPTION
## Problème (#424)

Avec le retry (#420), une tâche re-tentée **à l'identique** rejoue le même `IssueSpec` : l'agent n'a aucune trace de **pourquoi** la tentative précédente a échoué et reproduit le même bug. Preuve FacNor : la task 4 (auth) a échoué ~5 fois à l'identique ; elle n'est passée qu'une fois la sortie des tests **ré-injectée** dans la tentative suivante (et la task 6 a convergé en 1 retry **avec** contexte).

## Correctif

- **`failure_feedback(outcome)`** (pipeline) : synthèse **crisp** de l'échec — lignes `FAILED`/`ERROR` de pytest en priorité (6 max, ≤700 chars), sinon queue bornée de la sortie de tests, sinon logs agent (échec au stage `run`). Le choix « crisp » vient du run réel : un feedback verbeux **noie** l'agent (time-out de 40 min constaté) ; les lignes FAILED seules ont fait converger.
- **Driver** : `tasks.last_error` porte cette synthèse (persistée, #420) ; `_issue_from_task` ré-injecte le motif dans `IssueSpec.context` quand `attempt_count > 0` : *« ta tentative précédente a ÉCHOUÉ … Analyse et corrige d'abord cette cause précise »*. Le contexte passe par `to_prompt()` → inline-isé (anti-injection, inchangé).
- `QualityReport.test_output` **remonte ainsi jusqu'au driver et redescend vers l'agent** — le canal de feedback échec→agent demandé par l'issue.
- Persistance via #420 : le feedback **survit aux redémarrages** (une reprise re-tente avec le motif).

## Tests

- `test_failure_feedback_is_crisp_and_actionable` (pipeline) : lignes FAILED/ERROR seules retenues, fallback borné, logs agent au stage run.
- `test_retry_reinjects_crisp_failure_feedback` (driver) : tentative 1 sans feedback ; tentative 2 contient la ligne `FAILED tests/test_auth.py::test_login…` mais **pas** le bruit (`collected 4 items`).
- `test_run_stage_retry_feeds_agent_logs` : échec process agent → feedback = logs agent.
- Suites `pilot_driver`/`executor_pipeline`/`pilot_runtime` vertes ; `ruff check`/`format` OK.

S'appuie sur #420 (mergée). Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)