### PR TITLE
fix(executor,pilot): usage LLM perdu au timeout — contrat incrémental + perte journalisée (#464)

### DIFF
--- a/collegue/executor/openhands_agent.py
+++ b/collegue/executor/openhands_agent.py
@@ -34,11 +34,19 @@ from collegue.executor.agent import AgentResult, IssueSpec
 # Point d'entrée headless d'OpenHands (module exécuté dans le conteneur sandbox).
 OPENHANDS_ENTRYPOINT = "openhands.core.main"
 
-# Contrat d'usage LLM du canal coder (#441) : le runner (entrypoint OpenHands ou
-# tout wrapper SDK) imprime, par appel LLM ou en fin de run, une ligne
+# Contrat d'usage LLM du canal coder (#441, précisé par #464) : le runner
+# (entrypoint OpenHands ou tout wrapper SDK) imprime une ligne
 #   [collegue-usage] {"prompt_tokens": 1200, "completion_tokens": 480, "cost_usd": 0.0021}
-# Toutes les occurrences sont SOMMÉES par :func:`parse_usage_from_logs` et
-# alimentent le ledger de coût du run via ``AgentResult``.
+# Toutes les occurrences sont SOMMÉES par :func:`parse_usage_from_logs` —
+# chaque ligne doit donc porter un DELTA (l'usage d'UN appel LLM), jamais un
+# cumul (sommer des cumuls compterait double). Émission INCRÉMENTALE exigée
+# (#464) : une ligne par appel, au fil de l'eau — un runner qui n'émet qu'un
+# agrégat final dans un ``finally`` perd TOUT son usage quand le process est
+# tué de l'extérieur (timeout sandbox → ``docker kill``, OOM) : c'est
+# précisément la tentative la plus longue, donc la plus coûteuse, qui devient
+# invisible du ledger (run FacNor v3 : 41 min de tokens hors budget). Résiduel
+# assumé : un kill en plein appel perd au plus le DERNIER delta non émis (et ce
+# cas n'émet pas d'événement ``usage_lost`` — il y a déjà de l'usage compté).
 USAGE_MARKER = "[collegue-usage]"
 
 

--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -34,6 +34,7 @@ from collegue.executor.pr import PrClients, PrResult, open_pr
 from collegue.executor.quality_gate import QualityReport, Reviewer, run_quality_gate
 from collegue.executor.runner import ExecutionResult, run_issue
 from collegue.executor.workspace import Workspace, apply_seed_diff, prepare_workspace
+from collegue.sandbox.executor import TIMEOUT_NOTE
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +83,7 @@ _INFRA_NOISE_SIGNATURES = (
     # Kill du conteneur sandbox au timeout (#461) : quand pip pend sur PyPI, le
     # conteneur peut être tué avant d'imprimer un traceback réseau — la note du
     # sandbox est alors le seul indice, et ce n'est pas un diagnostic actionnable.
-    "[sandbox] délai dépassé après",
+    TIMEOUT_NOTE,
 )
 
 

--- a/collegue/pilot/audit.py
+++ b/collegue/pilot/audit.py
@@ -36,6 +36,10 @@ BUDGET_EVENT = "budget_event"
 CHECKPOINT_SAVED = "checkpoint_saved"
 RUN_STOP = "run_stop"
 COST_OBSERVED = "cost_observed"
+# #464 : exécution coder terminée par un kill externe (timeout sandbox) SANS
+# ligne d'usage — la dépense de la tentative est invisible du ledger ; on
+# journalise la perte au lieu de laisser un trou silencieux.
+USAGE_LOST = "usage_lost"
 
 # Noms des métriques persistées pour le ledger de coût par run.
 METRIC_RUN_COST_USD = "run_cost_usd"

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -43,6 +43,7 @@ from collegue.pilot.audit import (
     TASK_RECONCILED,
     TASK_RETRY,
     TASK_STARTED,
+    USAGE_LOST,
     CostSource,
     NullAuditLog,
     RunAuditLog,
@@ -56,6 +57,7 @@ from collegue.pilot.scheduler import (
     ready_tasks,
     remaining_tasks,
 )
+from collegue.sandbox.executor import TIMEOUT_NOTE
 
 # Statut projet une fois le MVP construit (le moteur d'amélioration = Phase 4).
 PROJECT_STATUS_IMPROVING = "improving"
@@ -608,6 +610,12 @@ async def run_project(
         coder_usd = float(getattr(agent_result, "cost_usd", 0.0) or 0.0)
         if coder_tokens or coder_usd:
             audit.record_cost(usd=coder_usd, tokens=coder_tokens, iteration=iteration)
+        elif TIMEOUT_NOTE in (getattr(agent_result, "logs", "") or ""):
+            # #464 : tentative tuée de l'extérieur (timeout sandbox) AVANT toute
+            # ligne [collegue-usage] — la dépense (la tentative la plus longue,
+            # donc la plus coûteuse) est invisible du ledger : perte journalisée
+            # au lieu d'un trou silencieux (budget sous-estimé en silence).
+            audit.record(USAGE_LOST, iteration=iteration, task_id=task.id, reason="sandbox_timeout")
         pr_number = outcome.pr.number if outcome.pr is not None else None
         audit.record(
             GATE_DECISION,

--- a/collegue/sandbox/executor.py
+++ b/collegue/sandbox/executor.py
@@ -43,6 +43,10 @@ DEFAULT_SANDBOX_IMAGE = "collegue-sandbox:latest"
 # Code de sortie conventionnel pour un dépassement de délai (cf. coreutils timeout).
 TIMEOUT_EXIT_CODE = 124
 
+# Préfixe de la note ajoutée à stderr quand le conteneur est tué au timeout —
+# consommé par le moteur (#461 : classification infra ; #464 : usage perdu).
+TIMEOUT_NOTE = "[sandbox] délai dépassé après"
+
 
 class SandboxUnavailable(RuntimeError):
     """Docker indisponible, ou refus de s'exécuter (ex. en root)."""
@@ -247,7 +251,7 @@ class DockerSandbox:
             stdout = self._read_capped(out_path)
             stderr = self._read_capped(err_path)
             if timed_out:
-                stderr += f"\n[sandbox] délai dépassé après {self.timeout:g}s"
+                stderr += f"\n{TIMEOUT_NOTE} {self.timeout:g}s"
             return SandboxResult(exit_code=exit_code, stdout=stdout, stderr=stderr, timed_out=timed_out)
         finally:
             for path in (out_path, err_path):

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -984,6 +984,82 @@ class _InfraThenGreenSandbox:
         return SandboxResult(exit_code=0, stdout="4 passed", stderr="")
 
 
+class _TimedOutAgent:
+    """Agent tué par le timeout sandbox : aucun usage émis, note sandbox dans les logs."""
+
+    def implement_issue(self, workspace, issue):
+        return AgentResult(success=False, logs="travail en cours...\n[sandbox] délai dépassé après 2400s")
+
+
+async def test_usage_lost_on_sandbox_timeout_is_audited(repo, manager):
+    """#464 : une tentative tuée de l'extérieur n'a pas pu émettre sa ligne
+    [collegue-usage] — la perte est JOURNALISÉE (usage_lost) au lieu d'un trou
+    silencieux dans le ledger."""
+    from collegue.pilot.audit import USAGE_LOST, RunAuditLog
+
+    async def _sleep(d):
+        pass
+
+    pid = _linear_project(manager, 1)
+    audit = RunAuditLog(pid)
+    await _run(
+        manager, repo, pid, dry_run=False, agent=_TimedOutAgent(), audit=audit, max_task_attempts=1, sleep_fn=_sleep
+    )
+    lost = [e for e in audit.events if e.kind == USAGE_LOST]
+    assert len(lost) == 1
+    assert lost[0].detail == {"task_id": manager.get_tasks(pid)[0].id, "reason": "sandbox_timeout"}
+
+
+async def test_no_usage_lost_event_when_usage_reported_or_no_timeout(repo, manager):
+    from collegue.pilot.audit import COST_OBSERVED, USAGE_LOST, RunAuditLog
+
+    async def _sleep(d):
+        pass
+
+    # Échec SANS note de timeout (agent 503) → pas d'événement usage_lost.
+    pid = _linear_project(manager, 1)
+    audit = RunAuditLog(pid)
+    await _run(
+        manager,
+        repo,
+        pid,
+        dry_run=False,
+        agent=_FlakyAgent(fail_times=99),
+        audit=audit,
+        max_task_attempts=1,
+        sleep_fn=_sleep,
+    )
+    assert not [e for e in audit.events if e.kind == USAGE_LOST]
+
+    # Timeout MAIS usage incrémental déjà émis → record_cost, pas usage_lost
+    # (perte bornée au dernier delta : déjà de l'usage compté, pas un trou).
+    class _TimedOutWithUsage:
+        def implement_issue(self, workspace, issue):
+            return AgentResult(
+                success=False,
+                logs="[collegue-usage] partiel\n[sandbox] délai dépassé après 2400s",
+                prompt_tokens=100,
+                completion_tokens=40,
+                cost_usd=0.01,
+            )
+
+    pid2 = _linear_project(manager, 1)
+    audit2 = RunAuditLog(pid2)
+    await _run(
+        manager,
+        repo,
+        pid2,
+        dry_run=False,
+        agent=_TimedOutWithUsage(),
+        audit=audit2,
+        max_task_attempts=1,
+        sleep_fn=_sleep,
+    )
+    assert not [e for e in audit2.events if e.kind == USAGE_LOST]
+    observed = [e for e in audit2.events if e.kind == COST_OBSERVED]
+    assert observed and observed[0].detail["tokens"] == 140
+
+
 class _InfraGateForeverSandbox:
     """Gate rouge sur bruit RÉSEAU pur (timeout PyPI, aucune ligne FAILED)."""
 


### PR DESCRIPTION
## Problème (#464)

Le contrat `[collegue-usage]` (#441) était documenté comme une émission de fin d'exécution : un kill externe (timeout sandbox → `docker kill`, OOM) supprimait l'unique point d'émission. Run v3, itération 18 (tâche 5, 41 min — la plus longue du run) : seule itération sans `cost_observed`, ses tokens invisibles du ledger et du budget. Les tentatives les plus coûteuses étaient exactement celles dont le coût disparaissait.

## Correctif

- **contrat précisé (#464)** : émission **incrémentale** exigée — une ligne **delta** par appel LLM (`parse_usage_from_logs` somme déjà les occurrences ; un agrégat final unique dans un `finally` perd tout au kill). Résiduel assumé et documenté : un kill en plein appel perd au plus le dernier delta non émis ;
- **`sandbox.TIMEOUT_NOTE`** : préfixe de la note de timeout partagé (consommé par la classification infra #461 et par #464, au lieu de littéraux dupliqués) ;
- **driver** : exécution coder **sans** usage dont les logs portent la note de timeout → événement d'audit `usage_lost` (`task_id`, `reason=sandbox_timeout`) — la perte est journalisée au lieu d'un trou silencieux (budget sous-estimé en silence) ;
- runner de référence du harness (hors repo, gitignoré) mis en conformité : deltas périodiques (30 s) par thread de fond + flush final — au pire un kill ne perd que la dernière fenêtre.

## Tests

- tentative tuée sans usage → `usage_lost` audité (task_id + reason) ;
- contre-épreuves : échec sans note de timeout → pas d'événement ; timeout **avec** usage incrémental déjà émis → `cost_observed` (140 tokens), pas de `usage_lost` ;
- détection sur les logs **agent** uniquement (un timeout de gate dans `test_output` ne déclenche rien) — vérifié en revue.

Revue adversariale pré-PR : 3 findings traités (runner harness rendu incrémental, polarité de test manquante ajoutée, résiduel partiel documenté) ; cycle d'imports, dashboard (pas de whitelist de kinds) et NullAuditLog vérifiés sains.

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)