### PR TITLE
feat(pilot): gouvernance de coût vivante — ledger par défaut + usage du canal coder (#441)

### DIFF
--- a/collegue/executor/agent.py
+++ b/collegue/executor/agent.py
@@ -72,6 +72,11 @@ class AgentResult:
     ``diff``/``files_changed`` sont auto-déclarés (best-effort) ; la capture
     autoritative du diff revient à l'exécuteur (E2). ``success=False`` signale que
     l'agent n'a pas pu produire de changement exploitable.
+
+    Usage LLM (#441) : auto-déclaré par l'agent (0 = inconnu/non rapporté) — le
+    pilote l'ajoute au ledger de coût du run. Sans ce canal, la dépense du coder
+    (majoritaire) reste invisible de toute gouvernance (ledger à 0 $ / 0 token
+    sur ~7 h de LLM au run FacNor v2).
     """
 
     success: bool
@@ -79,6 +84,13 @@ class AgentResult:
     files_changed: Tuple[str, ...] = ()
     logs: str = ""
     summary: str = ""
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    cost_usd: float = 0.0
+
+    @property
+    def total_tokens(self) -> int:
+        return int(self.prompt_tokens or 0) + int(self.completion_tokens or 0)
 
 
 @runtime_checkable

--- a/collegue/executor/openhands_agent.py
+++ b/collegue/executor/openhands_agent.py
@@ -23,6 +23,7 @@ Pré-requis d'une exécution réelle (différés, integration) :
 
 from __future__ import annotations
 
+import json
 import math
 import time
 from typing import List, Optional, Tuple
@@ -32,6 +33,41 @@ from collegue.executor.agent import AgentResult, IssueSpec
 
 # Point d'entrée headless d'OpenHands (module exécuté dans le conteneur sandbox).
 OPENHANDS_ENTRYPOINT = "openhands.core.main"
+
+# Contrat d'usage LLM du canal coder (#441) : le runner (entrypoint OpenHands ou
+# tout wrapper SDK) imprime, par appel LLM ou en fin de run, une ligne
+#   [collegue-usage] {"prompt_tokens": 1200, "completion_tokens": 480, "cost_usd": 0.0021}
+# Toutes les occurrences sont SOMMÉES par :func:`parse_usage_from_logs` et
+# alimentent le ledger de coût du run via ``AgentResult``.
+USAGE_MARKER = "[collegue-usage]"
+
+
+def parse_usage_from_logs(logs: str) -> Tuple[int, int, float]:
+    """``(prompt_tokens, completion_tokens, cost_usd)`` sommés depuis les logs (#441).
+
+    Best-effort : une ligne marquée mais illisible est ignorée (l'usage est une
+    télémétrie, jamais une cause d'échec). ``(0, 0, 0.0)`` si rien n'est rapporté
+    — le ledger distingue « zéro rapporté » de « gouvernance morte » par la
+    présence des événements ``cost_observed``.
+    """
+    prompt = completion = 0
+    cost = 0.0
+    for line in (logs or "").splitlines():
+        index = line.find(USAGE_MARKER)
+        if index < 0:
+            continue
+        payload = line[index + len(USAGE_MARKER) :].strip()
+        try:
+            data = json.loads(payload)
+            prompt += max(0, int(data.get("prompt_tokens") or 0))
+            completion += max(0, int(data.get("completion_tokens") or 0))
+            usd = float(data.get("cost_usd") or 0.0)
+            if math.isfinite(usd) and usd > 0:
+                cost += usd
+        except (ValueError, TypeError, AttributeError):
+            continue
+    return prompt, completion, cost
+
 
 # Politique retries/backoff par défaut du canal coder (#422) — alignée sur les
 # settings ``CODER_LLM_*`` de ``collegue.config``.
@@ -166,8 +202,12 @@ class OpenHandsAgent:
         self._last_launch = self._clock()
         result = self._sandbox.run_command(self.build_command(issue), workspace)
         logs = "\n".join(part for part in (result.stdout, result.stderr) if part).strip()
+        prompt_tokens, completion_tokens, cost_usd = parse_usage_from_logs(logs)
         return AgentResult(
             success=result.ok,
             logs=logs,
             summary=f"OpenHands sur l'issue #{issue.number}",
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            cost_usd=cost_usd,
         )

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -551,6 +551,17 @@ async def run_project(
             cur_usd, cur_tokens = cost_source()
             audit.record_cost(usd=cur_usd - last_usd, tokens=int(cur_tokens - last_tokens), iteration=iteration)
             last_usd, last_tokens = cur_usd, cur_tokens
+        # #441 : canal CODER — majoritaire en dépense et invisible du
+        # MetricsCollector serveur (process distinct dans le sandbox). L'usage
+        # auto-déclaré par l'agent alimente le même ledger (les deux canaux
+        # s'additionnent : ils ne comptent jamais les mêmes appels).
+        agent_result = outcome.execution.agent_result
+        coder_tokens = int(getattr(agent_result, "prompt_tokens", 0) or 0) + int(
+            getattr(agent_result, "completion_tokens", 0) or 0
+        )
+        coder_usd = float(getattr(agent_result, "cost_usd", 0.0) or 0.0)
+        if coder_tokens or coder_usd:
+            audit.record_cost(usd=coder_usd, tokens=coder_tokens, iteration=iteration)
         pr_number = outcome.pr.number if outcome.pr is not None else None
         audit.record(
             GATE_DECISION,

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -24,6 +24,7 @@ import logging
 import os
 from typing import List, Optional
 
+from collegue.pilot.audit import RunAuditLog, default_process_cost_source
 from collegue.pilot.budget import BudgetTimeController
 from collegue.pilot.driver import ProjectRunResult, run_project
 
@@ -150,6 +151,8 @@ async def run_project_from_settings(
     max_iterations: Optional[int] = None,
     improve: bool = False,
     run_improvement_fn=None,
+    audit=None,
+    cost_source=None,
 ) -> ProjectRunResult:
     """Assemble les dépendances (depuis la config) et lance ``run_project``.
 
@@ -159,6 +162,12 @@ async def run_project_from_settings(
 
     ``improve`` (H5) : enchaîne le moteur d'amélioration (Phase 4) sous le budget
     restant une fois le MVP construit (off par défaut ; activable via ``--improve``).
+
+    ``audit``/``cost_source`` (#441) : en RÉEL, branchés **par défaut** —
+    ``RunAuditLog`` persistant (ledger ``run_cost_usd``/``run_tokens`` en
+    métriques) + ``default_process_cost_source``. Sans ce câblage, la plomberie
+    H4 existait mais restait morte : 0 $ / 0 token journalisés sur ~7 h de LLM
+    au run FacNor v2, plafond budget structurellement inerte.
     """
     settings_obj = settings_obj or _settings()
     durability = collegue_home_durability_warning(settings_obj)
@@ -169,6 +178,13 @@ async def run_project_from_settings(
     agent = agent or _build_agent(sandbox, settings_obj)
     reviewer = reviewer or _build_reviewer(settings_obj)
     clients = clients or _build_clients(github_token if github_token is not None else os.environ.get(GITHUB_TOKEN_ENV))
+    # #441 : gouvernance de coût branchée PAR DÉFAUT en réel — audit persistant
+    # (ledger en métriques, lisible par run_cost_summary) + source de coût process.
+    # dry_run : aucun appel LLM réel → pas d'audit implicite (aucune écriture).
+    if audit is None and not dry_run:
+        audit = RunAuditLog(project_id, manager=manager, persist=True)
+    if cost_source is None and not dry_run:
+        cost_source = default_process_cost_source
     if budget is None:
         # Reprise (H5) : si un run a déjà démarré, on reconstruit le contrôleur depuis
         # le ``started_at`` d'ORIGINE → la deadline reste ABSOLUE (ne glisse pas à
@@ -205,6 +221,9 @@ async def run_project_from_settings(
         max_inflight_reviews=getattr(settings_obj, "STRICT_MAX_INFLIGHT_PRS", 1),
         # Gate configurable par projet (#438) : commande de tests + passe frontend.
         gate_options=_gate_options(settings_obj),
+        # Gouvernance de coût (#441) : ledger + source process branchés en réel.
+        audit=audit,
+        cost_source=cost_source,
     )
 
     # Reporting (journal de décisions) — réel uniquement (dry_run n'écrit rien).
@@ -216,9 +235,14 @@ async def run_project_from_settings(
         drain = ""
         if result.pending_reviews:
             drain = f" ; {len(result.pending_reviews)} tâche(s) in_review À DRAINER (merge requis)"
+        # #441 : bilan de coût du run dans le journal (ledger enfin vivant).
+        cost_note = ""
+        if audit is not None:
+            ledger = audit.cost_summary()
+            cost_note = f" ; coût≈{ledger.get('usd', 0.0)}$ / {ledger.get('tokens', 0)} tokens"
         manager.record_decision(
             project_id,
-            f"Run pilote: {result.stop_reason} — {result.iterations} tâche(s), PR {prs}{drain}",
+            f"Run pilote: {result.stop_reason} — {result.iterations} tâche(s), PR {prs}{drain}{cost_note}",
             rationale=f"statut projet={result.project_status or 'inchangé'}",
         )
 

--- a/tests/test_executor_agent.py
+++ b/tests/test_executor_agent.py
@@ -241,6 +241,41 @@ def test_openhands_implement_issue_timeout_is_not_success():
     assert agent.implement_issue("/work", IssueSpec(number=1, title="T")).success is False
 
 
+# --- usage LLM du canal coder (#441) ------------------------------------------------
+
+
+def test_parse_usage_from_logs_sums_marked_lines():
+    from collegue.executor.openhands_agent import parse_usage_from_logs
+
+    logs = (
+        "INFO démarrage\n"
+        '[collegue-usage] {"prompt_tokens": 1200, "completion_tokens": 480, "cost_usd": 0.0021}\n'
+        "bruit intermédiaire\n"
+        'préfixe [collegue-usage] {"prompt_tokens": 800, "completion_tokens": 20}\n'
+        "[collegue-usage] pas du json (ignoré, best-effort)\n"
+        '[collegue-usage] {"prompt_tokens": -5, "cost_usd": "NaN"}\n'
+    )
+    prompt, completion, cost = parse_usage_from_logs(logs)
+    assert prompt == 2000
+    assert completion == 500
+    assert cost == pytest.approx(0.0021)
+    assert parse_usage_from_logs("") == (0, 0, 0.0)
+
+
+def test_openhands_implement_issue_reports_usage():
+    """#441 : l'usage imprimé par le runner (contrat ``[collegue-usage]``) remonte
+    dans l'AgentResult — sans lui, la dépense du coder (canal majoritaire) reste
+    invisible du ledger (0 $ / 0 token sur 7 h au run v2)."""
+    out = 'travail…\n[collegue-usage] {"prompt_tokens": 1500, "completion_tokens": 300, "cost_usd": 0.004}\nfin'
+    sandbox = _FakeSandbox(SandboxResult(exit_code=0, stdout=out, stderr=""))
+    agent = OpenHandsAgent(sandbox=sandbox, settings_obj=_settings())
+    result = agent.implement_issue("/work", IssueSpec(number=3, title="T"))
+    assert result.prompt_tokens == 1500
+    assert result.completion_tokens == 300
+    assert result.total_tokens == 1800
+    assert result.cost_usd == pytest.approx(0.004)
+
+
 # --- Isolation ------------------------------------------------------------------
 
 

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -332,6 +332,34 @@ async def test_historical_mode_keeps_chaining_siblings(repo, manager):
     assert result.iterations == 2
 
 
+# --- gouvernance de coût : canal coder → ledger (#441) -------------------------------
+
+
+async def test_coder_usage_feeds_run_cost_ledger(repo, manager):
+    """#441 : l'usage auto-déclaré par l'agent (tokens/coût du canal coder,
+    majoritaire en dépense et invisible du MetricsCollector serveur) alimente le
+    ledger du run — la gouvernance de coût n'est plus structurellement morte."""
+    import dataclasses
+
+    from collegue.pilot.audit import RunAuditLog
+
+    class _UsageAgent:
+        def __init__(self):
+            self._ok = FakeCodeAgent()
+
+        def implement_issue(self, workspace, issue):
+            result = self._ok.implement_issue(workspace, issue)
+            return dataclasses.replace(result, prompt_tokens=1200, completion_tokens=300, cost_usd=0.002)
+
+    pid = _linear_project(manager, 2)
+    audit = RunAuditLog(pid)
+    result = await _run(manager, repo, pid, dry_run=False, agent=_UsageAgent(), audit=audit)
+    assert result.stop_reason == "completed"
+    assert audit.cost.tokens == 2 * 1500
+    assert audit.cost.usd == pytest.approx(2 * 0.002)
+    assert len([e for e in audit.events if e.kind == "cost_observed"]) == 2
+
+
 # --- hygiène des workspaces /tmp (#443) ----------------------------------------------
 
 

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -123,6 +123,43 @@ async def test_real_run_records_summary_decision(git_repo, manager):
     assert manager.get_tasks(pid)[0].status == "in_review"
 
 
+async def test_real_run_wires_cost_governance_by_default(git_repo, manager):
+    """#441 : en réel, audit persistant + source de coût branchés PAR DÉFAUT — le
+    ledger vit (métriques run_cost_usd/run_tokens lues par run_cost_summary) et le
+    journal de décisions porte le bilan, au lieu de 0 $ / 0 token sur 7 h de LLM."""
+    import dataclasses
+
+    from collegue.pilot.audit import run_cost_summary
+
+    class _UsageAgent:
+        def __init__(self):
+            self._ok = FakeCodeAgent()
+
+        def implement_issue(self, workspace, issue):
+            result = self._ok.implement_issue(workspace, issue)
+            return dataclasses.replace(result, prompt_tokens=1000, completion_tokens=200, cost_usd=0.003)
+
+    pid = _linear(manager, 1)
+    result = await run_project_from_settings(
+        pid,
+        git_repo,
+        owner="o",
+        repo="r",
+        dry_run=False,
+        manager=manager,
+        sandbox=_Sandbox(),
+        agent=_UsageAgent(),
+        reviewer=FakeReviewer(),
+        clients=_clients(),
+        budget=_Budget(),
+    )
+    assert result.stop_reason == "completed"
+    summary = run_cost_summary(manager, pid)
+    assert summary["tokens"] == 1200  # canal coder enfin compté
+    assert summary["usd"] == pytest.approx(0.003)
+    assert any("coût≈" in d.summary for d in manager.get_decisions(pid))
+
+
 # --- reporting ------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Problème (#441 — MOYENNE, run FacNor v2)

Toute la plomberie H4 existait (ledger de coût, `cost_source` du driver, `default_process_cost_source`) mais **rien ne la branchait** : le runtime assemblé ne passait ni `audit` ni `cost_source`, et le canal coder (OpenHands — l'essentiel de la dépense) ne remontait aucun compteur. Résultat : `cost {"usd": 0.0, "tokens": 0}` sur les 3 `run_stop` du run v2 (~7 h de LLM), plafond budget `$` **structurellement inerte**, aucun post-mortem de coût possible.

## Correctif

**1. Câblage par défaut en RÉEL** (`run_project_from_settings`) :
- `audit=None` → `RunAuditLog(project_id, manager=…, persist=True)` — le ledger vit en métriques persistées (`run_cost_usd`/`run_tokens`, lisibles par `run_cost_summary`) ;
- `cost_source=None` → `default_process_cost_source` (échantillonnage delta par tâche, mécanisme H4 existant) ;
- le journal de décisions porte le bilan : « coût≈X$ / Y tokens ». `dry_run` : rien d'implicite (aucune écriture).

**2. Usage du canal coder** :
- `AgentResult.prompt_tokens / completion_tokens / cost_usd` (+ propriété `total_tokens`) — usage auto-déclaré par l'agent ;
- **contrat `[collegue-usage]`** : le runner du sandbox imprime `[collegue-usage] {"prompt_tokens": …, "completion_tokens": …, "cost_usd": …}` (par appel ou en fin de run) ; `parse_usage_from_logs` somme toutes les occurrences (best-effort : ligne illisible ignorée — la télémétrie n'est jamais une cause d'échec) ;
- le **driver** ajoute cet usage au même ledger (`record_cost`) que la source process — les deux canaux s'additionnent, ils ne comptent jamais les mêmes appels.

**3. Hors moteur (documenté)** : le tarif LiteLLM custom du modèle (gemma-4 « model isn't mapped ») se règle dans l'image/runner sandbox — suivi avec #404 ; le runner devra imprimer le marqueur (côté harness, 3 lignes).

## Tests
- `parse_usage_from_logs` : somme multi-lignes, préfixes tolérés, JSON invalide/valeurs négatives ignorés.
- `OpenHandsAgent.implement_issue` remonte l'usage dans `AgentResult`.
- Driver : l'usage agent alimente le ledger (`cost_observed` ×2, totaux exacts).
- Runtime réel : métriques `run_cost_usd`/`run_tokens` persistées + « coût≈ » dans le journal — avec fakes, zéro LLM.
- Suite complète locale verte.

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)