### PR TITLE
fix(executor): pytest exit 5 toléré par le gate quand une passe frontend couvre (#463)

### DIFF
--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -239,6 +239,24 @@ def installability_command(workspace: str) -> Optional[str]:
     )
 
 
+# #463 : note visible quand « aucun test collecté » (pytest exit 5) est toléré.
+_EXIT5_NOTE = "[gate] pytest : aucun test collecté (exit 5) — toléré, une passe frontend couvre (#463)"
+
+
+def _tolerate_pytest_exit5(command: str) -> str:
+    """Mappe l'exit 5 de pytest (« aucun test collecté ») vers un succès (#463).
+
+    Sur les tâches greenfield/frontend, ne collecter aucun test pytest est
+    NORMAL (le livrable est du TS/JS, couvert par la passe frontend #438) — mais
+    le gate fail-closed confondait exit 5 et tests rouges : la tâche brûlait ses
+    tentatives sur un non-échec puis figeait le DAG. La connaissance vivait dans
+    une rustine du harness de validation au lieu du moteur. N'est appliqué que
+    quand une passe frontend va EFFECTIVEMENT tourner (fail-closed sinon) ;
+    tout autre exit non nul reste un échec.
+    """
+    return f"({command}); _rc=$?; if [ $_rc -eq 5 ]; then echo {shlex.quote(_EXIT5_NOTE)}; elif [ $_rc -ne 0 ]; then exit $_rc; fi"
+
+
 # Bannière insérée entre la passe Python et la passe frontend dans la sortie du gate.
 _FRONTEND_BANNER = "[gate] frontend : install + build + tests (#438)"
 
