### PR TITLE
fix(clients): compteur de tentatives réel + 404 attendus en debug (#465)

### DIFF
--- a/collegue/tools/clients/base.py
+++ b/collegue/tools/clients/base.py
@@ -126,10 +126,12 @@ class APIClient(ABC):  # noqa: B024
         return False
 
     def _execute_with_retry(self, operation: Callable[[], T], operation_name: str = "request") -> T:
-
         last_error = None
+        attempts = 0
+        last_status = 0
 
         for attempt in range(self.max_retries + 1):
+            attempts = attempt + 1
             try:
                 return operation()
             except Exception as e:
@@ -138,6 +140,7 @@ class APIClient(ABC):  # noqa: B024
                 response = getattr(e, "response", None)
                 if response is not None:
                     status_code = getattr(response, "status_code", status_code)
+                last_status = status_code
 
                 if not self._should_retry(e, status_code, attempt):
                     break
@@ -146,9 +149,16 @@ class APIClient(ABC):  # noqa: B024
                 self.logger.warning(f"{operation_name} failed (attempt {attempt + 1}), retrying in {delay}s: {e}")
                 time.sleep(delay)
 
-        # All retries exhausted
-        error_msg = f"{operation_name} failed after {self.max_retries + 1} attempts: {last_error}"
-        self.logger.error(error_msg)
+        # #465 : compteur RÉEL (un 404 court-circuite au 1er essai — afficher
+        # « after 4 attempts » était mensonger et noyait le diagnostic) ; un 404
+        # non retenté est souvent ATTENDU (sondage d'existence : contents/<fichier>
+        # sur une branche fraîche) → debug, pas error. Les vraies pannes (retries
+        # épuisés, 4xx/5xx autres) restent en error.
+        error_msg = f"{operation_name} failed after {attempts} attempt(s): {last_error}"
+        if last_status == 404:
+            self.logger.debug(error_msg)
+        else:
+            self.logger.error(error_msg)
         raise APIError(error_msg)
 
     def handle_response(self, response: Any, endpoint: str) -> APIResponse:

--- a/tests/test_clients_retry_logging.py
+++ b/tests/test_clients_retry_logging.py
@@ -1,0 +1,80 @@
+"""Tests #465 : logging honnête de ``_execute_with_retry`` (clients API).
+
+Un 404 attendu (sondage d'existence) court-circuite au 1er essai : le message
+final doit porter le compteur RÉEL (« after 1 attempt(s) », pas « after 4
+attempts ») et partir en ``debug`` — sur un run de plusieurs heures, des
+centaines de fausses « erreurs après 4 tentatives » noyaient les vraies pannes
+(run FacNor v3 : jusqu'à 17 lignes error par PR ouverte).
+"""
+
+import pytest
+
+from collegue.tools.clients.base import APIClient, APIError
+
+
+class _Client(APIClient):
+    """Client minimal : pas de réseau, l'opération est injectée par le test."""
+
+    def __init__(self):
+        super().__init__(base_url="https://api.example.test", max_retries=3, retry_delay=0.0)
+
+
+class _HTTPError(Exception):
+    def __init__(self, status_code: int, message: str):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _always_raise(exc):
+    def _op():
+        raise exc
+
+    return _op
+
+
+def test_expected_404_logs_real_attempt_count_at_debug(caplog):
+    client = _Client()
+    with caplog.at_level("DEBUG", logger=client.logger.name):
+        with pytest.raises(APIError) as excinfo:
+            client._execute_with_retry(_always_raise(_HTTPError(404, "Ressource introuvable")), "GET contents/x")
+    # Compteur RÉEL : le 404 n'est jamais retenté → 1 tentative, pas 4.
+    assert "failed after 1 attempt(s)" in str(excinfo.value)
+    records = [r for r in caplog.records if "failed after" in r.message]
+    assert records and all(r.levelname == "DEBUG" for r in records)
+
+
+def test_exhausted_retries_log_error_with_real_count(caplog):
+    client = _Client()
+    with caplog.at_level("DEBUG", logger=client.logger.name):
+        with pytest.raises(APIError) as excinfo:
+            client._execute_with_retry(_always_raise(_HTTPError(503, "Service Unavailable")), "GET ref")
+    # 503 retenté jusqu'à épuisement : max_retries + 1 tentatives, en ERROR.
+    assert "failed after 4 attempt(s)" in str(excinfo.value)
+    records = [r for r in caplog.records if "failed after" in r.message]
+    assert records and all(r.levelname == "ERROR" for r in records)
+
+
+def test_non_retryable_non_404_stays_error(caplog):
+    client = _Client()
+    with caplog.at_level("DEBUG", logger=client.logger.name):
+        with pytest.raises(APIError) as excinfo:
+            client._execute_with_retry(_always_raise(_HTTPError(422, "Validation Failed")), "PUT contents/x")
+    # 422 : ni retenté ni attendu — vraie erreur, compteur réel.
+    assert "failed after 1 attempt(s)" in str(excinfo.value)
+    records = [r for r in caplog.records if "failed after" in r.message]
+    assert records and all(r.levelname == "ERROR" for r in records)
+
+
+def test_success_after_transient_failure_no_final_log(caplog):
+    client = _Client()
+    calls = {"n": 0}
+
+    def _op():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _HTTPError(503, "blip")
+        return "ok"
+
+    with caplog.at_level("DEBUG", logger=client.logger.name):
+        assert client._execute_with_retry(_op, "GET ref") == "ok"
+    assert not [r for r in caplog.records if "failed after" in r.message]


### PR DESCRIPTION
## Problème (#465)

À chaque ouverture de PR, le pipeline sonde l'existence des fichiers (`GET contents/<fichier>`) sur la branche fraîche : ces 404 sont **attendus** et jamais retentés (court-circuit au 1er essai) — mais `_execute_with_retry` affichait inconditionnellement « failed after {max_retries+1} attempts » en **error**. Run v3 : jusqu'à **17 lignes error mensongères par PR**, noyant les vraies pannes et trompant observateurs/alerting.

## Correctif

- **compteur réel** : « failed after {N} attempt(s) » avec le nombre de tentatives effectivement faites ;
- **404 non retenté → `debug`** (sondage d'existence attendu) ; toute autre issue (retries épuisés, 4xx/5xx réels) reste en `error` ;
- 3e piste de l'issue (court-circuiter les lookups `contents/<fichier>`) **écartée comme incorrecte** : sur une branche créée depuis main, les fichiers *modifiés* existent et leur `sha` est requis pour le PUT ; seuls les fichiers *nouveaux* font 404 — précisément le cas dé-bruité ici.

## Tests (nouveau `tests/test_clients_retry_logging.py`)

- 404 → `APIError` « after 1 attempt(s) », loggé en DEBUG ;
- 503 épuisé → « after 4 attempt(s) », en ERROR ;
- 422 (non retenté, non attendu) → « after 1 attempt(s) », en ERROR ;
- succès après aléa transitoire → aucun log final.

Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)