### PR TITLE
fix(pilot): le message de requeue_task_for_redo atteint l'agent même en mode réparation (#460)

### DIFF
--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -274,17 +274,21 @@ def reconcile_in_review_tasks(tasks, manager, clients, *, owner: str, repo: str,
                 f"[reconcile] ta PR #{pr.number} a été FERMÉE sans merge en dehors du run — "
                 "son contenu n'est PAS dans le dépôt : repars du dépôt à jour et relivre la tâche."
             )
-            requeue_task_for_redo(manager, task.id, message=message)
-            task.status = TASK_STATUS_TODO
-            task.attempt_count = max(1, int(getattr(task, "attempt_count", 0) or 0))
-            task.last_error = message
+            fields = requeue_task_for_redo(manager, task.id, message=message)
+            for key, value in fields.items():
+                setattr(task, key, value)  # overlay mémoire aligné (#460)
             audit.record(TASK_RECONCILED, task_id=task.id, pr_number=pr.number, outcome="closed_requeued")
             logger.info("tâche %s : PR #%s fermée sans merge → redo (#442)", task.id, pr.number)
             reconciled += 1
     return reconciled
 
 
-def requeue_task_for_redo(manager, task_id: int, *, message: str, attempt_count: int = 1) -> None:
+# #460 : marqueur du préfixe posé par requeue_task_for_redo dans best_feedback —
+# détecté pour ne jamais empiler deux motifs de redo (le précédent est consommé).
+_REQUEUE_FEEDBACK_MARKER = " (échecs connus de la meilleure tentative : "
+
+
+def requeue_task_for_redo(manager, task_id: int, *, message: str, attempt_count: int = 1) -> dict:
     """Re-file une tâche pour un REDO complet après un événement externe (#434).
 
     Cas nominal : la PR d'une tâche ``in_review`` est devenue non mergeable
@@ -297,13 +301,34 @@ def requeue_task_for_redo(manager, task_id: int, *, message: str, attempt_count:
     ``attempt_count=1`` (défaut) : un conflit d'infrastructure ne consomme pas le
     budget de retries fonctionnels — on garde juste le minimum (> 0) pour que le
     feedback soit injecté.
+
+    #460 : le message est AUSSI posé dans ``best_feedback`` — en mode réparation
+    (#436, ``best_diff`` présent et échecs connus), le prompt n'utilise QUE
+    ``best_feedback`` : un message laissé dans le seul ``last_error`` serait
+    éclipsé et n'atteindrait jamais l'agent (constaté en run réel FacNor v3 :
+    l'opérateur a dû écrire ``best_feedback`` à la main en base). L'existant est
+    conservé en suffixe (les échecs connus restent visibles).
+
+    Retourne les champs posés, pour que l'appelant aligne son overlay mémoire.
     """
