### PR TITLE
feat(pilot): exposer les reviews en attente au stop — drain à la deadline (#440)

### DIFF
--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -135,6 +135,13 @@ class ProjectRunResult:
     processed: List[TaskOutcome] = field(default_factory=list)
     project_status: Optional[str] = None  # statut projet final écrit (ex. improving), sinon None
     improvement: Optional[object] = None  # ImprovementResult si le mode improving a été enchaîné (H5)
+    # #440 : tâches encore ``in_review`` AU MOMENT du stop (ids) — du travail
+    # TERMINÉ et validé (gate vert, PR ouverte) qui n'atteint `main` qu'après un
+    # merge. Au ``STOP_DEADLINE`` en particulier, l'appelant DOIT drainer ces
+    # reviews (passe de merge/réconciliation) au lieu de les découvrir en
+    # post-mortem : deadline = « ne plus DÉMARRER de travail », pas « abandonner
+    # le travail déjà validé ».
+    pending_reviews: List[int] = field(default_factory=list)
 
     @property
     def opened_prs(self) -> List[int]:
@@ -638,6 +645,10 @@ async def run_project(
         processed=processed,
         project_status=project_status,
         improvement=improvement,
+        # #440 : exposer le travail validé encore en attente de merge — la boucle
+        # s'arrête toujours ENTRE deux tâches (jamais en plein milieu), donc cette
+        # photo est exacte quel que soit le motif d'arrêt (deadline incluse).
+        pending_reviews=[t.id for t in tasks if t.status == TASK_STATUS_IN_REVIEW],
     )
 
 

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -210,9 +210,15 @@ async def run_project_from_settings(
     # Reporting (journal de décisions) — réel uniquement (dry_run n'écrit rien).
     if not dry_run:
         prs = ", ".join(str(n) for n in result.opened_prs) or "aucune"
+        # #440 : un arrêt deadline laisse du travail VALIDÉ en attente de merge —
+        # le signaler dans le journal pour que le drain ne dépende pas d'un
+        # post-mortem (la PR FacNor #72 est restée ouverte, mergée à la main).
+        drain = ""
+        if result.pending_reviews:
+            drain = f" ; {len(result.pending_reviews)} tâche(s) in_review À DRAINER (merge requis)"
         manager.record_decision(
             project_id,
-            f"Run pilote: {result.stop_reason} — {result.iterations} tâche(s), PR {prs}",
+            f"Run pilote: {result.stop_reason} — {result.iterations} tâche(s), PR {prs}{drain}",
             rationale=f"statut projet={result.project_status or 'inchangé'}",
         )
 
@@ -242,6 +248,10 @@ def format_run_report(result: ProjectRunResult, *, project_id: Optional[int] = N
         pr = f" → PR #{task.pr_number}" if task.pr_number is not None else ""
         lines.append(f"  [{badge}] #{task.task_id} {task.title} ({task.stage}){pr}")
     lines.append(f"PRs ouvertes : {result.opened_prs or '(aucune)'}")
+    pending = getattr(result, "pending_reviews", None) or []
+    if pending:
+        # #440 : travail validé en attente de merge — à drainer, surtout après deadline.
+        lines.append(f"⚠ Reviews en attente de merge (drain requis) : tâches {pending}")
     lines.append(f"Statut projet : {result.project_status or '(inchangé)'}")
     lines.append(f"Budget-temps restant : {_remaining_label(budget)}")
     return "\n".join(lines)

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -332,6 +332,47 @@ async def test_historical_mode_keeps_chaining_siblings(repo, manager):
     assert result.iterations == 2
 
 
+# --- drain des reviews au stop (#440) ------------------------------------------------
+
+
+async def test_deadline_stop_exposes_pending_reviews(repo, manager):
+    """#440 : au STOP_DEADLINE, les tâches `in_review` (gate vert, PR ouverte) sont
+    EXPOSÉES dans le résultat — l'appelant sait qu'un drain (merge) est requis au
+    lieu de découvrir la PR abandonnée en post-mortem (PR FacNor #72)."""
+    pid = _sibling_project(manager, 2)
+    result = await _run(manager, repo, pid, dry_run=False, budget=_Budget([CONT, DEADLINE]))
+    assert result.stop_reason == "deadline_reached"
+    s0 = manager.get_tasks(pid)[0]
+    assert result.pending_reviews == [s0.id]  # S0 validée, en attente de merge
+
+
+async def test_pending_reviews_reflect_all_unmerged_work(repo, manager):
+    # Vrai pour TOUT motif d'arrêt : un run `completed` en mode historique laisse
+    # toutes ses PRs en attente de merge — le drain les voit aussi.
+    pid = _sibling_project(manager, 2)
+    result = await _run(manager, repo, pid, dry_run=False)
+    assert result.stop_reason == "completed"
+    assert result.pending_reviews == [t.id for t in manager.get_tasks(pid)]
+
+    # …et vide quand tout est mergé (reprise d'un projet terminé).
+    for t in manager.get_tasks(pid):
+        manager.update_task_status(t.id, "merged")
+    result2 = await _run(manager, repo, pid, dry_run=False)
+    assert result2.pending_reviews == []
+
+
+def test_run_report_flags_pending_reviews():
+    # Le rapport lisible signale le drain requis (#440).
+    from collegue.pilot import format_run_report
+    from collegue.pilot.driver import ProjectRunResult
+
+    result = ProjectRunResult(stop_reason="deadline_reached", iterations=1, processed=[], pending_reviews=[11])
+    report = format_run_report(result, project_id=1)
+    assert "drain requis" in report and "[11]" in report
+    silent = ProjectRunResult(stop_reason="completed", iterations=0, processed=[])
+    assert "drain requis" not in format_run_report(silent, project_id=1)
+
+
 # --- options du gate par projet (#438) ----------------------------------------------
 
 


### PR DESCRIPTION
## Problème (#440 — MOYENNE, run FacNor v2)

`STOP_DEADLINE` était traité comme un arrêt sec identique à un crash : la PR `in_review` au **gate vert** restait abandonnée ouverte (PR FacNor #72, mergée à la main en post-mortem), et `ProjectRunResult` n'exposait que les PRs du run courant — rien ne disait à l'appelant qu'un **drain** était requis. Sémantiquement, deadline = « ne plus **démarrer** de travail », pas « abandonner le travail déjà validé ».

## Correctif

- **`ProjectRunResult.pending_reviews`** : ids des tâches `in_review` **au moment du stop** — photo exacte (la boucle s'arrête toujours entre deux tâches, jamais en plein milieu), quel que soit le motif d'arrêt. L'appelant (orchestration F4 et héritiers, merge-bot) sait exactement quoi drainer.
- **Runtime** : le journal de décisions (`record_decision`) et le rapport lisible (`format_run_report`) signalent « N tâche(s) in_review À DRAINER (merge requis) » — plus de découverte en post-mortem.

## Tests
- Deadline avec travail validé en vol → `pending_reviews` contient la tâche.
- Le champ reflète tout le travail non mergé (run `completed` historique inclus) et redevient vide après merges.
- Rapport lisible : ligne « drain requis » présente/absente selon le cas.
- Suite complète locale verte.

Closes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)