### PR TITLE
feat(executor): passe smoke-run du gate — l'app livrée doit démarrer et répondre (#458)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,3 +271,10 @@ tests/evals/reports/
 .claude
 # Données runtime Collègue (mémoire projet, monitoring) — jamais commitées
 .collegue/
+
+# Échafaudage du run de test autonome FacNor (drivers + état + venv) — hors repo.
+# Les correctifs moteur qu'il a révélés sont portés proprement via les issues #409-#414.
+scripts/facnor_run/
+docker/sandbox/Dockerfile.openhands
+.facnor_run/
+.venv-facnor/

--- a/collegue/config.py
+++ b/collegue/config.py
@@ -111,6 +111,18 @@ class Settings(BaseSettings):
     # Exiger qu'un diff touche au moins un fichier de test (sinon : simple
     # signal ⚠️ dans le rapport de gate / corps de PR).
     GATE_REQUIRE_TEST_CHANGES: bool = False
+    # Smoke run (#458) : passe finale qui DÉMARRE l'application livrée dans le
+    # conteneur du gate et vérifie qu'elle répond (< 500) — détecte les
+    # divergences d'init tests/prod (tests verts via create_all, prod en 500
+    # sur schema.sql incomplet). SMOKE_COMMAND : démarrage explicite (doit
+    # écouter sur 127.0.0.1:8765) ; vide → auto-détection FastAPI. SMOKE_PATHS :
+    # chemins sondés, séparés par des virgules.
+    GATE_SMOKE_RUN: bool = False
+    GATE_SMOKE_COMMAND: str = ""
+    GATE_SMOKE_PATHS: str = "/"
+    # Budget d'attente de réponse (s) — à garder sous le timeout du conteneur
+    # sandbox (120 s par défaut, partagé avec pip/pytest/npm).
+    GATE_SMOKE_TIMEOUT: float = 30.0
 
     ENGINE_INIT_TIMEOUT: float = 10.0
     ENGINE_WAIT_TIMEOUT: float = 30.0

