### PR TITLE
fix(pilot): le bruit infra n'écrase plus le feedback actionnable (#459)

### DIFF
--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -63,6 +63,44 @@ def log_tail(text: str, limit: int = 2000) -> str:
     return "…" + text[-limit:]
 
 
+# Signatures d'aléa d'INFRASTRUCTURE (réseau, dépôt de paquets, 5xx fournisseur)
+# dans un feedback d'échec (#459). Heuristique volontairement étroite : ces
+# motifs n'apparaissent pas dans un diagnostic fonctionnel.
+_INFRA_NOISE_SIGNATURES = (
+    "ReadTimeoutError",
+    "ReadTimeout",
+    "ConnectTimeoutError",
+    "ConnectTimeout",
+    "ConnectionError",
+    "ConnectionResetError",
+    "NewConnectionError",
+    "Temporary failure in name resolution",
+    "Connection refused",
+    "502 Server Error",
+    "503 Server Error",
+    "504 Server Error",
+)
+
+
+def is_infra_noise(feedback: str) -> bool:
+    """Vrai si ``feedback`` ressemble à un aléa d'infrastructure (#459).
+
+    Un timeout PyPI pendant le gate produit un traceback réseau SANS ligne
+    FAILED : ré-injecté tel quel, il ÉCRASE le diagnostic actionnable de la
+    tentative précédente (cas réel FacNor v3 : « email-validator manquant »
+    éclipsé par du bruit urllib3 — requeue opérateur nécessaire). Une ligne
+    FAILED/ERROR présente = diagnostic fonctionnel, jamais classé bruit.
+    """
+    text = feedback or ""
+    if not text:
+        return False
+    # « FAILED  » / « ERROR  » avec espace : les formes pytest. (pip écrit
+    # « ERROR: » avec deux-points — c'est justement du bruit d'install à classer.)
+    if any(line.strip().startswith(("FAILED ", "ERROR ")) for line in text.splitlines()):
+        return False
+    return any(signature in text for signature in _INFRA_NOISE_SIGNATURES)
+
+
 def failure_feedback(outcome: "ExecutionOutcome") -> str:
     """Synthèse **courte et actionnable** d'un échec, pour la tentative suivante (#424).
 

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -31,7 +31,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
 from collegue.executor.agent import IssueSpec
-from collegue.executor.pipeline import execute_issue, failure_feedback, log_tail
+from collegue.executor.pipeline import execute_issue, failure_feedback, is_infra_noise, log_tail
 from collegue.executor.workspace import branch_for_issue, cleanup_workspace
 from collegue.pilot.audit import (
     BUDGET_EVENT,
@@ -92,6 +92,11 @@ DEFAULT_MAX_INFLIGHT_REVIEWS = 1
 MAX_BEST_DIFF_CHARS = 200_000
 _PASSED_RE = re.compile(r"(\d+) passed")
 _FAILED_RE = re.compile(r"(\d+) failed")
+
+
+# #459 : suffixe « aléa infra » accroché au diagnostic préservé — remplacé à
+# chaque nouvel aléa (jamais empilé), pour que last_error reste borné.
+_INFRA_NOISE_SUFFIX_RE = re.compile(r" \(\+ aléa infra[^)]*\)$")
 
 
 def _attempt_score(outcome) -> Optional[Tuple[int, int]]:
@@ -626,6 +631,19 @@ async def run_project(
             diagnostic = failure_feedback(outcome)
             if diagnostic:
                 last_error += " — " + diagnostic
+            # #459 : un aléa d'infrastructure (timeout PyPI, 5xx) n'écrase pas un
+            # diagnostic actionnable — sinon l'échec terminal (et le redo) hérite
+            # du feedback le MOINS utile de la série. Le suffixe est REMPLACÉ,
+            # jamais empilé (borné sur les séries d'aléas).
+            previous_error = str(getattr(task, "last_error", None) or "")
+            # On ne classifie que la partie DIAGNOSTIC (après « — ») : le préfixe
+            # « [stage/reason] tentative N/M » casserait le garde FAILED-en-tête
+            # de is_infra_noise et désarmerait la protection pour tout projet web
+            # dont les échecs de tests mentionnent ConnectionError.
+            previous_diag = previous_error.split(" — ", 1)[-1]
+            if diagnostic and is_infra_noise(diagnostic) and previous_error and not is_infra_noise(previous_diag):
+                base = _INFRA_NOISE_SUFFIX_RE.sub("", previous_error)
+                last_error = f"{base} (+ aléa infra à la tentative {attempts} : [{outcome.stage}/{outcome.reason}])"
             task.last_error = last_error
 
             # #436 : mémoriser la MEILLEURE tentative (diff + score + échecs). Le

--- a/tests/test_executor_pipeline.py
+++ b/tests/test_executor_pipeline.py
@@ -475,3 +475,31 @@ async def test_manager_without_task_id_is_safe(repo, tmp_path):
     )
     assert outcome.success is True
     assert outcome.final_status is None  # rien à transitionner sans task_id
+
+
+# --- bruit infra vs diagnostic fonctionnel (#459) -----------------------------------
+
+
+def test_is_infra_noise_detects_network_tracebacks():
+    from collegue.executor.pipeline import is_infra_noise
+
+    assert is_infra_noise("urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='pypi.org')")
+    assert is_infra_noise("requests.exceptions.ConnectionError: Connection refused")
+    assert is_infra_noise("503 Server Error: Service Unavailable")
+
+
+def test_is_infra_noise_never_flags_functional_diagnostics():
+    from collegue.executor.pipeline import is_infra_noise
+
+    assert not is_infra_noise("")
+    assert not is_infra_noise("FAILED tests/test_x.py::test_a - assert 1 == 2")
+    # Une ligne FAILED présente = fonctionnel, même si du bruit réseau l'entoure.
+    assert not is_infra_noise(
+        "urllib3.exceptions.ReadTimeoutError: ...\nFAILED tests/test_x.py::test_a - ConnectionError"
+    )
+    assert not is_infra_noise("ADÉQUATION REFUSÉE — le diff ne réalise pas l'issue : schéma sans logique")
+    # Un échec FONCTIONNEL qui mentionne une exception réseau reste actionnable
+    # (projets web : TestClient/mocks lèvent ConnectionError dans les FAILED).
+    assert not is_infra_noise("FAILED tests/test_api.py::test_remote - requests.exceptions.ConnectionError: refusé")
+    # Le « ERROR: » de pip (deux-points) est du bruit d'install, PAS du pytest.
+    assert is_infra_noise("ERROR: Could not install packages due to an OSError: ReadTimeoutError")

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -897,6 +897,103 @@ async def test_retry_reinjects_crisp_failure_feedback(repo, manager):
     assert "collected 4 items" not in ctx  # le bruit n'est PAS ré-injecté
 
 
+class _InfraThenGreenSandbox:
+    """Échec FONCTIONNEL (ligne FAILED), puis aléa INFRA (traceback réseau sans
+    ligne FAILED), puis vert — la séquence exacte du run FacNor v3 (#459)."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def run_tests(self, workspace, command="pytest -q"):
+        self.calls += 1
+        if self.calls == 1:
+            # Le FAILED mentionne une exception réseau : il doit RESTER classé
+            # actionnable une fois stocké dans last_error (préfixe compris).
+            return SandboxResult(
+                exit_code=1,
+                stdout="FAILED tests/test_x.py::test_a - requests.exceptions.ConnectionError: email_validator absent",
+                stderr="",
+            )
+        if self.calls == 2:
+            return SandboxResult(
+                exit_code=1,
+                stdout=(
+                    "Collecting fastapi\n"
+                    "urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='files.pythonhosted.org')\n"
+                    "pip install a échoué"
+                ),
+                stderr="",
+            )
+        return SandboxResult(exit_code=0, stdout="4 passed", stderr="")
+
+
+async def test_infra_noise_does_not_clobber_actionable_feedback(repo, manager):
+    """#459 : un timeout PyPI à la tentative 2 n'écrase pas le diagnostic
+    actionnable de la tentative 1 — l'agent (tentative 3) et l'opérateur voient
+    toujours « email_validator », plus le marqueur d'aléa, borné."""
+
+    async def _sleep(d):
+        pass
+
+    pid = _linear_project(manager, 1)
+    agent = _RecordingAgent()
+    result = await _run(
+        manager,
+        repo,
+        pid,
+        dry_run=False,
+        agent=agent,
+        sandbox=_InfraThenGreenSandbox(),
+        max_task_attempts=3,
+        sleep_fn=_sleep,
+    )
+    assert result.stop_reason == "completed"
+    t = manager.get_tasks(pid)[0]
+    assert t.status == "in_review"
+    # Pendant la 3e tentative, last_error portait toujours le diagnostic utile.
+    ctx = agent.contexts[2]
+    assert "email_validator" in ctx
+    assert "ReadTimeoutError" not in ctx  # le bruit réseau n'est PAS ré-injecté
+
+
+async def test_infra_noise_suffix_is_replaced_not_stacked(repo, manager):
+    """#459 : une SÉRIE d'aléas infra ne fait pas gonfler last_error — le suffixe
+    est remplacé ; à l'échec terminal, le feedback persisté reste le diagnostic
+    fonctionnel, pas le dernier aléa."""
+
+    class _FunctionalThenInfraForever(_InfraThenGreenSandbox):
+        def run_tests(self, workspace, command="pytest -q"):
+            self.calls += 1
+            if self.calls == 1:
+                return SandboxResult(exit_code=1, stdout="FAILED tests/test_x.py::test_a - assert 1 == 2", stderr="")
+            return SandboxResult(
+                exit_code=1,
+                stdout="urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='pypi.org')",
+                stderr="",
+            )
+
+    async def _sleep(d):
+        pass
+
+    pid = _linear_project(manager, 1)
+    result = await _run(
+        manager,
+        repo,
+        pid,
+        dry_run=False,
+        agent=_RecordingAgent(),
+        sandbox=_FunctionalThenInfraForever(),
+        max_task_attempts=3,
+        sleep_fn=_sleep,
+    )
+    assert result.stop_reason == "blocked"
+    t = manager.get_tasks(pid)[0]
+    assert t.status == "failed"
+    assert "FAILED tests/test_x.py::test_a" in t.last_error  # le diagnostic survit
+    assert t.last_error.count("aléa infra") == 1  # suffixe remplacé, pas empilé
+    assert "tentative 3" in t.last_error  # ... et à jour
+
+
 async def test_run_stage_retry_feeds_agent_logs(repo, manager):
     # Échec au stage `run` (process agent) : le feedback vient des logs agent.
     async def _sleep(d):


### PR DESCRIPTION
## Problème (#459)

`last_error` était reconstruit à **chaque** tentative : un timeout PyPI pendant le gate (traceback urllib3, aucune ligne FAILED) écrasait le diagnostic fonctionnel de la tentative précédente. À l'échec terminal, l'opérateur et le redo héritaient du feedback le **moins** utile de la série — FacNor v3 : « email-validator manquant » éclipsé par du bruit réseau, requeue opérateur nécessaire pour reporter le diagnostic à la main.

## Correctif

- **`pipeline.is_infra_noise(feedback)`** : signatures d'aléa d'infrastructure (ReadTimeout/ConnectionError/résolution DNS/Connection refused/5xx fournisseur). Jamais déclenchée si une ligne pytest `FAILED `/`ERROR ` est présente (diagnostic fonctionnel) — mais le `ERROR:` de pip (deux-points) reste classé bruit d'install ;
- **driver** : quand le nouveau diagnostic est du bruit infra et que le `last_error` précédent était actionnable, ce dernier est **préservé**, suffixé `(+ aléa infra à la tentative N : [stage/reason])` — suffixe **remplacé** à chaque aléa (jamais empilé, `last_error` borné). Seule la partie diagnostic (après « — ») est classifiée, pour que la protection tienne aussi quand le FAILED mentionne une exception réseau (TestClient/mocks des projets web) ;
- conséquence : à l'échec terminal, le feedback persisté est le plus diagnostique de la série, et la tentative suivante reçoit toujours le motif utile (le bruit réseau n'est pas ré-injecté dans le prompt).

## Tests

- `is_infra_noise` : tracebacks réseau/5xx détectés ; FAILED/ADÉQUATION jamais classés bruit, y compris un FAILED mentionnant `ConnectionError` ; `ERROR:` pip = bruit ;
- driver, séquence réelle FacNor v3 (FAILED actionnable → timeout PyPI → vert) : le diagnostic survit dans le prompt de la tentative 3, le bruit réseau n'y entre pas ;
- série d'aléas → suffixe remplacé (count == 1), numéro de tentative à jour, diagnostic préservé à l'échec terminal.

Revue adversariale pré-PR : 2 findings corrigés (classification du diagnostic seul — sinon la protection se désarmait pour tout projet web ; garde resserré aux formes pytest `FAILED `/`ERROR ` avec espace).

Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)