### PR TITLE
fix(sandbox,executor): /tmp exécutable + diffs binaires ré-applicables (#454, #455)

### DIFF
--- a/collegue/executor/runner.py
+++ b/collegue/executor/runner.py
@@ -63,7 +63,10 @@ def run_issue(
     add = runner.run_command([git_bin, "add", "-A"], workspace.path)
     if not add.ok:
         raise WorkspaceError(f"git add a échoué: {add.stderr.strip() or add.stdout.strip()}")
-    diff_res = runner.run_command([git_bin, "diff", "--staged"], workspace.path)
+    # ``--binary`` (#455) : sans lui, un diff touchant un binaire (png, woff2…)
+    # n'embarque pas son payload → le réensemencement du retry (#436,
+    # ``apply_seed_diff``) échoue précisément sur les tâches frontend.
+    diff_res = runner.run_command([git_bin, "diff", "--staged", "--binary"], workspace.path)
     if not diff_res.ok:
         raise WorkspaceError(f"git diff a échoué: {diff_res.stderr.strip()}")
     names_res = runner.run_command([git_bin, "diff", "--staged", "--name-only"], workspace.path)

--- a/collegue/sandbox/executor.py
+++ b/collegue/sandbox/executor.py
@@ -155,7 +155,15 @@ class DockerSandbox:
             argv += ["--read-only"]  # root FS en lecture seule
         argv += [
             "--tmpfs",
-            "/tmp",  # scratch éphémère écrivable
+            # Scratch éphémère écrivable. ``exec`` EXPLICITE (#454) : les défauts
+            # docker (`noexec,nosuid,nodev`) rendent inimportable tout module natif
+            # (.so) installé sous /tmp — or ``HOME=/tmp`` y envoie `pip --user`
+            # (#414) et la passe d'installabilité y crée son venv (#439) :
+            # `failed to map segment from shared object`, gate rouge structurel.
+            # ``noexec`` n'est PAS une frontière de sécurité ici : ce conteneur
+            # exécute déjà délibérément le code du projet (pytest, npm). On garde
+            # ``nosuid``/``nodev``.
+            "/tmp:exec,nosuid,nodev",
             "-e",
             "HOME=/tmp",
         ]

--- a/tests/test_executor_pipeline.py
+++ b/tests/test_executor_pipeline.py
@@ -352,6 +352,32 @@ async def test_invalid_seed_diff_falls_back_to_clean_clone(repo):
     assert "existing.txt" not in outcome.execution.files_changed
 
 
+async def test_binary_diff_is_reseedable(repo):
+    """#455 : le diff autoritatif est capturé avec ``--binary`` — un fichier
+    binaire (png…) produit par une tentative est RÉ-APPLICABLE au retry (#436).
+    Sans le payload, ``git apply`` échouait (« sans la ligne complète d'index »)
+    et la mémoire de retry était neutralisée sur les tâches frontend."""
+    import os
+
+    from collegue.executor import AgentResult
+    from collegue.executor.workspace import apply_seed_diff, prepare_workspace
+
+    class _BinaryAgent:
+        def implement_issue(self, workspace, issue):
+            os.makedirs(os.path.join(workspace, "assets"), exist_ok=True)
+            with open(os.path.join(workspace, "assets", "hero.png"), "wb") as fh:
+                fh.write(b"\x89PNG\r\n\x1a\n" + bytes(range(64)))
+            return AgentResult(success=True, logs="ok", files_changed=("assets/hero.png",))
+
+    outcome = await execute_issue(ISSUE, repo, ctx=None, dry_run=True, **_kwargs(agent=_BinaryAgent()))
+    assert outcome.success is True
+    assert "GIT binary patch" in outcome.execution.diff  # payload embarqué
+
+    fresh = prepare_workspace(repo, ISSUE)
+    assert apply_seed_diff(fresh, outcome.execution.diff) is True
+    assert os.path.exists(os.path.join(fresh.path, "assets", "hero.png"))
+
+
 # --- barrière d'exception par tâche (#435) ----------------------------------------
 
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -36,7 +36,11 @@ def test_build_argv_isolation_flags(tmp_path):
     assert "--cap-drop ALL" in joined
     assert "--security-opt no-new-privileges" in joined
     assert "--read-only" in argv
-    assert "--tmpfs" in argv and "/tmp" in argv
+    # #454 : ``exec`` EXPLICITE — les défauts docker (noexec) rendent inimportable
+    # tout .so sous /tmp (venv du gate #439, pip --user #414 avec HOME=/tmp) ;
+    # on garde nosuid/nodev (noexec n'est pas une frontière ici : le conteneur
+    # exécute déjà le code du projet).
+    assert "--tmpfs" in argv and "/tmp:exec,nosuid,nodev" in argv
     assert "--pids-limit" in argv
     assert "--memory" in argv and "--cpus" in argv
     assert "-w" in argv and "/workspace" in argv


### PR DESCRIPTION
## Problème (#454 CRITIQUE + #455 HAUTE — run FacNor v3, blocage en 42 min)

**#454** : docker applique `noexec,nosuid,nodev` par défaut sur `--tmpfs /tmp`. Tout module natif (`.so`) installé sous `/tmp` est inimportable (`failed to map segment from shared object`). La passe d'installabilité (#439, venv sous `/tmp/.gate_venv`) était donc rouge **structurellement** → gate rouge à chaque tentative quel que soit le travail de l'agent → tâches 1-2 en échec terminal, run `blocked` en 42 min, 0 PR. Le même trou frappe `pip install --user` (#414) sous le `HOME=/tmp` du chemin durci par défaut (masqué sur les runs FacNor car le harness passait `HOME=/home/sandbox`).

**#455** : le diff autoritatif était capturé par `git diff --staged` **sans `--binary`** → un diff touchant un binaire (png d'un frontend) n'embarque pas son payload, et `apply_seed_diff` (#436) échoue au retry (« sans la ligne complète d'index ») — la mémoire de retry était neutralisée précisément sur les tâches frontend.

## Correctif

- **sandbox** : `--tmpfs /tmp:exec,nosuid,nodev` — `exec` explicite, `nosuid`/`nodev` conservés. `noexec` n'est pas une frontière de sécurité dans ce conteneur : il exécute déjà délibérément le code du projet (pytest, npm) ; en revanche il casse venv et pip --user.
- **runner** : capture `git diff --staged --binary` — le seed du retry redevient applicable sur les binaires (le plafond `MAX_BEST_DIFF_CHARS` borne déjà les diffs énormes : un asset lourd fait sauter la mémorisation, sans erreur).

## Tests
- argv sandbox : `/tmp:exec,nosuid,nodev` verrouillé.
- Round-trip binaire : agent produisant un png → `GIT binary patch` dans le diff → `apply_seed_diff` réussit sur un clone neuf, fichier présent.
- Suite complète locale verte.

Closes #454
Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)