### PR TITLE
fix(pilot): intégration sérielle en mode strict — 1 PR en vol par défaut (#434)

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -85,6 +85,11 @@ class Settings(BaseSettings):
     # code) ; le run s'arrête `awaiting_merge` quand seuls des merges manquent.
     # Faux (défaut historique) : le pilote démarre quand même mais SIGNALE le cas.
     DEPS_REQUIRE_MERGED: bool = False
+    # Intégration sérielle en mode strict (#434) : plafond de PRs « en vol »
+    # (tâches in_review) avant arrêt `awaiting_merge`. À 1 (défaut), des tâches
+    # sœurs ne sont plus construites depuis la même base → plus de PRs sœurs en
+    # conflit (merge 405 irrécupérable). Ignoré si DEPS_REQUIRE_MERGED est faux.
+    STRICT_MAX_INFLIGHT_PRS: int = 1
 
     ENGINE_INIT_TIMEOUT: float = 10.0
     ENGINE_WAIT_TIMEOUT: float = 30.0

--- a/collegue/pilot/__init__.py
+++ b/collegue/pilot/__init__.py
@@ -32,7 +32,7 @@ from collegue.pilot.budget import (
     BudgetTimeController,
     ContinueDecision,
 )
-from collegue.pilot.driver import ProjectRunResult, TaskOutcome, run_project
+from collegue.pilot.driver import ProjectRunResult, TaskOutcome, requeue_task_for_redo, run_project
 from collegue.pilot.guard import (
     GuardOutcome,
     HealthResult,
@@ -77,6 +77,7 @@ __all__ = [
     "run_project",
     "ProjectRunResult",
     "TaskOutcome",
+    "requeue_task_for_redo",
     # F4 — câblage runtime
     "run_project_from_settings",
     "format_run_report",

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -77,6 +77,12 @@ DEFAULT_MAX_TASK_ATTEMPTS = 1
 DEFAULT_RETRY_BACKOFF_SECONDS = 15.0
 RETRY_BACKOFF_CAP_SECONDS = 90.0
 
+# Intégration sérielle en mode strict (#434) : nombre max de PRs « en vol »
+# (tâches ``in_review``) avant de s'arrêter ``awaiting_merge``. À 1, chaque tâche
+# sœur se construit sur la précédente MERGÉE — des PRs sœurs ouvertes depuis la
+# même base ne peuvent plus entrer en conflit entre elles (merge 405 irrécupérable).
+DEFAULT_MAX_INFLIGHT_REVIEWS = 1
+
 logger = logging.getLogger(__name__)
 
 
@@ -159,6 +165,28 @@ def _issue_from_task(task, by_id=None) -> IssueSpec:
     )
 
 
+def requeue_task_for_redo(manager, task_id: int, *, message: str, attempt_count: int = 1) -> None:
+    """Re-file une tâche pour un REDO complet après un événement externe (#434).
+
+    Cas nominal : la PR d'une tâche ``in_review`` est devenue non mergeable
+    (conflit avec ``main`` — :class:`~collegue.tools.github_commands.PRNotMergeableError`).
+    L'orchestrateur ferme la PR puis appelle ce helper : la tâche repart ``todo``
+    avec ``attempt_count``/``last_error`` posés pour que le canal feedback (#424)
+    ré-injecte ``message`` dans le prompt de la nouvelle tentative (« ta PR était
+    en conflit, repars du dépôt à jour »).
+
+    ``attempt_count=1`` (défaut) : un conflit d'infrastructure ne consomme pas le
+    budget de retries fonctionnels — on garde juste le minimum (> 0) pour que le
+    feedback soit injecté.
+    """
+    manager.update_task(
+        task_id,
+        status=TASK_STATUS_TODO,
+        attempt_count=max(1, int(attempt_count)),
+        last_error=str(message),
+    )
+
+
 async def run_project(
     project_id: int,
     repo_source: str,
@@ -184,6 +212,7 @@ async def run_project(
     retry_backoff_seconds: float = DEFAULT_RETRY_BACKOFF_SECONDS,
     sleep_fn=None,
     require_merged_deps: bool = False,
+    max_inflight_reviews: int = DEFAULT_MAX_INFLIGHT_REVIEWS,
 ) -> ProjectRunResult:
     """Pilote un projet : chaîne ``execute_issue`` sur les tâches prêtes sous budget.
 
@@ -217,6 +246,15 @@ async def run_project(
     ``awaiting_merge`` (relancer après merge reprend naturellement). À faux
     (défaut historique), le démarrage d'un dépendant sur dépendance non mergée est
     SIGNALÉ (audit ``unmerged_deps`` + warning) au lieu d'être silencieux.
+
+    ``max_inflight_reviews`` (#434, mode strict uniquement) : plafond de tâches
+    ``in_review`` (PR ouverte non mergée) avant de s'arrêter ``awaiting_merge``.
+    À 1 (défaut), l'intégration est SÉRIELLE : des tâches sœurs (indépendantes
+    entre elles) ne sont plus construites depuis la même base — la base de
+    chacune inclut le merge de la précédente, donc plus de PRs sœurs en conflit
+    (merge 405 irrécupérable sans opérateur). Augmenter rétablit N PRs en vol
+    (au risque documenté de #434). Ignoré hors mode strict (comportement
+    historique inchangé : ``in_review`` débloque déjà les dépendants).
     """
     budget = budget or BudgetTimeController()
     audit = audit or NullAuditLog()
@@ -230,6 +268,10 @@ async def run_project(
         backoff = DEFAULT_RETRY_BACKOFF_SECONDS
     if not (backoff > 0 and backoff < float("inf")):  # nan/inf/négatif → pas d'attente
         backoff = 0.0
+    try:
+        max_inflight_reviews = max(1, int(max_inflight_reviews))
+    except (TypeError, ValueError):
+        max_inflight_reviews = DEFAULT_MAX_INFLIGHT_REVIEWS
     sleep = sleep_fn or asyncio.sleep
     tasks = manager.get_tasks(project_id)  # objets détachés : overlay mutable en mémoire
     tasks_by_id = {t.id: t for t in tasks}  # pour le contexte inter-tâches (#412)
@@ -299,6 +341,26 @@ async def run_project(
             else:
                 stop_reason = STOP_BLOCKED
             break
+
+        # #434 (mode strict) : borner les PRs « en vol ». Une tâche est prête, mais
+        # si ``max_inflight_reviews`` tâches sont déjà ``in_review``, la démarrer la
+        # construirait sur une base qui n'inclut PAS ces PRs → dès que l'une merge,
+        # les PRs sœurs touchant les mêmes fichiers deviennent non mergeables (405),
+        # sans aucune issue moteur. On s'arrête ``awaiting_merge`` : après le(s)
+        # merge(s) humains, un nouveau run repart d'une base à jour.
+        if require_merged_deps:
+            inflight = sum(1 for t in tasks if t.status == TASK_STATUS_IN_REVIEW)
+            if inflight >= max_inflight_reviews:
+                logger.info(
+                    "mode strict : %d PR(s) en vol (plafond %d) — arrêt awaiting_merge "
+                    "avant la tâche %s « %s » (#434, intégration sérielle)",
+                    inflight,
+                    max_inflight_reviews,
+                    task.id,
+                    task.title,
+                )
+                stop_reason = STOP_AWAITING_MERGE
+                break
 
         # #411 (mode historique) : démarrer un dépendant alors qu'une dépendance est
         # `in_review` signifie que son clone (`main`) ne contient PAS le code de la

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -176,6 +176,8 @@ async def run_project_from_settings(
         retry_backoff_seconds=getattr(settings_obj, "TASK_RETRY_BACKOFF_SECONDS", 15.0),
         # Cohérence inter-tâches (#411) : opt-in pour exiger le merge des deps.
         require_merged_deps=bool(getattr(settings_obj, "DEPS_REQUIRE_MERGED", False)),
+        # Intégration sérielle en mode strict (#434) : 1 PR en vol par défaut.
+        max_inflight_reviews=getattr(settings_obj, "STRICT_MAX_INFLIGHT_PRS", 1),
     )
 
     # Reporting (journal de décisions) — réel uniquement (dry_run n'écrit rien).

--- a/collegue/tools/github_commands/__init__.py
+++ b/collegue/tools/github_commands/__init__.py
@@ -16,7 +16,7 @@ from .issues import IssueCommands, IssueInfo
 from .labels import LabelCommands, LabelInfo
 from .milestones import MilestoneCommands, MilestoneInfo
 from .projects import ProjectCommands, ProjectInfo
-from .prs import Comment, FileChange, MergeResult, PRCommands, PRInfo
+from .prs import Comment, FileChange, MergeResult, PRCommands, PRInfo, PRNotMergeableError
 from .repos import RepoCommands, RepoInfo
 from .search import SearchCommands, SearchResult
 from .workflows import WorkflowCommands, WorkflowRun
@@ -27,6 +27,7 @@ __all__ = [
     "RepoInfo",
     "PRCommands",
     "PRInfo",
+    "PRNotMergeableError",
     "FileChange",
     "Comment",
     "MergeResult",

--- a/collegue/tools/github_commands/prs.py
+++ b/collegue/tools/github_commands/prs.py
@@ -15,6 +15,21 @@ from ._helpers import validate_ref
 _MERGE_METHODS = ("merge", "squash", "rebase")
 
 
+class PRNotMergeableError(ToolExecutionError):
+    """La PR est en CONFLIT avec sa base : le merge est impossible en l'état (#434).
+
+    Erreur **typée** (sous-classe de :class:`ToolExecutionError`) pour que les
+    appelants (auto-merge H2, orchestrations) puissent brancher une stratégie de
+    réparation — close + redo de la tâche (cf. ``requeue_task_for_redo`` du pilote),
+    update-branch… — au lieu de parser un 405 générique.
+    """
+
+    def __init__(self, pr_number: int, mergeable_state: str, message: str):
+        super().__init__(message)
+        self.pr_number = pr_number
+        self.mergeable_state = mergeable_state
+
+
 class PRInfo(BaseModel):
     number: int
     title: str
@@ -251,6 +266,21 @@ class PRCommands(GitHubClient):
                 "refus (anti-course)"
             )
 
+        # #434 : détecter le CONFLIT avant le PUT. GitHub expose ``mergeable``
+        # (False = conflit confirmé ; None = calcul en cours → on tente, le PUT
+        # tranchera) et ``mergeable_state`` (``dirty`` = conflit). Les autres états
+        # (behind/blocked/unstable) ne sont PAS des conflits : on laisse l'API
+        # décider (un ``behind`` merge très bien).
+        mergeable_state = str(current.get("mergeable_state") or "").lower()
+        if current.get("mergeable") is False or mergeable_state == "dirty":
+            raise PRNotMergeableError(
+                pr_number,
+                mergeable_state or "dirty",
+                f"PR #{pr_number} en conflit avec sa base (mergeable_state="
+                f"{mergeable_state or 'dirty'}) — merge impossible en l'état : "
+                "rebase/update-branch ou close+redo de la tâche requis",
+            )
+
         body: dict = {"merge_method": method}
         if commit_title:
             body["commit_title"] = commit_title
@@ -259,7 +289,23 @@ class PRCommands(GitHubClient):
         if expected_head_sha:
             body["sha"] = expected_head_sha
 
-        resp = self._api_put(f"/repos/{owner}/{repo}/pulls/{pr_number}/merge", body) or {}
+        try:
+            resp = self._api_put(f"/repos/{owner}/{repo}/pulls/{pr_number}/merge", body) or {}
+        except PRNotMergeableError:
+            raise
+        except ToolExecutionError as exc:
+            # ``mergeable`` peut être None/périmé au GET : GitHub répond alors
+            # 405 « Pull Request is not mergeable » au PUT. On re-type l'erreur
+            # pour offrir le même canal de réparation que la détection amont.
+            text = str(exc)
+            if "405" in text or "not mergeable" in text.lower():
+                raise PRNotMergeableError(
+                    pr_number,
+                    "dirty",
+                    f"PR #{pr_number} refusée au merge par GitHub (405 non mergeable) — "
+                    "conflit probable avec la base : rebase/update-branch ou close+redo requis",
+                ) from exc
+            raise
         # Un merge réussi renvoie toujours ``{"merged": true, "sha": ...}`` ; l'absence
         # de confirmation = échec (défaut False), jamais un succès supposé (fail-closed).
         return MergeResult(merged=bool(resp.get("merged", False)), sha=resp.get("sha"), message=resp.get("message", ""))

--- a/tests/test_github_merge_delete.py
+++ b/tests/test_github_merge_delete.py
@@ -9,7 +9,7 @@ branches protégées et fail-closed.
 import pytest
 
 from collegue.tools.base import ToolExecutionError
-from collegue.tools.github_commands import BranchCommands, MergeResult, PRCommands
+from collegue.tools.github_commands import BranchCommands, MergeResult, PRCommands, PRNotMergeableError
 
 
 class _Recorder:
@@ -93,6 +93,70 @@ def test_merge_pr_empty_put_response_is_not_merged():
     pr, _ = _pr_with({"merged": False, "state": "open", "head": {"sha": "h1"}})  # put_payload None → {}
     res = pr.merge_pr("o", "r", 7)
     assert res.merged is False
+
+
+# --- détection de conflit avant merge (#434) --------------------------------------
+
+
+def test_merge_pr_conflict_detected_before_put():
+    # Conflit signalé par GitHub (mergeable False / state dirty) → erreur TYPÉE
+    # avant tout PUT, pour que l'appelant branche close+redo/update-branch au lieu
+    # de parser un 405 générique.
+    pr, rec = _pr_with(
+        {"merged": False, "state": "open", "head": {"sha": "h"}, "mergeable": False, "mergeable_state": "dirty"}
+    )
+    with pytest.raises(PRNotMergeableError) as ei:
+        pr.merge_pr("o", "r", 64)
+    assert ei.value.pr_number == 64
+    assert ei.value.mergeable_state == "dirty"
+    assert not any(c[0] == "PUT" for c in rec.calls)
+
+
+def test_merge_pr_mergeable_unknown_proceeds():
+    # ``mergeable`` None (calcul GitHub en cours) n'est PAS un conflit confirmé :
+    # on laisse le PUT trancher (sinon fausses alertes sur les PRs fraîches).
+    pr, _ = _pr_with(
+        {"merged": False, "state": "open", "head": {"sha": "h"}, "mergeable": None, "mergeable_state": "unknown"},
+        put_payload={"merged": True, "sha": "s", "message": "ok"},
+    )
+    assert pr.merge_pr("o", "r", 7).merged is True
+
+
+def test_merge_pr_behind_is_not_a_conflict():
+    # ``behind`` (base avancée sans conflit) merge très bien : seul ``dirty``/
+    # ``mergeable=False`` déclenche l'erreur typée.
+    pr, _ = _pr_with(
+        {"merged": False, "state": "open", "head": {"sha": "h"}, "mergeable": True, "mergeable_state": "behind"},
+        put_payload={"merged": True, "sha": "s", "message": "ok"},
+    )
+    assert pr.merge_pr("o", "r", 7).merged is True
+
+
+def test_merge_pr_put_405_retyped_as_not_mergeable():
+    # GET avec ``mergeable`` périmé/absent → GitHub répond 405 au PUT : re-typé
+    # pour offrir le même canal de réparation que la détection amont.
+    pr, _ = _pr_with({"merged": False, "state": "open", "head": {"sha": "h"}})
+
+    def fail_put(endpoint, data):
+        raise ToolExecutionError("Erreur API GitHub: 405 Client Error: Method Not Allowed for url: .../merge")
+
+    pr._api_put = fail_put
+    with pytest.raises(PRNotMergeableError) as ei:
+        pr.merge_pr("o", "r", 71)
+    assert ei.value.pr_number == 71
+
+
+def test_merge_pr_other_http_errors_propagate_untyped():
+    # Une 500 quelconque reste une ToolExecutionError générique (pas un conflit).
+    pr, _ = _pr_with({"merged": False, "state": "open", "head": {"sha": "h"}})
+
+    def fail_put(endpoint, data):
+        raise ToolExecutionError("Erreur API GitHub: 500 Server Error")
+
+    pr._api_put = fail_put
+    with pytest.raises(ToolExecutionError) as ei:
+        pr.merge_pr("o", "r", 7)
+    assert not isinstance(ei.value, PRNotMergeableError)
 
 
 # --- delete_branch --------------------------------------------------------------

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -105,6 +105,14 @@ def _linear_project(manager, n=3):
     return pid
 
 
+def _sibling_project(manager, n=2):
+    """Tâches SŒURS : indépendantes entre elles (toutes prêtes dès la 1re passe)."""
+    pid = manager.create_project(name="demo-siblings")
+    for i in range(n):
+        manager.add_task(pid, title=f"S{i}")
+    return pid
+
+
 async def _run(manager, repo, pid, *, budget=None, dry_run=True, sandbox=None, agent=None, **kw):
     return await run_project(
         pid,
@@ -271,6 +279,72 @@ async def test_strict_mode_hard_failure_still_blocked(repo, manager):
     pid = _linear_project(manager, 2)
     result = await _run(manager, repo, pid, dry_run=False, require_merged_deps=True, sandbox=_Sandbox(ok=False))
     assert result.stop_reason == "blocked"
+
+
+# --- intégration sérielle en mode strict (#434) -------------------------------------
+
+
+async def test_strict_mode_serializes_sibling_prs(repo, manager):
+    """#434 : deux tâches SŒURS (indépendantes) ne sont plus construites depuis la
+    même base — dès la 1re PR en vol, le run s'arrête `awaiting_merge` ; la sœur
+    n'est construite qu'après le merge (sa base inclut alors la PR précédente →
+    plus de PRs sœurs en conflit, merge 405 irrécupérable)."""
+    pid = _sibling_project(manager, 2)
+    result = await _run(manager, repo, pid, dry_run=False, require_merged_deps=True)
+    assert result.stop_reason == "awaiting_merge"
+    assert result.iterations == 1  # S0 seulement : S1 attend le merge
+    s0, s1 = manager.get_tasks(pid)
+    assert s0.status == "in_review" and s1.status == "todo"
+
+    manager.update_task_status(s0.id, "merged")  # merge humain
+    result2 = await _run(manager, repo, pid, dry_run=False, require_merged_deps=True)
+    assert result2.iterations == 1
+    assert result2.stop_reason == "completed"
+    assert manager.get_tasks(pid)[1].status == "in_review"
+
+
+async def test_strict_mode_inflight_cap_is_configurable(repo, manager):
+    # max_inflight_reviews=2 : les deux sœurs partent dans la même passe (N PRs en
+    # vol, comportement pré-#434) — l'opérateur choisit explicitement son risque.
+    pid = _sibling_project(manager, 2)
+    result = await _run(manager, repo, pid, dry_run=False, require_merged_deps=True, max_inflight_reviews=2)
+    assert result.stop_reason == "completed"
+    assert result.iterations == 2
+
+
+async def test_strict_mode_resume_with_inflight_pr_starts_nothing(repo, manager):
+    # Reprise : une PR d'un run précédent est déjà en vol → on ne démarre RIEN
+    # (la base clonée ne l'inclut pas) ; `awaiting_merge` immédiat.
+    pid = _sibling_project(manager, 2)
+    manager.update_task_status(manager.get_tasks(pid)[0].id, "in_review")
+    result = await _run(manager, repo, pid, dry_run=False, require_merged_deps=True)
+    assert result.stop_reason == "awaiting_merge"
+    assert result.iterations == 0
+
+
+async def test_historical_mode_keeps_chaining_siblings(repo, manager):
+    # Hors mode strict : comportement inchangé, les sœurs s'enchaînent dans la passe
+    # (`in_review` débloque déjà — le plafond #434 ne s'applique qu'au mode strict).
+    pid = _sibling_project(manager, 2)
+    result = await _run(manager, repo, pid, dry_run=False)
+    assert result.stop_reason == "completed"
+    assert result.iterations == 2
+
+
+def test_requeue_task_for_redo_resets_for_feedback(manager):
+    """#434 : contrat du close+redo — la tâche repart `todo` avec un feedback (#424)
+    et un attempt_count MINIMAL (un conflit d'infrastructure ne consomme pas le
+    budget de retries fonctionnels)."""
+    from collegue.pilot import requeue_task_for_redo
+
+    pid = _linear_project(manager, 1)
+    tid = manager.get_tasks(pid)[0].id
+    manager.update_task(tid, status="in_review", attempt_count=2)
+    requeue_task_for_redo(manager, tid, message="[merge/conflit] ta PR était en conflit avec main — repars à jour")
+    t = manager.get_tasks(pid)[0]
+    assert t.status == "todo"
+    assert t.attempt_count == 1
+    assert "conflit" in t.last_error
 
 
 # --- ré-injection du feedback d'échec au retry (#424) ------------------------------


### PR DESCRIPTION
## Problème (#434 — CRITIQUE, run FacNor v2)

En mode strict (#411), le driver exécutait **toutes** les tâches prêtes d'une passe depuis la **même base** : dès le merge de la première PR sœur, les suivantes touchant les mêmes fichiers devenaient non mergeables (`mergeable_state=dirty` → **405** à l'API merge), sans **aucun** mécanisme moteur de sortie (ni détection, ni rebase, ni close+redo). Sur le run v2 : ~1 h 45 perdues (PRs FacNor #64 et #71), 2 hot-fix opérateur en plein vol, tâches 12–13 sacrifiées.

## Correctif

**1. `driver.run_project(max_inflight_reviews=1)` — intégration sérielle (option « simple et quasi gratuite » de l'issue)**
- En mode strict uniquement : dès que `max_inflight_reviews` tâches sont `in_review` (PR ouverte non mergée), le run s'arrête `awaiting_merge` **avant** de démarrer la tâche prête suivante.
- Chaque tâche sœur se construit donc sur la précédente **mergée** → plus de PRs sœurs en conflit (le run v1, qui mergeait après chaque PR, n'avait eu aucun conflit).
- Configurable : `STRICT_MAX_INFLIGHT_PRS` (config) pour rétablir N PRs en vol explicitement ; hors mode strict, comportement historique inchangé.

**2. `PRCommands.merge_pr` — détection de conflit typée**
- Lit `mergeable`/`mergeable_state` **avant** le PUT : conflit confirmé (`mergeable=False` ou `dirty`) → `PRNotMergeableError` (sous-classe de `ToolExecutionError`, avec `pr_number` + `mergeable_state`).
- Le 405 « not mergeable » du PUT (cas `mergeable` encore en calcul) est **re-typé** pareil — les appelants (auto-merge H2, orchestrations) branchent une réparation au lieu de parser des messages.
- `behind`/`unstable`/`mergeable=None` ne déclenchent PAS (pas des conflits).

**3. `requeue_task_for_redo(manager, task_id, message=…)` — contrat close+redo**
- Standardise ce que l'opérateur a codé en urgence dans le harness : la tâche repart `todo` avec `attempt_count` minimal (un conflit d'infra ne consomme pas le budget de retries fonctionnels) et `last_error` → ré-injecté dans le prompt via le canal feedback #424.

## Tests
- Driver : sérialisation des sœurs (1 itération puis `awaiting_merge`, reprise après merge), plafond configurable, reprise avec PR en vol (0 démarrage), mode historique inchangé, contrat du redo.
- `merge_pr` : conflit détecté avant PUT (aucun PUT émis), `mergeable=None` → on laisse le PUT trancher, `behind` ≠ conflit, 405 re-typé, 500 reste générique.
- Suite complète locale : verte.

Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)