### PR TITLE
feat(pilot): réconciliation GitHub→état des tâches in_review au démarrage (#442)

### DIFF
--- a/collegue/pilot/__init__.py
+++ b/collegue/pilot/__init__.py
@@ -32,7 +32,13 @@ from collegue.pilot.budget import (
     BudgetTimeController,
     ContinueDecision,
 )
-from collegue.pilot.driver import ProjectRunResult, TaskOutcome, requeue_task_for_redo, run_project
+from collegue.pilot.driver import (
+    ProjectRunResult,
+    TaskOutcome,
+    reconcile_in_review_tasks,
+    requeue_task_for_redo,
+    run_project,
+)
 from collegue.pilot.guard import (
     GuardOutcome,
     HealthResult,
@@ -78,6 +84,7 @@ __all__ = [
     "ProjectRunResult",
     "TaskOutcome",
     "requeue_task_for_redo",
+    "reconcile_in_review_tasks",
     # F4 — câblage runtime
     "run_project_from_settings",
     "format_run_report",

--- a/collegue/pilot/audit.py
+++ b/collegue/pilot/audit.py
@@ -27,6 +27,7 @@ CostSource = Callable[[], Tuple[float, int]]
 TASK_STARTED = "task_started"
 TASK_RETRY = "task_retry"  # tâche re-filée `todo` après un échec retentable (#420)
 TASK_FAILED = "task_failed"  # échec TERMINAL d'une tâche, raison + extrait de logs (#421)
+TASK_RECONCILED = "task_reconciled"  # état réaligné sur la vérité GitHub de sa PR (#442)
 DIFF_PRODUCED = "diff_produced"
 GATE_DECISION = "gate_decision"
 PR_OPENED = "pr_opened"

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -32,6 +32,7 @@ from typing import List, Optional, Tuple
 
 from collegue.executor.agent import IssueSpec
 from collegue.executor.pipeline import execute_issue, failure_feedback, log_tail
+from collegue.executor.workspace import branch_for_issue
 from collegue.pilot.audit import (
     BUDGET_EVENT,
     CHECKPOINT_SAVED,
@@ -39,6 +40,7 @@ from collegue.pilot.audit import (
     PR_OPENED,
     RUN_STOP,
     TASK_FAILED,
+    TASK_RECONCILED,
     TASK_RETRY,
     TASK_STARTED,
     CostSource,
@@ -61,6 +63,7 @@ TASK_STATUS_TODO = "todo"
 TASK_STATUS_IN_PROGRESS = "in_progress"
 TASK_STATUS_IN_REVIEW = "in_review"
 TASK_STATUS_FAILED = "failed"
+TASK_STATUS_MERGED = "merged"
 
 # Raisons d'arrêt du pilote.
 STOP_COMPLETED = "completed"  # plus rien à construire → MVP atteint
@@ -224,6 +227,58 @@ def _issue_from_task(task, by_id=None) -> IssueSpec:
     )
 
 
+def reconcile_in_review_tasks(tasks, manager, clients, *, owner: str, repo: str, audit=None) -> int:
+    """Réaligne les tâches ``in_review`` sur l'état RÉEL de leur PR GitHub (#442).
+
+    Entre deux runs, des PRs sont mergées ou fermées **hors moteur** (opérateur,
+    autre outil) : l'état persisté diverge alors silencieusement de la vérité
+    GitHub — un redémarrage repartirait d'un état faux (MVP jamais « complet »,
+    dépendants stricts bloqués ``awaiting_merge`` à tort). Pour chaque tâche
+    ``in_review`` (PR retrouvée par sa branche déterministe) :
+
+    - PR **mergée** → statut ``merged`` (terminal) ;
+    - PR **fermée sans merge** → redo (``todo`` + feedback #424, même canal que
+      le conflit #434) ;
+    - PR encore ouverte / introuvable / GitHub injoignable → état conservé
+      (**best-effort** : la réconciliation n'invente rien et ne tue pas le run).
+
+    Mute les objets ``tasks`` (overlay) ET persiste via ``manager``. Retourne le
+    nombre de tâches réalignées.
+    """
+    audit = audit or NullAuditLog()
+    reconciled = 0
+    for task in tasks:
+        if task.status != TASK_STATUS_IN_REVIEW:
+            continue
+        branch = branch_for_issue(task.issue_number or task.id)
+        try:
+            pr = clients.prs.find_pr_by_head(owner, repo, branch, state="all")
+        except Exception as exc:  # noqa: BLE001 - best-effort : GitHub down ≠ run mort
+            logger.warning("réconciliation #442 : PR introuvable pour la tâche %s (%s) — état conservé", task.id, exc)
+            continue
+        if pr is None:
+            continue
+        if getattr(pr, "merged", False):
+            task.status = TASK_STATUS_MERGED
+            manager.update_task_status(task.id, TASK_STATUS_MERGED)
+            audit.record(TASK_RECONCILED, task_id=task.id, pr_number=pr.number, outcome="merged")
+            logger.info("tâche %s : PR #%s mergée hors-run → statut merged (#442)", task.id, pr.number)
+            reconciled += 1
+        elif getattr(pr, "state", "") == "closed":
+            message = (
+                f"[reconcile] ta PR #{pr.number} a été FERMÉE sans merge en dehors du run — "
+                "son contenu n'est PAS dans le dépôt : repars du dépôt à jour et relivre la tâche."
+            )
+            requeue_task_for_redo(manager, task.id, message=message)
+            task.status = TASK_STATUS_TODO
+            task.attempt_count = max(1, int(getattr(task, "attempt_count", 0) or 0))
+            task.last_error = message
+            audit.record(TASK_RECONCILED, task_id=task.id, pr_number=pr.number, outcome="closed_requeued")
+            logger.info("tâche %s : PR #%s fermée sans merge → redo (#442)", task.id, pr.number)
+            reconciled += 1
+    return reconciled
+
+
 def requeue_task_for_redo(manager, task_id: int, *, message: str, attempt_count: int = 1) -> None:
     """Re-file une tâche pour un REDO complet après un événement externe (#434).
 
@@ -273,6 +328,7 @@ async def run_project(
     require_merged_deps: bool = False,
     max_inflight_reviews: int = DEFAULT_MAX_INFLIGHT_REVIEWS,
     gate_options=None,
+    reconcile_reviews: bool = True,
 ) -> ProjectRunResult:
     """Pilote un projet : chaîne ``execute_issue`` sur les tâches prêtes sous budget.
 
@@ -310,6 +366,11 @@ async def run_project(
     ``gate_options`` (#438) : kwargs transmis tels quels au gate qualité via
     ``execute_issue`` (``test_command``, ``frontend_gate``…) — configuration du
     gate par projet sans coupler le pilote à la config.
+
+    ``reconcile_reviews`` (#442, défaut vrai) : au démarrage d'un run RÉEL (avec
+    ``clients``), réaligne chaque tâche ``in_review`` sur l'état GitHub de sa PR
+    (mergée → ``merged`` ; fermée sans merge → redo) — le redémarrage après des
+    merges manuels (post-deadline notamment) redevient idempotent.
 
     ``max_inflight_reviews`` (#434, mode strict uniquement) : plafond de tâches
     ``in_review`` (PR ouverte non mergée) avant de s'arrêter ``awaiting_merge``.
@@ -363,6 +424,12 @@ async def run_project(
             task.status = TASK_STATUS_TODO
             if not dry_run:
                 manager.update_task_status(task.id, TASK_STATUS_TODO)
+
+    # #442 : réconciliation GitHub→état (réel uniquement, clients requis). Des PRs
+    # ont pu être mergées/fermées HORS moteur depuis le dernier run : sans
+    # réalignement, le redémarrage n'est pas idempotent.
+    if reconcile_reviews and not dry_run and clients is not None:
+        reconcile_in_review_tasks(tasks, manager, clients, owner=owner, repo=repo, audit=audit)
 
     # Avec retries, chaque tâche peut consommer jusqu'à max_task_attempts itérations.
     cap = max_iterations if max_iterations is not None else len(tasks) * max(2, max_task_attempts) + 5

--- a/collegue/tools/github_commands/prs.py
+++ b/collegue/tools/github_commands/prs.py
@@ -42,6 +42,9 @@ class PRInfo(BaseModel):
     updated_at: str
     labels: List[str] = []
     draft: bool = False
+    # #442 : une PR ``closed`` peut l'être par MERGE ou par simple fermeture —
+    # la réconciliation GitHub→état a besoin de distinguer les deux.
+    merged: bool = False
 
 
 class IssueInfo(BaseModel):
@@ -142,6 +145,8 @@ class PRCommands(GitHubClient):
             updated_at=pr["updated_at"],
             labels=[label["name"] for label in pr.get("labels", [])],
             draft=pr.get("draft", False),
+            # L'endpoint de liste n'a pas ``merged`` (bool) mais ``merged_at``.
+            merged=bool(pr.get("merged") or pr.get("merged_at")),
         )
 
     def get_pr(self, owner: str, repo: str, pr_number: int) -> PRInfo:
@@ -158,6 +163,7 @@ class PRCommands(GitHubClient):
             updated_at=data["updated_at"],
             labels=[l["name"] for l in data.get("labels", [])],
             draft=data.get("draft", False),
+            merged=bool(data.get("merged") or data.get("merged_at")),
         )
 
     def get_pr_files(self, owner: str, repo: str, pr_number: int, limit: int = 100) -> List[FileChange]:

--- a/tests/test_github_merge_delete.py
+++ b/tests/test_github_merge_delete.py
@@ -159,6 +159,42 @@ def test_merge_pr_other_http_errors_propagate_untyped():
     assert not isinstance(ei.value, PRNotMergeableError)
 
 
+# --- mapping merged (réconciliation #442) -----------------------------------------
+
+
+def _pr_payload(**overrides):
+    payload = {
+        "number": 72,
+        "title": "t",
+        "state": "closed",
+        "html_url": "https://gh/pull/72",
+        "user": {"login": "x"},
+        "base": {"ref": "main"},
+        "head": {"ref": "collegue/issue-11"},
+        "created_at": "2026-06-10T00:00:00Z",
+        "updated_at": "2026-06-10T01:00:00Z",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_find_pr_by_head_maps_merged_from_merged_at():
+    # L'endpoint de LISTE n'expose pas `merged` (bool) mais `merged_at` : une PR
+    # closed+merged doit être distinguable d'une closed-abandonnée (#442).
+    pr, _ = _pr_with([_pr_payload(merged_at="2026-06-10T02:00:00Z")])
+    info = pr.find_pr_by_head("o", "r", "collegue/issue-11", state="all")
+    assert info.merged is True and info.state == "closed"
+
+    pr2, _ = _pr_with([_pr_payload(merged_at=None)])
+    info2 = pr2.find_pr_by_head("o", "r", "collegue/issue-11", state="all")
+    assert info2.merged is False
+
+
+def test_get_pr_maps_merged_bool():
+    pr, _ = _pr_with(_pr_payload(merged=True))
+    assert pr.get_pr("o", "r", 72).merged is True
+
+
 # --- delete_branch --------------------------------------------------------------
 
 

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -114,7 +114,7 @@ def _sibling_project(manager, n=2):
     return pid
 
 
-async def _run(manager, repo, pid, *, budget=None, dry_run=True, sandbox=None, agent=None, **kw):
+async def _run(manager, repo, pid, *, budget=None, dry_run=True, sandbox=None, agent=None, clients=None, **kw):
     return await run_project(
         pid,
         repo,
@@ -126,7 +126,7 @@ async def _run(manager, repo, pid, *, budget=None, dry_run=True, sandbox=None, a
         budget=budget or _always(),
         sandbox=sandbox or _Sandbox(ok=True),
         reviewer=FakeReviewer(),
-        clients=_clients(),
+        clients=clients or _clients(),
         dry_run=dry_run,
         **kw,
     )
@@ -330,6 +330,110 @@ async def test_historical_mode_keeps_chaining_siblings(repo, manager):
     result = await _run(manager, repo, pid, dry_run=False)
     assert result.stop_reason == "completed"
     assert result.iterations == 2
+
+
+# --- réconciliation GitHub→état au démarrage (#442) ----------------------------------
+
+
+class _ReconcilePRs(_PRs):
+    """``find_pr_by_head`` scripté par branche (et journal des requêtes)."""
+
+    def __init__(self, mapping):
+        self._mapping = mapping
+        self.queries = []
+
+    def find_pr_by_head(self, owner, repo, head, base=None, state="open"):
+        self.queries.append((head, state))
+        value = self._mapping.get(head)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+def _reconcile_clients(mapping):
+    return PrClients(branches=_Branches(), files=_Files(), prs=_ReconcilePRs(mapping))
+
+
+async def test_reconcile_merged_pr_updates_state_and_unblocks_strict(repo, manager):
+    """#442 : une tâche in_review dont la PR a été MERGÉE hors-run (merge manuel
+    post-deadline) repart `merged` au démarrage — la reprise est idempotente et le
+    mode strict ne bloque plus `awaiting_merge` sur du travail déjà dans main."""
+    pid = _sibling_project(manager, 2)
+    s0 = manager.get_tasks(pid)[0]
+    manager.update_task_status(s0.id, "in_review")
+    branch = f"collegue/issue-{s0.id}"
+    clients = _reconcile_clients({branch: SimpleNamespace(number=72, state="closed", merged=True)})
+    result = await _run(manager, repo, pid, dry_run=False, clients=clients, require_merged_deps=True)
+    statuses = {t.title: t.status for t in manager.get_tasks(pid)}
+    assert statuses["S0"] == "merged"  # vérité GitHub réalignée
+    assert statuses["S1"] == "in_review"  # la sœur a pu se construire
+    assert result.iterations == 1
+    assert clients.prs.queries[0] == (branch, "all")
+
+
+async def test_reconcile_closed_pr_requeues_with_feedback(repo, manager):
+    # PR fermée SANS merge hors-run → redo : la tâche repart `todo` avec le
+    # feedback (#424) et est relivrée dans CE run.
+    pid = _linear_project(manager, 1)
+    t0 = manager.get_tasks(pid)[0]
+    manager.update_task_status(t0.id, "in_review")
+    branch = f"collegue/issue-{t0.id}"
+    clients = _reconcile_clients({branch: SimpleNamespace(number=64, state="closed", merged=False)})
+    agent = _RecordingAgent()
+    result = await _run(manager, repo, pid, dry_run=False, clients=clients, agent=agent)
+    assert result.iterations == 1  # relivrée dans ce run
+    assert "FERMÉE sans merge" in agent.contexts[0]  # feedback ré-injecté
+    assert manager.get_tasks(pid)[0].status == "in_review"
+
+
+async def test_reconcile_is_best_effort_and_conservative(repo, manager):
+    """PR encore ouverte → in_review conservé ; PR introuvable → état intact ;
+    GitHub injoignable → le run continue (best-effort, pas de mort du run)."""
+    from collegue.pilot.audit import RunAuditLog
+
+    pid = _sibling_project(manager, 3)
+    s0, s1, s2 = manager.get_tasks(pid)
+    for t in (s0, s1, s2):
+        manager.update_task_status(t.id, "in_review")
+    mapping = {
+        f"collegue/issue-{s0.id}": SimpleNamespace(number=70, state="open", merged=False),
+        f"collegue/issue-{s1.id}": None,
+        f"collegue/issue-{s2.id}": RuntimeError("GitHub 503"),
+    }
+    audit = RunAuditLog(pid)
+    result = await _run(manager, repo, pid, dry_run=False, clients=_reconcile_clients(mapping), audit=audit)
+    assert result.stop_reason == "completed"  # rien à construire, rien n'a explosé
+    assert all(t.status == "in_review" for t in manager.get_tasks(pid))
+    assert [e for e in audit.events if e.kind == "task_reconciled"] == []
+
+
+async def test_reconcile_skipped_in_dry_run(repo, manager):
+    # dry_run n'écrit rien : pas de réconciliation (aperçu sans effet de bord).
+    pid = _linear_project(manager, 1)
+    t0 = manager.get_tasks(pid)[0]
+    manager.update_task_status(t0.id, "in_review")
+    branch = f"collegue/issue-{t0.id}"
+    clients = _reconcile_clients({branch: SimpleNamespace(number=72, state="closed", merged=True)})
+    await _run(manager, repo, pid, dry_run=True, clients=clients)
+    assert clients.prs.queries == []
+    assert manager.get_tasks(pid)[0].status == "in_review"
+
+
+async def test_reconcile_audits_outcomes(repo, manager):
+    from collegue.pilot.audit import RunAuditLog
+
+    pid = _sibling_project(manager, 2)
+    s0, s1 = manager.get_tasks(pid)
+    manager.update_task_status(s0.id, "in_review")
+    manager.update_task_status(s1.id, "in_review")
+    mapping = {
+        f"collegue/issue-{s0.id}": SimpleNamespace(number=72, state="closed", merged=True),
+        f"collegue/issue-{s1.id}": SimpleNamespace(number=64, state="closed", merged=False),
+    }
+    audit = RunAuditLog(pid)
+    await _run(manager, repo, pid, dry_run=False, clients=_reconcile_clients(mapping), audit=audit)
+    outcomes = {e.detail["pr_number"]: e.detail["outcome"] for e in audit.events if e.kind == "task_reconciled"}
+    assert outcomes == {72: "merged", 64: "closed_requeued"}
 
 
 # --- drain des reviews au stop (#440) ------------------------------------------------


### PR DESCRIPTION
## Problème (#442 — BASSE, run FacNor v2)

Le moteur supposait être le **seul écrivain** du cycle de vie des PRs : une PR mergée ou fermée **hors moteur** (merge manuel post-deadline, autre outil) laissait sa tâche `in_review` en DB. Le redémarrage n'était pas idempotent : MVP jamais « complet », dépendants stricts bloqués `awaiting_merge` à tort. Cas réel : task 11 / PR FacNor #72 mergée post-run par l'opérateur → `state.db` resté faux.

## Correctif

**`reconcile_in_review_tasks`** (driver), appelée au démarrage de `run_project` (réel + `clients` fournis, opt-out `reconcile_reviews=False`) :
- chaque tâche `in_review` retrouve sa PR par sa **branche déterministe** (`collegue/issue-N`, `find_pr_by_head(state="all")`) ;
- PR **mergée** → statut `merged` (terminal) ; PR **fermée sans merge** → redo (`todo` + feedback #424, même canal que le conflit #434) ; ouverte / introuvable / GitHub injoignable → état **conservé** (best-effort : la réconciliation n'invente rien et ne tue pas le run) ;
- audit `task_reconciled` (outcome `merged` / `closed_requeued`) ; overlay ET DB mis à jour ; jamais en `dry_run`.

**`PRInfo.merged`** : l'endpoint de liste GitHub n'expose pas `merged` (bool) mais `merged_at` — les deux constructeurs (`find_pr_by_head`, `get_pr`) mappent désormais un booléen fiable, condition pour distinguer closed-mergée de closed-abandonnée.

## Tests
- PR mergée hors-run → `merged` au démarrage, la sœur stricte se construit (plus de faux `awaiting_merge` sur travail déjà dans main).
- PR fermée sans merge → redo + feedback « FERMÉE sans merge » ré-injecté, relivrée dans le même run.
- Ouverte / introuvable / GitHub 503 → état conservé, run survit, 0 événement.
- `dry_run` → aucune requête, aucun changement. Audit des deux outcomes.
- Mapping `merged_at`→`merged` (liste) et `merged` (GET).
- Suite complète locale verte.

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)