### PR TITLE
feat(executor): gate frontend fail-closed quand le workspace a un package.json (#438)

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -90,6 +90,12 @@ class Settings(BaseSettings):
     # sœurs ne sont plus construites depuis la même base → plus de PRs sœurs en
     # conflit (merge 405 irrécupérable). Ignoré si DEPS_REQUIRE_MERGED est faux.
     STRICT_MAX_INFLIGHT_PRS: int = 1
+    # Gate qualité multi-écosystème (#438) : si le workspace a un package.json,
+    # enchaîner npm install + build/type-check + tests front dans le même
+    # conteneur, fail-closed comme pytest (l'image sandbox doit fournir npm).
+    GATE_FRONTEND: bool = True
+    # Commande de tests du gate (vide → défaut `python -m pytest -q`).
+    GATE_TEST_COMMAND: str = ""
 
     ENGINE_INIT_TIMEOUT: float = 10.0
     ENGINE_WAIT_TIMEOUT: float = 30.0

--- a/collegue/executor/__init__.py
+++ b/collegue/executor/__init__.py
@@ -23,6 +23,7 @@ from collegue.executor.quality_gate import (
     Reviewer,
     ReviewFindingLite,
     ReviewOutcome,
+    frontend_gate_command,
     outcome_from_review,
     run_quality_gate,
 )
@@ -60,6 +61,7 @@ __all__ = [
     "ExpertReviewer",
     "QualityReport",
     "run_quality_gate",
+    "frontend_gate_command",
     "outcome_from_review",
     # E4 — ouverture de PR
     "PrClients",

--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Optional
+from typing import Mapping, Optional
 
 from collegue.executor.agent import AgentResult, CodeAgent, IssueSpec
 from collegue.executor.command import CommandRunner
@@ -129,6 +129,7 @@ async def execute_issue(
     project_id: Optional[int] = None,
     dry_run: bool = True,
     seed_diff: Optional[str] = None,
+    gate_options: Optional[Mapping[str, object]] = None,
 ) -> ExecutionOutcome:
     """Exécute une issue de bout en bout (workspace → agent → tests+revue → PR).
 
@@ -150,6 +151,11 @@ async def execute_issue(
     clone neuf avant l'agent (mémoire de retry — réparation incrémentale au lieu
     de régénération complète). Best-effort : un seed inapplicable est ignoré
     (clone vierge, comportement historique).
+
+    ``gate_options`` (#438) : kwargs additionnels transmis tels quels à
+    :func:`run_quality_gate` (``test_command``, ``frontend_gate``…) — c'est le
+    canal de configuration du gate par projet/runtime, sans coupler l'exécuteur
+    à la config.
     """
     persist = not dry_run  # les transitions d'état n'ont lieu qu'en exécution réelle
     final_status: Optional[str] = None
@@ -182,7 +188,13 @@ async def execute_issue(
         # E3 : gate qualité (fail-closed).
         stage = STAGE_GATE
         report = await run_quality_gate(
-            workspace.path, execution.diff, ctx, sandbox=sandbox, reviewer=reviewer, issue=issue
+            workspace.path,
+            execution.diff,
+            ctx,
+            sandbox=sandbox,
+            reviewer=reviewer,
+            issue=issue,
+            **dict(gate_options or {}),
         )
         if not report.passed:
             return ExecutionOutcome(

--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -22,6 +22,7 @@ qu'il ne puisse pas forger de fausse bannière/section (cf. P5).
 
 from __future__ import annotations
 
+import json
 import os
 from dataclasses import dataclass
 from typing import List, Optional, Protocol, Tuple, runtime_checkable
@@ -65,6 +66,65 @@ def deps_install_prelude(workspace: str) -> Optional[str]:
     if not parts:
         return None
     return "; ".join(f"({part} || echo '{_INSTALL_FAILED_NOTE}')" for part in parts)
+
+
+# Bannière insérée entre la passe Python et la passe frontend dans la sortie du gate.
+_FRONTEND_BANNER = "[gate] frontend : install + build + tests (#438)"
+
+
+def _real_test_script(scripts: dict) -> bool:
+    """Vrai si ``package.json`` déclare un script ``test`` RÉEL (pas le stub npm).
+
+    Le stub par défaut de ``npm init`` (« Error: no test specified… && exit 1 »)
+    ferait échouer le gate de TOUT projet front sans tests — on ne lance que les
+    vrais scripts.
+    """
+    script = str(scripts.get("test") or "")
+    return bool(script.strip()) and "no test specified" not in script
+
+
+def frontend_gate_command(workspace: str) -> Optional[str]:
+    """Commande de gate frontend quand le workspace a un ``package.json`` (#438).
+
+    Le gate historique ne lançait QUE pytest : compilation TypeScript, build Vite
+    et tests front n'étaient JAMAIS validés — des PRs front cassées au type-check
+    sont mergées en série avec un verdict « ✅ PASSÉ » (main FacNor : ``npm run
+    build`` rouge, 11 erreurs TS, toutes PRs gate vert).
+
+    **Fail-closed, comme pytest** : npm absent de l'image, install, build ou tests
+    front en échec ⇒ gate rouge. Enchaîné dans le **même** conteneur :
+
+    - install : ``npm ci`` (reproductible), repli ``npm install`` (pas de lockfile) ;
+    - build : script ``build`` s'il existe, sinon ``tsc --noEmit`` quand TypeScript
+      est déclaré (tsconfig.json + dépendance ``typescript`` — installée juste
+      avant, d'où ``--no-install``) ;
+    - tests front : script ``test`` réel uniquement (stub npm ignoré).
+
+    ``CI=true`` neutralise les modes watch (react-scripts, vitest) ; le cache npm
+    vit sous ``/tmp`` (rootfs read-only, #414). ``None`` si pas de ``package.json``.
+    """
+    pkg_path = os.path.join(workspace, "package.json")
+    if not os.path.isfile(pkg_path):
+        return None
+    scripts: dict = {}
+    declared: set = set()
+    try:
+        with open(pkg_path, encoding="utf-8") as handle:
+            data = json.load(handle) or {}
+        scripts = dict(data.get("scripts") or {})
+        declared = set(data.get("dependencies") or {}) | set(data.get("devDependencies") or {})
+    except (OSError, ValueError):
+        # package.json illisible : on garde au moins l'install (fail-closed — npm
+        # signalera lui-même le JSON invalide au lieu d'un gate silencieusement vert).
+        pass
+    steps = ["(npm ci --no-audit --no-fund --silent || npm install --no-audit --no-fund --silent)"]
+    if "build" in scripts:
+        steps.append("npm run build --silent")
+    elif "typescript" in declared and os.path.isfile(os.path.join(workspace, "tsconfig.json")):
+        steps.append("npx --no-install tsc --noEmit")
+    if _real_test_script(scripts):
+        steps.append("npm test --silent")
+    return "export CI=true NPM_CONFIG_CACHE=/tmp/.npm; " + " && ".join(steps)
 
 
 # Triple-backtick de remplacement : neutralise les fences pour qu'un texte non
@@ -199,6 +259,7 @@ async def run_quality_gate(
     issue: Optional[IssueSpec] = None,
     test_command: str = DEFAULT_TEST_COMMAND,
     install_deps: bool = True,
+    frontend_gate: bool = True,
 ) -> QualityReport:
     """Exécute les tests (sandbox) + la revue (reviewer) sur un diff. Fail-closed.
 
@@ -206,6 +267,10 @@ async def run_quality_gate(
     indisponibilité ⇒ ``passed=False``. Les ``BaseException`` remontent.
     ``install_deps`` (défaut vrai) : préfixe la commande de tests par l'installation
     des dépendances déclarées du projet (cf. :func:`deps_install_prelude`, #414).
+    ``frontend_gate`` (défaut vrai, #438) : si le workspace a un ``package.json``,
+    enchaîne install + build/type-check + tests front dans le même conteneur,
+    fail-closed (cf. :func:`frontend_gate_command`) — sans quoi « tests verts »
+    signifie « tests *Python* verts », même sur un diff 100 % frontend.
     """
     sandbox = sandbox or DockerSandbox()
     reviewer = reviewer or _default_reviewer()
@@ -218,6 +283,12 @@ async def run_quality_gate(
             prelude = deps_install_prelude(workspace)
             if prelude is not None:
                 command = f"{prelude}; {test_command}"
+        if frontend_gate:
+            front = frontend_gate_command(workspace)
+            if front is not None:
+                # `&&` : la passe frontend ne tourne que si pytest est vert (le
+                # verdict est déjà rouge sinon) et son échec rend le gate rouge.
+                command = f"({command}) && echo '{_FRONTEND_BANNER}' && ({front})"
         test_res = sandbox.run_tests(workspace, command)
         tests_passed = test_res.ok
         test_exit_code = test_res.exit_code

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -265,6 +265,7 @@ async def run_project(
     sleep_fn=None,
     require_merged_deps: bool = False,
     max_inflight_reviews: int = DEFAULT_MAX_INFLIGHT_REVIEWS,
+    gate_options=None,
 ) -> ProjectRunResult:
     """Pilote un projet : chaîne ``execute_issue`` sur les tâches prêtes sous budget.
 
@@ -298,6 +299,10 @@ async def run_project(
     ``awaiting_merge`` (relancer après merge reprend naturellement). À faux
     (défaut historique), le démarrage d'un dépendant sur dépendance non mergée est
     SIGNALÉ (audit ``unmerged_deps`` + warning) au lieu d'être silencieux.
+
+    ``gate_options`` (#438) : kwargs transmis tels quels au gate qualité via
+    ``execute_issue`` (``test_command``, ``frontend_gate``…) — configuration du
+    gate par projet sans coupler le pilote à la config.
 
     ``max_inflight_reviews`` (#434, mode strict uniquement) : plafond de tâches
     ``in_review`` (PR ouverte non mergée) avant de s'arrêter ``awaiting_merge``.
@@ -454,6 +459,7 @@ async def run_project(
             project_id=project_id,
             dry_run=dry_run,
             seed_diff=seed,
+            gate_options=gate_options,
         )
         iteration += 1
         if sample_cost:

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -102,6 +102,18 @@ def _build_clients(github_token):  # pragma: no cover - infra réelle (integrati
     return _default_clients(token=github_token)
 
 
+def _gate_options(settings_obj) -> dict:
+    """Options du gate qualité depuis la config (#438) — transmises à ``execute_issue``.
+
+    ``GATE_TEST_COMMAND`` vide/None → commande par défaut du gate (pytest).
+    """
+    options: dict = {"frontend_gate": bool(getattr(settings_obj, "GATE_FRONTEND", True))}
+    test_command = getattr(settings_obj, "GATE_TEST_COMMAND", None)
+    if test_command:
+        options["test_command"] = str(test_command)
+    return options
+
+
 # ── point d'entrée assemblé ────────────────────────────────────────────────────
 
 
@@ -178,6 +190,8 @@ async def run_project_from_settings(
         require_merged_deps=bool(getattr(settings_obj, "DEPS_REQUIRE_MERGED", False)),
         # Intégration sérielle en mode strict (#434) : 1 PR en vol par défaut.
         max_inflight_reviews=getattr(settings_obj, "STRICT_MAX_INFLIGHT_PRS", 1),
+        # Gate configurable par projet (#438) : commande de tests + passe frontend.
+        gate_options=_gate_options(settings_obj),
     )
 
     # Reporting (journal de décisions) — réel uniquement (dry_run n'écrit rien).

--- a/tests/test_executor_pipeline.py
+++ b/tests/test_executor_pipeline.py
@@ -289,6 +289,34 @@ async def test_budget_exception_propagates_through_pipeline(repo):
         await execute_issue(ISSUE, repo, ctx=None, dry_run=False, **_kwargs(reviewer=reviewer))
 
 
+# --- options du gate par projet (#438) ---------------------------------------------
+
+
+async def test_gate_options_are_threaded_to_quality_gate(repo):
+    # #438 : la configuration du gate (commande de tests, passe frontend…)
+    # traverse execute_issue sans coupler l'exécuteur à la config.
+    class _RecordingSandbox(_Sandbox):
+        def __init__(self):
+            super().__init__(ok=True)
+            self.commands = []
+
+        def run_tests(self, workspace, command="pytest -q"):
+            self.commands.append(command)
+            return super().run_tests(workspace, command)
+
+    sandbox = _RecordingSandbox()
+    outcome = await execute_issue(
+        ISSUE,
+        repo,
+        ctx=None,
+        dry_run=True,
+        gate_options={"test_command": "make check"},
+        **_kwargs(sandbox=sandbox),
+    )
+    assert outcome.success is True
+    assert sandbox.commands == ["make check"]
+
+
 # --- réensemencement du workspace au retry (#436) ----------------------------------
 
 

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -132,6 +132,95 @@ async def test_gate_install_deps_opt_out(tmp_path):
     assert "pip install" not in command
 
 
+# --- gate frontend (#438) ---------------------------------------------------------
+
+
+def _write_pkg(tmp_path, scripts=None, dev_deps=None):
+    import json as _json
+
+    payload = {"name": "front", "scripts": scripts or {}}
+    if dev_deps:
+        payload["devDependencies"] = dev_deps
+    (tmp_path / "package.json").write_text(_json.dumps(payload), encoding="utf-8")
+
+
+def test_frontend_gate_command_none_without_package_json(tmp_path):
+    from collegue.executor import frontend_gate_command
+
+    assert frontend_gate_command(str(tmp_path)) is None
+
+
+def test_frontend_gate_command_install_build_and_real_tests(tmp_path):
+    from collegue.executor import frontend_gate_command
+
+    _write_pkg(tmp_path, scripts={"build": "tsc && vite build", "test": "vitest run"})
+    command = frontend_gate_command(str(tmp_path))
+    assert "npm ci" in command and "npm install" in command  # install + repli
+    assert "npm run build" in command
+    assert "npm test" in command
+    assert "CI=true" in command  # neutralise les modes watch
+    assert "NPM_CONFIG_CACHE=/tmp/.npm" in command  # rootfs read-only (#414)
+    # fail-closed : chaque étape conditionne la suivante
+    assert command.index("npm ci") < command.index("npm run build") < command.index("npm test")
+    assert "&&" in command
+
+
+def test_frontend_gate_command_skips_npm_default_test_stub(tmp_path):
+    # Le stub `npm init` (« no test specified… exit 1 ») ferait échouer TOUT
+    # projet front sans tests : il n'est jamais lancé.
+    from collegue.executor import frontend_gate_command
+
+    _write_pkg(tmp_path, scripts={"build": "vite build", "test": 'echo "Error: no test specified" && exit 1'})
+    command = frontend_gate_command(str(tmp_path))
+    assert "npm test" not in command
+
+
+def test_frontend_gate_command_typecheck_fallback_without_build_script(tmp_path):
+    # Pas de script build mais TypeScript déclaré + tsconfig → `tsc --noEmit`
+    # (le bug InvoiceForm.tsx aurait été bloqué dès la première PR fautive).
+    from collegue.executor import frontend_gate_command
+
+    _write_pkg(tmp_path, scripts={}, dev_deps={"typescript": "^5"})
+    (tmp_path / "tsconfig.json").write_text("{}", encoding="utf-8")
+    command = frontend_gate_command(str(tmp_path))
+    assert "tsc --noEmit" in command
+
+    # …mais pas de type-check si TypeScript n'est pas déclaré (rien à vérifier).
+    (tmp_path / "tsconfig.json").unlink()
+    assert "tsc" not in frontend_gate_command(str(tmp_path))
+
+
+def test_frontend_gate_command_tolerates_invalid_package_json(tmp_path):
+    # JSON invalide : on garde l'install (npm signalera lui-même l'erreur) —
+    # fail-closed plutôt qu'un gate silencieusement vert.
+    from collegue.executor import frontend_gate_command
+
+    (tmp_path / "package.json").write_text("{pas du json", encoding="utf-8")
+    command = frontend_gate_command(str(tmp_path))
+    assert command is not None and "npm ci" in command
+
+
+async def test_gate_chains_frontend_after_pytest(tmp_path):
+    """#438 : avec un package.json, la passe frontend est enchaînée fail-closed
+    (`&&`) après pytest, dans la MÊME commande (même conteneur) — sans elle,
+    « tests verts » signifiait « tests *Python* verts » même sur un diff front."""
+    _write_pkg(tmp_path, scripts={"build": "vite build"})
+    sandbox = _green()
+    await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    _ws, command = sandbox.calls[0]
+    assert "python -m pytest" in command and "npm run build" in command
+    assert command.index("pytest") < command.index("npm run build")
+    assert ") && " in command  # la passe front rend le gate ROUGE si elle échoue
+
+
+async def test_gate_frontend_opt_out(tmp_path):
+    _write_pkg(tmp_path, scripts={"build": "vite build"})
+    sandbox = _green()
+    await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer(), frontend_gate=False)
+    _ws, command = sandbox.calls[0]
+    assert "npm" not in command
+
+
 # --- fail-closed ----------------------------------------------------------------
 
 

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -332,6 +332,27 @@ async def test_historical_mode_keeps_chaining_siblings(repo, manager):
     assert result.iterations == 2
 
 
+# --- options du gate par projet (#438) ----------------------------------------------
+
+
+async def test_gate_options_threaded_from_run_project(repo, manager):
+    # #438 : la config du gate traverse run_project → execute_issue → run_quality_gate.
+    class _RecordingSandbox(_Sandbox):
+        def __init__(self):
+            super().__init__(ok=True)
+            self.commands = []
+
+        def run_tests(self, workspace, command="pytest -q"):
+            self.commands.append(command)
+            return super().run_tests(workspace, command)
+
+    pid = _linear_project(manager, 1)
+    sandbox = _RecordingSandbox()
+    result = await _run(manager, repo, pid, dry_run=True, sandbox=sandbox, gate_options={"test_command": "make check"})
+    assert result.stop_reason == "completed"
+    assert sandbox.commands == ["make check"]
+
+
 # --- mémoire de la meilleure tentative entre retries (#436) -------------------------
 
 

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -243,6 +243,16 @@ def test_main_returns_1_on_blocked(monkeypatch):
     assert cli.main(_CLI_ARGS) == 1
 
 
+def test_gate_options_built_from_settings():
+    # #438 : la config GATE_* devient les kwargs du gate (vide → défauts du gate).
+    from collegue.pilot.runtime import _gate_options
+
+    custom = SimpleNamespace(GATE_FRONTEND=False, GATE_TEST_COMMAND="npm run check")
+    assert _gate_options(custom) == {"frontend_gate": False, "test_command": "npm run check"}
+    defaults = SimpleNamespace(GATE_TEST_COMMAND="")
+    assert _gate_options(defaults) == {"frontend_gate": True}
+
+
 # --- isolation ------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Problème (#438 — HAUTE, run FacNor v2)

La commande du gate était unique et codée en dur : `python -m pytest -q`. Pour un projet full-stack (cible affichée du moteur : Python + JS/TS), **tout le versant frontend** — compilation TypeScript, build Vite, tests front — n'était **jamais** exécuté. Résultat sur le produit v2 : `npm run build` → EXIT 2, `npx tsc --noEmit` → **11 erreurs** dans `InvoiceForm.tsx`, alors que toutes les PRs frontend étaient passées « ✅ PASSÉ ».

## Correctif

**`frontend_gate_command(workspace)`** — détection `package.json`, enchaîné **fail-closed** (`&&`) après pytest, dans le **même conteneur** :
- install : `npm ci` (reproductible), repli `npm install` (pas de lockfile) ;
- build : script `build` s'il existe, sinon `tsc --noEmit` quand TypeScript est déclaré (tsconfig + dep `typescript`) — le bug `InvoiceForm.tsx` aurait été bloqué dès la première PR fautive ;
- tests front : script `test` **réel** uniquement (le stub `npm init` « no test specified » est ignoré — sinon tout projet front sans tests échouerait) ;
- `CI=true` (neutralise les modes watch react-scripts/vitest), cache npm sous `/tmp` (rootfs read-only, #414).

**`gate_options` threadé** (`run_project` → `execute_issue` → `run_quality_gate`) : la configuration du gate par projet (`test_command`, `frontend_gate`) passe par un canal explicite, sans coupler l'exécuteur à la config.

**Config** : `GATE_FRONTEND` (défaut vrai — détection conditionnée à la présence de `package.json`, donc zéro changement pour les projets Python purs), `GATE_TEST_COMMAND` (vide → défaut pytest). Note : l'image sandbox doit fournir `npm` ; sinon le gate échoue **explicitement** (fail-closed, désactivable par config).

## Tests
- Construction de commande : install+build+tests ordonnés et chaînés `&&`, stub npm ignoré, `tsc --noEmit` seulement si TypeScript déclaré, JSON invalide toléré (install seule, npm signalera), `CI=true` + cache `/tmp`.
- Gate : passe front enchaînée après pytest dans la même commande ; opt-out.
- Threading : `execute_issue(gate_options=…)` et `run_project(gate_options=…)` atteignent le sandbox ; `_gate_options(settings)`.
- Suite complète locale verte.

Closes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)