### PR TITLE
fix(executor): barrière d'exception par tâche dans execute_issue (#435)

### DIFF
--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -24,15 +24,18 @@ items du board) — délibérément hors périmètre ici.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Optional
 
-from collegue.executor.agent import CodeAgent, IssueSpec
+from collegue.executor.agent import AgentResult, CodeAgent, IssueSpec
 from collegue.executor.command import CommandRunner
 from collegue.executor.pr import PrClients, PrResult, open_pr
 from collegue.executor.quality_gate import QualityReport, Reviewer, run_quality_gate
 from collegue.executor.runner import ExecutionResult, run_issue
 from collegue.executor.workspace import Workspace, prepare_workspace
+
+logger = logging.getLogger(__name__)
 
 TASK_STATUS_TODO = "todo"
 TASK_STATUS_IN_PROGRESS = "in_progress"
@@ -49,6 +52,7 @@ STAGE_PR = "pr"  # ouverture de PR
 REASON_NO_OP = "no_op"  # l'agent a tourné sans erreur mais n'a produit AUCUN diff
 REASON_AGENT_ERROR = "agent_error"  # le process agent a échoué (exit ≠ 0 / timeout)
 REASON_GATE_FAILED = "gate_failed"  # tests rouges ou revue bloquante
+REASON_ENGINE_ERROR = "engine_error"  # exception d'infrastructure interceptée (#435)
 
 
 def log_tail(text: str, limit: int = 2000) -> str:
@@ -68,7 +72,13 @@ def failure_feedback(outcome: "ExecutionOutcome") -> str:
     feedback bruité → time-out de 40 min ; lignes FAILED seules → convergence).
     À défaut de lignes de tests, queue bornée de la sortie de tests puis des logs
     agent (échec au stage ``run``).
