### PR TITLE
feat(pilot): cohérence inter-tâches sur PR non mergée — signal + mode strict DEPS_REQUIRE_MERGED (issue #411)

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -80,6 +80,11 @@ class Settings(BaseSettings):
     # côté driver). Un échec transitoire (503, no-op) ne fige plus tout le DAG.
     TASK_MAX_ATTEMPTS: int = 3
     TASK_RETRY_BACKOFF_SECONDS: float = 15.0
+    # Cohérence inter-tâches (#411) : si vrai, une dépendance `in_review` (PR non
+    # mergée) ne débloque PAS ses dépendants (leur clone ne contiendrait pas son
+    # code) ; le run s'arrête `awaiting_merge` quand seuls des merges manquent.
+    # Faux (défaut historique) : le pilote démarre quand même mais SIGNALE le cas.
+    DEPS_REQUIRE_MERGED: bool = False
 
     ENGINE_INIT_TIMEOUT: float = 10.0
     ENGINE_WAIT_TIMEOUT: float = 30.0

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -46,7 +46,13 @@ from collegue.pilot.audit import (
 )
 from collegue.pilot.budget import ACTION_DEADLINE, ACTION_PAUSED_BUDGET, BudgetTimeController
 from collegue.pilot.resume import persist_run_start
-from collegue.pilot.scheduler import next_task, remaining_tasks
+from collegue.pilot.scheduler import (
+    SATISFIED_STATUSES,
+    SATISFIED_STATUSES_STRICT,
+    next_task,
+    ready_tasks,
+    remaining_tasks,
+)
 
 # Statut projet une fois le MVP construit (le moteur d'amélioration = Phase 4).
 PROJECT_STATUS_IMPROVING = "improving"
@@ -60,6 +66,7 @@ STOP_COMPLETED = "completed"  # plus rien à construire → MVP atteint
 STOP_PAUSED_BUDGET = "paused_budget"
 STOP_DEADLINE = "deadline_reached"
 STOP_BLOCKED = "blocked"  # graphe coincé (dépendance échouée)
+STOP_AWAITING_MERGE = "awaiting_merge"  # mode strict (#411) : tout est prêt SAUF des merges humains
 STOP_SAFETY_CAP = "safety_cap"  # garde-fou anti-boucle
 
 # Retry au niveau tâche (#420). Le défaut du MODULE reste 1 (= pas de retry,
@@ -118,12 +125,24 @@ def _issue_from_task(task, by_id=None) -> IssueSpec:
     """
     parts = []
     deps = [by_id[d] for d in (task.depends_on or []) if by_id and d in by_id]
-    if deps:
-        titres = ", ".join(f"« {d.title} »" for d in deps)
+    # #411 : ne pas mentir à l'agent. Une dépendance `in_review` (PR ouverte, non
+    # mergée) n'est PAS dans le clone (`main`) — la présenter comme « déjà
+    # construite » pousserait l'agent à chercher du code absent.
+    pending = [d for d in deps if getattr(d, "status", None) == "in_review"]
+    built = [d for d in deps if d not in pending]
+    if built:
+        titres = ", ".join(f"« {d.title} »" for d in built)
         parts.append(
             f"Cette tâche dépend de tâches déjà construites : {titres}. "
             "Inspecte le dépôt existant et réutilise leur code, modèles et conventions "
             "(ne recrée pas ce qui existe)."
+        )
+    if pending:
+        titres = ", ".join(f"« {d.title} »" for d in pending)
+        parts.append(
+            f"Attention : cette tâche dépend aussi de {titres}, dont la PR n'est PAS encore "
+            "mergée — leur code peut être ABSENT du dépôt cloné. Reste cohérent avec leur "
+            "périmètre (mêmes conventions et interfaces) sans dupliquer leur travail."
         )
     last_error = getattr(task, "last_error", None)
     if int(getattr(task, "attempt_count", 0) or 0) > 0 and last_error:
@@ -164,6 +183,7 @@ async def run_project(
     max_task_attempts: int = DEFAULT_MAX_TASK_ATTEMPTS,
     retry_backoff_seconds: float = DEFAULT_RETRY_BACKOFF_SECONDS,
     sleep_fn=None,
+    require_merged_deps: bool = False,
 ) -> ProjectRunResult:
     """Pilote un projet : chaîne ``execute_issue`` sur les tâches prêtes sous budget.
 
@@ -190,6 +210,13 @@ async def run_project(
     atteint — un aléa transitoire (503, no-op) ne fige plus tout le DAG. Le compteur
     est persisté (``tasks.attempt_count``) → le plafond survit aux redémarrages.
     ``sleep_fn`` : injection de test (défaut ``asyncio.sleep``).
+
+    ``require_merged_deps`` (#411) : si vrai, une dépendance ``in_review`` (PR non
+    mergée) ne débloque PAS ses dépendants — leur clone (``main``) ne contiendrait
+    pas son code. Quand seuls des merges humains manquent, le run s'arrête
+    ``awaiting_merge`` (relancer après merge reprend naturellement). À faux
+    (défaut historique), le démarrage d'un dépendant sur dépendance non mergée est
+    SIGNALÉ (audit ``unmerged_deps`` + warning) au lieu d'être silencieux.
     """
     budget = budget or BudgetTimeController()
     audit = audit or NullAuditLog()
@@ -255,16 +282,44 @@ async def run_project(
             audit.record(BUDGET_EVENT, iteration=iteration, action=decision.action, reason=decision.reason)
             break
 
-        task = next_task(tasks)
+        dep_satisfied = SATISFIED_STATUSES_STRICT if require_merged_deps else SATISFIED_STATUSES
+        task = next_task(tasks, satisfied=dep_satisfied)
         if task is None:
             # Plus aucune tâche prête. En séquentiel, plus aucun reliquat
             # `in_progress` (remis à `todo` au démarrage) : s'il reste des tâches
-            # non terminées, c'est un graphe coincé (dépendance échouée) → bloqué ;
-            # sinon, tout est construit → MVP atteint.
-            stop_reason = STOP_COMPLETED if not remaining_tasks(tasks) else STOP_BLOCKED
+            # non terminées, c'est soit (mode strict, #411) un graphe seulement en
+            # attente de merges humains (des tâches seraient prêtes au sens
+            # historique : rien d'autre ne manque) → `awaiting_merge` (un nouveau
+            # run après merge reprend naturellement) ; soit un graphe coincé
+            # (dépendance échouée) → bloqué ; sinon, tout est construit → MVP.
+            if not remaining_tasks(tasks):
+                stop_reason = STOP_COMPLETED
+            elif require_merged_deps and ready_tasks(tasks):
+                stop_reason = STOP_AWAITING_MERGE
+            else:
+                stop_reason = STOP_BLOCKED
             break
 
-        audit.record(TASK_STARTED, iteration=iteration + 1, task_id=task.id, title=task.title)
+        # #411 (mode historique) : démarrer un dépendant alors qu'une dépendance est
+        # `in_review` signifie que son clone (`main`) ne contient PAS le code de la
+        # dépendance — on le SIGNALE (audit + warning) au lieu de le taire.
+        unmerged_deps = [
+            d
+            for d in (task.depends_on or [])
+            if d in tasks_by_id and getattr(tasks_by_id[d], "status", None) == "in_review"
+        ]
+        started_detail = {"task_id": task.id, "title": task.title}
+        if unmerged_deps:
+            started_detail["unmerged_deps"] = unmerged_deps
+            logger.warning(
+                "tâche %s « %s » démarrée alors que ses dépendances %s sont in_review (PR non "
+                "mergée) : leur code n'est pas dans le clone — incohérence possible (#411). "
+                "DEPS_REQUIRE_MERGED=true pour exiger le merge.",
+                task.id,
+                task.title,
+                unmerged_deps,
+            )
+        audit.record(TASK_STARTED, iteration=iteration + 1, **started_detail)
         outcome = await execute_issue(
             _issue_from_task(task, tasks_by_id),
             repo_source,

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -174,6 +174,8 @@ async def run_project_from_settings(
         # (TASK_MAX_ATTEMPTS=3 en config) ; le module driver isolé reste, lui, à 1.
         max_task_attempts=getattr(settings_obj, "TASK_MAX_ATTEMPTS", 3),
         retry_backoff_seconds=getattr(settings_obj, "TASK_RETRY_BACKOFF_SECONDS", 15.0),
+        # Cohérence inter-tâches (#411) : opt-in pour exiger le merge des deps.
+        require_merged_deps=bool(getattr(settings_obj, "DEPS_REQUIRE_MERGED", False)),
     )
 
     # Reporting (journal de décisions) — réel uniquement (dry_run n'écrit rien).

--- a/collegue/pilot/scheduler.py
+++ b/collegue/pilot/scheduler.py
@@ -8,7 +8,11 @@ consomme la sélection.
 Statuts (alignés Phase 2 ``todo``→``in_progress``→``in_review``) :
 - **satisfaisants** (débloquent un dépendant) : ``in_review``, ``done``, ``merged``.
   Une PR ouverte (``in_review``) suffit à débloquer la suite — on n'attend pas le
-  merge humain pour enchaîner la construction du MVP.
+  merge humain pour enchaîner la construction du MVP. **Caveat (#411)** : le
+  workspace d'un dépendant clone ``main``, qui ne contient PAS le code d'une
+  dépendance ``in_review`` (PR non mergée) — le pilote SIGNALE ce démarrage et
+  un mode strict (``satisfied=SATISFIED_STATUSES_STRICT``) permet d'exiger le
+  merge avant de débloquer.
 - **en cours** : ``in_progress`` (ni prête ni terminée).
 - **prête** : ``todo`` avec toutes ses dépendances satisfaites.
 - tout autre statut non satisfaisant et non actif (ex. ``failed``) bloque ses
@@ -19,10 +23,13 @@ Module **isolé** : non câblé au runtime (F4 câblera le pilote).
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, FrozenSet, List, Optional, Sequence
 
 # Statuts qui SATISFONT une dépendance (débloquent un dépendant).
 SATISFIED_STATUSES = frozenset({"in_review", "done", "merged"})
+# Variante STRICTE (#411) : une PR ouverte ne suffit pas — le code d'une dépendance
+# n'atterrit dans `main` (donc dans le clone du dépendant) qu'au MERGE.
+SATISFIED_STATUSES_STRICT = frozenset({"done", "merged"})
 # Statuts « en cours » : du travail progresse, pas un blocage.
 ACTIVE_STATUSES = frozenset({"in_progress"})
 # Statut d'une tâche pas encore démarrée.
@@ -74,27 +81,29 @@ def _validate_graph(tasks: Sequence) -> None:
                 stack.pop()
 
 
-def ready_tasks(tasks: Sequence) -> List:
+def ready_tasks(tasks: Sequence, *, satisfied: FrozenSet[str] = SATISFIED_STATUSES) -> List:
     """Tâches prêtes (``todo`` + dépendances satisfaites), en ordre déterministe (par id).
 
     Les tâches prêtes sont à la « frontière » du graphe (dépendances déjà
     terminées) donc mutuellement indépendantes : trier par id est déterministe et
     cohérent avec un ordre topologique. Lève :class:`SchedulerError` si le graphe
-    est invalide (cycle / dépendance absente).
+    est invalide (cycle / dépendance absente). ``satisfied`` (#411) : ensemble des
+    statuts qui débloquent (défaut historique ; ``SATISFIED_STATUSES_STRICT`` pour
+    exiger le merge).
     """
     _validate_graph(tasks)
     by_id = _by_id(tasks)
     ready = [
         task
         for task in tasks
-        if task.status == PENDING_STATUS and all(by_id[dep].status in SATISFIED_STATUSES for dep in _deps(task))
+        if task.status == PENDING_STATUS and all(by_id[dep].status in satisfied for dep in _deps(task))
     ]
     return sorted(ready, key=lambda task: task.id)
 
 
-def next_task(tasks: Sequence) -> Optional[object]:
+def next_task(tasks: Sequence, *, satisfied: FrozenSet[str] = SATISFIED_STATUSES) -> Optional[object]:
     """Prochaine tâche prête (la plus prioritaire), ou ``None`` s'il n'y en a pas."""
-    ready = ready_tasks(tasks)
+    ready = ready_tasks(tasks, satisfied=satisfied)
     return ready[0] if ready else None
 
 
@@ -103,7 +112,7 @@ def remaining_tasks(tasks: Sequence) -> List:
     return [task for task in tasks if task.status not in SATISFIED_STATUSES]
 
 
-def is_blocked(tasks: Sequence) -> bool:
+def is_blocked(tasks: Sequence, *, satisfied: FrozenSet[str] = SATISFIED_STATUSES) -> bool:
     """True si des tâches restent, mais aucune n'est prête **et** aucune n'est en cours.
 
     Signale un graphe « coincé » (p.ex. un dépendant d'une tâche ``failed``), pour
@@ -113,6 +122,6 @@ def is_blocked(tasks: Sequence) -> bool:
     remaining = remaining_tasks(tasks)
     if not remaining:
         return False
-    if ready_tasks(tasks):
+    if ready_tasks(tasks, satisfied=satisfied):
         return False
     return not any(task.status in ACTIVE_STATUSES for task in remaining)

--- a/docs/moteur_autonome.md
+++ b/docs/moteur_autonome.md
@@ -159,6 +159,9 @@ lit :
 | `MAX_TOKENS_BUDGET` | Plafond dur de tokens cumulés (`0` = désactivé). | `0` |
 | `BUDGET_EXHAUSTED_ACTION` | `pause` (refuse les appels LLM) ou `warn` (journalise seulement). | `pause` |
 | `COLLEGUE_RUN_DEADLINE_SECONDS` | Durée mur max d'un run (`0` = pas de deadline). | `0` |
+| `TASK_MAX_ATTEMPTS` | Tentatives max par tâche — retry avec backoff sur échec transitoire (`1` = pas de retry). | `3` |
+| `TASK_RETRY_BACKOFF_SECONDS` | Base du backoff linéaire entre tentatives (plafonné à 90 s). | `15` |
+| `DEPS_REQUIRE_MERGED` | Exige le **merge** d'une dépendance avant de débloquer ses dépendants (sinon le démarrage sur PR non mergée est signalé) ; arrêt `awaiting_merge` quand seuls des merges manquent. | `false` |
 | `LLM_CALL_TIMEOUT` | Timeout par appel LLM, secondes (`0` = off). | `0` |
 | `AUTO_MERGE_ENABLED` | Active l'auto-merge progressif (opt-in). | `false` |
 | `AUTO_MERGE_MAX_LOC` | Plafond de lignes nettes pour l'auto-merge. | `50` |

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -219,6 +219,60 @@ async def test_failed_task_blocks_dependents(repo, manager):
     assert statuses["T1"] == "todo"  # jamais lancée
 
 
+# --- cohérence inter-tâches sur PR non mergée (#411) -------------------------------
+
+
+async def test_unmerged_dep_start_is_signaled(repo, manager):
+    """#411 (mode historique) : démarrer un dépendant alors que sa dépendance est
+    `in_review` (PR non mergée → code absent du clone) est SIGNALÉ dans l'audit
+    (`task_started.unmerged_deps`) au lieu d'être silencieux."""
+    from collegue.pilot.audit import RunAuditLog
+
+    pid = _linear_project(manager, 2)
+    audit = RunAuditLog(pid)
+    result = await _run(manager, repo, pid, dry_run=False, audit=audit)
+    assert result.stop_reason == "completed"
+    started = [e for e in audit.events if e.kind == "task_started"]
+    t0 = manager.get_tasks(pid)[0]
+    assert "unmerged_deps" not in started[0].detail  # T0 (racine) : rien à signaler
+    assert started[1].detail["unmerged_deps"] == [t0.id]  # T1 démarrée sur T0 non mergée
+
+
+async def test_agent_context_flags_unmerged_dependency(repo, manager):
+    # Le contexte donné à l'agent ne MENT plus : une dépendance in_review n'est pas
+    # présentée comme « déjà construite » (son code peut être absent du clone).
+    pid = _linear_project(manager, 2)
+    agent = _RecordingAgent()
+    await _run(manager, repo, pid, dry_run=False, agent=agent)
+    ctx = agent.contexts[1]  # T1, dépend de T0 in_review
+    assert "PAS encore" in ctx and "ABSENT" in ctx
+    assert "déjà construites" not in ctx
+
+
+async def test_require_merged_deps_stops_awaiting_merge_then_resumes(repo, manager):
+    """#411 (mode strict) : la PR de T0 n'étant pas mergée, T1 ne démarre pas et le
+    run s'arrête `awaiting_merge` (≠ `blocked` : seul un merge humain manque).
+    Après le merge, un nouveau run reprend naturellement et termine."""
+    pid = _linear_project(manager, 2)
+    result = await _run(manager, repo, pid, dry_run=False, require_merged_deps=True)
+    assert result.iterations == 1  # T0 seulement
+    assert result.stop_reason == "awaiting_merge"
+    t0, t1 = manager.get_tasks(pid)
+    assert t0.status == "in_review" and t1.status == "todo"
+
+    manager.update_task_status(t0.id, "merged")  # merge humain
+    result2 = await _run(manager, repo, pid, dry_run=False, require_merged_deps=True)
+    assert result2.stop_reason == "completed"
+    assert manager.get_tasks(pid)[1].status == "in_review"
+
+
+async def test_strict_mode_hard_failure_still_blocked(repo, manager):
+    # Un échec dur n'est PAS un merge manquant : `blocked`, pas `awaiting_merge`.
+    pid = _linear_project(manager, 2)
+    result = await _run(manager, repo, pid, dry_run=False, require_merged_deps=True, sandbox=_Sandbox(ok=False))
+    assert result.stop_reason == "blocked"
+
+
 # --- ré-injection du feedback d'échec au retry (#424) ------------------------------
 
 

--- a/tests/test_pilot_scheduler.py
+++ b/tests/test_pilot_scheduler.py
@@ -156,3 +156,27 @@ def test_not_blocked_when_all_done(manager):
     a = manager.add_task(pid, title="A")
     manager.update_task_status(a, "done")
     assert is_blocked(manager.get_tasks(pid)) is False
+
+
+# --- mode strict : exiger le merge des dépendances (#411) -------------------------
+
+
+def test_strict_satisfied_requires_merge(manager):
+    """#411 : en mode strict, une dépendance `in_review` (PR non mergée) ne rend
+    PAS son dépendant prêt — le clone d'un dépendant part de `main`, qui ne
+    contient le code de la dépendance qu'au merge. Seuls done/merged débloquent."""
+    from collegue.pilot.scheduler import SATISFIED_STATUSES_STRICT
+
+    pid = manager.create_project(name="demo")
+    a = manager.add_task(pid, title="A")
+    b = manager.add_task(pid, title="B", depends_on=[a])
+
+    manager.update_task_status(a, "in_review")
+    tasks = manager.get_tasks(pid)
+    assert _ids(ready_tasks(tasks)) == [b]  # défaut historique : inchangé
+    assert ready_tasks(tasks, satisfied=SATISFIED_STATUSES_STRICT) == []  # strict : bloqué
+    assert next_task(tasks, satisfied=SATISFIED_STATUSES_STRICT) is None
+
+    manager.update_task_status(a, "merged")
+    tasks = manager.get_tasks(pid)
+    assert _ids(ready_tasks(tasks, satisfied=SATISFIED_STATUSES_STRICT)) == [b]


### PR DESCRIPTION
## Problème (#411)

`in_review` satisfait une dépendance, mais le workspace d'un dépendant **clone `main`**, qui ne contient pas le code d'une PR non mergée : le dépendant code contre un arbre **amputé de son prérequis**, silencieusement (imports manquants, schéma absent), sans aucun signal.

## Correctif (les deux options de l'issue, combinées)

**Mode historique (défaut, inchangé fonctionnellement) — « au minimum signaler » :**
- Démarrer un dépendant dont une dépendance est `in_review` émet `task_started.unmerged_deps=[ids]` dans l'audit + un `logger.warning` explicite.
- Le **contexte donné à l'agent ne ment plus** : une dépendance non mergée n'est plus présentée comme « déjà construite » mais comme *« PR non mergée — leur code peut être ABSENT du dépôt cloné ; reste cohérent avec leur périmètre sans dupliquer »* (corrige un biais du contexte #412).

**Mode strict opt-in (`DEPS_REQUIRE_MERGED=true`) — option 1 de l'issue :**
- `SATISFIED_STATUSES_STRICT = {done, merged}` : une PR ouverte ne débloque plus ses dépendants ; `ready_tasks`/`next_task`/`is_blocked` prennent `satisfied=…` (défaut historique inchangé).
- Quand **seuls des merges humains manquent** (des tâches seraient prêtes au sens historique), le run s'arrête avec une raison dédiée **`awaiting_merge`** — distincte de `blocked` (échec dur). Un run relancé après les merges **reprend naturellement** (l'état DB fait foi).
- Câblé dans le runtime via le setting `DEPS_REQUIRE_MERGED` (défaut `false`) ; doc exploitation mise à jour.

## Tests

- Scheduler : `test_strict_satisfied_requires_merge` (in_review ne débloque pas en strict ; merged débloque ; défaut inchangé).
- Driver : `test_unmerged_dep_start_is_signaled` (audit `unmerged_deps`), `test_agent_context_flags_unmerged_dependency` (contexte honnête), `test_require_merged_deps_stops_awaiting_merge_then_resumes` (arrêt dédié puis reprise après merge), `test_strict_mode_hard_failure_still_blocked` (échec dur ≠ merge manquant).
- Suites `pilot_driver`/`pilot_scheduler`/`executor_pipeline`/`pilot_runtime` vertes ; `ruff check`/`format` OK.

Reste possible en suivi (mentionné par l'issue, non bloquant) : préparer le workspace d'un dépendant à partir des branches de PR non mergées de ses dépendances — plus lourd (fetch des branches `collegue/issue-<N>` dans le clone), à traiter séparément si le mode strict ne suffit pas à l'usage.

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)