### PR TITLE
fix(pilot): relecture de la base avant tout verdict terminal — un requeue externe ne tue plus le run (#480)

### DIFF
--- a/collegue/pilot/audit.py
+++ b/collegue/pilot/audit.py
@@ -28,6 +28,7 @@ TASK_STARTED = "task_started"
 TASK_RETRY = "task_retry"  # tâche re-filée `todo` après un échec retentable (#420)
 TASK_FAILED = "task_failed"  # échec TERMINAL d'une tâche, raison + extrait de logs (#421)
 TASK_RECONCILED = "task_reconciled"  # état réaligné sur la vérité GitHub de sa PR (#442)
+OVERLAY_REFRESHED = "overlay_refreshed"  # overlay réaligné sur la base avant verdict terminal (#480)
 DIFF_PRODUCED = "diff_produced"
 GATE_DECISION = "gate_decision"
 PR_OPENED = "pr_opened"

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -43,6 +43,7 @@ from collegue.pilot.audit import (
     BUDGET_EVENT,
     CHECKPOINT_SAVED,
     GATE_DECISION,
+    OVERLAY_REFRESHED,
     PR_OPENED,
     RUN_STOP,
     TASK_FAILED,
@@ -350,6 +351,56 @@ def requeue_task_for_redo(manager, task_id: int, *, message: str, attempt_count:
     return fields
 
 
+# #480 : champs réalignés depuis la base avant tout verdict terminal. Le statut
+# pilote l'ordonnancement ; les autres portent le feedback d'un requeue externe
+# (requeue_task_for_redo, #460) jusqu'au prompt de la tentative suivante.
+# `kept_workspace` est volontairement EXCLU : le dict mémoire du run courant
+# (#443) fait foi — un réalignement croisé pourrait re-pointer un chemin purgé.
+_OVERLAY_REFRESH_FIELDS = (
+    "status",
+    "attempt_count",
+    "last_error",
+    "best_diff",
+    "best_passed",
+    "best_failed",
+    "best_feedback",
+)
+
+
+def refresh_tasks_from_db(tasks, manager, project_id: int) -> int:
+    """Réaligne l'overlay mémoire sur l'état persisté (#480) ; retourne le nb réaligné.
+
+    L'overlay (objets détachés chargés une fois en tête de :func:`run_project`)
+    devient PÉRIMÉ quand l'état bouge HORS de la boucle — requeue opérateur
+    pendant le run (:func:`requeue_task_for_redo`, usage documenté #460) : la
+    mémoire voit ``failed`` là où la base dit ``todo`` → verdict ``blocked`` à
+    tort, la même seconde qu'une PR ouverte (run FacNor v4 : PR #108 abandonnée,
+    2 relances opérateur — sans humain, run mort à 1/10). Mutation EN PLACE des
+    objets : ``tasks_by_id``, ``pending_reviews`` et le contexte inter-tâches
+    (#412) référencent ces instances. Best-effort : base injoignable ≠ run mort
+    (l'overlay courant fait foi).
+    """
+    try:
+        fresh = {t.id: t for t in manager.get_tasks(project_id)}
+    except Exception as exc:  # noqa: BLE001 - best-effort, même convention que reconcile (#442)
+        logger.warning("relecture base avant verdict (#480) impossible : %s — overlay conservé", exc)
+        return 0
+    realigned = 0
+    for task in tasks:
+        db_task = fresh.get(task.id)
+        if db_task is None:
+            continue
+        changed = False
+        for key in _OVERLAY_REFRESH_FIELDS:
+            value = getattr(db_task, key, None)
+            if getattr(task, key, None) != value:
+                setattr(task, key, value)
+                changed = True
+        if changed:
+            realigned += 1
+    return realigned
+
+
 async def run_project(
     project_id: int,
     repo_source: str,
@@ -539,6 +590,17 @@ async def run_project(
 
         dep_satisfied = SATISFIED_STATUSES_STRICT if require_merged_deps else SATISFIED_STATUSES
         task = next_task(tasks, satisfied=dep_satisfied)
+        if task is None and not dry_run:
+            # #480 : avant TOUT verdict terminal, relire la base — un requeue
+            # externe (#460) a pu remettre des tâches `todo` que l'overlay voit
+            # encore `failed` ; conclure `blocked` sur la seule mémoire éteint
+            # le run (et abandonne les PR in_review validées) à tort. Jamais en
+            # dry_run : rien n'y est persisté, l'overlay est la SEULE vérité.
+            realigned = refresh_tasks_from_db(tasks, manager, project_id)
+            if realigned:
+                logger.info("verdict terminal : %d tâche(s) réalignée(s) depuis la base (#480)", realigned)
+                audit.record(OVERLAY_REFRESHED, iteration=iteration, realigned=realigned)
+                task = next_task(tasks, satisfied=dep_satisfied)
         if task is None:
             # Plus aucune tâche prête. En séquentiel, plus aucun reliquat
             # `in_progress` (remis à `todo` au démarrage) : s'il reste des tâches

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -1542,3 +1542,148 @@ async def test_empty_project_completes_without_switching(repo, manager):
     # Projet vide : pas de MVP construit → pas de bascule improving (anti-vacuité).
     assert result.project_status is None
     assert manager.get_project(pid).status != "improving"
+
+
+# --- relecture base avant verdict terminal (#480) ---------------------------------
+
+
+class _RequeueOnFailureAudit:
+    """Simule l'opérateur qui requeue (requeue_task_for_redo) PENDANT le run,
+    dès l'échec terminal d'une tâche — l'overlay devient périmé (#480). Hooké
+    sur l'événement d'audit TASK_FAILED, émis APRÈS la persistance du failed
+    (même fenêtre que l'incident réel du run v4)."""
+
+    def __init__(self, pid, mgr, message):
+        from collegue.pilot.audit import RunAuditLog
+
+        self._inner = RunAuditLog(pid)
+        self._mgr = mgr
+        self._message = message
+        self.events = self._inner.events
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+    def record(self, kind, *, iteration=None, **detail):
+        from collegue.pilot.driver import requeue_task_for_redo
+
+        event = self._inner.record(kind, iteration=iteration, **detail)
+        if kind == "task_failed":
+            requeue_task_for_redo(self._mgr, detail["task_id"], message=self._message)
+        return event
+
+
+class _FailFor:
+    """Échoue (process agent) pour certains titres, délègue à FakeCodeAgent sinon."""
+
+    def __init__(self, titles):
+        self._titles = set(titles)
+        self._ok = FakeCodeAgent()
+
+    def implement_issue(self, workspace, issue):
+        if issue.title in self._titles:
+            return AgentResult(success=False, logs="échec simulé (#480)")
+        return self._ok.implement_issue(workspace, issue)
+
+
+async def test_stale_overlay_with_requeued_todo_does_not_stop_blocked(repo, manager):
+    """#480 (l'incident du run v4) : tâche requeuée `todo` en base pendant le
+    run mais `failed` dans l'overlay + une PR in_review → le verdict terminal
+    doit relire la base : `awaiting_merge` (travail prêt + PR à merger), plus
+    jamais `blocked` la même seconde qu'une PR ouverte."""
+
+    async def _sleep(d):
+        pass
+
+    pid = _sibling_project(manager, 2)
+    audit = _RequeueOnFailureAudit(pid, manager, "indice opérateur : repars du dépôt à jour")
+    result = await _run(
+        manager,
+        repo,
+        pid,
+        dry_run=False,
+        agent=_FailFor({"S0"}),
+        require_merged_deps=True,
+        max_task_attempts=1,
+        audit=audit,
+        sleep_fn=_sleep,
+    )
+    assert result.stop_reason == "awaiting_merge"
+    statuses = {t.title: t.status for t in manager.get_tasks(pid)}
+    assert statuses == {"S0": "todo", "S1": "in_review"}
+    in_review = [t.id for t in manager.get_tasks(pid) if t.status == "in_review"]
+    assert result.pending_reviews == in_review  # la PR validée est SIGNALÉE au drain
+    assert any(e.kind == "overlay_refreshed" for e in audit.events)
+
+
+async def test_external_requeue_replayed_after_db_reread(repo, manager):
+    """#480 : le redo externe est rejoué dans le MÊME run, avec son feedback —
+    la relecture réaligne aussi attempt_count/last_error/best_feedback, pas
+    seulement le statut."""
+
+    async def _sleep(d):
+        pass
+
+    pid = _linear_project(manager, 1)
+    agent = _FlakyAgent(fail_times=1)
+    audit = _RequeueOnFailureAudit(pid, manager, "ta PR était en conflit, repars du dépôt à jour")
+    result = await _run(
+        manager,
+        repo,
+        pid,
+        dry_run=False,
+        agent=agent,
+        max_task_attempts=1,
+        audit=audit,
+        sleep_fn=_sleep,
+    )
+    assert result.stop_reason == "completed"
+    assert manager.get_tasks(pid)[0].status == "in_review"
+    assert "repars du dépôt à jour" in agent.contexts[1]
+
+
+def test_refresh_tasks_from_db_is_best_effort(manager):
+    from collegue.pilot.driver import refresh_tasks_from_db
+
+    pid = _linear_project(manager, 1)
+    tasks = manager.get_tasks(pid)
+
+    class _BrokenManager:
+        def get_tasks(self, pid):
+            raise RuntimeError("base injoignable")
+
+    # Base injoignable → 0, sans lever : l'overlay courant fait foi.
+    assert refresh_tasks_from_db(tasks, _BrokenManager(), pid) == 0
+
+    # Écriture externe → réalignement en place de l'objet existant.
+    manager.update_task(tasks[0].id, status="failed", last_error="x", best_feedback="indice")
+    assert refresh_tasks_from_db(tasks, manager, pid) == 1
+    assert tasks[0].status == "failed"
+    assert tasks[0].last_error == "x"
+    assert tasks[0].best_feedback == "indice"
+    # Idempotent : plus rien à réaligner.
+    assert refresh_tasks_from_db(tasks, manager, pid) == 0
+
+
+async def test_dry_run_never_rereads_db_before_verdict(repo, manager):
+    """#480 (garde vitale) : en dry_run rien n'est persisté — l'overlay est la
+    SEULE vérité. Une relecture écraserait la simulation (tout redeviendrait
+    `todo`) et la boucle tournerait jusqu'au safety_cap."""
+
+    class _CountingManager:
+        def __init__(self, inner):
+            self._inner = inner
+            self.get_tasks_calls = 0
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+        def get_tasks(self, pid):
+            self.get_tasks_calls += 1
+            return self._inner.get_tasks(pid)
+
+    pid = _linear_project(manager, 2)
+    counting = _CountingManager(manager)
+    result = await _run(counting, repo, pid, dry_run=True)
+    assert result.stop_reason == "completed"
+    assert counting.get_tasks_calls == 1  # le seul chargement initial


### PR DESCRIPTION
## Problème (#480 — HAUTE)

La boucle du pilote travaille sur un **overlay mémoire** des tâches (objets détachés, chargés une fois). Le requeue opérateur (`requeue_task_for_redo`, usage documenté #460) écrit en base **pendant** le run : l'overlay devient périmé. Incident du run v4 (10:08:46) : PR #108 ouverte puis stop `blocked` **la même seconde** — en base les tâches requeuées étaient déjà `todo`, l'overlay les voyait `failed` → `next_task` ne rend rien → verdict terminal sur la seule mémoire. 2 relances opérateur ; sans humain, run mort à 1/10.

## Correctif

1. **`refresh_tasks_from_db(tasks, manager, project_id)`** : réaligne EN PLACE (`tasks_by_id`, `pending_reviews` et le contexte inter-tâches #412 référencent ces instances) les champs `status`, `attempt_count`, `last_error`, `best_*` — le feedback du requeue atteint le prompt de la tentative rejouée. `kept_workspace` exclu (le dict mémoire #443 du run courant fait foi). Best-effort : base injoignable → overlay conservé, warning.
2. **Branchement** : quand `next_task` ne rend rien et `not dry_run`, relecture + re-tentative d'ordonnancement avant TOUT verdict (`completed`/`awaiting_merge`/`blocked`) — un faux `completed` (et la bascule `improving` #H5 à tort) est évité aussi. Événement d'audit `overlay_refreshed`.
3. **Garde dry_run** : jamais de relecture — rien n'y est persisté, une relecture écraserait la simulation (boucle jusqu'au safety_cap).
4. **Drain des in_review** : le merge reste humain (§6, automerge fail-closed) — le moteur signale via `pending_reviews` (déjà sur tous les stops) ; le harness opérateur draine désormais sur tous les stops terminaux (patch local hors repo).

Bornes vérifiées : requeues externes répétés → bornés par le safety_cap (chaque reprise consomme `processed`) ; réalignement `in_review`→`merged` pendant le run → libère le plafond #434 et débloque les dépendants stricts dans le même segment.

## Tests

- **L'incident reproduit** : requeue hooké sur l'événement `task_failed` (émis APRÈS la persistance du `failed` — la fenêtre exacte de l'incident) + PR sœur in_review → `awaiting_merge` (plus jamais `blocked`), PR signalée au drain, événement `overlay_refreshed` présent. Rouge avant le fix (`blocked`).
- Le redo externe est **rejoué dans le même run** avec son feedback dans le prompt (rouge avant le fix).
- Helper best-effort : base injoignable → 0 sans lever ; réalignement effectif puis idempotent.
- dry_run : exactement 1 lecture de base (le chargement initial) — propriété vitale verrouillée par deux asserts indépendants.
- Revue adversariale pré-PR : APPROUVÉ (140/140, contre-épreuve avec fix neutralisé : les tests redonnent le verdict mort du v4).

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)