### PR TITLE
feat(executor): contrôle d'adéquation diff↔issue au gate (#437)

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -103,6 +103,14 @@ class Settings(BaseSettings):
     # paquets pré-installés de l'image sandbox (réseau PyPI requis).
     GATE_REQUIRE_DEPS_INSTALL: bool = False
     GATE_CHECK_INSTALLABILITY: bool = False
+    # Adéquation diff↔issue (#437) : contrôle LLM fail-closed « ce diff
+    # implémente-t-il l'issue ? » lancé quand le reste du gate est vert — une
+    # « livraison fantôme » (feature fermée par +1 ligne de requirements) ne
+    # passe plus. Opt-in : un appel LLM par PR candidate.
+    GATE_ADEQUACY: bool = False
+    # Exiger qu'un diff touche au moins un fichier de test (sinon : simple
+    # signal ⚠️ dans le rapport de gate / corps de PR).
+    GATE_REQUIRE_TEST_CHANGES: bool = False
 
     ENGINE_INIT_TIMEOUT: float = 10.0
     ENGINE_WAIT_TIMEOUT: float = 30.0

--- a/collegue/executor/__init__.py
+++ b/collegue/executor/__init__.py
@@ -17,16 +17,22 @@ from collegue.executor.openhands_agent import OpenHandsAgent
 from collegue.executor.pipeline import ExecutionOutcome, execute_issue
 from collegue.executor.pr import PrClients, PrResult, build_pr_body, exec_marker, open_pr
 from collegue.executor.quality_gate import (
+    AdequacyChecker,
+    AdequacyOutcome,
     ExpertReviewer,
+    FakeAdequacyChecker,
     FakeReviewer,
+    LLMAdequacyChecker,
     QualityReport,
     Reviewer,
     ReviewFindingLite,
     ReviewOutcome,
     frontend_gate_command,
     installability_command,
+    issue_expects_code,
     outcome_from_review,
     run_quality_gate,
+    tests_touched,
 )
 from collegue.executor.revert import (
     RevertError,
@@ -65,6 +71,12 @@ __all__ = [
     "frontend_gate_command",
     "installability_command",
     "outcome_from_review",
+    "AdequacyChecker",
+    "AdequacyOutcome",
+    "FakeAdequacyChecker",
+    "LLMAdequacyChecker",
+    "issue_expects_code",
+    "tests_touched",
     # E4 — ouverture de PR
     "PrClients",
     "PrResult",

--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -76,9 +76,17 @@ def failure_feedback(outcome: "ExecutionOutcome") -> str:
     Exception d'infrastructure (#435, ``outcome.error``) : c'est ELLE le motif —
     les logs agent (potentiellement ceux d'une exécution réussie, si la panne est
     survenue à l'ouverture de PR) seraient un feedback trompeur.
+
+    Adéquation refusée (#437) : les tests sont VERTS — le motif utile est la
+    justification du contrôle (« la feature n'est pas implémentée »), pas la
+    sortie des tests.
     """
     if outcome.error:
         return log_tail(outcome.error, 400)
+    report = outcome.quality_report
+    if report is not None and getattr(report, "adequacy_implemented", None) is False:
+        justification = getattr(report, "adequacy_justification", "") or "le diff n'implémente pas l'issue"
+        return ("ADÉQUATION REFUSÉE — le diff ne réalise pas l'issue : " + justification)[:700]
     if outcome.quality_report is not None and outcome.quality_report.test_output:
         output = outcome.quality_report.test_output
         fails = [line.strip() for line in output.splitlines() if line.strip().startswith(("FAILED", "ERROR"))]

--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -24,8 +24,9 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from dataclasses import dataclass
-from typing import List, Optional, Protocol, Tuple, runtime_checkable
+from typing import Iterator, List, Optional, Protocol, Tuple, runtime_checkable
 
 from collegue.executor.agent import IssueSpec
 from collegue.sandbox.executor import DockerSandbox
@@ -208,6 +209,21 @@ class Reviewer(Protocol):
     async def review(self, diff: str, ctx, *, issue: Optional[IssueSpec] = None) -> ReviewOutcome: ...
 
 
+@dataclass(frozen=True)
+class AdequacyOutcome:
+    """Verdict d'adéquation diff↔issue (#437)."""
+
+    implemented: bool
+    justification: str = ""
+
+
+@runtime_checkable
+class AdequacyChecker(Protocol):
+    """Contrôle « ce diff implémente-t-il l'issue ? » (#437). Async (LLM possible)."""
+
+    async def check(self, diff: str, issue: IssueSpec, ctx) -> AdequacyOutcome: ...
+
+
 @dataclass
 class QualityReport:
     """Verdict combiné tests + revue d'un diff."""
@@ -224,6 +240,15 @@ class QualityReport:
     # (mode toléré) — le vert des tests peut venir des paquets de l'IMAGE, pas du
     # requirements.txt du projet. Signal fort pour la PR et l'audit.
     deps_install_failed: bool = False
+    # #437 : contrôle d'adéquation diff↔issue (None = non évalué). Fail-closed :
+    # implemented=False ou erreur du checker ⇒ passed=False.
+    adequacy_implemented: Optional[bool] = None
+    adequacy_justification: str = ""
+    adequacy_error: Optional[str] = None
+    # #437 : le diff touche-t-il au moins un fichier de test ? (signal — défaut
+    # True pour ne pas générer d'avertissement sur les rapports construits sans
+    # cette information).
+    tests_touched: bool = True
 
     def to_markdown(self) -> str:
         """Rapport Markdown pour le corps de PR (texte de revue fencé, anti-injection)."""
@@ -261,8 +286,149 @@ class QualityReport:
                 f"[{_fence_safe_line(finding.severity)}] "
                 f"{_fence_safe_line(finding.category)} : {_fence_safe_line(finding.title)}"
             )
-        lines += ["```", "", f"**Verdict** : {'✅ PASSÉ' if self.passed else '❌ NON PASSÉ'}"]
+        lines += ["```"]
+        if self.adequacy_implemented is not None or self.adequacy_error:
+            if self.adequacy_error:
+                badge = "⚠️ indisponible (fail-closed)"
+                detail = self.adequacy_error
+            else:
+                badge = "✅ conforme" if self.adequacy_implemented else "⛔ NON conforme"
+                detail = self.adequacy_justification
+            lines += ["", f"**Adéquation à l'issue (#437)** : {badge}"]
+            if detail:
+                lines.append(f"> {_fence_safe_line(detail)}")
+        if not self.tests_touched:
+            lines += [
+                "",
+                "> ⚠️ **aucun fichier de test touché** par ce diff (#437) — la feature livrée "
+                "n'est couverte par aucun test nouveau ou modifié.",
+            ]
+        lines += ["", f"**Verdict** : {'✅ PASSÉ' if self.passed else '❌ NON PASSÉ'}"]
         return "\n".join(lines)
+
+
+# Indices d'un livrable NON-code dans le titre d'une issue (#437). Fail-closed :
+# sans indice explicite, une issue est réputée attendre du CODE.
+_NON_CODE_HINTS = (
+    "doc",
+    "readme",
+    "config",
+    "données",
+    "data",
+    "seed",
+    "dépendance",
+    "dependance",
+    "changelog",
+    "licence",
+    "license",
+)
+
+
+def issue_expects_code(issue: IssueSpec) -> bool:
+    """Heuristique fail-closed : cette issue attend-elle une implémentation CODE ? (#437)
+
+    ``True`` par défaut ; ``False`` seulement quand le titre annonce explicitement
+    un livrable non-code (documentation, configuration, données…). C'est ce qui
+    distingue un « diff data-only attendu » d'une **livraison fantôme** (feature
+    fermée par +1 ligne de requirements — cas réel FacNor #69/export PDF).
+    """
+    title = (issue.title or "").lower()
+    return not any(hint in title for hint in _NON_CODE_HINTS)
+
+
+# Fichiers de test : tests/, __tests__/, test_x.py, x_test.go, x.test.ts, x.spec.ts…
+_TEST_PATH_RE = re.compile(r"(^|/)(tests?|__tests__)(/|$)|(^|/)test_[^/]+$|[^/]+[._]test\.[a-z]+$|[^/]+\.spec\.[a-z]+$")
+
+
+def tests_touched(diff: str) -> bool:
+    """Le diff touche-t-il au moins un fichier de test ? (#437, signal de couverture)."""
+    return any(_TEST_PATH_RE.search(path.lower()) for path in _diff_paths(diff))
+
+
+_ADEQUACY_SYSTEM = (
+    "Tu es un relecteur d'ADÉQUATION (rôle REVIEWER). On te donne une issue (titre, "
+    "critères d'acceptation) et le diff livré pour la fermer. Tu ne juges PAS le style : "
+    "uniquement si le diff RÉALISE concrètement ce que l'issue demande. "
+    'Réponds STRICTEMENT en JSON : {"implemented": true|false, "justification": "..."}. '
+    "implemented=false si la feature est absente ou hors-spec (ex. : une seule ligne de "
+    "dépendance pour un service entier, un schéma sans la logique demandée)."
+)
+
+
+def _parse_adequacy(text: str) -> AdequacyOutcome:
+    """Parsing tolérant de la réponse du LLM — **fail-closed** (illisible ⇒ non conforme)."""
+    raw = (text or "").strip()
+    match = re.search(r"\{.*\}", raw, flags=re.S)
+    if match:
+        try:
+            data = json.loads(match.group(0))
+            return AdequacyOutcome(
+                implemented=bool(data.get("implemented")),
+                justification=str(data.get("justification") or "")[:500],
+            )
+        except ValueError:
+            pass
+    if not raw:
+        return AdequacyOutcome(False, "réponse vide du contrôle d'adéquation")
+    return AdequacyOutcome(False, f"réponse illisible du contrôle d'adéquation : {raw[:300]}")
+
+
+class LLMAdequacyChecker:
+    """:class:`AdequacyChecker` par LLM (#437) — fail-closed.
+
+    ``sample_fn`` : ``async (prompt, system_prompt) -> str``, injectable (mocké en
+    CI) ; défaut = ``generate_text`` des providers LLM avec la config du serveur.
+    Le diff est borné (``max_diff_chars``) pour rester dans la fenêtre du modèle.
+    """
+
+    def __init__(self, sample_fn=None, *, max_diff_chars: int = 20000):
+        self._sample_fn = sample_fn or _default_adequacy_sample_fn()
+        self._max_diff_chars = max_diff_chars
+
+    async def check(self, diff: str, issue: IssueSpec, ctx) -> AdequacyOutcome:
+        prompt = (
+            f"## Issue à fermer\n{issue.to_prompt()}\n\n"
+            f"## Diff livré\n```diff\n{(diff or '(diff vide)')[: self._max_diff_chars]}\n```\n\n"
+            "Ce diff implémente-t-il concrètement l'issue ?"
+        )
+        text = await self._sample_fn(prompt, _ADEQUACY_SYSTEM)
+        return _parse_adequacy(text)
+
+
+def _default_adequacy_sample_fn():  # pragma: no cover - chemin réel (integration)
+    from collegue.config import settings
+    from collegue.resources.llm.providers import LLMConfig, generate_text
+
+    config = LLMConfig(
+        model_name=settings.llm_model,
+        api_key=settings.llm_api_key,
+        max_tokens=settings.MAX_TOKENS,
+        temperature=0.2,  # verdict, pas créativité
+    )
+
+    async def sample(prompt: str, system_prompt: str) -> str:
+        response = await generate_text(config, prompt, system_prompt)
+        return response.text
+
+    return sample
+
+
+class FakeAdequacyChecker:
+    """:class:`AdequacyChecker` déterministe pour la CI (aucun LLM)."""
+
+    def __init__(
+        self, *, implemented: bool = True, justification: str = "conforme", raises: Optional[Exception] = None
+    ):
+        self._implemented = implemented
+        self._justification = justification
+        self._raises = raises
+        self.calls: List[int] = []
+
+    async def check(self, diff: str, issue: IssueSpec, ctx) -> AdequacyOutcome:
+        self.calls.append(issue.number)
+        if self._raises is not None:
+            raise self._raises
+        return AdequacyOutcome(implemented=self._implemented, justification=self._justification)
 
 
 class FakeReviewer:
@@ -307,6 +473,8 @@ async def run_quality_gate(
     frontend_gate: bool = True,
     require_deps_install: bool = False,
     check_installability: bool = False,
+    adequacy_checker: Optional[AdequacyChecker] = None,
+    require_test_changes: bool = False,
 ) -> QualityReport:
     """Exécute les tests (sandbox) + la revue (reviewer) sur un diff. Fail-closed.
 
@@ -324,6 +492,12 @@ async def run_quality_gate(
     ``check_installability`` (#439) : ajoute la passe d'installabilité en venv NU
     (cf. :func:`installability_command`) — prouve que le livrable s'installe
     depuis SES requirements, pas depuis les paquets de l'image sandbox.
+    ``adequacy_checker`` (#437) : contrôle « ce diff implémente-t-il l'issue ? »
+    (LLM rôle REVIEWER, fail-closed), lancé seulement quand le reste du gate est
+    vert ET qu'une ``issue`` est fournie — un diff trivial sans rapport avec les
+    critères (« livraison fantôme ») ne passe plus.
+    ``require_test_changes`` (#437) : exige qu'au moins un fichier de test soit
+    touché par le diff (sinon, simple signal ``tests_touched`` dans le rapport).
     """
     sandbox = sandbox or DockerSandbox()
     reviewer = reviewer or _default_reviewer()
@@ -374,7 +548,25 @@ async def run_quality_gate(
         review_findings = ()
         review_blocking = True
 
-    passed = bool(tests_passed and not review_blocking and review_error is None)
+    # 3. Adéquation diff↔issue (#437) — lancée seulement si le reste est vert
+    #    (économie d'appels LLM : un gate déjà rouge n'a pas besoin du verdict).
+    #    Fail-closed : non conforme OU erreur du checker ⇒ non passé.
+    would_pass = bool(tests_passed and not review_blocking and review_error is None)
+    adequacy_implemented: Optional[bool] = None
+    adequacy_justification = ""
+    adequacy_error: Optional[str] = None
+    if adequacy_checker is not None and issue is not None and would_pass:
+        try:
+            adequacy = await adequacy_checker.check(diff, issue, ctx)
+            adequacy_implemented = bool(adequacy.implemented)
+            adequacy_justification = adequacy.justification
+        except Exception as exc:  # noqa: BLE001 - fail-closed ; BaseException (budget) remonte
+            adequacy_error = str(exc) or repr(exc)
+
+    touched = tests_touched(diff)
+    passed = would_pass and adequacy_implemented is not False and adequacy_error is None
+    if require_test_changes and not touched:
+        passed = False
     return QualityReport(
         tests_passed=tests_passed,
         test_exit_code=test_exit_code,
@@ -385,6 +577,10 @@ async def run_quality_gate(
         passed=passed,
         review_error=review_error,
         deps_install_failed=deps_install_failed,
+        adequacy_implemented=adequacy_implemented,
+        adequacy_justification=adequacy_justification,
+        adequacy_error=adequacy_error,
+        tests_touched=touched,
     )
 
 
@@ -424,18 +620,10 @@ _REVIEW_LANG_BY_EXT = {
 }
 
 
-def _detect_review_language(diff: str) -> Optional[str]:
-    """Langage dominant d'un diff parmi ceux que ``code_review`` sait reviewer.
-
-    Parse les chemins de fichiers du diff (lignes ``+++ b/…`` / ``diff --git a/… b/…``)
-    et compte les extensions reconnues. Retourne le langage le plus représenté, ou
-    ``None`` si le diff ne contient **aucun** fichier de code supporté (que du SQL,
-    Markdown, config…). Sans ça, l'``ExpertReviewer`` envoyait tout en ``python`` →
-    un diff SQL/JS était jugé « Python cassé » (score 0.00) et bloquait à tort. [#409]
-    """
-    counts: dict[str, int] = {}
+def _diff_paths(diff: str) -> Iterator[str]:
+    """Chemins (uniques) des fichiers touchés par un diff unifié git."""
     seen: set[str] = set()
-    for line in diff.splitlines():
+    for line in (diff or "").splitlines():
         path = None
         if line.startswith("+++ b/"):
             path = line[len("+++ b/") :].strip()
@@ -446,6 +634,20 @@ def _detect_review_language(diff: str) -> Optional[str]:
         if not path or path == "/dev/null" or path in seen:
             continue
         seen.add(path)
+        yield path
+
+
+def _detect_review_language(diff: str) -> Optional[str]:
+    """Langage dominant d'un diff parmi ceux que ``code_review`` sait reviewer.
+
+    Parse les chemins de fichiers du diff (lignes ``+++ b/…`` / ``diff --git a/… b/…``)
+    et compte les extensions reconnues. Retourne le langage le plus représenté, ou
+    ``None`` si le diff ne contient **aucun** fichier de code supporté (que du SQL,
+    Markdown, config…). Sans ça, l'``ExpertReviewer`` envoyait tout en ``python`` →
+    un diff SQL/JS était jugé « Python cassé » (score 0.00) et bloquait à tort. [#409]
+    """
+    counts: dict[str, int] = {}
+    for path in _diff_paths(diff):
         _root, ext = os.path.splitext(path)
         lang = _REVIEW_LANG_BY_EXT.get(ext.lower())
         if lang:
@@ -474,9 +676,30 @@ class ExpertReviewer:
 
         language = _detect_review_language(diff)
         if language is None:
-            # Aucun fichier de code supporté (python/js/ts/php) dans le diff → la revue
-            # experte, calibrée pour ces langages, n'a rien à juger. On NE la lance PAS
-            # (sinon du SQL/Markdown/config serait noté comme du Python cassé → 0.00 →
+            # Aucun fichier de code supporté (python/js/ts/php) dans le diff.
+            # #437 : si l'issue attend une IMPLÉMENTATION, un diff sans code est
+            # une livraison fantôme probable (cas réel : « export PDF » fermé par
+            # +1 ligne de requirements) → BLOQUANT, plus un skip neutre.
+            if issue is not None and issue_expects_code(issue):
+                return ReviewOutcome(
+                    summary=(
+                        "revue bloquante : le diff ne contient AUCUN fichier de code supporté "
+                        "(python/js/ts/php) alors que l'issue attend une implémentation — "
+                        "livraison fantôme probable (#437)"
+                    ),
+                    quality_score=0.0,
+                    findings=(
+                        ReviewFindingLite(
+                            category="adequacy",
+                            severity="critical",
+                            title="diff sans code pour une issue d'implémentation",
+                        ),
+                    ),
+                    blocking=True,
+                )
+            # Livrable non-code ATTENDU (docs, config, données) ou pas d'issue : la
+            # revue experte, calibrée pour le code, n'a rien à juger. On NE la lance
+            # PAS (sinon du SQL/Markdown serait noté comme du Python cassé → 0.00 →
             # blocage à tort). Outcome neutre, NON bloquant. [#409]
             return ReviewOutcome(
                 summary="revue experte ignorée : aucun fichier de code supporté (python/js/ts/php) dans le diff",

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -103,7 +103,7 @@ def _build_clients(github_token):  # pragma: no cover - infra réelle (integrati
 
 
 def _gate_options(settings_obj) -> dict:
-    """Options du gate qualité depuis la config (#438/#439) — vers ``execute_issue``.
+    """Options du gate qualité depuis la config (#437/#438/#439) — vers ``execute_issue``.
 
     ``GATE_TEST_COMMAND`` vide/None → commande par défaut du gate (pytest).
     """
@@ -111,11 +111,20 @@ def _gate_options(settings_obj) -> dict:
         "frontend_gate": bool(getattr(settings_obj, "GATE_FRONTEND", True)),
         "require_deps_install": bool(getattr(settings_obj, "GATE_REQUIRE_DEPS_INSTALL", False)),
         "check_installability": bool(getattr(settings_obj, "GATE_CHECK_INSTALLABILITY", False)),
+        "require_test_changes": bool(getattr(settings_obj, "GATE_REQUIRE_TEST_CHANGES", False)),
     }
     test_command = getattr(settings_obj, "GATE_TEST_COMMAND", None)
     if test_command:
         options["test_command"] = str(test_command)
+    if bool(getattr(settings_obj, "GATE_ADEQUACY", False)):
+        options["adequacy_checker"] = _build_adequacy_checker(settings_obj)
     return options
+
+
+def _build_adequacy_checker(settings_obj):  # pragma: no cover - infra réelle (integration)
+    from collegue.executor.quality_gate import LLMAdequacyChecker
+
+    return LLMAdequacyChecker()
 
 
 # ── point d'entrée assemblé ────────────────────────────────────────────────────

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -294,6 +294,153 @@ async def test_check_installability_appends_nude_venv_pass(tmp_path):
     assert ".gate_venv" not in sandbox2.calls[0][1]
 
 
+# --- adéquation diff↔issue (#437) --------------------------------------------------
+
+
+def test_issue_expects_code_heuristic():
+    from collegue.executor import issue_expects_code
+
+    # Fail-closed : une feature attend du code…
+    assert issue_expects_code(IssueSpec(number=1, title="Implémentation du service d'export PDF")) is True
+    # …un livrable explicitement non-code, non.
+    assert issue_expects_code(IssueSpec(number=2, title="Documentation de l'API")) is False
+    assert issue_expects_code(IssueSpec(number=3, title="Mise à jour de la configuration CI")) is False
+
+
+async def test_review_blocks_phantom_delivery_diff():
+    """#437 : la livraison fantôme exacte du run v2 — issue feature (« export PDF »)
+    fermée par +1 ligne de requirements.txt. Le skip neutre #409 devenait la faille :
+    diff sans code → revue ignorée → gate vert. Désormais BLOQUANT."""
+    req_diff = "diff --git a/requirements.txt b/requirements.txt\n+reportlab\n"
+    feature = IssueSpec(number=55, title="Implémentation du service d'export PDF")
+    reviewer = ExpertReviewer(tool=None)  # l'outil ne doit JAMAIS être sollicité
+    outcome = await reviewer.review(req_diff, ctx=None, issue=feature)
+    assert outcome.blocking is True
+    assert "fantôme" in outcome.summary
+    assert outcome.findings and outcome.findings[0].severity == "critical"
+
+
+async def test_review_still_neutral_for_expected_non_code_diff():
+    # Livrable non-code ATTENDU (docs) : comportement #409 conservé (neutre).
+    md_diff = "diff --git a/README.md b/README.md\n+# titre\n"
+    docs_issue = IssueSpec(number=9, title="Documentation utilisateur")
+    outcome = await ExpertReviewer(tool=None).review(md_diff, ctx=None, issue=docs_issue)
+    assert outcome.blocking is False
+
+    # …et sans issue fournie : neutre aussi (comportement historique).
+    outcome2 = await ExpertReviewer(tool=None).review(md_diff, ctx=None)
+    assert outcome2.blocking is False
+
+
+async def test_adequacy_checker_blocks_gate_when_not_implemented(tmp_path):
+    """#437 : tests verts + revue OK mais le diff n'implémente PAS l'issue →
+    gate NON passé, justification visible dans le rapport (et donc la PR)."""
+    from collegue.executor import FakeAdequacyChecker
+
+    checker = FakeAdequacyChecker(implemented=False, justification="aucune route PDF, reportlab jamais importé")
+    report = await run_quality_gate(
+        str(tmp_path), DIFF, ctx=None, sandbox=_green(), reviewer=FakeReviewer(), issue=ISSUE, adequacy_checker=checker
+    )
+    assert checker.calls == [ISSUE.number]
+    assert report.tests_passed is True
+    assert report.adequacy_implemented is False
+    assert report.passed is False  # fail-closed
+    markdown = report.to_markdown()
+    assert "Adéquation à l'issue" in markdown and "NON conforme" in markdown
+    assert "aucune route PDF" in markdown
+
+
+async def test_adequacy_checker_pass_keeps_gate_green(tmp_path):
+    from collegue.executor import FakeAdequacyChecker
+
+    checker = FakeAdequacyChecker(implemented=True, justification="service livré et testé")
+    report = await run_quality_gate(
+        str(tmp_path), DIFF, ctx=None, sandbox=_green(), reviewer=FakeReviewer(), issue=ISSUE, adequacy_checker=checker
+    )
+    assert report.passed is True
+    assert report.adequacy_implemented is True
+
+
+async def test_adequacy_checker_not_called_when_gate_already_red(tmp_path):
+    # Économie LLM : un gate déjà rouge n'appelle pas le contrôle d'adéquation.
+    from collegue.executor import FakeAdequacyChecker
+
+    checker = FakeAdequacyChecker(implemented=True)
+    report = await run_quality_gate(
+        str(tmp_path), DIFF, ctx=None, sandbox=_red(), reviewer=FakeReviewer(), issue=ISSUE, adequacy_checker=checker
+    )
+    assert checker.calls == []
+    assert report.adequacy_implemented is None
+    assert report.passed is False
+
+
+async def test_adequacy_checker_exception_is_fail_closed(tmp_path):
+    from collegue.executor import FakeAdequacyChecker
+
+    checker = FakeAdequacyChecker(raises=RuntimeError("LLM indisponible"))
+    report = await run_quality_gate(
+        str(tmp_path), DIFF, ctx=None, sandbox=_green(), reviewer=FakeReviewer(), issue=ISSUE, adequacy_checker=checker
+    )
+    assert report.adequacy_error is not None
+    assert report.passed is False
+    assert "indisponible" in report.to_markdown()
+
+
+def test_parse_adequacy_is_fail_closed():
+    from collegue.executor.quality_gate import _parse_adequacy
+
+    ok = _parse_adequacy('{"implemented": true, "justification": "service livré"}')
+    assert ok.implemented is True and "livré" in ok.justification
+    fenced = _parse_adequacy('```json\n{"implemented": false, "justification": "feature absente"}\n```')
+    assert fenced.implemented is False
+    assert _parse_adequacy("je ne sais pas").implemented is False  # illisible ⇒ non conforme
+    assert _parse_adequacy("").implemented is False
+
+
+async def test_llm_adequacy_checker_round_trip():
+    from collegue.executor import LLMAdequacyChecker
+
+    prompts = []
+
+    async def fake_sample(prompt, system_prompt):
+        prompts.append((prompt, system_prompt))
+        return '{"implemented": false, "justification": "le diff ne contient que requirements.txt"}'
+
+    checker = LLMAdequacyChecker(fake_sample)
+    outcome = await checker.check("diff --git a/requirements.txt b/requirements.txt\n+x\n", ISSUE, ctx=None)
+    assert outcome.implemented is False
+    prompt, system = prompts[0]
+    assert "Diff livré" in prompt and ISSUE.title in prompt
+    assert "JSON" in system
+
+
+# --- signal « aucun test touché » (#437) --------------------------------------------
+
+
+def test_tests_touched_detection():
+    from collegue.executor import tests_touched
+
+    assert tests_touched("diff --git a/tests/test_api.py b/tests/test_api.py\n+x\n") is True
+    assert tests_touched("diff --git a/src/InvoiceForm.test.tsx b/src/InvoiceForm.test.tsx\n+x\n") is True
+    assert tests_touched("diff --git a/src/form.spec.ts b/src/form.spec.ts\n+x\n") is True
+    assert tests_touched("diff --git a/app/main.py b/app/main.py\n+x\n") is False
+    assert tests_touched("") is False
+
+
+async def test_require_test_changes_blocks_codeless_coverage(tmp_path):
+    report = await run_quality_gate(
+        str(tmp_path), DIFF, ctx=None, sandbox=_green(), reviewer=FakeReviewer(), require_test_changes=True
+    )
+    assert report.tests_touched is False
+    assert report.passed is False
+    assert "aucun fichier de test touché" in report.to_markdown()
+
+    # Par défaut : simple signal, pas bloquant.
+    report2 = await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=_green(), reviewer=FakeReviewer())
+    assert report2.passed is True
+    assert "aucun fichier de test touché" in report2.to_markdown()
+
+
 # --- fail-closed ----------------------------------------------------------------
 
 
@@ -418,11 +565,13 @@ async def test_expert_reviewer_maps_tool_response():
 
 async def test_review_skipped_for_unsupported_language_diff():
     """#409 : un diff sans fichier de code supporté (SQL seul) → revue IGNORÉE et
-    NON bloquante ; l'outil n'est PAS appelé (plus de faux 0.00 sur du non-code)."""
+    NON bloquante ; l'outil n'est PAS appelé (plus de faux 0.00 sur du non-code).
+    (Depuis #437 : ne vaut que si l'issue n'attend PAS de code — ici données/seed.)"""
     sql_diff = "diff --git a/schema.sql b/schema.sql\n+CREATE TABLE t (id INT);\n"
     tool = _FakeTool(_response(0.0))  # bloquerait s'il était appelé
     reviewer = ExpertReviewer(tool=tool)
-    outcome = await reviewer.review(sql_diff, ctx=None, issue=ISSUE)
+    data_issue = IssueSpec(number=5, title="Seed des données de démonstration")
+    outcome = await reviewer.review(sql_diff, ctx=None, issue=data_issue)
     assert outcome.blocking is False
     assert tool.calls == []  # outil non sollicité
 

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -244,7 +244,7 @@ def test_main_returns_1_on_blocked(monkeypatch):
 
 
 def test_gate_options_built_from_settings():
-    # #438/#439 : la config GATE_* devient les kwargs du gate (vide → défauts du gate).
+    # #437/#438/#439 : la config GATE_* devient les kwargs du gate (vide → défauts).
     from collegue.pilot.runtime import _gate_options
 
     custom = SimpleNamespace(
@@ -252,19 +252,26 @@ def test_gate_options_built_from_settings():
         GATE_TEST_COMMAND="npm run check",
         GATE_REQUIRE_DEPS_INSTALL=True,
         GATE_CHECK_INSTALLABILITY=True,
+        GATE_REQUIRE_TEST_CHANGES=True,
     )
     assert _gate_options(custom) == {
         "frontend_gate": False,
         "test_command": "npm run check",
         "require_deps_install": True,
         "check_installability": True,
+        "require_test_changes": True,
     }
     defaults = SimpleNamespace(GATE_TEST_COMMAND="")
     assert _gate_options(defaults) == {
         "frontend_gate": True,
         "require_deps_install": False,
         "check_installability": False,
+        "require_test_changes": False,
     }
+    # GATE_ADEQUACY (opt-in) câble un checker LLM dans les options.
+    with_adequacy = SimpleNamespace(GATE_ADEQUACY=True)
+    options = _gate_options(with_adequacy)
+    assert options["adequacy_checker"] is not None
 
 
 # --- isolation ------------------------------------------------------------------


### PR DESCRIPTION
## Problème (#437 — HAUTE, run FacNor v2)

Le gate mesurait « le diff ne régresse pas », jamais « le diff **implémente** l'issue ». Preuves du run : issue FacNor #55 « export PDF » fermée par la PR #69 qui modifie **uniquement `requirements.txt` (+1 ligne)** — 0 code PDF dans le produit ; #51 « numérotation séquentielle » fermée par un schéma sans logique. Pire : le skip de revue #409 (diff sans fichier de code → outcome **neutre**) faisait que ces diffs fantômes n'étaient même pas revus.

## Correctif

**1. Diff non-code = BLOQUANT quand l'issue attend du code** (corrige la faille #409) :
- `issue_expects_code(issue)` — heuristique **fail-closed** sur le titre (True par défaut ; False seulement pour un livrable explicitement non-code : documentation, config, données/seed…).
- `ExpertReviewer` : diff sans fichier de code supporté + issue d'implémentation → revue **bloquante** « livraison fantôme probable », finding `critical`. Le skip neutre reste pour les livrables non-code attendus et quand aucune issue n'est fournie.

**2. Contrôle d'adéquation LLM** (`AdequacyChecker` protocole + `LLMAdequacyChecker`, opt-in `GATE_ADEQUACY`) :
- « Ce diff implémente-t-il concrètement l'issue ? » — `IssueSpec.to_prompt()` (anti-injection) + diff borné → JSON `{implemented, justification}`, parsing **fail-closed** (réponse illisible ⇒ non conforme).
- Lancé **seulement quand le reste du gate est vert** (économie : ≤ 1 appel LLM par PR candidate) ; non conforme ou erreur du checker ⇒ `passed=False`.
- La justification apparaît dans le rapport de PR **et** dans le feedback de retry (`failure_feedback` la priorise — la sortie verte des tests serait un motif trompeur).

**3. Signal de couverture** : `tests_touched(diff)` (`tests/`, `test_*.py`, `*.spec.ts`, `*_test.go`…) — ⚠️ dans le rapport quand aucun fichier de test n'est touché ; bloquant en opt-in (`GATE_REQUIRE_TEST_CHANGES`).

## Tests
- La livraison fantôme exacte du run (requirements-only + issue feature) → revue bloquante, outil expert jamais sollicité ; docs/données → neutre conservé.
- Adequacy : non conforme → gate rouge + justification dans le markdown ; conforme → vert ; exception → fail-closed ; **pas d'appel quand le gate est déjà rouge** ; parsing JSON/fencé/illisible ; round-trip `LLMAdequacyChecker` avec `sample_fn` mocké.
- `tests_touched` (py/ts/go/spec) + mode bloquant opt-in + bannières markdown.
- Suite complète locale verte.

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)