@@ -698,20 +716,32 @@ async def run_quality_gate(
                 # Strict (#439) : install bloquante. Toléré (#414) : les tests
                 # tournent quand même, l'échec laisse sa note dans la sortie.
                 command = f"({prelude}) && {test_command}" if require_deps_install else f"{prelude}; {test_command}"
+        front_commands: List[str] = []
         if frontend_gate:
             for front_dir in _frontend_dirs(workspace):
                 front = frontend_gate_command(workspace, subdir=front_dir)
                 if front is None:
                     continue
-                # `&&` : chaque passe frontend ne tourne que si la précédente est
-                # verte (le verdict est déjà rouge sinon) et son échec rend le
-                # gate rouge. Une passe PAR répertoire détecté (#457 : la racine
-                # ET les sous-répertoires de 1er niveau — layout monorepo).
+                # Une passe PAR répertoire détecté (#457 : la racine ET les
+                # sous-répertoires de 1er niveau — layout monorepo).
                 banner = _FRONTEND_BANNER if front_dir == "." else f"{_FRONTEND_BANNER} [{front_dir}]"
-                command = f"({command}) && echo {shlex.quote(banner)} && ({front})"
+                front_commands.append(f"echo {shlex.quote(banner)} && ({front})")
+        if front_commands:
+            # #463 : « aucun test pytest collecté » est NORMAL quand une passe
+            # frontend couvre la tâche — exit 5 toléré DANS ce cas seulement.
+            command = _tolerate_pytest_exit5(command)
+        for front in front_commands:
+            # `&&` : chaque passe frontend ne tourne que si la précédente est
+            # verte (le verdict est déjà rouge sinon) et son échec rend le
+            # gate rouge.
+            command = f"({command}) && {front}"
         if check_installability:
             installability = installability_command(workspace)
             if installability is not None:
+                if front_commands:
+                    # La collecte de la passe d'installabilité (#439) renvoie
+                    # AUSSI exit 5 sans test pytest — même tolérance (#463).
+                    installability = _tolerate_pytest_exit5(installability)
                 command = f"({command}) && echo '{_INSTALLABILITY_BANNER}' && ({installability})"
         if smoke_run:
             smoke = smoke_run_command(workspace, command=smoke_command, paths=smoke_paths, timeout=smoke_timeout)

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -291,6 +291,66 @@ async def test_gate_runs_one_frontend_pass_per_detected_dir(tmp_path):
     assert "cd -- frontend && " in command
 
 
+# --- pytest exit 5 : « aucun test collecté » (#463) --------------------------------
+
+
+def test_tolerate_exit5_shell_semantics():
+    """Le wrapper EXÉCUTÉ : exit 5 → 0 (+ note), exit 1 → 1, exit 0 → 0."""
+    import subprocess
+
+    from collegue.executor.quality_gate import _EXIT5_NOTE, _tolerate_pytest_exit5
+
+    def run(inner):
+        return subprocess.run(["sh", "-c", _tolerate_pytest_exit5(inner)], capture_output=True, text=True)
+
+    five = run("exit 5")
+    assert five.returncode == 0
+    assert _EXIT5_NOTE in five.stdout
+    assert run("exit 1").returncode == 1
+    ok = run("echo vert")
+    assert ok.returncode == 0 and _EXIT5_NOTE not in ok.stdout
+
+
+async def test_gate_tolerates_exit5_when_frontend_pass_covers(tmp_path):
+    """#463 (cas réel FacNor v3) : tâche frontend sans test pytest → exit 5
+    toléré (la passe npm couvre), enchaînement préservé."""
+    front = tmp_path / "frontend"
+    front.mkdir()
+    _write_pkg(front, scripts={"build": "vite build"})
+    sandbox = _green()
+    await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    _ws, command = sandbox.calls[0]
+    assert "_rc=$?" in command and "-eq 5" in command  # tolérance présente
+    assert command.index("-eq 5") < command.index("npm")  # ... AVANT la passe npm
+    assert "cd -- frontend && " in command
+
+
+async def test_gate_exit5_still_fails_without_frontend(tmp_path):
+    """Fail-closed conservé : sans passe frontend, exit 5 reste un échec
+    (un projet Python sans AUCUN test ne passe pas le gate en silence)."""
+    sandbox = _FakeSandbox(SandboxResult(exit_code=5, stdout="no tests ran", stderr=""))
+    report = await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    _ws, command = sandbox.calls[0]
+    assert "-eq 5" not in command  # pas de tolérance hors couverture frontend
+    assert report.tests_passed is False
+    assert report.passed is False
+
+
+async def test_gate_exit5_tolerance_applies_to_installability_collect(tmp_path):
+    """#463 : la collecte de la passe d'installabilité (#439) renvoie aussi
+    exit 5 sans test pytest — même tolérance quand le front couvre."""
+    front = tmp_path / "frontend"
+    front.mkdir()
+    _write_pkg(front, scripts={"build": "vite build"})
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    sandbox = _green()
+    await run_quality_gate(
+        str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer(), check_installability=True
+    )
+    _ws, command = sandbox.calls[0]
+    assert command.count("-eq 5") == 2  # pytest principal + collecte installabilité
+
+
 # --- smoke run (#458) ---------------------------------------------------------------
 
 


### PR DESCRIPTION
## Problème (#463)

Sur les tâches greenfield/frontend, ne collecter **aucun** test pytest est normal (le livrable est du TS/JS, couvert par la passe frontend #438) — mais le gate fail-closed confondait exit 5 (« aucun test collecté ») et tests rouges : la tâche brûlait ses 3 tentatives sur un non-échec puis figeait le DAG. La tolérance vivait dans une rustine du harness de validation (monkey-patch de `sandbox.run_tests`) au lieu du moteur — 4 tâches frontend du run v3 en dépendaient.

## Correctif

- **`_tolerate_pytest_exit5`** : wrapper shell qui mappe exit 5 → succès (note visible dans la sortie du gate) ; tout autre exit non nul se propage (exit 2 = vraie erreur de collecte → toujours rouge, vérifié contre pytest réel) ;
- appliqué **uniquement** quand ≥ 1 passe frontend va effectivement tourner (fail-closed conservé : un projet Python sans aucun test ne passe pas le gate en silence) ;
- même tolérance pour la collecte de la passe d'installabilité (#439), qui renvoie aussi exit 5 sans test pytest ;
- la passe smoke-run (#458) reste textuellement dernière (heredoc intact) ;
- les options pytest greenfield (ex. `asyncio_mode`) passent déjà par `GATE_TEST_COMMAND` — la 2e moitié de la rustine harness est couverte par la config existante.

## Tests

- le wrapper **exécuté** (sh réel) : exit 5 → 0 + note ; exit 1 → 1 ; exit 0 → 0 sans note ;
- cas réel FacNor v3 : `frontend/package.json` sans test pytest → tolérance présente, avant la passe npm ;
- fail-closed : sans frontend, exit 5 reste un échec (`tests_passed=False`) ;
- tolérance aussi sur la collecte d'installabilité (2 wrappers).

Revue adversariale pré-PR : aucune correction requise — sémantiques shell (propagation des exits, `if` implicite à 0, heredoc-dernier), interactions de la note avec `is_infra_noise`/`deps_install_failed`/score, et distinction exit 2 vs 5 vérifiées empiriquement.

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)