+
+    Exception d'infrastructure (#435, ``outcome.error``) : c'est ELLE le motif —
+    les logs agent (potentiellement ceux d'une exécution réussie, si la panne est
+    survenue à l'ouverture de PR) seraient un feedback trompeur.
     """
+    if outcome.error:
+        return log_tail(outcome.error, 400)
     if outcome.quality_report is not None and outcome.quality_report.test_output:
         output = outcome.quality_report.test_output
         fails = [line.strip() for line in output.splitlines() if line.strip().startswith(("FAILED", "ERROR"))]
@@ -84,12 +94,13 @@ class ExecutionOutcome:
 
     success: bool  # le pipeline est allé jusqu'à la PR (gate passé)
     stage: str  # dernière étape atteinte : run | gate | pr
-    workspace: Workspace
+    workspace: Optional[Workspace]  # None si l'exception a frappé avant la préparation (#435)
     execution: ExecutionResult
     quality_report: Optional[QualityReport] = None
     pr: Optional[PrResult] = None
     final_status: Optional[str] = None  # statut de tâche effectivement écrit (None si dry_run / pas de manager)
-    reason: Optional[str] = None  # raison d'échec (no_op | agent_error | gate_failed), None si succès
+    reason: Optional[str] = None  # raison d'échec (no_op | agent_error | gate_failed | engine_error), None si succès
+    error: Optional[str] = None  # exception d'infrastructure interceptée (#435), None sinon
 
 
 def _set_status(manager, task_id, status: str, *, enabled: bool) -> Optional[str]:
@@ -124,58 +135,101 @@ async def execute_issue(
     ou gate non passé), ``success=False`` et aucune PR n'est ouverte ; l'état ne
     dépasse pas ``in_progress``. ``dry_run`` (défaut) n'écrit rien et n'effectue
     aucune transition d'état.
+
+    **Barrière d'exception (#435)** : une exception d'infrastructure pendant le
+    traitement (``WorkspaceError`` au clone, erreur réseau GitHub à l'ouverture de
+    PR, bug ponctuel d'un adaptateur) ne remonte PLUS crue — elle est convertie en
+    outcome ``failed`` (``reason="engine_error"``, ``stage`` = étape atteinte,
+    ``error`` = exception) qui entre dans le chemin retry existant du pilote
+    (#420/#424). Une panne ponctuelle d'UNE tâche ne tue plus le run entier alors
+    que le reste du DAG est exécutable. Les ``BaseException`` (annulation asyncio,
+    arrêt process) propagent, elles, normalement.
     """
     persist = not dry_run  # les transitions d'état n'ont lieu qu'en exécution réelle
     final_status: Optional[str] = None
+    stage = STAGE_RUN
+    workspace: Optional[Workspace] = None
+    execution: Optional[ExecutionResult] = None
+    report: Optional[QualityReport] = None
 
-    workspace = prepare_workspace(repo_source, issue)
-    final_status = _set_status(manager, task_id, TASK_STATUS_IN_PROGRESS, enabled=persist) or final_status
+    try:
+        workspace = prepare_workspace(repo_source, issue)
+        final_status = _set_status(manager, task_id, TASK_STATUS_IN_PROGRESS, enabled=persist) or final_status
 
-    # E2 : exécution de l'agent + capture du diff (l'état est piloté ici, pas par run_issue).
-    execution = run_issue(agent, workspace, issue, runner=runner)
-    if not execution.changed:
-        # #421 : distinguer le no-op (agent OK, zéro diff — souvent transitoire)
-        # de l'erreur du process agent (exit ≠ 0) — la couche retry en dépend.
-        reason = REASON_NO_OP if execution.agent_result.success else REASON_AGENT_ERROR
-        return ExecutionOutcome(
-            success=False,
-            stage=STAGE_RUN,
-            workspace=workspace,
-            execution=execution,
-            final_status=final_status,
-            reason=reason,
+        # E2 : exécution de l'agent + capture du diff (l'état est piloté ici, pas par run_issue).
+        execution = run_issue(agent, workspace, issue, runner=runner)
+        if not execution.changed:
+            # #421 : distinguer le no-op (agent OK, zéro diff — souvent transitoire)
+            # de l'erreur du process agent (exit ≠ 0) — la couche retry en dépend.
+            reason = REASON_NO_OP if execution.agent_result.success else REASON_AGENT_ERROR
+            return ExecutionOutcome(
+                success=False,
+                stage=STAGE_RUN,
+                workspace=workspace,
+                execution=execution,
+                final_status=final_status,
+                reason=reason,
+            )
+
+        # E3 : gate qualité (fail-closed).
+        stage = STAGE_GATE
+        report = await run_quality_gate(
+            workspace.path, execution.diff, ctx, sandbox=sandbox, reviewer=reviewer, issue=issue
         )
+        if not report.passed:
+            return ExecutionOutcome(
+                success=False,
+                stage=STAGE_GATE,
+                workspace=workspace,
+                execution=execution,
+                quality_report=report,
+                final_status=final_status,
+                reason=REASON_GATE_FAILED,
+            )
 
-    # E3 : gate qualité (fail-closed).
-    report = await run_quality_gate(
-        workspace.path, execution.diff, ctx, sandbox=sandbox, reviewer=reviewer, issue=issue
-    )
-    if not report.passed:
+        # E4 : ouverture de PR (dry_run respecté).
+        stage = STAGE_PR
+        pr = open_pr(
+            workspace,
+            report,
+            issue,
+            owner,
+            repo,
+            files_changed=execution.files_changed,
+            base=base,
+            clients=clients,
+            dry_run=dry_run,
+            manager=manager,
+            project_id=project_id,
+        )
+        final_status = _set_status(manager, task_id, TASK_STATUS_IN_REVIEW, enabled=persist) or final_status
+    except Exception as exc:  # barrière volontairement large (#435) — fail-closed, retentable
+        error = f"{type(exc).__name__}: {exc}"
+        logger.exception(
+            "exception d'infrastructure pendant l'issue #%s (stage=%s) — convertie en échec retentable (#435)",
+            issue.number,
+            stage,
+        )
+        if execution is None:
+            # L'agent n'a jamais tourné (panne au clone / à la transition d'état) :
+            # résultat synthétique pour que l'outcome reste exploitable partout.
+            execution = ExecutionResult(
+                agent_result=AgentResult(success=False, logs=f"[engine] exception avant l'agent — {error}"),
+                changed=False,
+                diff="",
+                files_changed=(),
+                success=False,
+            )
         return ExecutionOutcome(
             success=False,
-            stage=STAGE_GATE,
+            stage=stage,
             workspace=workspace,
             execution=execution,
             quality_report=report,
             final_status=final_status,
-            reason=REASON_GATE_FAILED,
+            reason=REASON_ENGINE_ERROR,
+            error=error,
         )
-
-    # E4 : ouverture de PR (dry_run respecté).
-    pr = open_pr(
-        workspace,
-        report,
-        issue,
-        owner,
-        repo,
-        files_changed=execution.files_changed,
-        base=base,
-        clients=clients,
-        dry_run=dry_run,
-        manager=manager,
-        project_id=project_id,
-    )
-    final_status = _set_status(manager, task_id, TASK_STATUS_IN_REVIEW, enabled=persist) or final_status
 
     return ExecutionOutcome(
         success=True,

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -436,6 +436,8 @@ async def run_project(
             task.status = TASK_STATUS_IN_REVIEW
         else:
             detail = {"task_id": task.id, "stage": outcome.stage, "reason": outcome.reason}
+            if getattr(outcome, "error", None):  # exception d'infrastructure (#435)
+                detail["error"] = log_tail(outcome.error, 600)
             agent_tail = log_tail(outcome.execution.agent_result.logs)
             if agent_tail:
                 detail["agent_log_tail"] = agent_tail

--- a/tests/test_executor_pipeline.py
+++ b/tests/test_executor_pipeline.py
@@ -289,6 +289,67 @@ async def test_budget_exception_propagates_through_pipeline(repo):
         await execute_issue(ISSUE, repo, ctx=None, dry_run=False, **_kwargs(reviewer=reviewer))
 
 
+# --- barrière d'exception par tâche (#435) ----------------------------------------
+
+
+class _BoomAgent:
+    def implement_issue(self, workspace, issue):
+        raise RuntimeError("panne réseau simulée")
+
+
+async def test_infra_exception_becomes_engine_error_outcome(repo):
+    """#435 : une exception d'infrastructure ne remonte PLUS crue — outcome failed
+    (reason=engine_error, stage atteint), exception dans ``error`` ET en feedback :
+    elle entre dans le chemin retry du pilote au lieu de tuer le run entier."""
+    from collegue.executor.pipeline import failure_feedback
+
+    outcome = await execute_issue(ISSUE, repo, ctx=None, dry_run=True, **_kwargs(agent=_BoomAgent()))
+    assert outcome.success is False
+    assert outcome.reason == "engine_error"
+    assert outcome.stage == "run"
+    assert "panne réseau simulée" in outcome.error
+    assert "panne réseau simulée" in failure_feedback(outcome)
+
+
+async def test_workspace_error_caught_with_synthetic_execution(tmp_path):
+    # Panne AVANT l'agent (clone impossible) : l'outcome reste exploitable
+    # (workspace None, exécution synthétique) au lieu d'une WorkspaceError crue.
+    outcome = await execute_issue(ISSUE, str(tmp_path / "absent"), ctx=None, dry_run=True, **_kwargs())
+    assert outcome.success is False and outcome.reason == "engine_error"
+    assert outcome.stage == "run"
+    assert outcome.workspace is None
+    assert "[engine] exception avant l'agent" in outcome.execution.agent_result.logs
+
+
+async def test_pr_stage_exception_keeps_stage_and_real_feedback(repo):
+    # Panne réseau à l'OUVERTURE de PR : stage=pr, et le feedback est l'exception —
+    # PAS les logs (verts) de l'agent, qui seraient un motif de retry trompeur.
+    from collegue.executor.pipeline import failure_feedback
+
+    class _DownPRs(_PRs):
+        def create_pr(self, owner, repo, title, head, base, body):
+            raise ConnectionError("GitHub 502 simulé")
+
+    clients = PrClients(branches=_Branches(), files=_Files(), prs=_DownPRs())
+    outcome = await execute_issue(ISSUE, repo, ctx=None, dry_run=False, **_kwargs(clients=clients))
+    assert outcome.success is False and outcome.reason == "engine_error"
+    assert outcome.stage == "pr"
+    assert "GitHub 502" in failure_feedback(outcome)
+
+
+async def test_base_exception_still_propagates_from_agent(repo):
+    # Les BaseException (annulation asyncio, arrêt process) traversent la barrière —
+    # même contrat que BudgetExceeded ci-dessus.
+    import asyncio
+
+    class _Cancel:
+        def implement_issue(self, workspace, issue):
+            raise asyncio.CancelledError()
+
+    with pytest.raises(asyncio.CancelledError):
+        await execute_issue(ISSUE, repo, ctx=None, dry_run=True, **_kwargs(agent=_Cancel()))
+
+
 # --- garanties d'état -----------------------------------------------------------
 
 

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -331,6 +331,69 @@ async def test_historical_mode_keeps_chaining_siblings(repo, manager):
     assert result.iterations == 2
 
 
+# --- barrière d'exception par tâche (#435) ------------------------------------------
+
+
+class _ExplodingThenOkAgent:
+    """Lève une exception CRUE N fois (panne d'infrastructure) puis réussit."""
+
+    def __init__(self, boom_times=1):
+        self.calls = 0
+        self.contexts = []
+        self._boom_times = boom_times
+        self._ok = FakeCodeAgent()
+
+    def implement_issue(self, workspace, issue):
+        self.calls += 1
+        self.contexts.append(issue.context)
+        if self.calls <= self._boom_times:
+            raise RuntimeError("connexion réinitialisée (simulé)")
+        return self._ok.implement_issue(workspace, issue)
+
+
+async def test_engine_exception_enters_retry_path_not_run_crash(repo, manager):
+    """#435 : une exception d'infrastructure d'UNE tâche ne tue plus le run — elle
+    devient un échec retentable (engine_error) qui entre dans le canal #420/#424
+    (attempt_count, backoff, feedback ré-injecté) et le run aboutit."""
+    from collegue.pilot.audit import RunAuditLog
+
+    async def _sleep(d):
+        pass
+
+    pid = _linear_project(manager, 1)
+    agent = _ExplodingThenOkAgent(boom_times=1)
+    audit = RunAuditLog(pid)
+    result = await _run(
+        manager, repo, pid, dry_run=False, agent=agent, audit=audit, max_task_attempts=3, sleep_fn=_sleep
+    )
+    assert result.stop_reason == "completed"
+    retries = [e for e in audit.events if e.kind == "task_retry"]
+    assert retries and retries[0].detail["reason"] == "engine_error"
+    assert "connexion réinitialisée" in retries[0].detail["error"]
+    assert "connexion réinitialisée" in agent.contexts[1]  # feedback #424 ré-injecté
+
+
+async def test_engine_exception_is_isolated_to_its_task(repo, manager):
+    # Panne DURABLE sur S0 (exception à chaque tentative) → failed terminal ; le
+    # run survit et construit S1 (avant : l'exception tuait run_project entier).
+    class _SelectiveBoom:
+        def __init__(self):
+            self._ok = FakeCodeAgent()
+
+        def implement_issue(self, workspace, issue):
+            if issue.title == "S0":
+                raise OSError("disque plein simulé")
+            return self._ok.implement_issue(workspace, issue)
+
+    pid = _sibling_project(manager, 2)
+    result = await _run(manager, repo, pid, dry_run=False, agent=_SelectiveBoom())
+    statuses = {t.title: t.status for t in manager.get_tasks(pid)}
+    assert statuses == {"S0": "failed", "S1": "in_review"}
+    assert result.stop_reason == "blocked"  # S0 échouée : le graphe reste incomplet
+    s0 = next(t for t in manager.get_tasks(pid) if t.title == "S0")
+    assert "engine_error" in s0.last_error and "disque plein" in s0.last_error
+
+
 def test_requeue_task_for_redo_resets_for_feedback(manager):
     """#434 : contrat du close+redo — la tâche repart `todo` avec un feedback (#424)
     et un attempt_count MINIMAL (un conflit d'infrastructure ne consomme pas le


### PR DESCRIPTION
## Problème (#435 — HAUTE, run FacNor v2)

Le chemin retry (#420/#421/#424) ne s'applique qu'aux échecs **rapportés** (`ExecutionOutcome.success=False`). Toute **exception** pendant le traitement d'une tâche — `WorkspaceError` de `prepare_workspace`, erreur réseau GitHub dans `open_pr`, bug ponctuel d'un adaptateur — remontait crue à travers `run_project` et tuait le run entier, alors que le reste du DAG restait exécutable. La résilience effective du run v2 reposait sur une boucle de redémarrage **opérateur** autour du driver.

## Correctif

**Barrière dans `execute_issue` (protège tous les appelants, avec le `stage` précis) :**
- `try/except Exception` sur tout le pipeline, avec suivi du stage atteint (`run` → `gate` → `pr`).
- Exception → outcome `failed` avec **nouveau `reason="engine_error"`**, exception dans `outcome.error`, et exécution **synthétique** si la panne précède l'agent (`workspace=None` toléré) — l'outcome reste exploitable partout.
- L'échec entre **naturellement dans le canal retry existant** du pilote : `attempt_count`, backoff, `last_error`, audit `task_retry`/`task_failed` (avec `detail["error"]`).
- `failure_feedback` : priorité à `outcome.error` — sinon une panne à l'ouverture de PR ré-injecterait les logs (verts) de l'agent comme motif de retry, feedback trompeur.
- **Les `BaseException` traversent toujours** : `BudgetExceeded` (auto-pause budget, test existant conservé), `CancelledError`, arrêt process.

## Tests
- Pipeline : exception agent → `engine_error`/`stage=run`/feedback = l'exception ; clone impossible → outcome synthétique exploitable ; panne à l'ouverture de PR → `stage=pr` + feedback = l'exception (pas les logs agent) ; `CancelledError` propage.
- Driver : panne transitoire → retry `engine_error` + feedback ré-injecté dans le prompt suivant → run `completed` ; panne durable sur S0 → `failed` terminal **et S1 construite quand même** (le run survit).
- Suite complète locale : verte.

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)