### PR TITLE
fix(executor): réensemencement best_diff en 3-way + restauration du clone sur conflit (#479)

### DIFF
--- a/collegue/executor/runner.py
+++ b/collegue/executor/runner.py
@@ -66,7 +66,9 @@ def run_issue(
     # ``--binary`` (#455) : sans lui, un diff touchant un binaire (png, woff2…)
     # n'embarque pas son payload → le réensemencement du retry (#436,
     # ``apply_seed_diff``) échoue précisément sur les tâches frontend.
-    diff_res = runner.run_command([git_bin, "diff", "--staged", "--binary"], workspace.path)
+    # ``--full-index`` (#479) : lignes index complètes — le 3-way du retry
+    # retrouve les blobs de base sans ambiguïté d'abréviation.
+    diff_res = runner.run_command([git_bin, "diff", "--staged", "--binary", "--full-index"], workspace.path)
     if not diff_res.ok:
         raise WorkspaceError(f"git diff a échoué: {diff_res.stderr.strip()}")
     names_res = runner.run_command([git_bin, "diff", "--staged", "--name-only"], workspace.path)

--- a/collegue/executor/workspace.py
+++ b/collegue/executor/workspace.py
@@ -170,11 +170,18 @@ def sweep_stale_temp_clones(
 def apply_seed_diff(workspace: Workspace, diff: str, *, git_bin: str = "git") -> bool:
     """Ré-applique le diff d'une tentative précédente sur un clone neuf (#436).
 
-    **Best-effort** : un diff qui ne s'applique plus (base déplacée entre deux
-    tentatives, diff corrompu) renvoie ``False`` — l'appelant continue sur le
-    clone vierge (mode historique) au lieu d'échouer. Le diff est appliqué SANS
-    commit : il apparaît comme modifications locales, donc dans le diff
-    autoritatif de la tentative (la PR portera l'état complet, seed + réparation).
+    **Best-effort** : un diff qui ne s'applique plus (conflit réel, diff
+    corrompu) renvoie ``False`` — l'appelant continue sur le clone vierge (mode
+    historique) au lieu d'échouer. Le diff est appliqué SANS commit : il
+    apparaît comme modifications locales, donc dans le diff autoritatif de la
+    tentative (la PR portera l'état complet, seed + réparation).
+
+    Application en **3-way** (#479) : le diff est capturé contre le main du
+    clone de SA tentative, et l'intégration sérielle (#434) fait avancer main
+    entre deux tentatives — l'application simple échouait dès que le contexte
+    avait bougé (« base déplacée », ×13 sur le run FacNor v4). Le clone étant
+    complet, les blobs de base sont présents ; s'ils manquent, git retombe de
+    lui-même sur l'application directe.
     """
     if not (diff or "").strip():
         return False
@@ -183,13 +190,19 @@ def apply_seed_diff(workspace: Workspace, diff: str, *, git_bin: str = "git") ->
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(diff if diff.endswith("\n") else diff + "\n")
-        result = runner.run_command([git_bin, "apply", "--whitespace=nowarn", patch_path], workspace.path)
+        result = runner.run_command([git_bin, "apply", "-3", "--whitespace=nowarn", patch_path], workspace.path)
         if not result.ok:
             logger.warning(
-                "seed_diff inapplicable sur %s (base déplacée ?) — la tentative repart du clone vierge : %s",
+                "seed_diff inapplicable sur %s (conflit réel avec le main avancé ?)"
+                " — la tentative repart du clone vierge : %s",
                 workspace.path,
                 (result.stderr or result.stdout or "").strip()[:300],
             )
+            # #479 : l'apply simple était atomique, pas le 3-way — un conflit
+            # laisse des marqueurs <<<<<<< et des ajouts indexés dans l'arbre.
+            # On restaure le clone vierge promis par le fallback (#436).
+            runner.run_command([git_bin, "reset", "--hard", "--quiet"], workspace.path)
+            runner.run_command([git_bin, "clean", "-fdq"], workspace.path)
         return bool(result.ok)
     finally:
         os.unlink(patch_path)

--- a/tests/test_executor_workspace.py
+++ b/tests/test_executor_workspace.py
@@ -294,3 +294,74 @@ def test_sweep_skips_symlinks_and_counts_honestly(tmp_path):
 
     assert sweep_stale_temp_clones(tmp_dir=str(tmp_path)) == 0  # lien ignoré
     assert link.exists() and target.exists()
+
+
+# --- apply_seed_diff : 3-way (#479) -----------------------------------------------
+
+
+def _capture_staged_diff(ws_path):
+    _git(ws_path, "add", "-A")
+    return _git_out(ws_path, "diff", "--staged", "--binary", "--full-index")
+
+
+def test_seed_diff_survives_main_advance(tmp_path):
+    """#479 : l'intégration sérielle (#434) fait avancer main entre deux
+    tentatives — le seed capturé contre l'ancien main doit encore s'appliquer
+    (3-way) au lieu de repartir du clone vierge (« base déplacée » ×13 en v4)."""
+    import pathlib
+
+    from collegue.executor.workspace import apply_seed_diff
+
+    src = _make_repo(tmp_path / "source", files={"app.py": "l1\nl2\nl3\nl4\nl5\n"})
+    ws1 = prepare_workspace(src, ISSUE)
+    pathlib.Path(ws1.path, "app.py").write_text("l1\nl2\nMODIF-AGENT\nl4\nl5\n")
+    seed = _capture_staged_diff(ws1.path)
+
+    # Merge sériel simulé : main avance (ligne ajoutée en tête, contexte déplacé).
+    src_path = pathlib.Path(src)
+    (src_path / "app.py").write_text("EN-TETE\nl1\nl2\nl3\nl4\nl5\n")
+    _git(src_path, "add", "-A")
+    _git(src_path, "commit", "-q", "-m", "merge sériel d'une PR sœur")
+
+    ws2 = prepare_workspace(src, ISSUE)
+    assert apply_seed_diff(ws2, seed) is True
+    content = pathlib.Path(ws2.path, "app.py").read_text()
+    assert "EN-TETE" in content and "MODIF-AGENT" in content
+
+
+def test_seed_diff_conflict_restores_pristine_clone(tmp_path):
+    """#479 : contrairement à l'apply simple (atomique), un 3-way en CONFLIT
+    laisse marqueurs et ajouts indexés — le fallback doit rendre le clone
+    vierge promis par #436, pas un arbre sale."""
+    import os
+    import pathlib
+
+    from collegue.executor.workspace import apply_seed_diff
+
+    src = _make_repo(tmp_path / "source", files={"app.py": "l1\nl2\nl3\nl4\nl5\n"})
+    ws1 = prepare_workspace(src, ISSUE)
+    pathlib.Path(ws1.path, "app.py").write_text("l1\nl2\nMODIF-AGENT\nl4\nl5\n")
+    pathlib.Path(ws1.path, "neuf.txt").write_text("nouveau fichier du seed\n")
+    seed = _capture_staged_diff(ws1.path)
+
+    # Réécriture CONCURRENTE de la même ligne sur main : conflit réel.
+    src_path = pathlib.Path(src)
+    (src_path / "app.py").write_text("l1\nl2\nREECRITURE-CONCURRENTE\nl4\nl5\n")
+    _git(src_path, "add", "-A")
+    _git(src_path, "commit", "-q", "-m", "réécriture concurrente")
+
+    ws2 = prepare_workspace(src, ISSUE)
+    assert apply_seed_diff(ws2, seed) is False
+    assert _git_out(ws2.path, "status", "--porcelain") == ""  # ni UU, ni A
+    assert "<<<<<<<" not in pathlib.Path(ws2.path, "app.py").read_text()
+    assert not os.path.exists(os.path.join(ws2.path, "neuf.txt"))
+
+
+def test_run_issue_diff_has_full_index(repo):
+    """#479 : la capture du diff autoritatif embarque les index complets —
+    le 3-way du retry retrouve les blobs de base sans ambiguïté."""
+    import re
+
+    ws = prepare_workspace(repo, ISSUE)
+    result = run_issue(FakeCodeAgent(), ws, ISSUE)
+    assert re.search(r"^index [0-9a-f]{40,}\.\.[0-9a-f]{40,}", result.diff, re.M)


### PR DESCRIPTION
## Problème (#479 — HAUTE)

La mémoire de code #436 (`best_diff` ré-appliqué au retry) a été **inopérante 13 fois** sur le run v4 : « seed_diff inapplicable … (base déplacée ?) ». Le diff est capturé contre le main du clone de **sa** tentative ; l'intégration sérielle (#434) fait avancer main à chaque merge de PR sœur → au retry, `git apply` simple échoue dès que le contexte a bougé. La convergence ne tenait que par `best_feedback` (texte).

## Correctif

1. **`git apply -3`** (3-way) dans `apply_seed_diff` : le clone est complet, les blobs de base sont toujours présents (l'ancienne base reste ancêtre du nouveau main en intégration sérielle). Blobs absents → git retombe de lui-même sur l'application directe → fallback clone vierge conservé en dernier recours.
2. **Restauration sur conflit** : contrairement à l'apply simple (atomique), un 3-way en conflit réel laisse l'arbre SALE (marqueurs `<<<<<<<`, ajouts indexés) — vérifié empiriquement. Sur échec : `git reset --hard` + `git clean -fdq` rendent le clone vierge promis par #436 (sans `-x` : les fichiers ignorés du projet ne sont pas touchés ; seul appelant = clone neuf).
3. **`--full-index`** sur la capture du diff autoritatif : lignes index complètes, le 3-way résout les blobs sans ambiguïté d'abréviation (les `best_diff` déjà persistés en index abrégés restent applicables — vérifié).

## Tests

- **Le test exigé par l'issue** : merge sériel simulé entre capture et réapplication → le seed s'applique encore (rouge avant le fix).
- Conflit réel (réécriture concurrente) → `False` + arbre **vierge** restauré (porcelain vide, pas de marqueurs, fichier neuf du seed supprimé) — verrouille la régression qu'un « -3 » naïf introduirait.
- Diff autoritatif porte des index ≥ 40 hex (rouge avant le fix).
- Non-régressions #436/#455 conservées : seed propre, diff corrompu → clone vierge, diff binaire réensemençable.
- Revue adversariale pré-PR : APPROUVÉ — vérifications empiriques git 2.53 (binaire+3-way, seed déjà mergé → no-op propre, héritage des index abrégés, chaîne run_issue post-seed indexé).

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)