### PR TITLE
fix(executor,pilot): grâce infra #461 réarmée — préfixes pytest alignés + cascade d'install réseau classée infra (#477)

### DIFF
--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -106,6 +106,43 @@ def is_infra_noise(feedback: str) -> bool:
     return any(signature in text for signature in _INFRA_NOISE_SIGNATURES)
 
 
+def is_infra_gate_failure(outcome: "ExecutionOutcome") -> bool:
+    """Vrai si un échec de gate est imputable à un aléa d'infrastructure (#477).
+
+    Deux chemins :
+
+    - le diagnostic court (:func:`failure_feedback`) porte une signature réseau
+      (cas nominal #459/#461 : traceback pip sans ligne pytest) ;
+    - l'installation des dépendances a échoué (``deps_install_failed``, #439)
+      **et** la sortie complète du gate contient une signature réseau. La
+      cascade « pip timeout → ModuleNotFoundError à la collecte » produit des
+      lignes ``ERROR `` d'apparence fonctionnelle qui désarmaient la grâce #461
+      alors que la cause première était un aléa PyPI/DNS (cas réel FacNor v4 :
+      échec terminal de la tâche 6 sur un pur ReadTimeoutError pip).
+
+    Un échec d'install SANS signature réseau (requirements invalide, paquet
+    inexistant) reste fonctionnel : c'est précisément ce que la passe #439
+    doit sanctionner. Et un gate rouge à tests VERTS (revue bloquante,
+    adéquation #437) n'est jamais gracié : le verdict est fonctionnel même si
+    l'install a connu un aléa réseau en chemin (les deux cas cibles — timeout
+    pip, cascade de collecte — ont toujours des tests rouges).
+    """
+    if outcome.reason != REASON_GATE_FAILED:
+        return False
+    report = outcome.quality_report
+    if report is not None and report.tests_passed:
+        # Gate rouge à tests VERTS (revue bloquante, adéquation #437,
+        # require_test_changes) : verdict fonctionnel — même si la queue de
+        # sortie charrie un aléa réseau d'install, il n'est pas la cause.
+        return False
+    if is_infra_noise(failure_feedback(outcome)):
+        return True
+    if report is not None and getattr(report, "deps_install_failed", False):
+        output = report.test_output or ""
+        return any(signature in output for signature in _INFRA_NOISE_SIGNATURES)
+    return False
+
+
 def failure_feedback(outcome: "ExecutionOutcome") -> str:
     """Synthèse **courte et actionnable** d'un échec, pour la tentative suivante (#424).
 
@@ -132,7 +169,12 @@ def failure_feedback(outcome: "ExecutionOutcome") -> str:
         return ("ADÉQUATION REFUSÉE — le diff ne réalise pas l'issue : " + justification)[:700]
     if outcome.quality_report is not None and outcome.quality_report.test_output:
         output = outcome.quality_report.test_output
-        fails = [line.strip() for line in output.splitlines() if line.strip().startswith(("FAILED", "ERROR"))]
+        # « FAILED  » / « ERROR  » avec espace : les formes du short summary
+        # pytest, alignées sur is_infra_noise (#477). Sans l'espace, la ligne
+        # pip « ERROR: Exception: » (deux-points) était relayée comme diagnostic
+        # « fonctionnel » — inactionnable — et le traceback réseau (ReadTimeout…)
+        # était jeté : la grâce #461 ne voyait jamais la signature infra.
+        fails = [line.strip() for line in output.splitlines() if line.strip().startswith(("FAILED ", "ERROR "))]
         if fails:
             return " ; ".join(fails[:6])[:700]
         return log_tail(output, 400)

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -31,7 +31,13 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
 from collegue.executor.agent import IssueSpec
-from collegue.executor.pipeline import REASON_GATE_FAILED, execute_issue, failure_feedback, is_infra_noise, log_tail
+from collegue.executor.pipeline import (
+    execute_issue,
+    failure_feedback,
+    is_infra_gate_failure,
+    is_infra_noise,
+    log_tail,
+)
 from collegue.executor.workspace import branch_for_issue, cleanup_workspace, sweep_stale_temp_clones
 from collegue.pilot.audit import (
     BUDGET_EVENT,
@@ -709,8 +715,10 @@ async def run_project(
             # produisaient le même gate_failed décompté du budget : chaque
             # micro-coupure réseau rapprochait une tâche SAINE de l'échec
             # terminal. Un gate rouge au diagnostic purement infra ne consomme
-            # pas de tentative fonctionnelle (grâce bornée par tâche).
-            infra_gate_failure = outcome.reason == REASON_GATE_FAILED and is_infra_noise(diagnostic)
+            # pas de tentative fonctionnelle (grâce bornée par tâche). La
+            # classification (#477) couvre aussi la cascade « install en échec
+            # réseau → ModuleNotFoundError de collecte » via deps_install_failed.
+            infra_gate_failure = is_infra_gate_failure(outcome)
             grace_used = int(infra_gate_grace.get(task.id, 0))
             graced = infra_gate_failure and grace_used < MAX_INFRA_GATE_GRACE
             if graced:
@@ -735,7 +743,11 @@ async def run_project(
             # de is_infra_noise et désarmerait la protection pour tout projet web
             # dont les échecs de tests mentionnent ConnectionError.
             previous_diag = previous_error.split(" — ", 1)[-1]
-            if diagnostic and is_infra_noise(diagnostic) and previous_error and not is_infra_noise(previous_diag):
+            # #477 : la cascade d'install graciée porte un diagnostic d'apparence
+            # fonctionnelle (ModuleNotFoundError fantôme) — la classification du
+            # GATE fait foi, pas la forme du texte : elle aussi préserve.
+            infra_diag = infra_gate_failure or is_infra_noise(diagnostic)
+            if diagnostic and infra_diag and previous_error and not is_infra_noise(previous_diag):
                 base = _INFRA_NOISE_SUFFIX_RE.sub("", previous_error)
                 last_error = f"{base} (+ aléa infra à la tentative {attempts} : [{outcome.stage}/{outcome.reason}])"
             task.last_error = last_error

--- a/tests/test_executor_pipeline.py
+++ b/tests/test_executor_pipeline.py
@@ -506,3 +506,116 @@ def test_is_infra_noise_never_flags_functional_diagnostics():
     # Kill du conteneur au timeout (#461) : la note sandbox est le seul indice
     # quand pip pend sans avoir imprimé de traceback réseau.
     assert is_infra_noise("Collecting fastapi\n[sandbox] délai dépassé après 120s")
+
+
+# --- classification infra d'un échec de gate (#477) ----------------------------------
+
+
+def _gate_outcome(output, *, deps_install_failed=False, reason="gate_failed", tests_passed=False):
+    from collegue.executor import AgentResult, QualityReport, Workspace
+    from collegue.executor.pipeline import ExecutionOutcome
+    from collegue.executor.runner import ExecutionResult
+
+    return ExecutionOutcome(
+        success=False,
+        stage="gate",
+        workspace=Workspace(path="/w", branch="b", base_commit="c"),
+        execution=ExecutionResult(
+            agent_result=AgentResult(success=True, logs="journal"),
+            changed=True,
+            diff="",
+            files_changed=("a.py",),
+            success=True,
+        ),
+        quality_report=QualityReport(
+            tests_passed=tests_passed,
+            test_exit_code=0 if tests_passed else 1,
+            test_output=output,
+            review_summary="",
+            review_findings=(),
+            review_blocking=tests_passed,  # gate rouge à tests verts = revue bloquante (#437)
+            passed=False,
+            deps_install_failed=deps_install_failed,
+        ),
+        reason=reason,
+    )
+
+
+# Sortie réelle du run FacNor v4 (12:17, tâche 6) : pip échoue sur un timeout
+# PyPI — la ligne « ERROR: Exception: » (deux-points) précède le traceback réseau.
+_PIP_TIMEOUT_OUTPUT = (
+    "Collecting fastapi\n"
+    "ERROR: Exception:\n"
+    "Traceback (most recent call last):\n"
+    '  File "/usr/local/lib/python3.12/site-packages/pip/_vendor/urllib3/response.py", line 438, in _error_catcher\n'
+    "    yield\n"
+    "pip._vendor.urllib3.exceptions.ReadTimeoutError: "
+    "HTTPSConnectionPool(host='pypi.org', port=443): Read timed out.\n"
+)
+
+
+def test_failure_feedback_ignores_pip_error_colon_lines():
+    """#477 : « ERROR: Exception: » (pip) n'est PAS un diagnostic pytest — le
+    feedback doit retomber sur la queue de sortie, qui PORTE la signature réseau,
+    pour que la grâce #461 puisse classer l'échec en aléa infra."""
+    from collegue.executor.pipeline import failure_feedback, is_infra_noise
+
+    outcome = _gate_outcome(_PIP_TIMEOUT_OUTPUT)
+    feedback = failure_feedback(outcome)
+    assert feedback != "ERROR: Exception:"
+    assert "ReadTimeoutError" in feedback
+    assert is_infra_noise(feedback)
+
+
+def test_is_infra_gate_failure_on_pip_timeout():
+    from collegue.executor.pipeline import is_infra_gate_failure
+
+    assert is_infra_gate_failure(_gate_outcome(_PIP_TIMEOUT_OUTPUT))
+    # Même sortie mais échec hors gate (run/no_op) : jamais gracié.
+    assert not is_infra_gate_failure(_gate_outcome(_PIP_TIMEOUT_OUTPUT, reason="no_op"))
+
+
+def test_is_infra_gate_failure_on_install_cascade():
+    """#477 : install en échec réseau (prelude #414 fail-open) → la collecte
+    cascade en « ERROR tests/… » d'apparence fonctionnelle. deps_install_failed
+    + signature réseau dans la sortie complète ⇒ aléa infra quand même."""
+    from collegue.executor.pipeline import failure_feedback, is_infra_gate_failure, is_infra_noise
+
+    cascade = (
+        "Temporary failure in name resolution\n"
+        "[gate] installation des dépendances en échec — tests lancés quand même (#414)\n"
+        "ERROR tests/test_auth.py - ModuleNotFoundError: No module named 'httpx'\n"
+    )
+    outcome = _gate_outcome(cascade, deps_install_failed=True)
+    # Le diagnostic court reste fonctionnel (lignes ERROR pytest)…
+    assert not is_infra_noise(failure_feedback(outcome))
+    # … mais la classification du gate, elle, voit la cause première réseau.
+    assert is_infra_gate_failure(outcome)
+
+
+def test_is_infra_gate_failure_keeps_functional_install_failures():
+    """Un échec d'install SANS signature réseau (requirements invalide) reste
+    fonctionnel : c'est le contrat que la passe #439 doit sanctionner."""
+    from collegue.executor.pipeline import is_infra_gate_failure
+
+    functional = (
+        "ERROR: No matching distribution found for paquet-inexistant==1.0\n"
+        "[gate] installation des dépendances en échec — tests lancés quand même (#414)\n"
+        "ERROR tests/test_auth.py - ModuleNotFoundError: No module named 'paquet_inexistant'\n"
+    )
+    assert not is_infra_gate_failure(_gate_outcome(functional, deps_install_failed=True))
+
+
+def test_is_infra_gate_failure_never_graces_green_tests():
+    """Garde (revue #477) : gate rouge pour revue bloquante / adéquation (#437)
+    avec tests VERTS — même si l'install a connu un aléa réseau en chemin (note
+    #414 + signature dans la sortie), le verdict est fonctionnel : pas de grâce."""
+    from collegue.executor.pipeline import is_infra_gate_failure
+
+    green_but_blocked = (
+        "Temporary failure in name resolution\n"
+        "[gate] installation des dépendances en échec — tests lancés quand même (#414)\n"
+        "12 passed in 1.02s\n"
+    )
+    outcome = _gate_outcome(green_but_blocked, deps_install_failed=True, tests_passed=True)
+    assert not is_infra_gate_failure(outcome)

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -1255,6 +1255,50 @@ async def test_functional_gate_failure_still_consumes_budget(repo, manager):
     assert t.attempt_count == 2  # aucun gracié
 
 
