### PR TITLE
fix(pilot,executor): GC des workspaces persistant entre segments + GC des clones de revert (#466)

### DIFF
--- a/alembic/versions/0007_task_kept_workspace.py
+++ b/alembic/versions/0007_task_kept_workspace.py
@@ -1,0 +1,34 @@
+"""workspace d'échec conservé persisté sur tasks (GC inter-segments)
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2026-06-11
+
+Ajoute ``tasks.kept_workspace`` (#466) : le chemin du clone conservé après un
+échec terminal (#443) survit aux restarts de process — le succès/merge de la
+tâche peut alors le purger quel que soit le segment, et le balayage de
+démarrage supprime ceux des tâches désormais ``in_review``/``merged``/``done``.
+batch_alter_table pour rester portable SQLite/PostgreSQL.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0007"
+down_revision: Union[str, None] = "0006"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("tasks") as batch_op:
+        batch_op.add_column(sa.Column("kept_workspace", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("tasks") as batch_op:
+        batch_op.drop_column("kept_workspace")

--- a/collegue/executor/revert.py
+++ b/collegue/executor/revert.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
 import tempfile
 from dataclasses import dataclass
 from typing import Optional
@@ -112,11 +113,14 @@ def prepare_revert(
     if not os.path.isdir(os.path.join(source, ".git")):
         raise RevertError(f"repo_source n'est pas un dépôt git: {repo_source}")
 
+    owns_parent = dest_root is None
     parent = dest_root or tempfile.mkdtemp(prefix="collegue-revert-")
     os.makedirs(parent, exist_ok=True)
     dest = os.path.join(parent, "workspace")
     clone = runner.run_command([git_bin, "clone", "--quiet", source, dest], parent)
     if not clone.ok:
+        if owns_parent:  # #466 : un clone raté ne laisse pas de répertoire orphelin
+            shutil.rmtree(parent, ignore_errors=True)
         raise RevertError(f"git clone a échoué: {clone.stderr.strip() or clone.stdout.strip()}")
 
     # L'identité de commit est fournie par ``revert_commit`` (en ``-c``), pas besoin de
@@ -124,6 +128,8 @@ def prepare_revert(
     revert_branch = branch or f"{REVERT_BRANCH_PREFIX}{sha[:12]}"
     checkout = runner.run_command([git_bin, "checkout", "-q", "-b", revert_branch], dest)
     if not checkout.ok:
+        if owns_parent:
+            shutil.rmtree(parent, ignore_errors=True)
         raise RevertError(f"git checkout -b {revert_branch} a échoué: {checkout.stderr.strip()}")
 
     result = revert_commit(dest, sha, merge_parent=merge_parent, runner=runner, git_bin=git_bin)

--- a/collegue/executor/workspace.py
+++ b/collegue/executor/workspace.py
@@ -17,7 +17,9 @@ import logging
 import os
 import shutil
 import tempfile
+import time
 from dataclasses import dataclass
+from typing import Optional
 
 from collegue.executor.agent import IssueSpec
 from collegue.executor.command import LocalCommandRunner
@@ -109,8 +111,60 @@ def cleanup_workspace(workspace_or_path) -> None:
         return
     path = os.path.abspath(str(path))
     parent = os.path.dirname(path)
-    target = parent if os.path.basename(parent).startswith("collegue-exec-") else path
+    # #466 : les clones de revert (`collegue-revert-*/workspace`) suivent le même
+    # layout que les clones d'exécution — même purge du répertoire racine.
+    _OWN_PREFIXES = ("collegue-exec-", "collegue-revert-")
+    if os.path.basename(parent).startswith(_OWN_PREFIXES):
+        target = parent
+    else:
+        # Garde de confinement (#466) : des chemins issus de la PERSISTANCE
+        # (tasks.kept_workspace) arrivent désormais ici — une valeur corrompue
+        # (« / », « /home »…) deviendrait un rmtree récursif non borné sur un
+        # moteur autonome qui se relance seul. Hors préfixes connus, on ne
+        # supprime que STRICTEMENT sous le répertoire temporaire.
+        tmp_root = os.path.realpath(tempfile.gettempdir())
+        if not os.path.realpath(path).startswith(tmp_root + os.sep):
+            logger.warning("cleanup_workspace : chemin hors périmètre, suppression refusée : %s", path)
+            return
+        target = path
     shutil.rmtree(target, ignore_errors=True)
+
+
+def sweep_stale_temp_clones(
+    *,
+    prefixes: tuple = ("collegue-revert-",),
+    max_age_seconds: float = 7 * 24 * 3600,
+    tmp_dir: Optional[str] = None,
+) -> int:
+    """Supprime les clones temporaires ORPHELINS plus vieux que ``max_age_seconds`` (#466).
+
+    Les répertoires ``collegue-revert-*`` ne sont référencés nulle part (ni état,
+    ni audit) : sans balayage, ils s'accumulent sans borne sur un moteur qui
+    tourne des jours. Critère d'ancienneté (mtime) plutôt que d'inventaire — un
+    revert FRAIS (sa branche locale est le livrable pour le push humain/H3) n'est
+    jamais touché. Best-effort, ne lève jamais. Renvoie le nombre supprimé.
+    """
+    root = tmp_dir or tempfile.gettempdir()
+    removed = 0
+    try:
+        entries = os.listdir(root)
+    except OSError:
+        return 0
+    deadline = time.time() - float(max_age_seconds)
+    for entry in entries:
+        if not entry.startswith(tuple(prefixes)):
+            continue
+        candidate = os.path.join(root, entry)
+        try:
+            if os.path.islink(candidate):
+                continue  # rmtree refuse les symlinks — et on ne suit jamais un lien
+            if os.path.isdir(candidate) and os.path.getmtime(candidate) < deadline:
+                shutil.rmtree(candidate, ignore_errors=True)
+                if not os.path.exists(candidate):  # compteur honnête
+                    removed += 1
+        except OSError:
+            continue
+    return removed
 
 
 def apply_seed_diff(workspace: Workspace, diff: str, *, git_bin: str = "git") -> bool:

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -32,7 +32,7 @@ from typing import List, Optional, Tuple
 
 from collegue.executor.agent import IssueSpec
 from collegue.executor.pipeline import REASON_GATE_FAILED, execute_issue, failure_feedback, is_infra_noise, log_tail
-from collegue.executor.workspace import branch_for_issue, cleanup_workspace
+from collegue.executor.workspace import branch_for_issue, cleanup_workspace, sweep_stale_temp_clones
 from collegue.pilot.audit import (
     BUDGET_EVENT,
     CHECKPOINT_SAVED,
@@ -291,6 +291,11 @@ def reconcile_in_review_tasks(tasks, manager, clients, *, owner: str, repo: str,
 # rouge, on recommence à décompter (pas de boucle infinie sur PyPI down).
 MAX_INFRA_GATE_GRACE = 2
 
+# #466 : statuts pour lesquels un workspace d'échec conservé (#443) ne sert
+# plus (la tâche a abouti) — purgé au balayage de démarrage, quel que soit le
+# segment qui l'avait conservé.
+_KEPT_WORKSPACE_DONE_STATUSES = frozenset({"in_review", "merged", "done"})
+
 # #460 : marqueur du préfixe posé par requeue_task_for_redo dans best_feedback —
 # détecté pour ne jamais empiler deux motifs de redo (le précédent est consommé).
 _REQUEUE_FEEDBACK_MARKER = " (échecs connus de la meilleure tentative : "
@@ -498,6 +503,21 @@ async def run_project(
     # MAX_INFRA_GATE_GRACE — un timeout PyPI ne brûle plus une tentative saine.
     infra_gate_grace: dict = {}
 
+    # #466 : balayage de démarrage. (a) Les workspaces conservés PERSISTÉS des
+    # tâches désormais abouties — le dict en mémoire de #443 repartait vide à
+    # chaque restart, les clones des segments précédents re-fuyaient. (b) Les
+    # clones de revert orphelins trop vieux (rien ne les référence).
+    if cleanup_workspaces and not dry_run:
+        for t in tasks:
+            kept = getattr(t, "kept_workspace", None)
+            if kept and getattr(t, "status", None) in _KEPT_WORKSPACE_DONE_STATUSES:
+                cleanup_workspace(kept)
+                t.kept_workspace = None
+                manager.update_task(t.id, kept_workspace=None)
+        swept = sweep_stale_temp_clones()
+        if swept:
+            logger.info("balayage démarrage : %d clone(s) collegue-revert-* périmé(s) supprimé(s)", swept)
+
     while True:
         if len(processed) >= cap:
             stop_reason = STOP_SAFETY_CAP
@@ -644,14 +664,23 @@ async def run_project(
         if cleanup_workspaces:
             if outcome.success:
                 cleanup_workspace(outcome.workspace)
-                previous = kept_workspaces.pop(task.id, None)
+                # #466 : le chemin PERSISTÉ couvre les clones conservés par un
+                # segment précédent (le dict mémoire repartait vide au restart).
+                previous = kept_workspaces.pop(task.id, None) or getattr(task, "kept_workspace", None)
                 if previous:
                     cleanup_workspace(previous)
+                if getattr(task, "kept_workspace", None):
+                    task.kept_workspace = None
+                    if not dry_run:
+                        manager.update_task(task.id, kept_workspace=None)
             elif outcome.workspace is not None:
-                previous = kept_workspaces.get(task.id)
-                if previous:
+                previous = kept_workspaces.get(task.id) or getattr(task, "kept_workspace", None)
+                if previous and previous != outcome.workspace.path:
                     cleanup_workspace(previous)
                 kept_workspaces[task.id] = outcome.workspace.path
+                task.kept_workspace = outcome.workspace.path
+                if not dry_run:
+                    manager.update_task(task.id, kept_workspace=outcome.workspace.path)
 
         # Overlay en mémoire (+ persistance en réel). Succès → in_review (déjà
         # persisté par execute_issue). Échec : tant qu'il reste des tentatives

--- a/collegue/pilot/guard.py
+++ b/collegue/pilot/guard.py
@@ -23,6 +23,7 @@ from typing import Optional
 
 from collegue.executor.command import CommandRunner, LocalCommandRunner
 from collegue.executor.revert import RevertError, RevertResult, prepare_revert
+from collegue.executor.workspace import cleanup_workspace
 
 DEFAULT_HEALTH_COMMAND = "pytest -q"
 # Sorties signalant qu'AUCUN test n'a réellement tourné (exit 0 trompeur).
@@ -176,6 +177,12 @@ def guard_post_merge(
     reverted = bool(revert and revert.reverted)
     revert_failed = not reverted
     branch = getattr(revert, "branch", None)
+    if revert_failed and revert is not None and getattr(revert, "workspace", None):
+        # #466 : un revert en échec (abort, workspace laissé propre) n'a produit
+        # AUCUNE branche utile — son clone est purgé au lieu de fuir dans /tmp.
+        # Un revert RÉUSSI garde le sien : sa branche locale est le livrable
+        # (push humain / H3) ; le balayage d'ancienneté le ramassera au-delà.
+        cleanup_workspace(revert.workspace)
     if revert_failed:
         summary = f"ÉCHEC du revert de {merge_sha[:12]} — intervention humaine requise ({health.reason})"
         audit_kind = "auto_revert_failed"

--- a/collegue/state/models.py
+++ b/collegue/state/models.py
@@ -119,6 +119,9 @@ class Task(Base):
     best_passed: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     best_failed: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     best_feedback: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    # #466 : chemin du workspace d'échec CONSERVÉ pour debug (#443) — persisté
+    # pour que la purge au succès/merge fonctionne à travers les restarts.
+    kept_workspace: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         UTCDateTime, nullable=False, default=_utcnow, server_default=func.now()
     )

--- a/tests/test_executor_revert.py
+++ b/tests/test_executor_revert.py
@@ -102,3 +102,31 @@ def test_revert_pr_preview_is_pure():
     assert "§6" in out["body"]
     with pytest.raises(RevertError):
         revert_pr_preview("nope")
+
+
+# --- pas de clone orphelin quand prepare_revert échoue (#466) -----------------------
+
+
+def test_failed_clone_leaves_no_orphan_dir(tmp_path, monkeypatch):
+    import tempfile
+
+    from collegue.executor.revert import RevertError, prepare_revert
+
+    created = []
+    real_mkdtemp = tempfile.mkdtemp
+
+    def _tracking_mkdtemp(*a, **k):
+        path = real_mkdtemp(*a, **k)
+        created.append(path)
+        return path
+
+    import collegue.executor.revert as revert_mod
+
+    monkeypatch.setattr(revert_mod.tempfile, "mkdtemp", _tracking_mkdtemp)
+    with pytest.raises(RevertError):
+        prepare_revert(str(tmp_path / "pas-un-depot"), "a" * 40)
+    # RevertError AVANT mkdtemp (source invalide) ou APRÈS (clone raté) : dans
+    # les deux cas, aucun répertoire collegue-revert-* ne survit.
+    import os
+
+    assert all(not os.path.exists(p) for p in created)

--- a/tests/test_executor_workspace.py
+++ b/tests/test_executor_workspace.py
@@ -212,3 +212,85 @@ def test_cleanup_workspace_tolerates_missing_and_none():
     cleanup_workspace("/tmp/collegue-exec-inexistant/workspace")  # ne lève pas
     cleanup_workspace(None)
     cleanup_workspace("")
+
+
+# --- GC des clones temporaires (#466) -----------------------------------------------
+
+
+def test_cleanup_workspace_strips_revert_parent(tmp_path):
+    from collegue.executor.workspace import cleanup_workspace
+
+    parent = tmp_path / "collegue-revert-abc123"
+    ws = parent / "workspace"
+    ws.mkdir(parents=True)
+    cleanup_workspace(str(ws))
+    assert not parent.exists()  # le répertoire racine part avec
+
+
+def test_sweep_stale_temp_clones_age_based(tmp_path):
+    """#466 : seuls les répertoires PÉRIMÉS du préfixe sont supprimés — un revert
+    frais (sa branche locale est le livrable) et les autres préfixes survivent."""
+    import os
+    import time
+
+    from collegue.executor.workspace import sweep_stale_temp_clones
+
+    old_dir = tmp_path / "collegue-revert-old"
+    fresh_dir = tmp_path / "collegue-revert-fresh"
+    other = tmp_path / "collegue-exec-old"
+    for d in (old_dir, fresh_dir, other):
+        d.mkdir()
+    stale = time.time() - 8 * 24 * 3600
+    os.utime(old_dir, (stale, stale))
+    os.utime(other, (stale, stale))
+
+    removed = sweep_stale_temp_clones(tmp_dir=str(tmp_path))
+    assert removed == 1
+    assert not old_dir.exists()
+    assert fresh_dir.exists() and other.exists()
+
+
+def test_sweep_tolerates_missing_tmp_dir(tmp_path):
+    from collegue.executor.workspace import sweep_stale_temp_clones
+
+    assert sweep_stale_temp_clones(tmp_dir=str(tmp_path / "absent")) == 0
+
+
+def test_cleanup_workspace_refuses_paths_outside_perimeter(monkeypatch, tmp_path):
+    """#466 (revue) : un kept_workspace corrompu en base (« / », « /home »…) ne
+    doit JAMAIS devenir un rmtree récursif — hors préfixes collegue-*, seule une
+    cible strictement sous le tempdir est supprimée."""
+    import collegue.executor.workspace as ws_mod
+    from collegue.executor.workspace import cleanup_workspace
+
+    deleted = []
+    monkeypatch.setattr(ws_mod.shutil, "rmtree", lambda p, **k: deleted.append(p))
+
+    cleanup_workspace("/")
+    cleanup_workspace("/home/quelquun")
+    cleanup_workspace(str(tmp_path.parent.parent / "hors-tmp") if "/tmp" not in str(tmp_path) else "/opt/x")
+    assert deleted == []  # tout refusé
+
+    # Sous le tempdir sans préfixe connu : supprimé (comportement historique).
+    import tempfile
+
+    inside = tempfile.mkdtemp(prefix="autre-")
+    cleanup_workspace(inside)
+    assert deleted == [inside]
+
+
+def test_sweep_skips_symlinks_and_counts_honestly(tmp_path):
+    import os
+    import time
+
+    from collegue.executor.workspace import sweep_stale_temp_clones
+
+    target = tmp_path / "cible"
+    target.mkdir()
+    link = tmp_path / "collegue-revert-lien"
+    link.symlink_to(target)
+    stale = time.time() - 8 * 24 * 3600
+    os.utime(target, (stale, stale))
+
+    assert sweep_stale_temp_clones(tmp_dir=str(tmp_path)) == 0  # lien ignoré
+    assert link.exists() and target.exists()

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -433,6 +433,69 @@ async def test_retry_then_success_purges_kept_failure_workspace(repo, manager):
     assert all(not os.path.exists(p) for p in agent.paths)
 
 
+async def test_kept_workspace_path_is_persisted_and_cleared(repo, manager):
+    """#466 : le chemin du clone conservé est PERSISTÉ (tasks.kept_workspace) —
+    le dict mémoire de #443 repartait vide à chaque restart, les clones des
+    segments précédents re-fuyaient."""
+
+    async def _sleep(d):
+        pass
+
+    pid = _linear_project(manager, 1)
+    agent = _WorkspaceTrackingAgent()
+    await _run(
+        manager,
+        repo,
+        pid,
+        dry_run=False,
+        agent=agent,
+        sandbox=_Sandbox(ok=False),
+        max_task_attempts=1,
+        sleep_fn=_sleep,
+    )
+    t = manager.get_tasks(pid)[0]
+    assert t.status == "failed"
+    assert t.kept_workspace == agent.paths[-1]  # persisté
+    assert os.path.exists(t.kept_workspace)
+
+    # « Restart » : la tâche est re-filée et réussit → le clone du segment
+    # précédent est purgé via le chemin PERSISTÉ et la colonne remise à zéro.
+    manager.update_task(t.id, status="todo", attempt_count=0, last_error=None)
+    result = await _run(manager, repo, pid, dry_run=False, agent=_WorkspaceTrackingAgent(), sleep_fn=_sleep)
+    assert result.stop_reason == "completed"
+    t = manager.get_tasks(pid)[0]
+    assert t.status == "in_review"
+    assert t.kept_workspace is None
+    assert all(not os.path.exists(p) for p in agent.paths)
+
+
+async def test_startup_sweep_purges_kept_workspaces_of_done_tasks(repo, manager, tmp_path):
+    """#466 (cas réel v3) : la tâche 4 a réussi au segment 3 mais les clones des
+    segments 1-2 restaient sur disque — le balayage de démarrage les purge dès
+    que la tâche est in_review/merged/done."""
+    import shutil
+
+    async def _sleep(d):
+        pass
+
+    pid = _linear_project(manager, 2)
+    t0, t1 = manager.get_tasks(pid)
+    stale = tmp_path / "collegue-exec-stale" / "workspace"
+    stale.mkdir(parents=True)
+    manager.update_task(t0.id, status="merged", kept_workspace=str(stale))
+    # Tâche en échec TERMINAL : son clone de debug est CONSERVÉ par le balayage.
+    debug = tmp_path / "collegue-exec-debug" / "workspace"
+    debug.mkdir(parents=True)
+    manager.update_task(t1.id, status="failed", kept_workspace=str(debug))
+
+    await _run(manager, repo, pid, dry_run=False, agent=FakeCodeAgent(), sleep_fn=_sleep)
+    assert not stale.parent.exists()  # purgé (tâche aboutie)
+    assert debug.parent.exists()  # conservé (debug encore utile)
+    assert manager.get_tasks(pid)[0].kept_workspace is None
+    assert manager.get_tasks(pid)[1].kept_workspace == str(debug)
+    shutil.rmtree(debug.parent, ignore_errors=True)
+
+
 async def test_cleanup_workspaces_opt_out_keeps_everything(repo, manager):
     from collegue.executor import cleanup_workspace
 


### PR DESCRIPTION
## Problème (#466)

Le GC de #443 reposait sur un dict purement en mémoire : toute reprise de run repartait avec un dict vide — les clones d'échecs terminaux des segments précédents re-fuyaient (run v3 : la tâche 4 a réussi au segment 3, les 2 clones des segments 1-2 sont restés sur disque). Les répertoires `collegue-revert-*` n'étaient, eux, référencés **nulle part** : aucun GC, ni au succès ni au démarrage.

## Correctif

- **`tasks.kept_workspace`** (migration alembic 0007) : le chemin du clone conservé est persisté — le succès d'une tâche purge aussi le clone d'un segment précédent, et la colonne est remise à zéro ;
- **balayage de démarrage** : workspaces conservés des tâches désormais `in_review`/`merged`/`done` purgés (ceux des tâches `failed` restent pour le debug) + clones `collegue-revert-*` plus vieux que 7 jours supprimés (critère d'ancienneté : un revert frais garde sa branche locale — c'est le livrable du push humain/H3) ;
- `cleanup_workspace` reconnaît le préfixe `collegue-revert-*` (purge du répertoire racine, comme `collegue-exec-*`) ;
- `prepare_revert` ne laisse plus de répertoire orphelin quand le clone/checkout échoue (seulement quand il a créé le répertoire lui-même) ; un revert en **échec** (aucune branche utile) est purgé immédiatement par la garde ;
- **garde de confinement** (revue adversariale) : des chemins issus de la persistance arrivent désormais dans `cleanup_workspace` — une valeur corrompue (`/`, `/home`…) deviendrait un `rmtree` récursif non borné sur un moteur qui se relance seul. Hors préfixes `collegue-*`, seule une cible strictement sous le tempdir est supprimée ; le balayage ignore les symlinks et son compteur est honnête.

## Tests

- chemin persisté à l'échec, purgé (disque + colonne) au succès — y compris le clone d'un « segment précédent » ;
- balayage de démarrage : tâche `merged` purgée, tâche `failed` conservée ;
- `cleanup_workspace` : racine `collegue-revert-*` strippée ; `/`, `/home/...`, chemins hors tempdir **refusés** (rmtree espionné : zéro appel) ;
- sweep : seuls les répertoires périmés du préfixe partent, fraîcheur/autres préfixes/symlinks intacts, tempdir absent toléré ;
- `prepare_revert` en échec → aucun répertoire orphelin ;
- migration 0007 chaînée sur 0006, opt-out `cleanup_workspaces=False` sans écriture (test existant).

Revue adversariale pré-PR : 3 findings corrigés — dont le critique (`rmtree("/")` possible sur valeur DB corrompue, vérifié empiriquement en sandbox par le reviewer).

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)