### PR TITLE
fix(pilot): RunCostLedger réamorcé depuis l'état persisté au restart (#462)

### DIFF
--- a/collegue/pilot/audit.py
+++ b/collegue/pilot/audit.py
@@ -141,6 +141,39 @@ class RunAuditLog:
         self._persist = wants_persist
         self.events: List[RunEvent] = []
         self.cost = RunCostLedger()
+        # #462 : réamorcer le cumul depuis la dernière métrique persistée —
+        # symétrique de load_run_start (resume). Sans ça, chaque restart de
+        # process publiait son cumul LOCAL comme cumul du run : run FacNor v3
+        # en 3 segments → 5,38 M tokens annoncés pour 8,98 M réellement
+        # consommés (-40 %), budget et reporting faux dès la première reprise.
+        if self._persist:
+            self._reseed_cost_from_metrics()
+
+    def _reseed_cost_from_metrics(self) -> None:
+        """Repart du dernier cumul ``run_cost_usd``/``run_tokens`` persisté (#462).
+
+        Best-effort : un manager sans ``get_metrics`` ou une lecture en échec
+        laissent simplement le ledger à zéro (comportement historique).
+        """
+        getter = getattr(self._manager, "get_metrics", None)
+        if getter is None:
+            return
+        usd, tokens = 0.0, 0
+        try:
+            # Toute la lecture sous le try (y compris le parsing) : une ligne
+            # corrompue (NaN/inf écrit à la main) ne doit pas empêcher le run
+            # de DÉMARRER — l'audit ne casse jamais le run.
+            for metric in getter(self.project_id):  # ordonné par id : la dernière valeur gagne
+                if metric.name == METRIC_RUN_COST_USD and math.isfinite(metric.value):
+                    usd = float(metric.value)
+                elif metric.name == METRIC_RUN_TOKENS and math.isfinite(metric.value):
+                    tokens = int(metric.value)
+        except Exception:
+            return
+        if usd > 0:
+            self.cost.usd = usd
+        if tokens > 0:
+            self.cost.tokens = tokens
 
     def record(self, kind: str, *, iteration: Optional[int] = None, **detail: Any) -> RunEvent:
         """Enregistre un événement (et le persiste si activé). Best-effort."""

--- a/tests/test_pilot_audit.py
+++ b/tests/test_pilot_audit.py
@@ -124,6 +124,66 @@ def test_run_cost_summary_zero_when_no_metrics(manager):
     assert run_cost_summary(manager, pid) == {"usd": 0.0, "tokens": 0}
 
 