-    manager.update_task(
-        task_id,
-        status=TASK_STATUS_TODO,
-        attempt_count=max(1, int(attempt_count)),
-        last_error=str(message),
-    )
+    fields = {
+        "status": TASK_STATUS_TODO,
+        "attempt_count": max(1, int(attempt_count)),
+        "last_error": str(message),
+    }
+    task = manager.get_task(task_id) if hasattr(manager, "get_task") else None
+    previous_feedback = getattr(task, "best_feedback", None) if task is not None else None
+    if previous_feedback and _REQUEUE_FEEDBACK_MARKER in previous_feedback:
+        # Dé-nidifier : un requeue précédent a déjà préfixé — son motif est
+        # consommé, seul le diagnostic d'origine reste pertinent (borné, même
+        # convention que le suffixe « aléa infra » de #459).
+        previous_feedback = previous_feedback.split(_REQUEUE_FEEDBACK_MARKER, 1)[1][:-1]
+    if previous_feedback:
+        fields["best_feedback"] = f"{message}{_REQUEUE_FEEDBACK_MARKER}{previous_feedback})"
+    else:
+        fields["best_feedback"] = str(message)
+    manager.update_task(task_id, **fields)
+    return fields
 
 
 async def run_project(

--- a/collegue/state/manager.py
+++ b/collegue/state/manager.py
@@ -150,6 +150,11 @@ class ProjectStateManager:
         with self.session() as s:
             return list(s.scalars(select(Task).where(Task.project_id == project_id).order_by(Task.id)))
 
+    def get_task(self, task_id: int) -> Optional[Task]:
+        """Une tâche par id (``None`` si absente)."""
+        with self.session() as s:
+            return s.get(Task, task_id)
+
     def update_task_status(self, task_id: int, status: str) -> bool:
         with self.session() as s:
             task = s.get(Task, task_id)

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -827,6 +827,63 @@ def test_requeue_task_for_redo_resets_for_feedback(manager):
     assert t.status == "todo"
     assert t.attempt_count == 1
     assert "conflit" in t.last_error
+    assert "conflit" in t.best_feedback  # #460 : le canal réparation aussi
+
+
+def test_requeue_message_reaches_repair_prompt(manager):
+    """#460 (cas réel FacNor v3) : une tâche en mode réparation (#436 — best_diff
+    présent, échecs connus) re-filée via requeue_task_for_redo doit voir le
+    message du redo dans son PROMPT — avant, seul best_feedback y était injecté
+    et l'opérateur devait l'écrire à la main en base."""
+    from collegue.pilot import requeue_task_for_redo
+    from collegue.pilot.driver import _issue_from_task
+
+    pid = _linear_project(manager, 1)
+    tid = manager.get_tasks(pid)[0].id
+    manager.update_task(
+        tid,
+        status="failed",
+        attempt_count=3,
+        best_diff="diff --git a/x.py b/x.py\n+x",
+        best_passed=20,
+        best_failed=2,
+        best_feedback="FAILED tests/test_auth.py::test_login - no such table",
+    )
+    requeue_task_for_redo(manager, tid, message="[opérateur] crée le schéma dans les fixtures de test")
+    task = manager.get_tasks(pid)[0]
+    context = _issue_from_task(task).context
+    assert "RÉPARATION CIBLÉE" in context  # le mode réparation reste actif
+    assert "crée le schéma dans les fixtures" in context  # le message ATTEINT l'agent
+    assert "test_login" in context  # ... sans perdre les échecs connus
+
+
+def test_requeue_without_prior_feedback_sets_message(manager):
+    from collegue.pilot import requeue_task_for_redo
+
+    pid = _linear_project(manager, 1)
+    tid = manager.get_tasks(pid)[0].id
+    manager.update_task(tid, status="in_review")
+    fields = requeue_task_for_redo(manager, tid, message="[reconcile] PR fermée hors-run")
+    assert fields["best_feedback"] == "[reconcile] PR fermée hors-run"
+    t = manager.get_tasks(pid)[0]
+    assert t.best_feedback == "[reconcile] PR fermée hors-run"
+
+
+def test_requeue_twice_replaces_redo_motive_not_stacks(manager):
+    """#460 : deux requeues successifs ne nidifient pas les motifs — le motif
+    précédent est consommé, seul le diagnostic d'ORIGINE est conservé."""
+    from collegue.pilot import requeue_task_for_redo
+
+    pid = _linear_project(manager, 1)
+    tid = manager.get_tasks(pid)[0].id
+    manager.update_task(tid, status="in_review", best_feedback="FAILED tests/test_x.py::t - boom")
+    requeue_task_for_redo(manager, tid, message="[reconcile] PR fermée hors-run")
+    requeue_task_for_redo(manager, tid, message="[merge/conflit] PR en conflit avec main")
+    t = manager.get_tasks(pid)[0]
+    assert "conflit" in t.best_feedback
+    assert "FAILED tests/test_x.py::t - boom" in t.best_feedback  # l'origine survit
+    assert "PR fermée hors-run" not in t.best_feedback  # le motif consommé disparaît
+    assert t.best_feedback.count("échecs connus") == 1  # jamais nidifié
 
 
 # --- ré-injection du feedback d'échec au retry (#424) ------------------------------


### PR DESCRIPTION
## Problème (#460)

Deux canaux de feedback concurrents sans règle de fraîcheur : en mode réparation (#436 — `best_diff` présent, échecs connus), le prompt n'utilise **que** `best_feedback`. Un motif de redo posé dans le seul `last_error` (conflit de PR #434, PR fermée hors-run #442, consigne opérateur) était **éclipsé** et n'atteignait jamais l'agent — FacNor v3 : l'opérateur a dû écrire `best_feedback` à la main en base pour que sa consigne passe.

## Correctif

- `requeue_task_for_redo` pose **aussi** le message dans `best_feedback`, en conservant l'existant en suffixe (`(échecs connus de la meilleure tentative : …)`) — le motif du redo arrive en tête du prompt de réparation sans perdre le diagnostic des échecs ;
- deux requeues successifs ne **nidifient pas** : le motif précédent (consommé) est remplacé, seul le diagnostic d'origine est conservé (même convention de bornage que le suffixe « aléa infra » de #459) ;
- le helper retourne les champs posés ; `reconcile_in_review_tasks` (#442) aligne son overlay mémoire dessus (statut/compteur/feedback cohérents dans le run courant — l'overlay divergeait du DB sur `attempt_count`) ;
- `StateManager.get_task(task_id)` : lecture unitaire (symétrique d'`update_task`), sûre après fermeture de session (`expire_on_commit=False`, contrat du module).

## Tests

- contrat du requeue : `best_feedback` porte le message (avec et sans feedback préexistant) ;
- cas réel FacNor v3 : tâche en mode réparation re-filée avec une consigne opérateur → la consigne **atteint le prompt**, sans perdre les échecs connus ;
- double requeue → motif remplacé, jamais nidifié, diagnostic d'origine conservé ;
- chemin vert (`best_failed == 0`) déjà couvert : le message passe par la branche `last_error`.

Revue adversariale pré-PR : 1 finding corrigé (nidification des motifs sur requeues répétés) ; DetachedInstanceError, overlay reconcile et consommateurs de `best_feedback` vérifiés sains.

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)