### PR TITLE
fix(executor): gate frontend monorepo — package.json détecté en sous-répertoire (#457)

### DIFF
--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 from dataclasses import dataclass
 from typing import Iterator, List, Optional, Protocol, Tuple, runtime_checkable
 
@@ -117,8 +118,34 @@ def _real_test_script(scripts: dict) -> bool:
     return bool(script.strip()) and "no test specified" not in script
 
 
-def frontend_gate_command(workspace: str) -> Optional[str]:
-    """Commande de gate frontend quand le workspace a un ``package.json`` (#438).
+def _frontend_dirs(workspace: str) -> List[str]:
+    """Répertoires (relatifs) candidats à la passe frontend (#457).
+
+    La racine d'abord (comportement historique #438), puis les sous-répertoires
+    de **premier niveau** contenant un ``package.json``. Le layout CIBLE du moteur
+    pour les projets web (backend Python à la racine + ``frontend/``) place le
+    ``package.json`` dans un sous-répertoire : ne sonder que la racine rendait la
+    passe silencieusement absente — main mergé avec 42 erreurs TypeScript, tout
+    gate vert (run FacNor v3). ``node_modules`` et les répertoires cachés sont
+    ignorés ; tri déterministe.
+    """
+    dirs: List[str] = []
+    if os.path.isfile(os.path.join(workspace, "package.json")):
+        dirs.append(".")
+    try:
+        entries = sorted(os.listdir(workspace))
+    except OSError:
+        return dirs
+    for entry in entries:
+        if entry.startswith(".") or entry == "node_modules":
+            continue
+        if os.path.isfile(os.path.join(workspace, entry, "package.json")):
+            dirs.append(entry)
+    return dirs
+
+
+def frontend_gate_command(workspace: str, subdir: str = ".") -> Optional[str]:
+    """Commande de gate frontend pour le ``package.json`` de ``workspace/subdir`` (#438).
 
     Le gate historique ne lançait QUE pytest : compilation TypeScript, build Vite
     et tests front n'étaient JAMAIS validés — des PRs front cassées au type-check
@@ -134,10 +161,13 @@ def frontend_gate_command(workspace: str) -> Optional[str]:
       avant, d'où ``--no-install``) ;
     - tests front : script ``test`` réel uniquement (stub npm ignoré).
 
-    ``CI=true`` neutralise les modes watch (react-scripts, vitest) ; le cache npm
-    vit sous ``/tmp`` (rootfs read-only, #414). ``None`` si pas de ``package.json``.
+    ``subdir`` (#457) : répertoire relatif du front dans le workspace (monorepo
+    backend + ``frontend/``) — la commande s'exécute dedans (``cd``). ``CI=true``
+    neutralise les modes watch (react-scripts, vitest) ; le cache npm vit sous
+    ``/tmp`` (rootfs read-only, #414). ``None`` si pas de ``package.json``.
     """
-    pkg_path = os.path.join(workspace, "package.json")
+    base = workspace if subdir == "." else os.path.join(workspace, subdir)
+    pkg_path = os.path.join(base, "package.json")
     if not os.path.isfile(pkg_path):
         return None
     scripts: dict = {}
@@ -154,11 +184,17 @@ def frontend_gate_command(workspace: str) -> Optional[str]:
     steps = ["(npm ci --no-audit --no-fund --silent || npm install --no-audit --no-fund --silent)"]
     if "build" in scripts:
         steps.append("npm run build --silent")
-    elif "typescript" in declared and os.path.isfile(os.path.join(workspace, "tsconfig.json")):
+    elif "typescript" in declared and os.path.isfile(os.path.join(base, "tsconfig.json")):
         steps.append("npx --no-install tsc --noEmit")
     if _real_test_script(scripts):
         steps.append("npm test --silent")
-    return "export CI=true NPM_CONFIG_CACHE=/tmp/.npm; " + " && ".join(steps)
+    prefix = "export CI=true NPM_CONFIG_CACHE=/tmp/.npm; "
+    if subdir != ".":
+        # `--` : un nom de répertoire commençant par `-` (contenu non fiable,
+        # écrit par l'agent) serait sinon consommé comme OPTION de `cd` — la
+        # passe npm tournerait silencieusement dans $HOME au lieu du front.
+        prefix += f"cd -- {shlex.quote(subdir)} && "
+    return prefix + " && ".join(steps)
 
 
 # Triple-backtick de remplacement : neutralise les fences pour qu'un texte non
@@ -482,10 +518,12 @@ async def run_quality_gate(
     indisponibilité ⇒ ``passed=False``. Les ``BaseException`` remontent.
     ``install_deps`` (défaut vrai) : préfixe la commande de tests par l'installation
     des dépendances déclarées du projet (cf. :func:`deps_install_prelude`, #414).
-    ``frontend_gate`` (défaut vrai, #438) : si le workspace a un ``package.json``,
-    enchaîne install + build/type-check + tests front dans le même conteneur,
-    fail-closed (cf. :func:`frontend_gate_command`) — sans quoi « tests verts »
-    signifie « tests *Python* verts », même sur un diff 100 % frontend.
+    ``frontend_gate`` (défaut vrai, #438) : pour chaque ``package.json`` détecté —
+    à la racine OU dans un sous-répertoire de 1er niveau (#457, layout monorepo
+    backend+``frontend/``) — enchaîne install + build/type-check + tests front
+    dans le même conteneur, fail-closed (cf. :func:`frontend_gate_command`) —
+    sans quoi « tests verts » signifie « tests *Python* verts », même sur un diff
+    100 % frontend.
     ``require_deps_install`` (#439) : l'échec d'installation des dépendances
     déclarées devient BLOQUANT (au lieu d'être toléré et seulement signalé via
     ``QualityReport.deps_install_failed``).
@@ -514,11 +552,16 @@ async def run_quality_gate(
                 # tournent quand même, l'échec laisse sa note dans la sortie.
                 command = f"({prelude}) && {test_command}" if require_deps_install else f"{prelude}; {test_command}"
         if frontend_gate:
-            front = frontend_gate_command(workspace)
-            if front is not None:
-                # `&&` : la passe frontend ne tourne que si pytest est vert (le
-                # verdict est déjà rouge sinon) et son échec rend le gate rouge.
-                command = f"({command}) && echo '{_FRONTEND_BANNER}' && ({front})"
+            for front_dir in _frontend_dirs(workspace):
+                front = frontend_gate_command(workspace, subdir=front_dir)
+                if front is None:
+                    continue
+                # `&&` : chaque passe frontend ne tourne que si la précédente est
+                # verte (le verdict est déjà rouge sinon) et son échec rend le
+                # gate rouge. Une passe PAR répertoire détecté (#457 : la racine
+                # ET les sous-répertoires de 1er niveau — layout monorepo).
+                banner = _FRONTEND_BANNER if front_dir == "." else f"{_FRONTEND_BANNER} [{front_dir}]"
+                command = f"({command}) && echo {shlex.quote(banner)} && ({front})"
         if check_installability:
             installability = installability_command(workspace)
             if installability is not None:

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -221,6 +221,76 @@ async def test_gate_frontend_opt_out(tmp_path):
     assert "npm" not in command
 
 
+# --- gate frontend en sous-répertoire (#457, layout monorepo) ----------------------
+
+
+def test_frontend_dirs_detects_root_and_first_level(tmp_path):
+    """#457 : la racine d'abord (comportement #438), puis les sous-répertoires de
+    1er niveau — node_modules et répertoires cachés ignorés, tri déterministe."""
+    from collegue.executor.quality_gate import _frontend_dirs
+
+    _write_pkg(tmp_path, scripts={})
+    for sub in ("frontend", "web", "node_modules", ".hidden"):
+        (tmp_path / sub).mkdir()
+        _write_pkg(tmp_path / sub, scripts={})
+    (tmp_path / "backend").mkdir()  # sans package.json → ignoré
+    assert _frontend_dirs(str(tmp_path)) == [".", "frontend", "web"]
+
+
+def test_frontend_dirs_empty_without_any_package_json(tmp_path):
+    from collegue.executor.quality_gate import _frontend_dirs
+
+    (tmp_path / "backend").mkdir()
+    assert _frontend_dirs(str(tmp_path)) == []
+
+
+def test_frontend_gate_command_subdir_runs_inside_it(tmp_path):
+    """#457 : pour un package.json en sous-répertoire, la commande `cd` dedans et
+    lit SES scripts/tsconfig (pas ceux de la racine)."""
+    from collegue.executor import frontend_gate_command
+
+    front = tmp_path / "frontend"
+    front.mkdir()
+    _write_pkg(front, scripts={}, dev_deps={"typescript": "^5"})
+    (front / "tsconfig.json").write_text("{}", encoding="utf-8")
+    command = frontend_gate_command(str(tmp_path), subdir="frontend")
+    assert command is not None
+    assert "cd -- frontend && " in command
+    assert "tsc --noEmit" in command  # tsconfig du SOUS-répertoire détecté
+    assert command.index("cd -- frontend") < command.index("npm ci")
+
+    # Pas de package.json dans le sous-répertoire → None.
+    assert frontend_gate_command(str(tmp_path), subdir="autre") is None
+
+
+async def test_gate_runs_frontend_pass_for_subdir_package_json(tmp_path):
+    """#457 (cas réel FacNor v3) : package.json livré dans frontend/ SEULEMENT →
+    la passe npm doit tourner quand même (42 erreurs TS mergées tout gate vert)."""
+    front = tmp_path / "frontend"
+    front.mkdir()
+    _write_pkg(front, scripts={"build": "vite build"})
+    sandbox = _green()
+    await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    _ws, command = sandbox.calls[0]
+    assert "cd -- frontend && " in command
+    assert "npm run build" in command
+    assert command.index("pytest") < command.index("npm run build")
+    assert ") && " in command  # fail-closed : l'échec npm rend le gate rouge
+
+
+async def test_gate_runs_one_frontend_pass_per_detected_dir(tmp_path):
+    """#457 : racine + sous-répertoire → une passe npm PAR répertoire détecté."""
+    _write_pkg(tmp_path, scripts={"build": "vite build"})
+    front = tmp_path / "frontend"
+    front.mkdir()
+    _write_pkg(front, scripts={"build": "tsc && vite build"})
+    sandbox = _green()
+    await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    _ws, command = sandbox.calls[0]
+    assert command.count("npm run build") == 2
+    assert "cd -- frontend && " in command
+
+
 # --- installabilité du livrable (#439) ---------------------------------------------
 
 


### PR DESCRIPTION
## Problème (#457)

Le gate frontend (#438) ne sondait `package.json` qu'à la **racine** du workspace. Or le layout cible du moteur pour les projets web (backend Python à la racine + `frontend/`) place le `package.json` dans un sous-répertoire : la passe npm n'a **jamais tourné** de toute la campagne FacNor v3 — main mergé avec **42 erreurs TypeScript**, tout gate vert.

## Correctif

- `_frontend_dirs(workspace)` : détecte `package.json` à la racine **et** dans les sous-répertoires de 1er niveau (`node_modules` et répertoires cachés ignorés, tri déterministe) ;
- `frontend_gate_command(workspace, subdir=".")` : la commande fait `cd -- <subdir>` et lit **ses** scripts/tsconfig (le `--` protège des noms de répertoire commençant par `-`, contenu non fiable écrit par l'agent) ;
- `run_quality_gate` : une passe frontend **par répertoire détecté**, enchaînée fail-closed (`&&`), bannière suffixée du répertoire ;
- comportement racine inchangé (tests #438 existants intacts).

## Tests

- `_frontend_dirs` : racine + 1er niveau, exclusions node_modules/cachés, workspace sans front ;
- commande en sous-répertoire : `cd -- frontend && …`, tsconfig du sous-répertoire, `None` sans package.json ;
- cas réel FacNor v3 : package.json **uniquement** dans `frontend/` → la passe npm tourne ;
- racine + sous-répertoire → 2 passes npm.

Revue adversariale pré-PR : 1 finding corrigé (`cd` sans `--` → un répertoire nommé `-L` aurait fait tourner npm dans `$HOME`).

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)