--- a/collegue/executor/__init__.py
+++ b/collegue/executor/__init__.py
@@ -32,6 +32,7 @@ from collegue.executor.quality_gate import (
     issue_expects_code,
     outcome_from_review,
     run_quality_gate,
+    smoke_run_command,
     tests_touched,
 )
 from collegue.executor.revert import (
@@ -77,6 +78,7 @@ __all__ = [
     "run_quality_gate",
     "frontend_gate_command",
     "installability_command",
+    "smoke_run_command",
     "outcome_from_review",
     "AdequacyChecker",
     "AdequacyOutcome",

--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -79,6 +79,142 @@ def deps_install_prelude(workspace: str, *, strict: bool = False) -> Optional[st
 _INSTALLABILITY_BANNER = "[gate] installabilité : venv nu + requirements + collecte (#439)"
 _GATE_VENV = "/tmp/.gate_venv"
 
+# Passe smoke-run (#458) : port d'écoute imposé dans le conteneur du gate.
+_SMOKE_BANNER = "[gate] smoke run : l'app démarre et répond (#458)"
+_SMOKE_PORT = 8765
+_SMOKE_HEREDOC = "COLLEGUE_SMOKE_458"
+
+# Entrées FastAPI usuelles : (chemin relatif, cible uvicorn). Détection
+# délibérément conservatrice — sans entrée reconnue, la passe est SKIPPÉE
+# (pas de faux rouge sur un projet non-web), sauf commande explicite.
+_ASGI_APP_CANDIDATES = (
+    ("main.py", "main:app"),
+    ("app.py", "app:app"),
+    (os.path.join("app", "main.py"), "app.main:app"),
+    (os.path.join("src", "main.py"), "src.main:app"),
+)
+
+# Sonde exécutée DANS le conteneur du gate : démarre le serveur, attend qu'il
+# réponde, vérifie chaque chemin (<500 = vivant ; 4xx toléré — route protégée
+# ou méthode — l'app A répondu), imprime la queue du log serveur en cas d'échec.
+# %%-formaté (pas f-string) : le code python embarqué garde ses accolades.
+_SMOKE_PROBE_TEMPLATE = """\
+import subprocess, sys, time, urllib.error, urllib.request
+
+command = %(command)r
+paths = %(paths)r
+timeout = %(timeout)r
+log = open("/tmp/.collegue_smoke.log", "w+", encoding="utf-8", errors="replace")
+proc = subprocess.Popen(command, shell=True, stdout=log, stderr=subprocess.STDOUT)
+base = "http://127.0.0.1:%(port)d"
+deadline = time.time() + timeout
+verdicts = []
+for path in paths:
+    status = None
+    attempted = False
+    # Au moins UNE tentative par chemin, même si le précédent a épuisé le délai
+    # (sinon : faux rouge « sans réponse » sur un chemin jamais contacté).
+    while not attempted or time.time() < deadline:
+        attempted = True
+        if proc.poll() is not None:
+            break  # le serveur est mort avant de répondre
+        try:
+            status = urllib.request.urlopen(base + path, timeout=2).status
+            break
+        except urllib.error.HTTPError as exc:
+            status = exc.code
+            break
+        except Exception:
+            time.sleep(0.5)
+    verdicts.append((path, status))
+time.sleep(0.3)  # resserre la fenêtre « répond une fois puis meurt »
+ok = proc.poll() is None and all(s is not None and s < 500 for _p, s in verdicts)
+for path, status in verdicts:
+    print("[gate] smoke run", path, "->", status if status is not None else "sans réponse")
+if proc.poll() is not None:
+    print(
+        "[gate] smoke run : le processus serveur s'est terminé (code", str(proc.poll()) + ")",
+        "— la commande de démarrage doit rester au premier plan",
+    )
+if not ok:
+    log.flush()
+    log.seek(0)
+    print("[gate] smoke run ÉCHEC — queue du log serveur :")
+    print(log.read()[-4000:])
+proc.terminate()
+sys.exit(0 if ok else 1)
+"""
+
+
+def _detect_asgi_app(workspace: str) -> Optional[str]:
+    """Cible uvicorn (``module:app``) si le workspace expose une app FastAPI (#458)."""
+    for rel, target in _ASGI_APP_CANDIDATES:
+        path = os.path.join(workspace, rel)
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path, encoding="utf-8", errors="replace") as handle:
+                # Lecture bornée : fichier non fiable (écrit par l'agent), et
+                # « FastAPI( » vit toujours en tête de module.
+                source = handle.read(65536)
+        except OSError:
+            continue
+        if "FastAPI(" in source:
+            return target
+    return None
+
+
+def _smoke_probe_script(command: str, paths: Tuple[str, ...], timeout: float, *, port: int = _SMOKE_PORT) -> str:
+    """Source python de la sonde smoke-run (pur — testable par ``compile``)."""
+    # `/` de tête normalisé : sans lui, urlopen("…:8765health") lèverait à
+    # chaque tentative et brûlerait tout le délai en silence.
+    normalized = tuple(path if path.startswith("/") else "/" + path for path in paths) or ("/",)
+    return _SMOKE_PROBE_TEMPLATE % {
+        "command": command,
+        "paths": normalized,
+        "timeout": float(timeout),
+        "port": int(port),
+    }
+
+
+def smoke_run_command(
+    workspace: str,
+    *,
+    command: Optional[str] = None,
+    paths: Tuple[str, ...] = ("/",),
+    timeout: float = 30.0,
+) -> Optional[str]:
+    """Commande de la passe smoke-run (#458). Fail-closed une fois déclenchée.
+
+    Le gate validait le livrable par pytest + revue sans JAMAIS lancer
+    l'application : toute divergence entre l'init des tests et celui de la prod
+    passait sous le radar (FacNor v3 : 34 tests verts via ``create_all``, mais
+    ``schema.sql`` incomplet → flux central en 500 sur installation fraîche,
+    tous gates verts — pour la 2e campagne consécutive).
+
+    - ``command`` : commande de démarrage explicite — elle doit écouter sur
+      ``127.0.0.1:8765`` et **rester au premier plan** (un wrapper qui
+      daemonise est vu comme « serveur mort ») ; sinon auto-détection FastAPI
+      (cf. :data:`_ASGI_APP_CANDIDATES`) → ``python -m uvicorn`` ;
+    - ``paths`` : chemins sondés — chacun doit répondre **< 500** (4xx toléré :
+      l'app a répondu ; 5xx ou silence = rouge) ;
+    - ``timeout`` : budget total d'attente de réponse (secondes) — à garder
+      sous le timeout du conteneur sandbox (120 s par défaut, partagé avec
+      pip/pytest/npm) ;
+    - ``None`` si aucune app détectable ET pas de commande explicite (projet
+      non-web : la passe ne s'applique pas).
+
+    S'exécute dans le **même** conteneur que les autres passes (les deps du
+    projet y sont déjà installées, #414) ; tout meurt avec le conteneur.
+    """
+    if not command:
+        target = _detect_asgi_app(workspace)
+        if target is None:
+            return None
+        command = f"python -m uvicorn {target} --host 127.0.0.1 --port {_SMOKE_PORT}"
+    script = _smoke_probe_script(command, paths, timeout)
+    return f"python - <<'{_SMOKE_HEREDOC}'\n{script}{_SMOKE_HEREDOC}"
+
 
 def installability_command(workspace: str) -> Optional[str]:
     """Passe d'installabilité en environnement NU (#439). Fail-closed.
@@ -511,6 +647,10 @@ async def run_quality_gate(
     check_installability: bool = False,
     adequacy_checker: Optional[AdequacyChecker] = None,
     require_test_changes: bool = False,
+    smoke_run: bool = False,
+    smoke_command: Optional[str] = None,
+    smoke_paths: Tuple[str, ...] = ("/",),
+    smoke_timeout: float = 30.0,
 ) -> QualityReport:
     """Exécute les tests (sandbox) + la revue (reviewer) sur un diff. Fail-closed.
 
@@ -536,6 +676,13 @@ async def run_quality_gate(
     critères (« livraison fantôme ») ne passe plus.
     ``require_test_changes`` (#437) : exige qu'au moins un fichier de test soit
     touché par le diff (sinon, simple signal ``tests_touched`` dans le rapport).
+    ``smoke_run`` (#458) : passe finale qui DÉMARRE l'application dans le même
+    conteneur et vérifie qu'elle répond (cf. :func:`smoke_run_command`) — sans
+    elle, une divergence d'init tests/prod livre un produit en 500 avec tous
+    les gates verts. ``smoke_command`` : démarrage explicite (écoute sur
+    127.0.0.1:8765) ; ``smoke_paths`` : chemins sondés (chacun doit répondre
+    < 500). Skippée si aucune app n'est détectable et qu'aucune commande n'est
+    fournie.
     """
     sandbox = sandbox or DockerSandbox()
     reviewer = reviewer or _default_reviewer()
@@ -566,6 +713,12 @@ async def run_quality_gate(
             installability = installability_command(workspace)
             if installability is not None:
                 command = f"({command}) && echo '{_INSTALLABILITY_BANNER}' && ({installability})"
+        if smoke_run:
+            smoke = smoke_run_command(workspace, command=smoke_command, paths=smoke_paths, timeout=smoke_timeout)
+            if smoke is not None:
+                # Dernière passe (le heredoc doit clore la commande) : l'app est
+                # lancée dans le même conteneur, après install des deps (#414).
+                command = f"({command}) && echo {shlex.quote(_SMOKE_BANNER)} && {smoke}"
         test_res = sandbox.run_tests(workspace, command)
         tests_passed = test_res.ok
         test_exit_code = test_res.exit_code

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -119,6 +119,17 @@ def _gate_options(settings_obj) -> dict:
         options["test_command"] = str(test_command)
     if bool(getattr(settings_obj, "GATE_ADEQUACY", False)):
         options["adequacy_checker"] = _build_adequacy_checker(settings_obj)
+    # Smoke run (#458, opt-in) : démarrer l'app livrée et vérifier qu'elle répond.
+    if bool(getattr(settings_obj, "GATE_SMOKE_RUN", False)):
+        options["smoke_run"] = True
+        smoke_command = getattr(settings_obj, "GATE_SMOKE_COMMAND", None)
+        if smoke_command:
+            options["smoke_command"] = str(smoke_command)
+        raw_paths = str(getattr(settings_obj, "GATE_SMOKE_PATHS", "") or "")
+        smoke_paths = tuple(path.strip() for path in raw_paths.split(",") if path.strip())
+        if smoke_paths:
+            options["smoke_paths"] = smoke_paths
+        options["smoke_timeout"] = float(getattr(settings_obj, "GATE_SMOKE_TIMEOUT", 30.0))
     return options
 
 

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -291,6 +291,152 @@ async def test_gate_runs_one_frontend_pass_per_detected_dir(tmp_path):
     assert "cd -- frontend && " in command
 
 
+# --- smoke run (#458) ---------------------------------------------------------------
+
+
+def _write_fastapi_app(tmp_path, rel="main.py"):
+    target = tmp_path / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("from fastapi import FastAPI\napp = FastAPI()\n", encoding="utf-8")
+
+
+def test_detect_asgi_app_finds_fastapi_entrypoints(tmp_path):
+    from collegue.executor.quality_gate import _detect_asgi_app
+
+    assert _detect_asgi_app(str(tmp_path)) is None  # rien à détecter
+    _write_fastapi_app(tmp_path, "app/main.py")
+    assert _detect_asgi_app(str(tmp_path)) == "app.main:app"
+    _write_fastapi_app(tmp_path, "main.py")
+    assert _detect_asgi_app(str(tmp_path)) == "main:app"  # racine prioritaire
+
+    # Un main.py SANS FastAPI n'est pas une app détectable.
+    (tmp_path / "main.py").write_text("print('cli')\n", encoding="utf-8")
+    (tmp_path / "app" / "main.py").write_text("print('cli')\n", encoding="utf-8")
+    assert _detect_asgi_app(str(tmp_path)) is None
+
+
+def test_smoke_run_command_none_without_app_nor_command(tmp_path):
+    from collegue.executor import smoke_run_command
+
+    assert smoke_run_command(str(tmp_path)) is None
+
+
+def test_smoke_run_command_autodetects_fastapi(tmp_path):
+    from collegue.executor import smoke_run_command
+
+    _write_fastapi_app(tmp_path)
+    command = smoke_run_command(str(tmp_path))
+    assert command is not None
+    assert "python -m uvicorn main:app" in command
+    assert "127.0.0.1" in command and "8765" in command
+    assert command.startswith("python - <<'COLLEGUE_SMOKE_458'")
+
+
+def test_smoke_run_command_explicit_command_and_paths(tmp_path):
+    # Commande explicite : pas besoin d'app détectable ; les chemins sont embarqués.
+    from collegue.executor import smoke_run_command
+
+    command = smoke_run_command(str(tmp_path), command="python serve.py", paths=("/health", "/factures/"))
+    assert command is not None
+    assert "'python serve.py'" in command
+    assert "/health" in command and "/factures/" in command
+
+
+def test_smoke_probe_script_is_valid_python(tmp_path):
+    """La sonde embarquée doit COMPILER (une SyntaxError dans le template rendrait
+    la passe rouge en prod pour une mauvaise raison)."""
+    from collegue.executor.quality_gate import _smoke_probe_script
+
+    script = _smoke_probe_script('uvicorn "x":app', ("/", "/a b"), 30.0)
+    compile(script, "<smoke>", "exec")
+
+
+def test_smoke_probe_script_normalizes_leading_slash():
+    # Sans `/` de tête, urlopen("…:8765health") lèverait à chaque tentative et
+    # brûlerait tout le délai en silence (faux « sans réponse »).
+    from collegue.executor.quality_gate import _smoke_probe_script
+
+    script = _smoke_probe_script("python serve.py", ("health", "/ok"), 5.0)
+    assert "'/health'" in script and "'/ok'" in script
+
+
+def _free_port():
+    import socket
+
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _run_probe(command, timeout=10.0, port=None):
+    import subprocess
+    import sys
+
+    from collegue.executor.quality_gate import _smoke_probe_script
+
+    script = _smoke_probe_script(command, ("/",), timeout, port=port or _free_port())
+    return subprocess.run([sys.executable, "-"], input=script, text=True, capture_output=True, timeout=60)
+
+
+def test_smoke_probe_green_against_real_server():
+    """La sonde EXÉCUTÉE (pas seulement compilée) : un serveur HTTP réel qui
+    répond sur / → exit 0. Port libre pour ne pas dépendre de l'état local —
+    en prod la sonde tourne sur 8765 dans son conteneur isolé."""
+    import sys
+
+    port = _free_port()
+    proc = _run_probe(f"{sys.executable} -m http.server {port} --bind 127.0.0.1", port=port)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "-> 200" in proc.stdout
+
+
+def test_smoke_probe_red_when_server_exits():
+    """Un « serveur » qui se termine aussitôt → rouge, avec le diagnostic
+    « doit rester au premier plan » (et pas un simple silence)."""
+    import sys
+
+    proc = _run_probe(f"{sys.executable} -c 'pass'", timeout=5.0)
+    assert proc.returncode == 1
+    assert "premier plan" in proc.stdout
+
+
+async def test_gate_smoke_run_appended_last(tmp_path):
+    """#458 : la passe smoke-run est enchaînée fail-closed EN DERNIER (le heredoc
+    clôt la commande), après les autres passes."""
+    _write_fastapi_app(tmp_path)
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    sandbox = _green()
+    await run_quality_gate(
+        str(tmp_path),
+        DIFF,
+        ctx=None,
+        sandbox=sandbox,
+        reviewer=FakeReviewer(),
+        smoke_run=True,
+        check_installability=True,
+    )
+    _ws, command = sandbox.calls[0]
+    assert "smoke run" in command
+    assert "python -m uvicorn main:app" in command
+    assert command.index("installabilité") < command.index("smoke run")
+    assert command.rstrip().endswith("COLLEGUE_SMOKE_458")
+
+
+async def test_gate_smoke_run_default_off_and_skipped_without_app(tmp_path):
+    _write_fastapi_app(tmp_path)
+    sandbox = _green()
+    await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    _ws, command = sandbox.calls[0]
+    assert "smoke" not in command  # opt-in
+
+    bare = tmp_path / "bare"
+    bare.mkdir()
+    sandbox2 = _green()
+    await run_quality_gate(str(bare), DIFF, ctx=None, sandbox=sandbox2, reviewer=FakeReviewer(), smoke_run=True)
+    _ws, command2 = sandbox2.calls[0]
+    assert "smoke" not in command2  # aucune app détectable → passe skippée
+
+
 # --- installabilité du livrable (#439) ---------------------------------------------
 
 

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -310,6 +310,19 @@ def test_gate_options_built_from_settings():
     options = _gate_options(with_adequacy)
     assert options["adequacy_checker"] is not None
 
+    # GATE_SMOKE_RUN (#458, opt-in) : commande + chemins sondés câblés.
+    with_smoke = SimpleNamespace(
+        GATE_SMOKE_RUN=True,
+        GATE_SMOKE_COMMAND="python serve.py",
+        GATE_SMOKE_PATHS="/health, /factures/",
+    )
+    options = _gate_options(with_smoke)
+    assert options["smoke_run"] is True
+    assert options["smoke_command"] == "python serve.py"
+    assert options["smoke_paths"] == ("/health", "/factures/")
+    assert options["smoke_timeout"] == 30.0
+    assert "smoke_run" not in _gate_options(SimpleNamespace())  # défaut : off
+
 
 # --- isolation ------------------------------------------------------------------
 


### PR DESCRIPTION
## Problème (#458)

Le gate validait par pytest + revue sans **jamais lancer l'application** : toute divergence entre l'init des tests et celui de la prod passait sous le radar. FacNor v3 : 34 tests verts via `create_all`, mais `schema.sql` incomplet → flux central (`POST /factures/`) en **500 sur installation fraîche**, tous gates verts — pour la 2e campagne consécutive.

## Correctif

- **`smoke_run_command` (#458)** : passe finale du gate qui démarre l'app dans le **même** conteneur que les autres passes (deps déjà installées, #414) et sonde des chemins HTTP — chacun doit répondre **< 500** (4xx toléré : l'app a répondu ; 5xx/silence/process mort = rouge). En échec : queue du log serveur imprimée dans la sortie du gate + diagnostic dédié si le process s'est terminé (« doit rester au premier plan ») ;
- auto-détection FastAPI (`main.py`, `app.py`, `app/main.py`, `src/main.py`, lecture bornée 64 Ko) → `python -m uvicorn` ; ou commande explicite (écoute sur `127.0.0.1:8765`, premier plan). Aucune app détectable et pas de commande → passe **skippée** (projet non-web) ;
- garanties de la sonde : `/` de tête normalisé sur les chemins, ≥ 1 tentative par chemin même si le délai est consommé, fenêtre « répond une fois puis meurt » resserrée ;
- `run_quality_gate` : params `smoke_run`/`smoke_command`/`smoke_paths`/`smoke_timeout`, passe enchaînée **en dernier** (le heredoc clôt la commande) ;
- config `GATE_SMOKE_RUN`/`GATE_SMOKE_COMMAND`/`GATE_SMOKE_PATHS`/`GATE_SMOKE_TIMEOUT` (opt-in), câblée par `runtime._gate_options`.

## Tests

- Détection FastAPI (racine prioritaire, fichier sans FastAPI ignoré) ; skip sans app ni commande ; commande explicite + chemins embarqués ;
- la sonde **compile** ET **s'exécute** : vert contre un `http.server` réel (port libre), rouge avec diagnostic « premier plan » quand le serveur se termine ;
- composition : passe ajoutée en dernier après l'installabilité, opt-in par défaut ;
- `_gate_options` : mapping config → kwargs (y compris timeout).

Revue adversariale pré-PR : sonde fuzzée (pas d'évasion repr/heredoc/shell possible) ; 5 findings de diagnostic corrigés (normalisation des chemins, message premier-plan, ≥1 tentative/chemin, lecture bornée, timeout configurable).

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)