+class _InstallCascadeGateSandbox:
+    """Cascade #477 : install réseau en échec (note #414 fail-open) → la collecte
+    produit des « ERROR tests/… » d'apparence fonctionnelle — cause première infra."""
+
+    def run_tests(self, workspace, command="pytest -q"):
+        from collegue.executor.quality_gate import _INSTALL_FAILED_NOTE
+
+        return SandboxResult(
+            exit_code=1,
+            stdout=(
+                "Temporary failure in name resolution\n"
+                f"{_INSTALL_FAILED_NOTE}\n"
+                "ERROR tests/test_auth.py - ModuleNotFoundError: No module named 'httpx'\n"
+            ),
+            stderr="",
+        )
+
+
+async def test_install_cascade_network_failure_is_graced(repo, manager):
+    """#477 : la cascade « pip timeout → ModuleNotFoundError de collecte » est
+    classée aléa infra via deps_install_failed + signature réseau — graciée,
+    alors que son diagnostic court (lignes ERROR pytest) semble fonctionnel."""
+    from collegue.pilot.audit import RunAuditLog
+
+    async def _sleep(d):
+        pass
+
+    pid = _linear_project(manager, 1)
+    audit = RunAuditLog(pid)
+    await _run(
+        manager,
+        repo,
+        pid,
+        dry_run=False,
+        agent=FakeCodeAgent(),
+        sandbox=_InstallCascadeGateSandbox(),
+        max_task_attempts=1,
+        audit=audit,
+        sleep_fn=_sleep,
+    )
+    graced = [e for e in audit.events if e.kind in ("task_retry", "task_failed") and e.detail.get("infra_grace")]
+    assert len(graced) == 2  # MAX_INFRA_GATE_GRACE : la cascade est bien graciée
+
+
 async def test_infra_noise_does_not_clobber_actionable_feedback(repo, manager):
     """#459 : un timeout PyPI à la tentative 2 n'écrase pas le diagnostic
     actionnable de la tentative 1 — l'agent (tentative 3) et l'opérateur voient


### PR DESCRIPTION
## Problème (#477 — HAUTE)

La grâce infra #461 était **inerte** : 0 occurrence sur 24 échecs de gate du run FacNor v4, échec terminal de la tâche 6 sur un pur `ReadTimeoutError` pip décompté comme échec fonctionnel, `best_feedback` stocké « ERROR: Exception: » (ligne pip, inactionnable).

Double cause :
1. `failure_feedback` capturait les lignes par `startswith(("FAILED", "ERROR"))` **sans espace** : la ligne pip « ERROR: Exception: » (deux-points) était relayée comme diagnostic « pytest » et le traceback réseau jeté — `is_infra_noise` (qui filtre **avec** espace) ne voyait jamais la signature.
2. La cascade « install réseau en échec (prélude #414 fail-open) → `ModuleNotFoundError` de collecte » produit des lignes `ERROR tests/…` d'apparence fonctionnelle alors que `deps_install_failed` (#439) est vrai.

## Correctif

- **`failure_feedback`** : filtre aligné sur les formes du short summary pytest (`"FAILED "`/`"ERROR "` avec espace). Sortie pip pure → le feedback retombe sur la queue de sortie, qui porte la signature réseau → grâce #461 active.
- **Nouveau `is_infra_gate_failure(outcome)`** (pipeline.py) : un échec de gate est infra si le diagnostic court porte une signature réseau, OU si `deps_install_failed` est vrai **et** la sortie complète porte une signature réseau. Gardes : jamais hors `gate_failed`, et **jamais à tests verts** (revue bloquante / adéquation #437 — verdict fonctionnel même si un blip d'install traîne dans la sortie).
- **`driver`** : la grâce ET la préservation #459 du `last_error` s'appuient sur cette classification — une cascade graciée n'écrase plus un diagnostic actionnable avec un `ModuleNotFoundError` fantôme.

## Tests

- Sortie réelle du run (« ERROR: Exception: » + traceback `ReadTimeoutError`) → feedback porte `ReadTimeoutError`, `is_infra_noise(feedback)` vrai, `is_infra_gate_failure` vrai.
- Cascade d'install (note #414 + signature réseau + `ERROR tests/…`) → graciée de bout en bout (test driver, 2 événements `infra_grace` d'audit).
- Contre-épreuves : échec d'install **sans** signature réseau → fonctionnel (contrat #439 intact) ; gate rouge à tests **verts** + bruit réseau → jamais gracié ; échec fonctionnel classique → décompte normal (test existant conservé).
- Revue adversariale pré-PR : 2 défauts attrapés et corrigés (grâce possible sur verdict fonctionnel à tests verts ; écrasement #459 par le diagnostic fantôme de cascade).

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)