+# --- le ledger survit aux restarts de process (#462) -------------------------------
+
+
+def test_ledger_reseeded_after_process_restart(manager):
+    """#462 (cas réel FacNor v3) : run en 3 segments → le run_stop final
+    annonçait 5,38 M tokens pour 8,98 M consommés (-40 %). Un nouveau
+    RunAuditLog persistant repart du dernier cumul persisté, et les métriques
+    suivantes restent un cumul de RUN, pas de segment."""
+    pid = manager.create_project(name="restart")
+    segment1 = RunAuditLog(pid, manager=manager, clock=_fixed_clock, persist=True)
+    segment1.record_cost(usd=0.05, tokens=2_000_000)
+
+    # « Restart de process » : nouvelle construction, même état persisté.
+    segment2 = RunAuditLog(pid, manager=manager, clock=_fixed_clock, persist=True)
+    assert segment2.cost.tokens == 2_000_000  # réamorcé, pas zéro
+    assert segment2.cost.usd == 0.05
+    segment2.record_cost(usd=0.03, tokens=1_500_000)
+    assert run_cost_summary(manager, pid) == {"usd": 0.08, "tokens": 3_500_000}
+
+    segment3 = RunAuditLog(pid, manager=manager, clock=_fixed_clock, persist=True)
+    segment3.record_cost(usd=0.02, tokens=5_000_000)
+    assert run_cost_summary(manager, pid) == {"usd": 0.1, "tokens": 8_500_000}
+
+
+def test_ledger_reseed_only_when_persisting(manager):
+    pid = manager.create_project(name="np")
+    RunAuditLog(pid, manager=manager, clock=_fixed_clock, persist=True).record_cost(usd=0.05, tokens=100)
+    # Sans persistance (ex. dry_run), pas de réamorçage : ledger local à zéro.
+    fresh = RunAuditLog(pid, manager=manager, clock=_fixed_clock, persist=False)
+    assert fresh.cost.tokens == 0 and fresh.cost.usd == 0.0
+
+
+def test_ledger_reseed_tolerates_corrupt_metric_rows():
+    """#462 (revue) : une ligne NaN/inf (autre backend, écriture manuelle) ne
+    doit pas empêcher le run de DÉMARRER — l'audit ne casse jamais le run.
+    (SQLite refuse NaN à l'insertion → stub de manager.)"""
+    from types import SimpleNamespace
+
+    class _CorruptMetricsManager:
+        def record_decision(self, *a, **k): ...
+        def add_metric(self, *a, **k): ...
+        def get_metrics(self, project_id, name=None):
+            return [
+                SimpleNamespace(name="run_tokens", value=float("nan")),
+                SimpleNamespace(name="run_cost_usd", value=float("inf")),
+            ]
+
+    log = RunAuditLog(1, manager=_CorruptMetricsManager(), clock=_fixed_clock, persist=True)
+    assert log.cost.tokens == 0 and log.cost.usd == 0.0
+
+
+def test_ledger_reseed_tolerates_manager_without_get_metrics():
+    class _Capable:
+        def record_decision(self, *a, **k): ...
+        def add_metric(self, *a, **k): ...
+
+    log = RunAuditLog(1, manager=_Capable(), persist=True)
+    assert log.cost.tokens == 0  # best-effort : pas de get_metrics → zéro
+
+
 def test_persistence_failure_does_not_break_run():
     # Manager dont record_decision lève : l'audit doit avaler l'erreur (best-effort).
     class _Boom:


### PR DESCRIPTION
## Problème (#462)

Le ledger de coût (#441) était purement en mémoire, réinitialisé à chaque construction de `RunAuditLog` (donc à chaque restart de process) : chaque segment publiait son cumul **local** comme cumul du run. FacNor v3 en 3 segments : `run_stop` et le dashboard annonçaient **5,38 M tokens** pour **8 976 336** réellement consommés (-40 %) — un plafond de budget par run devenait inopérant dès la première reprise, alors que `started_at`, lui, survivait déjà (resume.py).

## Correctif

- **`_reseed_cost_from_metrics`** : à la construction d'un `RunAuditLog` persistant, le ledger repart de la dernière métrique `run_cost_usd`/`run_tokens` persistée — symétrique de `load_run_start` ;
- **best-effort intégral** : manager sans `get_metrics`, lecture en échec ou ligne corrompue (NaN/inf) → ledger à zéro (comportement historique) ; l'audit ne casse **jamais** le démarrage d'un run (parsing entier sous le `try`, durci suite à la revue) ;
- sémantique inchangée pour `run_cost_summary`/dashboard (dernier cumul par projet) — les totaux deviennent simplement justes à travers les segments.

## Tests

- scénario réel FacNor v3 (3 segments) : chaque segment repart du cumul, total final = somme des trois ;
- `persist=False` (dry_run) → pas de réamorçage ;
- manager sans `get_metrics` et lignes NaN/inf (stub — SQLite refuse NaN à l'insertion) → zéro, pas d'exception.

Revue adversariale pré-PR : 1 finding corrigé (parsing hors du try — une ligne corrompue aurait empêché le run de démarrer) ; double-comptage, budget gate, NullAuditLog et dashboard vérifiés sains ; sémantique inter-runs (projet = run logique) cohérente avec `persist_run_start`.

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)