### PR TITLE
fix(executor): largeur pytest forcée (COLUMNS=220) + dé-troncature du short summary dans le feedback (#478)

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -94,7 +94,8 @@ class Settings(BaseSettings):
     # enchaîner npm install + build/type-check + tests front dans le même
     # conteneur, fail-closed comme pytest (l'image sandbox doit fournir npm).
     GATE_FRONTEND: bool = True
-    # Commande de tests du gate (vide → défaut `python -m pytest -q`).
+    # Commande de tests du gate (vide → défaut `COLUMNS=220 python -m pytest -q`).
+    # Une commande custom doit forcer elle-même sa largeur de summary (#478).
     GATE_TEST_COMMAND: str = ""
     # Installabilité (#439). REQUIRE_DEPS_INSTALL : l'échec d'installation des
     # deps déclarées rend le gate ROUGE (au lieu d'un signal toléré). CHECK_

--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -143,6 +143,37 @@ def is_infra_gate_failure(outcome: "ExecutionOutcome") -> bool:
     return False
 
 
+# #478 : marqueur de troncature du short summary pytest (ASCII « ... » — distinct
+# du « … » de log_tail, qui est un autre chemin).
+_PYTEST_TRUNCATION = "..."
+
+
+def _detruncate_summary_line(line: str, output: str) -> str:
+    """Restitue le diagnostic complet d'une ligne de short summary tronquée (#478).
+
+    En non-tty, pytest borne « FAILED nodeid - message » à COLUMNS (80 par
+    défaut) et tronque avec « ... » — le nom du paquet manquant disparaissait du
+    feedback (cas réel FacNor v4 : « requires the httpx pack... », 3 cycles
+    brûlés à deviner + requeues opérateur). Le message ENTIER vit dans les
+    lignes ``E   …`` du traceback de la même sortie : on l'y reprend (préfixe
+    tronqué → première ligne E qui le contient). Best-effort : sans
+    correspondance, la ligne tronquée est relayée telle quelle.
+    """
+    if not line.endswith(_PYTEST_TRUNCATION):
+        return line
+    head, sep, message = line.partition(" - ")
+    prefix = message[: -len(_PYTEST_TRUNCATION)].strip()
+    if not sep or not prefix:
+        return line
+    for raw in output.splitlines():
+        candidate = raw.strip()
+        if candidate.startswith("E ") and prefix in candidate:
+            # Borné : une ligne E géante ne doit pas manger le budget [:700]
+            # du feedback et masquer les autres lignes FAILED.
+            return f"{head} - {candidate[1:].strip()[:300]}"
+    return line
+
+
 def failure_feedback(outcome: "ExecutionOutcome") -> str:
     """Synthèse **courte et actionnable** d'un échec, pour la tentative suivante (#424).
 
@@ -176,7 +207,9 @@ def failure_feedback(outcome: "ExecutionOutcome") -> str:
         # était jeté : la grâce #461 ne voyait jamais la signature infra.
         fails = [line.strip() for line in output.splitlines() if line.strip().startswith(("FAILED ", "ERROR "))]
         if fails:
-            return " ; ".join(fails[:6])[:700]
+            # #478 : filet — le diagnostic complet est repris du traceback quand
+            # le short summary a été tronqué à la largeur du terminal.
+            return " ; ".join(_detruncate_summary_line(line, output) for line in fails[:6])[:700]
         return log_tail(output, 400)
     return log_tail(outcome.execution.agent_result.logs, 400)
 

--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -38,7 +38,13 @@ from collegue.textnorm import inline
 # d'un projet en layout `src/`/`app/` qui importent par package (`from app.x import …`,
 # `from src.x import …`) lèvent `ModuleNotFoundError` à la collecte → le gate échoue
 # à tort (tests verts vus comme rouges). Voir issue #413.
-DEFAULT_TEST_COMMAND = "python -m pytest -q"
+# #478 : en non-tty (conteneur), pytest borne son short summary à COLUMNS
+# (défaut 80) et tronque le diagnostic avec « ... » — le nom du paquet manquant
+# (httpx, python-multipart…) disparaissait du feedback de retry, brûlant des
+# cycles à deviner. Largeur large forcée sur TOUTES les invocations pytest du
+# gate (préfixe d'env sh — inerte pour pip/uvicorn).
+_PYTEST_WIDE_COLUMNS = "COLUMNS=220"
+DEFAULT_TEST_COMMAND = f"{_PYTEST_WIDE_COLUMNS} python -m pytest -q"
 # Note visible dans la sortie du gate quand l'installation des deps échoue (#414).
 _INSTALL_FAILED_NOTE = "[gate] installation des dépendances en échec — tests lancés quand même (#414)"
 
@@ -242,7 +248,7 @@ def installability_command(workspace: str) -> Optional[str]:
         f"python -m venv --clear {_GATE_VENV}"
         f" && {_GATE_VENV}/bin/python -m pip install {pip_flags} -r requirements.txt"
         f" && {_GATE_VENV}/bin/python -m pip install {pip_flags} pytest"
-        f" && {_GATE_VENV}/bin/python -m pytest --collect-only -q"
+        f" && {_PYTEST_WIDE_COLUMNS} {_GATE_VENV}/bin/python -m pytest --collect-only -q"
     )
 
 

--- a/tests/test_executor_pipeline.py
+++ b/tests/test_executor_pipeline.py
@@ -508,6 +508,58 @@ def test_is_infra_noise_never_flags_functional_diagnostics():
     assert is_infra_noise("Collecting fastapi\n[sandbox] délai dépassé après 120s")
 
 
+# --- dé-troncature du short summary pytest (#478) ------------------------------------
+
+
+def test_failure_feedback_detruncates_pytest_short_summary():
+    """#478 : pytest borne « FAILED nodeid - message » à COLUMNS (80 en non-tty)
+    et tronque avec « ... » au moment exact où il nommait le paquet manquant —
+    le message entier est repris des lignes ``E   …`` du traceback."""
+    from collegue.executor.pipeline import failure_feedback
+
+    output = (
+        "==== ERRORS ====\n"
+        "_ ERROR collecting tests/test_auth.py _\n"
+        'E   RuntimeError: Form data requires "python-multipart" to be installed. '
+        "You can install it with pip install python-multipart\n"
+        "==== short test summary info ====\n"
+        'ERROR tests/test_auth.py - RuntimeError: Form data requires "python-multipart...\n'
+    )
+    feedback = failure_feedback(_gate_outcome(output))
+    assert "pip install python-multipart" in feedback
+    assert not feedback.endswith("...")
+
+    # Cas réel httpx (run v4, 09:21) : « The starlette.testclient module requ… ».
+    output_httpx = (
+        "E   RuntimeError: The starlette.testclient module requires the httpx package to be installed.\n"
+        "==== short test summary info ====\n"
+        "FAILED tests/test_app.py::test_root - RuntimeError: The starlette.testclient module requ...\n"
+    )
+    assert "httpx" in failure_feedback(_gate_outcome(output_httpx))
+
+
+def test_detruncate_is_best_effort_and_bounded():
+    """Sans ligne E correspondante, la ligne tronquée est relayée telle quelle ;
+    une ligne E géante est bornée pour ne pas masquer les FAILED suivants."""
+    from collegue.executor.pipeline import _detruncate_summary_line
+
+    # Pas de traceback correspondant → inchangée.
+    line = "FAILED tests/test_x.py::t - RuntimeError: mystere..."
+    assert _detruncate_summary_line(line, "du bruit sans rapport") == line
+    # Ligne sans « - » (nodeid nu) → inchangée.
+    bare = "ERROR tests/test_auth.py..."
+    assert _detruncate_summary_line(bare, "E   peu importe") == bare
+    # Ligne non tronquée → inchangée (le filet ne réécrit jamais un diagnostic sain).
+    clean = "FAILED tests/test_x.py::t - assert 1 == 2"
+    assert _detruncate_summary_line(clean, "E   assert 1 == 2 long contexte") == clean
+    # Ligne E géante → reprise bornée à 300 caractères de message.
+    long_msg = "RuntimeError: contexte " + "x" * 500
+    out = f"E   {long_msg}\n"
+    detrunc = _detruncate_summary_line("FAILED tests/test_y.py::t - RuntimeError: contexte...", out)
+    assert detrunc.startswith("FAILED tests/test_y.py::t - RuntimeError: contexte")
+    assert len(detrunc) <= len("FAILED tests/test_y.py::t - ") + 300
+
+
 # --- classification infra d'un échec de gate (#477) ----------------------------------
 
 

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -80,7 +80,7 @@ async def test_default_test_command_invokes_pytest_as_module():
     await run_quality_gate("/ws", DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
     assert sandbox.calls, "le gate doit exécuter les tests"
     _ws, command = sandbox.calls[0]
-    assert command.startswith("python -m pytest"), f"commande de test inattendue: {command!r}"
+    assert command.startswith("COLUMNS=220 python -m pytest"), f"commande de test inattendue: {command!r}"
 
 
 # --- installation des deps du projet (#414) --------------------------------------
@@ -110,7 +110,7 @@ async def test_gate_no_install_when_no_deps_declared(tmp_path):
     sandbox = _green()
     await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
     _ws, command = sandbox.calls[0]
-    assert command == "python -m pytest -q"
+    assert command == "COLUMNS=220 python -m pytest -q"
 
 
 async def test_gate_install_failure_is_tolerated_in_command(tmp_path):
@@ -534,7 +534,7 @@ async def test_require_deps_install_makes_install_blocking(tmp_path):
     )
     _ws, command = sandbox.calls[0]
     assert "|| echo" not in command
-    assert ") && python -m pytest" in command
+    assert ") && COLUMNS=220 python -m pytest" in command
 
 
 def test_installability_command_has_network_retries(tmp_path):
@@ -547,6 +547,22 @@ def test_installability_command_has_network_retries(tmp_path):
     command = installability_command(str(tmp_path))
     assert command.count("--retries 5") == 2  # requirements + pytest
     assert command.count("--timeout 30") == 2
+
+
+async def test_gate_pytest_commands_force_wide_columns(tmp_path):
+    """#478 : en non-tty, pytest borne son short summary à COLUMNS (80 par
+    défaut) et tronquait le nom du paquet manquant du feedback — toutes les
+    invocations pytest du gate forcent une largeur large."""
+    from collegue.executor import installability_command
+
+    sandbox = _green()
+    await run_quality_gate("/ws", DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    _ws, command = sandbox.calls[0]
+    assert "COLUMNS=220 python -m pytest -q" in command
+
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    install = installability_command(str(tmp_path))
+    assert "COLUMNS=220 /tmp/.gate_venv/bin/python -m pytest --collect-only -q" in install
 
 
 def test_installability_command_requires_requirements(tmp_path):


### PR DESCRIPTION
## Problème (#478 — HAUTE)

En conteneur (non-tty), pytest borne son short summary à `COLUMNS` (défaut 80) et tronque avec « ... » — **au moment exact où il nommait le paquet manquant**. Cas réels du run v4 : « The starlette.testclient module requ… » (httpx coupé), « Form data requires "python-multipart… ». Conséquence : 3 cycles LLM brûlés à deviner + requeues opérateur dictant les noms de paquets — exactement ce que la boucle de feedback #424 devait éviter.

## Correctif

1. **`COLUMNS=220`** préfixé sur toutes les invocations pytest du gate : `DEFAULT_TEST_COMMAND` et le segment `--collect-only` d'installabilité (#439). Vérifié empiriquement à travers toutes les compositions du gate (prélude #414 `;`/`&&`, wrapper exit-5 #463 en sous-shell, passes frontend/smoke enchaînées après) — l'affectation ne touche que la commande simple pytest, inerte pour pip/npm/uvicorn.
2. **Filet `_detruncate_summary_line`** dans `failure_feedback` : une ligne `FAILED`/`ERROR` du summary qui se termine par « ... » est complétée depuis la ligne `E   …` du traceback qui porte le préfixe tronqué (best-effort ; borné à 300 chars par ligne, cap global [:700] conservé). Sans correspondance, la ligne est relayée telle quelle — le filet ne mutile jamais un diagnostic sain.
3. `GATE_TEST_COMMAND` custom : largeur à forcer soi-même (documenté en commentaire config) — l'auto-préfixe serait fragile sur les commandes composées.

## Tests

- Sorties pytest réelles du run (python-multipart, httpx) → le feedback contient le nom du paquet **en entier**.
- Best-effort : ligne tronquée sans ligne E correspondante / nodeid nu / diagnostic sain → relayés inchangés ; ligne E géante → bornée à 300.
- `run_quality_gate` et `installability_command` portent le préfixe (3 assertions existantes mises à jour — elles encodaient l'ancien défaut et deviennent les non-régressions).
- Interaction #477 vérifiée : les lignes dé-tronquées gardent leur tête `FAILED `/`ERROR ` → classification infra inchangée.
- Revue adversariale pré-PR : APPROUVÉ (vérifications empiriques dash/pytest 9, 176/176 tests verts).

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)