### PR TITLE
feat(pilot): nettoyage des workspaces /tmp en fin de tâche (#443)

### DIFF
--- a/collegue/executor/__init__.py
+++ b/collegue/executor/__init__.py
@@ -42,7 +42,13 @@ from collegue.executor.revert import (
     revert_pr_preview,
 )
 from collegue.executor.runner import ExecutionResult, run_issue
-from collegue.executor.workspace import Workspace, WorkspaceError, branch_for_issue, prepare_workspace
+from collegue.executor.workspace import (
+    Workspace,
+    WorkspaceError,
+    branch_for_issue,
+    cleanup_workspace,
+    prepare_workspace,
+)
 
 __all__ = [
     # E1 — contrat agent
@@ -58,6 +64,7 @@ __all__ = [
     "WorkspaceError",
     "branch_for_issue",
     "prepare_workspace",
+    "cleanup_workspace",
     "ExecutionResult",
     "run_issue",
     # E3 — gate qualité

--- a/collegue/executor/workspace.py
+++ b/collegue/executor/workspace.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 import tempfile
 from dataclasses import dataclass
 
@@ -90,6 +91,26 @@ def prepare_workspace(
         raise WorkspaceError(f"git checkout -b {branch} a échoué: {checkout.stderr.strip()}")
 
     return Workspace(path=dest, branch=branch, base_commit=base_commit)
+
+
+def cleanup_workspace(workspace_or_path) -> None:
+    """Supprime un workspace et son répertoire racine temporaire (#443). Best-effort.
+
+    Chaque tâche clone le projet sous ``/tmp/collegue-exec-*/workspace`` et
+    personne ne le détruisait : 22 clones / 233 Mo après le run FacNor v2, fuite
+    LINÉAIRE (un clone par tentative) jusqu'à l'erreur disque sur un moteur qui
+    tourne des jours. Supprime le parent ``collegue-exec-*`` quand c'est bien lui
+    (sinon, par prudence, seulement le répertoire du workspace — cas
+    ``dest_root`` fourni par l'appelant). ``ignore_errors`` : un nettoyage ne
+    fait jamais échouer un run (même pattern que ``guard.py``).
+    """
+    path = getattr(workspace_or_path, "path", workspace_or_path)
+    if not path:
+        return
+    path = os.path.abspath(str(path))
+    parent = os.path.dirname(path)
+    target = parent if os.path.basename(parent).startswith("collegue-exec-") else path
+    shutil.rmtree(target, ignore_errors=True)
 
 
 def apply_seed_diff(workspace: Workspace, diff: str, *, git_bin: str = "git") -> bool:

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -32,7 +32,7 @@ from typing import List, Optional, Tuple
 
 from collegue.executor.agent import IssueSpec
 from collegue.executor.pipeline import execute_issue, failure_feedback, log_tail
-from collegue.executor.workspace import branch_for_issue
+from collegue.executor.workspace import branch_for_issue, cleanup_workspace
 from collegue.pilot.audit import (
     BUDGET_EVENT,
     CHECKPOINT_SAVED,
@@ -329,6 +329,7 @@ async def run_project(
     max_inflight_reviews: int = DEFAULT_MAX_INFLIGHT_REVIEWS,
     gate_options=None,
     reconcile_reviews: bool = True,
+    cleanup_workspaces: bool = True,
 ) -> ProjectRunResult:
     """Pilote un projet : chaîne ``execute_issue`` sur les tâches prêtes sous budget.
 
@@ -371,6 +372,13 @@ async def run_project(
     ``clients``), réaligne chaque tâche ``in_review`` sur l'état GitHub de sa PR
     (mergée → ``merged`` ; fermée sans merge → redo) — le redémarrage après des
     merges manuels (post-deadline notamment) redevient idempotent.
+
+    ``cleanup_workspaces`` (#443, défaut vrai) : le pilote détruit les clones
+    ``/tmp/collegue-exec-*`` en fin de tâche — succès : suppression immédiate ;
+    échec : on ne conserve que le DERNIER workspace de la tâche (debug), les
+    précédents sont purgés (et celui d'une tâche finalement réussie aussi).
+    Sans ça, un clone par tentative s'accumule jusqu'à l'erreur disque (233 Mo
+    sur 7 h au run v2 — fuite linéaire). ``False`` : tout conserver (debug).
 
     ``max_inflight_reviews`` (#434, mode strict uniquement) : plafond de tâches
     ``in_review`` (PR ouverte non mergée) avant de s'arrêter ``awaiting_merge``.
@@ -441,6 +449,9 @@ async def run_project(
 
     processed: List[TaskOutcome] = []
     stop_reason = STOP_COMPLETED
+    # #443 : dernier workspace CONSERVÉ par tâche (échec → debug). Toute nouvelle
+    # tentative purge le précédent — au plus UN clone par tâche échouée survit.
+    kept_workspaces: dict = {}
 
     while True:
         if len(processed) >= cap:
@@ -560,6 +571,22 @@ async def run_project(
                 pr_number=pr_number,
             )
         )
+
+        # #443 : hygiène des clones /tmp. Succès → le workspace ne sert plus (la
+        # PR est ouverte) : suppression, y compris celui d'un échec précédent de
+        # la même tâche. Échec → on garde CE workspace pour le debug et on purge
+        # le précédent de la tâche (au plus un clone conservé par tâche échouée).
+        if cleanup_workspaces:
+            if outcome.success:
+                cleanup_workspace(outcome.workspace)
+                previous = kept_workspaces.pop(task.id, None)
+                if previous:
+                    cleanup_workspace(previous)
+            elif outcome.workspace is not None:
+                previous = kept_workspaces.get(task.id)
+                if previous:
+                    cleanup_workspace(previous)
+                kept_workspaces[task.id] = outcome.workspace.path
 
         # Overlay en mémoire (+ persistance en réel). Succès → in_review (déjà
         # persisté par execute_issue). Échec : tant qu'il reste des tentatives

--- a/tests/test_executor_workspace.py
+++ b/tests/test_executor_workspace.py
@@ -4,6 +4,7 @@ Utilise git en local sur un dépôt-fixture (pas de Docker) ; la variante sandbo
 réelle est couverte en ``integration``.
 """
 
+import os
 import subprocess
 
 import pytest
@@ -176,3 +177,38 @@ def test_local_runner_caps_output(tmp_path):
     res = runner.run_command(["sh", "-c", "printf 'a%.0s' $(seq 1 50)"], str(tmp_path))
     assert "tronquée" in res.stdout
     assert len(res.stdout.encode("utf-8")) < 60  # bien borné
+
+
+# --- nettoyage des workspaces (#443) ----------------------------------------------
+
+
+def test_cleanup_workspace_removes_temp_root(repo):
+    from collegue.executor import IssueSpec, cleanup_workspace, prepare_workspace
+
+    ws = prepare_workspace(repo, IssueSpec(number=7, title="T"))
+    parent = os.path.dirname(ws.path)
+    assert os.path.basename(parent).startswith("collegue-exec-")
+    cleanup_workspace(ws)
+    assert not os.path.exists(parent)  # le répertoire racine /tmp disparaît aussi
+
+
+def test_cleanup_workspace_confined_when_dest_root_is_custom(repo, tmp_path):
+    # ``dest_root`` fourni par l'appelant : on ne supprime QUE le clone, jamais le
+    # répertoire parent qui ne nous appartient pas.
+    from collegue.executor import IssueSpec, cleanup_workspace, prepare_workspace
+
+    root = tmp_path / "mine"
+    root.mkdir()
+    (root / "garde.txt").write_text("à conserver", encoding="utf-8")
+    ws = prepare_workspace(repo, IssueSpec(number=8, title="T"), dest_root=str(root))
+    cleanup_workspace(ws)
+    assert not os.path.exists(ws.path)
+    assert (root / "garde.txt").exists()  # le parent n'a pas été touché
+
+
+def test_cleanup_workspace_tolerates_missing_and_none():
+    from collegue.executor import cleanup_workspace
+
+    cleanup_workspace("/tmp/collegue-exec-inexistant/workspace")  # ne lève pas
+    cleanup_workspace(None)
+    cleanup_workspace("")

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -332,6 +332,90 @@ async def test_historical_mode_keeps_chaining_siblings(repo, manager):
     assert result.iterations == 2
 
 
+# --- hygiène des workspaces /tmp (#443) ----------------------------------------------
+
+
+class _WorkspaceTrackingAgent:
+    """FakeCodeAgent qui journalise le chemin de chaque workspace reçu."""
+
+    def __init__(self):
+        self.paths = []
+        self._inner = FakeCodeAgent()
+
+    def implement_issue(self, workspace, issue):
+        self.paths.append(workspace)
+        return self._inner.implement_issue(workspace, issue)
+
+
+async def test_successful_task_workspace_is_cleaned(repo, manager):
+    """#443 : plus de fuite /tmp — le clone d'une tâche réussie est détruit dès la
+    PR ouverte (22 clones / 233 Mo laissés par le run v2, fuite linéaire)."""
+    pid = _linear_project(manager, 2)
+    agent = _WorkspaceTrackingAgent()
+    result = await _run(manager, repo, pid, dry_run=False, agent=agent)
+    assert result.stop_reason == "completed"
+    assert len(agent.paths) == 2
+    assert all(not os.path.exists(p) for p in agent.paths)
+
+
+async def test_failed_task_keeps_only_last_workspace(repo, manager):
+    # Échec terminal après retries : seul le DERNIER clone survit (post-mortem).
+    from collegue.executor import cleanup_workspace
+
+    async def _sleep(d):
+        pass
+
+    pid = _linear_project(manager, 1)
+    agent = _WorkspaceTrackingAgent()
+    result = await _run(
+        manager,
+        repo,
+        pid,
+        dry_run=False,
+        agent=agent,
+        sandbox=_Sandbox(ok=False),
+        max_task_attempts=2,
+        sleep_fn=_sleep,
+    )
+    assert result.stop_reason == "blocked"
+    first, last = agent.paths
+    assert not os.path.exists(first)  # tentative 1 purgée
+    assert os.path.exists(last)  # dernier état conservé pour le debug
+    cleanup_workspace(last)  # hygiène du test
+
+
+async def test_retry_then_success_purges_kept_failure_workspace(repo, manager):
+    # Une tâche qui finit par réussir ne laisse RIEN derrière elle.
+    async def _sleep(d):
+        pass
+
+    pid = _linear_project(manager, 1)
+    agent = _WorkspaceTrackingAgent()
+    result = await _run(
+        manager,
+        repo,
+        pid,
+        dry_run=False,
+        agent=agent,
+        sandbox=_FlakySandbox(fail_times=1),
+        max_task_attempts=3,
+        sleep_fn=_sleep,
+    )
+    assert result.stop_reason == "completed"
+    assert all(not os.path.exists(p) for p in agent.paths)
+
+
+async def test_cleanup_workspaces_opt_out_keeps_everything(repo, manager):
+    from collegue.executor import cleanup_workspace
+
+    pid = _linear_project(manager, 1)
+    agent = _WorkspaceTrackingAgent()
+    await _run(manager, repo, pid, dry_run=False, agent=agent, cleanup_workspaces=False)
+    assert all(os.path.exists(p) for p in agent.paths)  # debug : tout conservé
+    for p in agent.paths:
+        cleanup_workspace(p)  # hygiène du test
+
+
 # --- réconciliation GitHub→état au démarrage (#442) ----------------------------------
 
 


### PR DESCRIPTION
## Problème (#443 — BASSE, run FacNor v2)

Chaque exécution de tâche clonait le projet sous `/tmp/collegue-exec-*` (un clone **par tentative**) et **personne ne détruisait jamais** ces répertoires : 22 clones / 233 Mo après le run v2 (dont un de 104 Mo avec `node_modules`). Fuite **linéaire** : un moteur censé tourner des jours remplit `/tmp` jusqu'à l'erreur disque — qui, avant la barrière #435, tuait le run.

## Correctif

**`cleanup_workspace`** (executor) : supprime le répertoire racine `collegue-exec-*` du workspace — **confiné** (un `dest_root` fourni par l'appelant n'est jamais touché, seul le clone l'est) et `ignore_errors` (un nettoyage ne fait jamais échouer un run — même pattern que `guard.py`).

**Politique de rétention dans le driver** (`cleanup_workspaces=True` par défaut) :
- **succès** → suppression immédiate (la PR est ouverte, le clone ne sert plus), y compris le workspace conservé d'un échec précédent de la même tâche ;
- **échec** → on ne conserve que le **dernier** workspace de la tâche (post-mortem), les précédents sont purgés — au plus un clone par tâche échouée ;
- une tâche qui finit par réussir ne laisse **rien** derrière elle ;
- opt-out `cleanup_workspaces=False` (debug : tout conserver).

## Tests
- Tâches réussies → clones détruits ; échec terminal après retries → seul le dernier survit ; retry puis succès → zéro résidu ; opt-out conserve tout.
- `cleanup_workspace` : supprime la racine temporaire ; confiné avec `dest_root` custom (le parent de l'appelant survit) ; tolère absent/None/vide.
- Suite complète locale verte.

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)