### PR TITLE
feat(executor): installabilité du livrable au gate (#439)

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -96,6 +96,13 @@ class Settings(BaseSettings):
     GATE_FRONTEND: bool = True
     # Commande de tests du gate (vide → défaut `python -m pytest -q`).
     GATE_TEST_COMMAND: str = ""
+    # Installabilité (#439). REQUIRE_DEPS_INSTALL : l'échec d'installation des
+    # deps déclarées rend le gate ROUGE (au lieu d'un signal toléré). CHECK_
+    # INSTALLABILITY : passe venv NU (install -r requirements + collecte pytest)
+    # — prouve que le livrable s'installe depuis SES requirements, pas depuis les
+    # paquets pré-installés de l'image sandbox (réseau PyPI requis).
+    GATE_REQUIRE_DEPS_INSTALL: bool = False
+    GATE_CHECK_INSTALLABILITY: bool = False
 
     ENGINE_INIT_TIMEOUT: float = 10.0
     ENGINE_WAIT_TIMEOUT: float = 30.0

--- a/collegue/executor/__init__.py
+++ b/collegue/executor/__init__.py
@@ -24,6 +24,7 @@ from collegue.executor.quality_gate import (
     ReviewFindingLite,
     ReviewOutcome,
     frontend_gate_command,
+    installability_command,
     outcome_from_review,
     run_quality_gate,
 )
@@ -62,6 +63,7 @@ __all__ = [
     "QualityReport",
     "run_quality_gate",
     "frontend_gate_command",
+    "installability_command",
     "outcome_from_review",
     # E4 — ouverture de PR
     "PrClients",

--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -41,7 +41,7 @@ DEFAULT_TEST_COMMAND = "python -m pytest -q"
 _INSTALL_FAILED_NOTE = "[gate] installation des dépendances en échec — tests lancés quand même (#414)"
 
 
-def deps_install_prelude(workspace: str) -> Optional[str]:
+def deps_install_prelude(workspace: str, *, strict: bool = False) -> Optional[str]:
     """Préambule shell installant les dépendances du projet avant les tests (#414).
 
     Le conteneur de tests est **éphémère** et distinct de celui où l'agent a
@@ -53,9 +53,12 @@ def deps_install_prelude(workspace: str) -> Optional[str]:
     - install et tests partagent le **même** conteneur : ``pip install --user``
       écrit sous ``HOME=/tmp`` (tmpfs compatible rootfs read-only) qui **meurt avec
       le conteneur** → on PRÉFIXE la commande de tests au lieu d'un run séparé ;
-    - échec d'install **toléré** (``|| echo``) : les tests tournent quand même
-      (comportement historique préservé, ex. sandbox sans réseau), mais la cause
-      reste visible dans la sortie du gate ;
+    - échec d'install **toléré** par défaut (``|| echo``) : les tests tournent
+      quand même (comportement historique, ex. sandbox sans réseau) et la cause
+      reste visible dans la sortie du gate — détectée et remontée dans
+      ``QualityReport.deps_install_failed`` (#439) ;
+    - ``strict=True`` (#439) : l'échec d'installation devient BLOQUANT (``&&``) —
+      l'installabilité des dépendances déclarées fait partie du contrat ;
     - ``None`` si le workspace ne déclare aucune dépendance installable.
     """
     parts: List[str] = []
@@ -65,7 +68,37 @@ def deps_install_prelude(workspace: str) -> Optional[str]:
         parts.append("python -m pip install --user --no-cache-dir -q -e .")
     if not parts:
         return None
+    if strict:
+        return " && ".join(f"({part})" for part in parts)
     return "; ".join(f"({part} || echo '{_INSTALL_FAILED_NOTE}')" for part in parts)
+
+
+# Bannière de la passe d'installabilité dans la sortie du gate (#439).
+_INSTALLABILITY_BANNER = "[gate] installabilité : venv nu + requirements + collecte (#439)"
+_GATE_VENV = "/tmp/.gate_venv"
+
+
+def installability_command(workspace: str) -> Optional[str]:
+    """Passe d'installabilité en environnement NU (#439). Fail-closed.
+
+    L'image sandbox pré-installe une stack web pour servir l'**agent** (#414) :
+    une dépendance manquante ou mal pinnée de ``requirements.txt`` y est
+    invisible — gate vert sur un projet **non installable** ailleurs (FacNor v2 :
+    ``email-validator``/``httpx``/``python-multipart`` absents, ``pytest`` EXIT 4
+    en environnement propre). Cette passe valide le **contrat d'installation** du
+    livrable : venv vierge → ``pip install -r requirements.txt`` → collecte
+    pytest (exécute les imports de conftest/tests, exactement le mode d'échec
+    constaté). ``None`` sans ``requirements.txt``. Nécessite le réseau (PyPI) —
+    opt-in via ``check_installability``.
+    """
+    if not os.path.isfile(os.path.join(workspace, "requirements.txt")):
+        return None
+    return (
+        f"python -m venv --clear {_GATE_VENV}"
+        f" && {_GATE_VENV}/bin/python -m pip install --no-cache-dir -q -r requirements.txt"
+        f" && {_GATE_VENV}/bin/python -m pip install --no-cache-dir -q pytest"
+        f" && {_GATE_VENV}/bin/python -m pytest --collect-only -q"
+    )
 
 
 # Bannière insérée entre la passe Python et la passe frontend dans la sortie du gate.
@@ -187,6 +220,10 @@ class QualityReport:
     review_blocking: bool
     passed: bool
     review_error: Optional[str] = None
+    # #439 : l'installation des dépendances déclarées a échoué pendant le gate
+    # (mode toléré) — le vert des tests peut venir des paquets de l'IMAGE, pas du
+    # requirements.txt du projet. Signal fort pour la PR et l'audit.
+    deps_install_failed: bool = False
 
     def to_markdown(self) -> str:
         """Rapport Markdown pour le corps de PR (texte de revue fencé, anti-injection)."""
@@ -195,6 +232,14 @@ class QualityReport:
             "## Gate qualité",
             "",
             f"**Tests** : {tests_badge} (code de sortie {self.test_exit_code})",
+        ]
+        if self.deps_install_failed:
+            lines.append(
+                "> ⚠️ **installation des dépendances déclarées EN ÉCHEC** pendant le gate (#439) — "
+                "le vert peut venir des paquets pré-installés de l'image sandbox, pas du "
+                "`requirements.txt` du projet (installabilité non prouvée)."
+            )
+        lines += [
             "",
             "<details><summary>Sortie des tests</summary>",
             "",
@@ -260,6 +305,8 @@ async def run_quality_gate(
     test_command: str = DEFAULT_TEST_COMMAND,
     install_deps: bool = True,
     frontend_gate: bool = True,
+    require_deps_install: bool = False,
+    check_installability: bool = False,
 ) -> QualityReport:
     """Exécute les tests (sandbox) + la revue (reviewer) sur un diff. Fail-closed.
 
@@ -271,28 +318,44 @@ async def run_quality_gate(
     enchaîne install + build/type-check + tests front dans le même conteneur,
     fail-closed (cf. :func:`frontend_gate_command`) — sans quoi « tests verts »
     signifie « tests *Python* verts », même sur un diff 100 % frontend.
+    ``require_deps_install`` (#439) : l'échec d'installation des dépendances
+    déclarées devient BLOQUANT (au lieu d'être toléré et seulement signalé via
+    ``QualityReport.deps_install_failed``).
+    ``check_installability`` (#439) : ajoute la passe d'installabilité en venv NU
+    (cf. :func:`installability_command`) — prouve que le livrable s'installe
+    depuis SES requirements, pas depuis les paquets de l'image sandbox.
     """
     sandbox = sandbox or DockerSandbox()
     reviewer = reviewer or _default_reviewer()
 
     # 1. Tests dans le sandbox. Une incapacité à les exécuter = non passé
     #    (fail-closed), pas une exception qui remonterait.
+    deps_install_failed = False
     try:
         command = test_command
         if install_deps:
-            prelude = deps_install_prelude(workspace)
+            prelude = deps_install_prelude(workspace, strict=require_deps_install)
             if prelude is not None:
-                command = f"{prelude}; {test_command}"
+                # Strict (#439) : install bloquante. Toléré (#414) : les tests
+                # tournent quand même, l'échec laisse sa note dans la sortie.
+                command = f"({prelude}) && {test_command}" if require_deps_install else f"{prelude}; {test_command}"
         if frontend_gate:
             front = frontend_gate_command(workspace)
             if front is not None:
                 # `&&` : la passe frontend ne tourne que si pytest est vert (le
                 # verdict est déjà rouge sinon) et son échec rend le gate rouge.
                 command = f"({command}) && echo '{_FRONTEND_BANNER}' && ({front})"
+        if check_installability:
+            installability = installability_command(workspace)
+            if installability is not None:
+                command = f"({command}) && echo '{_INSTALLABILITY_BANNER}' && ({installability})"
         test_res = sandbox.run_tests(workspace, command)
         tests_passed = test_res.ok
         test_exit_code = test_res.exit_code
         test_output = "\n".join(part for part in (test_res.stdout, test_res.stderr) if part).strip()
+        # #439 : la note du prelude toléré (#414) devient un SIGNAL structuré —
+        # un vert obtenu avec une install en échec n'a pas la même valeur.
+        deps_install_failed = _INSTALL_FAILED_NOTE in test_output
     except Exception as exc:  # noqa: BLE001 - fail-closed ; BaseException (budget) remonte
         tests_passed = False
         test_exit_code = -1
@@ -321,6 +384,7 @@ async def run_quality_gate(
         review_blocking=review_blocking,
         passed=passed,
         review_error=review_error,
+        deps_install_failed=deps_install_failed,
     )
 
 

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -103,11 +103,15 @@ def _build_clients(github_token):  # pragma: no cover - infra réelle (integrati
 
 
 def _gate_options(settings_obj) -> dict:
-    """Options du gate qualité depuis la config (#438) — transmises à ``execute_issue``.
+    """Options du gate qualité depuis la config (#438/#439) — vers ``execute_issue``.
 
     ``GATE_TEST_COMMAND`` vide/None → commande par défaut du gate (pytest).
     """
-    options: dict = {"frontend_gate": bool(getattr(settings_obj, "GATE_FRONTEND", True))}
+    options: dict = {
+        "frontend_gate": bool(getattr(settings_obj, "GATE_FRONTEND", True)),
+        "require_deps_install": bool(getattr(settings_obj, "GATE_REQUIRE_DEPS_INSTALL", False)),
+        "check_installability": bool(getattr(settings_obj, "GATE_CHECK_INSTALLABILITY", False)),
+    }
     test_command = getattr(settings_obj, "GATE_TEST_COMMAND", None)
     if test_command:
         options["test_command"] = str(test_command)

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -221,6 +221,79 @@ async def test_gate_frontend_opt_out(tmp_path):
     assert "npm" not in command
 
 
+# --- installabilité du livrable (#439) ---------------------------------------------
+
+
+async def test_deps_install_failure_is_surfaced_as_signal(tmp_path):
+    """#439 : l'échec d'installation des deps déclarées (toléré, #414) devient un
+    SIGNAL structuré — un vert obtenu grâce aux paquets de l'IMAGE n'a pas la
+    même valeur qu'un vert installable partout."""
+    from collegue.sandbox import SandboxResult
+
+    (tmp_path / "requirements.txt").write_text("paquet-inexistant\n", encoding="utf-8")
+    out = "[gate] installation des dépendances en échec — tests lancés quand même (#414)\n2 passed"
+    sandbox = _FakeSandbox(SandboxResult(exit_code=0, stdout=out, stderr=""))
+    report = await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    assert report.passed is True  # toléré par défaut (sandbox sans réseau, #414)
+    assert report.deps_install_failed is True  # …mais le signal SURVIT
+    markdown = report.to_markdown()
+    assert "installation des dépendances déclarées EN ÉCHEC" in markdown
+    assert "installabilité non prouvée" in markdown
+
+
+async def test_deps_install_ok_has_no_signal(tmp_path):
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    report = await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=_green(), reviewer=FakeReviewer())
+    assert report.deps_install_failed is False
+    assert "EN ÉCHEC" not in report.to_markdown()
+
+
+async def test_require_deps_install_makes_install_blocking(tmp_path):
+    # Mode strict (#439) : plus de `|| echo` — l'install conditionne les tests
+    # (`&&`), son échec rend le gate rouge au lieu d'un vert trompeur.
+    (tmp_path / "requirements.txt").write_text("x\n", encoding="utf-8")
+    sandbox = _green()
+    await run_quality_gate(
+        str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer(), require_deps_install=True
+    )
+    _ws, command = sandbox.calls[0]
+    assert "|| echo" not in command
+    assert ") && python -m pytest" in command
+
+
+def test_installability_command_requires_requirements(tmp_path):
+    from collegue.executor import installability_command
+
+    assert installability_command(str(tmp_path)) is None
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    command = installability_command(str(tmp_path))
+    # venv NU → install depuis les requirements du projet → collecte (imports).
+    assert "python -m venv --clear /tmp/.gate_venv" in command
+    assert "-r requirements.txt" in command
+    assert "pytest --collect-only" in command
+    assert " && " in command  # fail-closed à chaque étape
+
+
+async def test_check_installability_appends_nude_venv_pass(tmp_path):
+    """#439 : la passe d'installabilité tourne dans un venv VIERGE — une dep
+    manquante du requirements.txt (masquée par l'image sandbox, ex.
+    email-validator sur FacNor v2) fait enfin échouer le gate."""
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    sandbox = _green()
+    await run_quality_gate(
+        str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer(), check_installability=True
+    )
+    _ws, command = sandbox.calls[0]
+    assert "installabilité" in command  # bannière
+    assert "/tmp/.gate_venv" in command
+    assert command.index("pytest -q") < command.index("--collect-only")  # après la passe normale
+
+    # …et opt-out par défaut (réseau PyPI requis).
+    sandbox2 = _green()
+    await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox2, reviewer=FakeReviewer())
+    assert ".gate_venv" not in sandbox2.calls[0][1]
+
+
 # --- fail-closed ----------------------------------------------------------------
 
 

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -244,13 +244,27 @@ def test_main_returns_1_on_blocked(monkeypatch):
 
 
 def test_gate_options_built_from_settings():
-    # #438 : la config GATE_* devient les kwargs du gate (vide → défauts du gate).
+    # #438/#439 : la config GATE_* devient les kwargs du gate (vide → défauts du gate).
     from collegue.pilot.runtime import _gate_options
 
-    custom = SimpleNamespace(GATE_FRONTEND=False, GATE_TEST_COMMAND="npm run check")
-    assert _gate_options(custom) == {"frontend_gate": False, "test_command": "npm run check"}
+    custom = SimpleNamespace(
+        GATE_FRONTEND=False,
+        GATE_TEST_COMMAND="npm run check",
+        GATE_REQUIRE_DEPS_INSTALL=True,
+        GATE_CHECK_INSTALLABILITY=True,
+    )
+    assert _gate_options(custom) == {
+        "frontend_gate": False,
+        "test_command": "npm run check",
+        "require_deps_install": True,
+        "check_installability": True,
+    }
     defaults = SimpleNamespace(GATE_TEST_COMMAND="")
-    assert _gate_options(defaults) == {"frontend_gate": True}
+    assert _gate_options(defaults) == {
+        "frontend_gate": True,
+        "require_deps_install": False,
+        "check_installability": False,
+    }
 
 
 # --- isolation ------------------------------------------------------------------


### PR DESCRIPTION
## Problème (#439 — HAUTE, run FacNor v2)

L'image sandbox pré-installe « la stack web courante » pour servir l'**agent** (#414). Effet pervers : l'environnement de gate est strictement plus riche que ce que le projet déclare — une dépendance manquante ou mal pinnée de `requirements.txt` est **masquée** par l'image → gate vert sur un projet **non installable** ailleurs. Constaté sur le livrable v2 en environnement propre : `pytest` EXIT 4 (`email-validator` manquant), `httpx`/`python-multipart` absents aussi, `passlib[bcrypt]` non pinné → bcrypt 5 incompatible. Pire, l'échec d'installation du prelude était **toléré en silence** (`|| echo`).

## Correctif

**1. L'échec d'install devient un signal structuré** (toujours toléré par défaut — #414, sandbox sans réseau) :
- `QualityReport.deps_install_failed` + bannière ⚠️ dans le corps de PR : « installation des dépendances déclarées EN ÉCHEC — le vert peut venir des paquets pré-installés de l'image (installabilité non prouvée) ».

**2. Mode strict opt-in** (`require_deps_install` / `GATE_REQUIRE_DEPS_INSTALL`) :
- le prelude passe de `(install || echo note); pytest` à `(install) && pytest` — l'échec d'installation rend le gate **rouge**.

**3. Passe d'installabilité en venv NU** (`check_installability` / `GATE_CHECK_INSTALLABILITY`, opt-in — réseau PyPI requis) :
- `python -m venv --clear /tmp/.gate_venv && pip install -r requirements.txt && pip install pytest && pytest --collect-only -q`, enchaînée fail-closed après les passes normales ;
- `--collect-only` exécute les imports de conftest/tests — **exactement** le mode d'échec constaté (EXIT 4) ; prouve que le livrable s'installe depuis **ses** requirements, pas depuis l'image.

Documenté dans la config : l'image pré-installée sert l'agent, pas la preuve de portabilité.

## Tests
- Signal : sortie contenant la note #414 → `deps_install_failed=True` + bannière markdown ; absent sinon.
- Strict : plus de `|| echo`, install conditionne pytest (`&&`).
- `installability_command` : None sans requirements ; venv `--clear` + install + collecte, chaîne `&&` ; appendée après la passe normale quand activée ; absente par défaut.
- `_gate_options` propage les deux flags. Suite complète locale verte.

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)