### PR TITLE
fix(pilot,executor): un timeout PyPI dans le gate ne brûle plus une tentative fonctionnelle (#461)

### DIFF
--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -79,6 +79,10 @@ _INFRA_NOISE_SIGNATURES = (
     "502 Server Error",
     "503 Server Error",
     "504 Server Error",
+    # Kill du conteneur sandbox au timeout (#461) : quand pip pend sur PyPI, le
+    # conteneur peut être tué avant d'imprimer un traceback réseau — la note du
+    # sandbox est alors le seul indice, et ce n'est pas un diagnostic actionnable.
+    "[sandbox] délai dépassé après",
 )
 
 

--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -231,10 +231,14 @@ def installability_command(workspace: str) -> Optional[str]:
     """
     if not os.path.isfile(os.path.join(workspace, "requirements.txt")):
         return None
+    # --retries/--timeout EXPLICITES (#461) : une micro-coupure PyPI pendant la
+    # passe coûtait une tentative fonctionnelle entière (échec terminal FacNor
+    # v3, itération 14) — pip ré-essaie d'abord, le moteur ne décompte qu'après.
+    pip_flags = "--no-cache-dir -q --retries 5 --timeout 60"
     return (
         f"python -m venv --clear {_GATE_VENV}"
-        f" && {_GATE_VENV}/bin/python -m pip install --no-cache-dir -q -r requirements.txt"
-        f" && {_GATE_VENV}/bin/python -m pip install --no-cache-dir -q pytest"
+        f" && {_GATE_VENV}/bin/python -m pip install {pip_flags} -r requirements.txt"
+        f" && {_GATE_VENV}/bin/python -m pip install {pip_flags} pytest"
         f" && {_GATE_VENV}/bin/python -m pytest --collect-only -q"
     )
 

--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -234,7 +234,10 @@ def installability_command(workspace: str) -> Optional[str]:
     # --retries/--timeout EXPLICITES (#461) : une micro-coupure PyPI pendant la
     # passe coûtait une tentative fonctionnelle entière (échec terminal FacNor
     # v3, itération 14) — pip ré-essaie d'abord, le moteur ne décompte qu'après.
-    pip_flags = "--no-cache-dir -q --retries 5 --timeout 60"
+    # --timeout 30 (pas plus) : le conteneur du gate a un budget TOTAL de
+    # 120 s — un timeout socket long plus un retry le dépasserait (kill du
+    # conteneur, le pire diagnostic possible).
+    pip_flags = "--no-cache-dir -q --retries 5 --timeout 30"
     return (
         f"python -m venv --clear {_GATE_VENV}"
         f" && {_GATE_VENV}/bin/python -m pip install {pip_flags} -r requirements.txt"

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -197,7 +197,7 @@ def _issue_from_task(task, by_id=None) -> IssueSpec:
     last_error = getattr(task, "last_error", None)
     attempts = int(getattr(task, "attempt_count", 0) or 0)
     best_diff = getattr(task, "best_diff", None)
-    if attempts > 0 and best_diff:
+    if best_diff:  # présence suffisante (#461 : une grâce peut laisser attempts=0)
         # #436 : le workspace du retry est RÉENSEMENCÉ avec la meilleure tentative
         # → consigne en mode réparation CIBLÉE (pas de régénération complète, qui
         # sous variance LLM détruit du travail quasi-abouti — oscillation).
@@ -476,7 +476,11 @@ async def run_project(
         reconcile_in_review_tasks(tasks, manager, clients, owner=owner, repo=repo, audit=audit)
 
     # Avec retries, chaque tâche peut consommer jusqu'à max_task_attempts itérations.
-    cap = max_iterations if max_iterations is not None else len(tasks) * max(2, max_task_attempts) + 5
+    cap = (
+        max_iterations
+        if max_iterations is not None
+        else len(tasks) * (max(2, max_task_attempts) + MAX_INFRA_GATE_GRACE) + 5
+    )
 
     # Reprise : repartir du numéro d'itération du dernier checkpoint (l'état des
     # tâches en DB fournit la vraie reprise — les tâches terminées sont ignorées).
@@ -565,7 +569,10 @@ async def run_project(
         audit.record(TASK_STARTED, iteration=iteration + 1, **started_detail)
         # #436 : au retry, réensemencer le workspace avec la meilleure tentative
         # (le diff survit en DB → la mémoire traverse aussi les redémarrages).
-        seed = getattr(task, "best_diff", None) if int(getattr(task, "attempt_count", 0) or 0) > 0 else None
+        # #436/#461 : la PRÉSENCE de best_diff suffit (un aléa infra gracié,
+        # #461, peut laisser attempt_count à 0 alors qu'une tentative verte est
+        # mémorisée — la régénérer de zéro gaspillerait le travail).
+        seed = getattr(task, "best_diff", None) or None
         outcome = await execute_issue(
             _issue_from_task(task, tasks_by_id),
             repo_source,
@@ -668,7 +675,8 @@ async def run_project(
             # pas de tentative fonctionnelle (grâce bornée par tâche).
             infra_gate_failure = outcome.reason == REASON_GATE_FAILED and is_infra_noise(diagnostic)
             grace_used = int(infra_gate_grace.get(task.id, 0))
-            if infra_gate_failure and grace_used < MAX_INFRA_GATE_GRACE:
+            graced = infra_gate_failure and grace_used < MAX_INFRA_GATE_GRACE
+            if graced:
                 infra_gate_grace[task.id] = grace_used + 1
                 attempts = int(getattr(task, "attempt_count", 0) or 0)  # NON décompté
                 detail["infra_grace"] = grace_used + 1
@@ -676,6 +684,8 @@ async def run_project(
                 attempts = int(getattr(task, "attempt_count", 0) or 0) + 1
             task.attempt_count = attempts
             last_error = f"[{outcome.stage}/{outcome.reason}] tentative {attempts}/{max_task_attempts}"
+            if graced:
+                last_error += " (aléa infra non décompté)"
             if diagnostic:
                 last_error += " — " + diagnostic
             # #459 : un aléa d'infrastructure (timeout PyPI, 5xx) n'écrase pas un
@@ -722,7 +732,10 @@ async def run_project(
                     manager.update_task(
                         task.id, status=TASK_STATUS_TODO, attempt_count=attempts, last_error=last_error, **best_fields
                     )
-                delay = min(backoff * attempts, RETRY_BACKOFF_CAP_SECONDS) if backoff > 0 else 0.0
+                # max(attempts, 1) : une grâce #461 laisse attempts à 0 — sans
+                # plancher, le retry repartirait SANS backoff contre l'infra qui
+                # vient précisément de timeouter.
+                delay = min(backoff * max(attempts, 1), RETRY_BACKOFF_CAP_SECONDS) if backoff > 0 else 0.0
                 audit.record(
                     TASK_RETRY,
                     iteration=iteration,

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -31,7 +31,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
 from collegue.executor.agent import IssueSpec
-from collegue.executor.pipeline import execute_issue, failure_feedback, is_infra_noise, log_tail
+from collegue.executor.pipeline import REASON_GATE_FAILED, execute_issue, failure_feedback, is_infra_noise, log_tail
 from collegue.executor.workspace import branch_for_issue, cleanup_workspace
 from collegue.pilot.audit import (
     BUDGET_EVENT,
@@ -283,6 +283,12 @@ def reconcile_in_review_tasks(tasks, manager, clients, *, owner: str, repo: str,
     return reconciled
 
 
+# #461 : aléas d'infrastructure pendant le GATE (timeout PyPI dans la passe
+# d'installabilité, 5xx) — nombre max d'échecs non décomptés du budget de
+# tentatives FONCTIONNELLES, par tâche et par run. Borné : si l'infra reste
+# rouge, on recommence à décompter (pas de boucle infinie sur PyPI down).
+MAX_INFRA_GATE_GRACE = 2
+
 # #460 : marqueur du préfixe posé par requeue_task_for_redo dans best_feedback —
 # détecté pour ne jamais empiler deux motifs de redo (le précédent est consommé).
 _REQUEUE_FEEDBACK_MARKER = " (échecs connus de la meilleure tentative : "
@@ -482,6 +488,9 @@ async def run_project(
     # #443 : dernier workspace CONSERVÉ par tâche (échec → debug). Toute nouvelle
     # tentative purge le précédent — au plus UN clone par tâche échouée survit.
     kept_workspaces: dict = {}
+    # #461 : aléas infra du gate non décomptés (task_id → nombre), borné par
+    # MAX_INFRA_GATE_GRACE — un timeout PyPI ne brûle plus une tentative saine.
+    infra_gate_grace: dict = {}
 
     while True:
         if len(processed) >= cap:
@@ -648,12 +657,25 @@ async def run_project(
             if outcome.quality_report is not None and outcome.quality_report.test_output:
                 detail["test_output_tail"] = log_tail(outcome.quality_report.test_output, 1000)
 
-            attempts = int(getattr(task, "attempt_count", 0) or 0) + 1
-            task.attempt_count = attempts
             # Synthèse CRISP (#424) : lignes FAILED/ERROR de pytest en priorité —
             # c'est ce qui sera ré-injecté dans le prompt de la tentative suivante.
-            last_error = f"[{outcome.stage}/{outcome.reason}] tentative {attempts}/{max_task_attempts}"
             diagnostic = failure_feedback(outcome)
+            # #461 : « le livrable ne s'installe pas » (fonctionnel — le but de la
+            # passe #439) et « PyPI n'a pas répondu » (infra transitoire)
+            # produisaient le même gate_failed décompté du budget : chaque
+            # micro-coupure réseau rapprochait une tâche SAINE de l'échec
+            # terminal. Un gate rouge au diagnostic purement infra ne consomme
+            # pas de tentative fonctionnelle (grâce bornée par tâche).
+            infra_gate_failure = outcome.reason == REASON_GATE_FAILED and is_infra_noise(diagnostic)
+            grace_used = int(infra_gate_grace.get(task.id, 0))
+            if infra_gate_failure and grace_used < MAX_INFRA_GATE_GRACE:
+                infra_gate_grace[task.id] = grace_used + 1
+                attempts = int(getattr(task, "attempt_count", 0) or 0)  # NON décompté
+                detail["infra_grace"] = grace_used + 1
+            else:
+                attempts = int(getattr(task, "attempt_count", 0) or 0) + 1
+            task.attempt_count = attempts
+            last_error = f"[{outcome.stage}/{outcome.reason}] tentative {attempts}/{max_task_attempts}"
             if diagnostic:
                 last_error += " — " + diagnostic
             # #459 : un aléa d'infrastructure (timeout PyPI, 5xx) n'écrase pas un

--- a/tests/test_executor_pipeline.py
+++ b/tests/test_executor_pipeline.py
@@ -503,3 +503,6 @@ def test_is_infra_noise_never_flags_functional_diagnostics():
     assert not is_infra_noise("FAILED tests/test_api.py::test_remote - requests.exceptions.ConnectionError: refusé")
     # Le « ERROR: » de pip (deux-points) est du bruit d'install, PAS du pytest.
     assert is_infra_noise("ERROR: Could not install packages due to an OSError: ReadTimeoutError")
+    # Kill du conteneur au timeout (#461) : la note sandbox est le seul indice
+    # quand pip pend sans avoir imprimé de traceback réseau.
+    assert is_infra_noise("Collecting fastapi\n[sandbox] délai dépassé après 120s")

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -477,6 +477,18 @@ async def test_require_deps_install_makes_install_blocking(tmp_path):
     assert ") && python -m pytest" in command
 
 
+def test_installability_command_has_network_retries(tmp_path):
+    """#461 : la passe dépend de PyPI — pip ré-essaie (--retries/--timeout)
+    avant que le moteur ne voie un gate rouge (une micro-coupure réseau coûtait
+    une tentative fonctionnelle entière)."""
+    from collegue.executor import installability_command
+
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    command = installability_command(str(tmp_path))
+    assert command.count("--retries 5") == 2  # requirements + pytest
+    assert command.count("--timeout 60") == 2
+
+
 def test_installability_command_requires_requirements(tmp_path):
     from collegue.executor import installability_command
 

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -486,7 +486,7 @@ def test_installability_command_has_network_retries(tmp_path):
     (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
     command = installability_command(str(tmp_path))
     assert command.count("--retries 5") == 2  # requirements + pytest
-    assert command.count("--timeout 60") == 2
+    assert command.count("--timeout 30") == 2
 
 
 def test_installability_command_requires_requirements(tmp_path):

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -984,6 +984,96 @@ class _InfraThenGreenSandbox:
         return SandboxResult(exit_code=0, stdout="4 passed", stderr="")
 
 
+class _InfraGateForeverSandbox:
+    """Gate rouge sur bruit RÉSEAU pur (timeout PyPI, aucune ligne FAILED)."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def run_tests(self, workspace, command="pytest -q"):
+        self.calls += 1
+        return SandboxResult(
+            exit_code=1,
+            stdout="urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='files.pythonhosted.org')",
+            stderr="",
+        )
+
+
+async def test_infra_gate_failure_does_not_consume_attempt_budget(repo, manager):
+    """#461 : un gate rouge au diagnostic purement infra ne décompte pas le
+    budget fonctionnel (grâce bornée) — puis recommence à décompter au-delà de
+    MAX_INFRA_GATE_GRACE (pas de boucle infinie sur PyPI down)."""
+    from collegue.pilot.driver import MAX_INFRA_GATE_GRACE
+
+    async def _sleep(d):
+        pass
+
+    pid = _linear_project(manager, 1)
+    result = await _run(
+        manager,
+        repo,
+        pid,
+        dry_run=False,
+        agent=FakeCodeAgent(),
+        sandbox=_InfraGateForeverSandbox(),
+        max_task_attempts=2,
+        sleep_fn=_sleep,
+    )
+    # MAX_INFRA_GATE_GRACE aléas graciés + 2 tentatives décomptées → terminal 2/2.
+    assert result.stop_reason == "blocked"
+    t = manager.get_tasks(pid)[0]
+    assert t.status == "failed"
+    assert t.attempt_count == 2
+    assert MAX_INFRA_GATE_GRACE == 2  # contrat de borne (pas de boucle infinie)
+
+
+async def test_infra_gate_grace_recorded_in_audit(repo, manager):
+    from collegue.pilot.audit import RunAuditLog
+
+    async def _sleep(d):
+        pass
+
+    pid = _linear_project(manager, 1)
+    audit = RunAuditLog(pid)
+    await _run(
+        manager,
+        repo,
+        pid,
+        dry_run=False,
+        agent=FakeCodeAgent(),
+        sandbox=_InfraGateForeverSandbox(),
+        max_task_attempts=1,
+        audit=audit,
+        sleep_fn=_sleep,
+    )
+    graced = [e for e in audit.events if e.kind in ("task_retry", "task_failed") and e.detail.get("infra_grace")]
+    assert len(graced) == 2  # MAX_INFRA_GATE_GRACE
+    assert [e.detail["infra_grace"] for e in graced] == [1, 2]
+
+
+async def test_functional_gate_failure_still_consumes_budget(repo, manager):
+    """Contre-épreuve #461 : un échec FONCTIONNEL (lignes FAILED) décompte
+    normalement — la grâce ne s'applique qu'au bruit infra."""
+
+    async def _sleep(d):
+        pass
+
+    pid = _linear_project(manager, 1)
+    result = await _run(
+        manager,
+        repo,
+        pid,
+        dry_run=False,
+        agent=FakeCodeAgent(),
+        sandbox=_FlakySandbox(fail_times=99),
+        max_task_attempts=2,
+        sleep_fn=_sleep,
+    )
+    assert result.stop_reason == "blocked"
+    t = manager.get_tasks(pid)[0]
+    assert t.attempt_count == 2  # aucun gracié
+
+
 async def test_infra_noise_does_not_clobber_actionable_feedback(repo, manager):
     """#459 : un timeout PyPI à la tentative 2 n'écrase pas le diagnostic
     actionnable de la tentative 1 — l'agent (tentative 3) et l'opérateur voient

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -1027,6 +1027,48 @@ async def test_infra_gate_failure_does_not_consume_attempt_budget(repo, manager)
     assert MAX_INFRA_GATE_GRACE == 2  # contrat de borne (pas de boucle infinie)
 
 
+async def test_graced_retry_still_backs_off(repo, manager):
+    """#461 (revue) : une grâce laisse attempts à 0 — sans plancher, le retry
+    repartirait SANS backoff contre l'infra qui vient de timeouter."""
+    pid = _linear_project(manager, 1)
+    sleeps = []
+
+    async def _sleep(d):
+        sleeps.append(d)
+
+    await _run(
+        manager,
+        repo,
+        pid,
+        dry_run=False,
+        agent=FakeCodeAgent(),
+        sandbox=_InfraGateForeverSandbox(),
+        max_task_attempts=1,
+        sleep_fn=_sleep,
+    )
+    assert sleeps and all(d >= 15.0 for d in sleeps)
+
+
+def test_repair_mode_active_with_best_diff_even_at_zero_attempts(manager):
+    """#461 (revue) : une grâce peut laisser attempt_count=0 avec une tentative
+    verte mémorisée — la PRÉSENCE de best_diff suffit à activer la réparation."""
+    from collegue.pilot.driver import _issue_from_task
+
+    pid = _linear_project(manager, 1)
+    tid = manager.get_tasks(pid)[0].id
+    manager.update_task(
+        tid,
+        attempt_count=0,
+        best_diff="diff --git a/x.py b/x.py\n+x",
+        best_passed=34,
+        best_failed=0,
+        last_error="[gate/gate_failed] tentative 0/3 (aléa infra non décompté) — ReadTimeoutError",
+    )
+    context = _issue_from_task(manager.get_tasks(pid)[0]).context
+    assert "RÉPARATION CIBLÉE" in context
+    assert "34 test(s) verts" in context
+
+
 async def test_infra_gate_grace_recorded_in_audit(repo, manager):
     from collegue.pilot.audit import RunAuditLog
 


### PR DESCRIPTION
## Problème (#461)

« Le livrable ne s'installe pas » (fonctionnel — le but de la passe #439) et « PyPI n'a pas répondu » (infra transitoire) produisaient le même `gate_failed` décompté du budget : chaque micro-coupure réseau rapprochait une tâche **saine** de l'échec terminal. FacNor v3, itération 14 : un `ReadTimeoutError` sur files.pythonhosted.org a directement contribué à un échec terminal nécessitant une reprise opérateur.

## Correctif

- **`installability_command` (#439)** : `pip --retries 5 --timeout 30` explicites (requirements + pytest) — pip ré-essaie d'abord ; timeout à 30 s (pas plus) pour rester sous le budget total du conteneur (120 s) ;
- **driver** : un `gate_failed` au diagnostic purement infra (`is_infra_noise`, #459) ne consomme pas de tentative fonctionnelle — **grâce bornée** (`MAX_INFRA_GATE_GRACE = 2` par tâche et par run : si l'infra reste rouge, on recommence à décompter, pas de boucle infinie sur PyPI down) ; libellé `(aléa infra non décompté)` dans `last_error` ;
- **audit** : événements `task_retry`/`task_failed` marqués `infra_grace=N` quand l'aléa est gracié ;
- durcissements issus de la revue adversariale : backoff plancher `max(attempts, 1)` (une grâce laissait le retry repartir **sans** attendre) ; réensemencement (#436) et mode réparation déclenchés sur la **présence** de `best_diff` (une grâce peut laisser `attempt_count=0` avec une tentative verte mémorisée) ; cap d'itérations auto élargi des grâces ; note `[sandbox] délai dépassé après` classée infra (seul indice quand le conteneur est tué avant le traceback réseau).

## Tests

- `installability_command` : `--retries 5`/`--timeout 30` sur les deux installs ;
- grâce : gate rouge infra ×N → budget intact pendant la grâce, terminal après (contrat de borne 2) ; audit `infra_grace=[1,2]` ; contre-épreuve : un échec **fonctionnel** (FAILED) décompte normalement ;
- backoff ≥ 15 s même gracié ; réparation active avec `best_diff` à `attempt_count=0` ; note sandbox classée bruit infra.

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)