### PR TITLE
feat(executor): remédiation déterministe des dépendances manquantes dans le gate (#481)

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -104,6 +104,9 @@ class Settings(BaseSettings):
     # paquets pré-installés de l'image sandbox (réseau PyPI requis).
     GATE_REQUIRE_DEPS_INSTALL: bool = False
     GATE_CHECK_INSTALLABILITY: bool = False
+    # #481 : remédiation déterministe des dépendances manquantes pendant le gate
+    # (table module→paquet + relance bornée, sans LLM). Défaut ON — opt-out.
+    GATE_FIX_REQUIREMENTS: bool = True
     # Adéquation diff↔issue (#437) : contrôle LLM fail-closed « ce diff
     # implémente-t-il l'issue ? » lancé quand le reste du gate est vert — une
     # « livraison fantôme » (feature fermée par +1 ligne de requirements) ne

--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -25,14 +25,14 @@ items du board) — délibérément hors périmètre ici.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Mapping, Optional
 
 from collegue.executor.agent import AgentResult, CodeAgent, IssueSpec
 from collegue.executor.command import CommandRunner
 from collegue.executor.pr import PrClients, PrResult, open_pr
 from collegue.executor.quality_gate import QualityReport, Reviewer, run_quality_gate
-from collegue.executor.runner import ExecutionResult, run_issue
+from collegue.executor.runner import ExecutionResult, capture_diff, run_issue
 from collegue.executor.workspace import Workspace, apply_seed_diff, prepare_workspace
 from collegue.sandbox.executor import TIMEOUT_NOTE
 
@@ -322,6 +322,17 @@ async def execute_issue(
             issue=issue,
             **dict(gate_options or {}),
         )
+        if getattr(report, "requirements_added", ()):
+            # #481 : le gate a amendé requirements.txt (remédiation déterministe)
+            # — recapturer le diff autoritatif, sinon la PR (open_pr pousse
+            # files_changed) et la mémoire de retry (#436, best_diff) partiraient
+            # SANS le correctif (récidive du bug livré). Stage borné à
+            # requirements.txt : le gate écrit des artefacts dans le workspace
+            # monté (node_modules, __pycache__, fichiers du smoke) qu'un add -A
+            # global embarquerait dans la PR. Une WorkspaceError ici est
+            # absorbée par la barrière #435 (engine_error, retentable).
+            diff, files_changed = capture_diff(workspace, runner=runner, paths=("requirements.txt",))
+            execution = replace(execution, diff=diff, files_changed=files_changed, changed=bool(files_changed))
         if not report.passed:
             return ExecutionOutcome(
                 success=False,

--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -26,6 +26,7 @@ import json
 import os
 import re
 import shlex
+import sys
 from dataclasses import dataclass
 from typing import Iterator, List, Optional, Protocol, Tuple, runtime_checkable
 
@@ -249,7 +250,131 @@ def installability_command(workspace: str) -> Optional[str]:
         f" && {_GATE_VENV}/bin/python -m pip install {pip_flags} -r requirements.txt"
         f" && {_GATE_VENV}/bin/python -m pip install {pip_flags} pytest"
         f" && {_PYTEST_WIDE_COLUMNS} {_GATE_VENV}/bin/python -m pytest --collect-only -q"
+        " --continue-on-collection-errors"
     )
+
+
+# #481 : module importé → paquet PyPI quand les noms divergent (cas connus du
+# run FacNor v4 + classiques). Heuristique sinon : nom-module ≈ nom-paquet.
+_MODULE_TO_PACKAGE = {
+    "jose": "python-jose[cryptography]",
+    "email_validator": "email-validator",
+    "multipart": "python-multipart",
+    "dotenv": "python-dotenv",
+    "jwt": "PyJWT",
+    "yaml": "PyYAML",
+    "PIL": "Pillow",
+    "bs4": "beautifulsoup4",
+    "dateutil": "python-dateutil",
+    "fitz": "PyMuPDF",
+}
+_MISSING_MODULE_RE = re.compile(r"ModuleNotFoundError: No module named '([A-Za-z0-9_.]+)'")
+_REQ_NAME_RE = re.compile(r"^\s*([A-Za-z0-9._-]+)")
+# FacNor v4 tâche 2 : 3 paquets découverts en série (chaîne d'imports — Python ne
+# révèle que le PREMIER module manquant d'un fichier, quel que soit le flag pytest).
+_MAX_REMEDIATION_ROUNDS = 3
+
+
+def _canonical(name: str) -> str:
+    """Nom de paquet normalisé PEP 503 (comparaisons requirements)."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def missing_modules(output: str) -> List[str]:
+    """Modules de premier niveau des ``ModuleNotFoundError`` (dédupliqués, ordre stable)."""
+    seen: List[str] = []
+    for match in _MISSING_MODULE_RE.finditer(output or ""):
+        module = match.group(1).split(".")[0]
+        if module and module not in seen:
+            seen.append(module)
+    return seen
+
+
+def requirement_for_module(module: str) -> str:
+    """Paquet PyPI proposé pour un module manquant (table, sinon heuristique _ → -)."""
+    return _MODULE_TO_PACKAGE.get(module, module.replace("_", "-"))
+
+
+def _is_local_module(workspace: str, module: str) -> bool:
+    """Vrai si ``module`` correspond à un fichier/répertoire du projet (#481).
+
+    Cherche ``mod``/``mod.py`` à la racine, sous ``src/`` ET sous chaque
+    sous-répertoire de premier niveau : un import plat intra-package
+    (``app/main.py`` qui fait ``import utils`` pour ``app/utils.py``) lève le
+    même ``ModuleNotFoundError`` qu'un paquet manquant — l'installer depuis
+    PyPI serait une dependency confusion (le gate pourrait même VERDIR sur la
+    sémantique d'un paquet homonyme étranger).
+    """
+    prefixes = ["", "src"]
+    try:
+        prefixes += [
+            entry
+            for entry in os.listdir(workspace)
+            if not entry.startswith(".") and entry != "node_modules" and os.path.isdir(os.path.join(workspace, entry))
+        ]
+    except OSError:
+        pass
+    return any(
+        os.path.exists(os.path.join(workspace, prefix, suffix))
+        for prefix in prefixes
+        for suffix in (module, f"{module}.py")
+    )
+
+
+def remediate_missing_requirements(workspace: str, output: str) -> Tuple[str, ...]:
+    """Ajoute à ``requirements.txt`` les paquets des modules manquants (#481).
+
+    Remédiation **déterministe, sans LLM** : « module X introuvable en venv nu »
+    se répare en ajoutant le paquet à ``requirements.txt`` — repasser par un
+    cycle génération + gate complet coûtait un cycle PAR paquet (77,6 % du
+    budget tokens du run v4 brûlé en tentatives échouées, majoritairement sur
+    cette classe). Garde-fous, tous INDISPENSABLES :
+
+    - ``requirements.txt`` doit exister (on ne crée pas le contrat d'install) ;
+    - module LOCAL du workspace (``mod/``, ``mod.py``, ``src/mod``) jamais
+      ajouté — un layout ``src/`` ferait installer un paquet PyPI homonyme du
+      projet (dependency confusion) ;
+    - module de la stdlib jamais ajouté ;
+    - paquet déjà déclaré (nom PEP 503, extras/pins ignorés) jamais dupliqué.
+
+    Retourne les paquets ajoutés (tuple vide si rien à faire).
+    """
+    req_path = os.path.join(workspace, "requirements.txt")
+    if not os.path.isfile(req_path):
+        return ()
+    modules = missing_modules(output)
+    if not modules:
+        return ()
+    try:
+        with open(req_path, encoding="utf-8") as handle:
+            existing_text = handle.read()
+    except (OSError, UnicodeDecodeError):
+        # Fichier illisible/non-UTF8 : pas de remédiation (et surtout pas de
+        # réécriture qui corromprait le fichier) — cycle LLM normal.
+        return ()
+    declared = set()
+    for line in existing_text.splitlines():
+        match = _REQ_NAME_RE.match(line)
+        if match:
+            declared.add(_canonical(match.group(1)))
+    stdlib = getattr(sys, "stdlib_module_names", frozenset())
+    additions: List[str] = []
+    for module in modules:
+        if module in stdlib:
+            continue
+        if _is_local_module(workspace, module):
+            continue  # module local du projet, pas un paquet PyPI
+        package = requirement_for_module(module)
+        if _canonical(_REQ_NAME_RE.match(package).group(1)) in declared:
+            continue  # déjà déclaré : manquant pour une AUTRE raison (pin cassé…)
+        additions.append(package)
+        declared.add(_canonical(_REQ_NAME_RE.match(package).group(1)))
+    if not additions:
+        return ()
+    body = existing_text if existing_text.endswith("\n") or not existing_text else existing_text + "\n"
+    with open(req_path, "w", encoding="utf-8") as handle:
+        handle.write(body + "\n".join(additions) + "\n")
+    return tuple(additions)
 
 
 # #463 : note visible quand « aucun test collecté » (pytest exit 5) est toléré.
@@ -452,6 +577,9 @@ class QualityReport:
     # True pour ne pas générer d'avertissement sur les rapports construits sans
     # cette information).
     tests_touched: bool = True
+    # #481 : paquets ajoutés à requirements.txt par la remédiation déterministe
+    # du gate (modules manquants) — visibles dans la PR et l'audit.
+    requirements_added: Tuple[str, ...] = ()
 
     def to_markdown(self) -> str:
         """Rapport Markdown pour le corps de PR (texte de revue fencé, anti-injection)."""
@@ -466,6 +594,11 @@ class QualityReport:
                 "> ⚠️ **installation des dépendances déclarées EN ÉCHEC** pendant le gate (#439) — "
                 "le vert peut venir des paquets pré-installés de l'image sandbox, pas du "
                 "`requirements.txt` du projet (installabilité non prouvée)."
+            )
+        if self.requirements_added:
+            lines.append(
+                "> 🔧 **dépendances manquantes ajoutées automatiquement** à `requirements.txt` (#481) : "
+                + ", ".join(f"`{p}`" for p in self.requirements_added)
             )
         lines += [
             "",
@@ -682,6 +815,7 @@ async def run_quality_gate(
     smoke_command: Optional[str] = None,
     smoke_paths: Tuple[str, ...] = ("/",),
     smoke_timeout: float = 30.0,
+    fix_missing_requirements: bool = True,
 ) -> QualityReport:
     """Exécute les tests (sandbox) + la revue (reviewer) sur un diff. Fail-closed.
 
@@ -721,6 +855,7 @@ async def run_quality_gate(
     # 1. Tests dans le sandbox. Une incapacité à les exécuter = non passé
     #    (fail-closed), pas une exception qui remonterait.
     deps_install_failed = False
+    requirements_added: List[str] = []
     try:
         command = test_command
         if install_deps:
@@ -763,6 +898,22 @@ async def run_quality_gate(
                 # lancée dans le même conteneur, après install des deps (#414).
                 command = f"({command}) && echo {shlex.quote(_SMOKE_BANNER)} && {smoke}"
         test_res = sandbox.run_tests(workspace, command)
+        if fix_missing_requirements:
+            # #481 : une ModuleNotFoundError en venv nu est un trou de
+            # requirements.txt, pas un problème de code — remédiation
+            # déterministe (table module→paquet) + relance de la MÊME commande,
+            # au lieu d'un cycle LLM complet PAR paquet. Borné : une chaîne
+            # d'imports ne révèle qu'un module manquant par passage.
+            for _ in range(_MAX_REMEDIATION_ROUNDS):
+                if test_res.ok:
+                    break
+                added = remediate_missing_requirements(
+                    workspace, "\n".join(part for part in (test_res.stdout, test_res.stderr) if part)
+                )
+                if not added:
+                    break
+                requirements_added.extend(added)
+                test_res = sandbox.run_tests(workspace, command)
         tests_passed = test_res.ok
         test_exit_code = test_res.exit_code
         test_output = "\n".join(part for part in (test_res.stdout, test_res.stderr) if part).strip()
@@ -820,6 +971,7 @@ async def run_quality_gate(
         adequacy_justification=adequacy_justification,
         adequacy_error=adequacy_error,
         tests_touched=touched,
+        requirements_added=tuple(requirements_added),
     )
 
 

--- a/collegue/executor/runner.py
+++ b/collegue/executor/runner.py
@@ -57,30 +57,57 @@ def run_issue(
 
     agent_result = agent.implement_issue(workspace.path, issue)
 
-    # Diff autoritatif : on stage tout (inclut les fichiers neufs/supprimés) puis on
-    # lit le diff vs HEAD. `git diff --staged` retourne 0 même quand il y a des
-    # changements ; un code non nul = vraie erreur de plomberie → on lève.
-    add = runner.run_command([git_bin, "add", "-A"], workspace.path)
+    diff, files_changed = capture_diff(workspace, runner=runner, git_bin=git_bin)
+    changed = bool(files_changed)
+    return ExecutionResult(
+        agent_result=agent_result,
+        changed=changed,
+        diff=diff,
+        files_changed=files_changed,
+        success=bool(agent_result.success and changed),
+    )
+
+
+def capture_diff(
+    workspace: Workspace,
+    *,
+    runner: Optional[CommandRunner] = None,
+    git_bin: str = "git",
+    paths: Optional[Tuple[str, ...]] = None,
+) -> Tuple[str, Tuple[str, ...]]:
+    """Diff autoritatif du workspace (``git add -A`` → ``diff --staged``) + fichiers touchés.
+
+    Factorisé (#481) : le pipeline recapture le diff quand le gate a amendé le
+    workspace (remédiation requirements) — sans recapture, la PR et la mémoire
+    de retry (#436) partiraient SANS le correctif.
+
+    ``paths`` (#481, revue) : borne le **stage** à ces chemins — le gate écrit
+    des artefacts dans le workspace monté (``__pycache__``, ``node_modules``,
+    fichiers du smoke run) : un ``add -A`` global post-gate les embarquerait
+    dans la PR et ferait sauter ``best_diff`` (> ``MAX_BEST_DIFF_CHARS``). Le
+    diff lu reste l'état STAGED complet (les changements de l'agent, déjà
+    stagés par :func:`run_issue`, en font partie).
+
+    On stage tout (inclut les fichiers neufs/supprimés) puis on lit le diff vs
+    HEAD. ``git diff --staged`` retourne 0 même quand il y a des changements ;
+    un code non nul = vraie erreur de plomberie → :class:`WorkspaceError`.
+    ``--binary`` (#455) : sans lui, un diff touchant un binaire (png, woff2…)
+    n'embarque pas son payload → le réensemencement du retry échoue précisément
+    sur les tâches frontend. ``--full-index`` (#479) : lignes index complètes —
+    le 3-way du retry retrouve les blobs de base sans ambiguïté d'abréviation.
+    """
+    runner = runner or LocalCommandRunner()
+    add_argv = [git_bin, "add", "-A"]
+    if paths:
+        add_argv += ["--", *paths]
+    add = runner.run_command(add_argv, workspace.path)
     if not add.ok:
         raise WorkspaceError(f"git add a échoué: {add.stderr.strip() or add.stdout.strip()}")
-    # ``--binary`` (#455) : sans lui, un diff touchant un binaire (png, woff2…)
-    # n'embarque pas son payload → le réensemencement du retry (#436,
-    # ``apply_seed_diff``) échoue précisément sur les tâches frontend.
-    # ``--full-index`` (#479) : lignes index complètes — le 3-way du retry
-    # retrouve les blobs de base sans ambiguïté d'abréviation.
     diff_res = runner.run_command([git_bin, "diff", "--staged", "--binary", "--full-index"], workspace.path)
     if not diff_res.ok:
         raise WorkspaceError(f"git diff a échoué: {diff_res.stderr.strip()}")
     names_res = runner.run_command([git_bin, "diff", "--staged", "--name-only"], workspace.path)
     if not names_res.ok:
         raise WorkspaceError(f"git diff --name-only a échoué: {names_res.stderr.strip()}")
-
     files_changed = tuple(line for line in names_res.stdout.splitlines() if line.strip())
-    changed = bool(files_changed)
-    return ExecutionResult(
-        agent_result=agent_result,
-        changed=changed,
-        diff=diff_res.stdout,
-        files_changed=files_changed,
-        success=bool(agent_result.success and changed),
-    )
+    return diff_res.stdout, files_changed

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -114,6 +114,10 @@ def _gate_options(settings_obj) -> dict:
         "check_installability": bool(getattr(settings_obj, "GATE_CHECK_INSTALLABILITY", False)),
         "require_test_changes": bool(getattr(settings_obj, "GATE_REQUIRE_TEST_CHANGES", False)),
     }
+    # #481 : remédiation requirements (défaut ON côté gate) — clé émise
+    # seulement en opt-out, pour ne pas grossir les options par défaut.
+    if not bool(getattr(settings_obj, "GATE_FIX_REQUIREMENTS", True)):
+        options["fix_missing_requirements"] = False
     test_command = getattr(settings_obj, "GATE_TEST_COMMAND", None)
     if test_command:
         options["test_command"] = str(test_command)

--- a/tests/test_executor_pipeline.py
+++ b/tests/test_executor_pipeline.py
@@ -671,3 +671,83 @@ def test_is_infra_gate_failure_never_graces_green_tests():
     )
     outcome = _gate_outcome(green_but_blocked, deps_install_failed=True, tests_passed=True)
     assert not is_infra_gate_failure(outcome)
+
+
+# --- remédiation requirements : recapture du diff (#481) -----------------------------
+
+
+class _SeqGateSandbox:
+    """Rouge (ModuleNotFoundError) puis vert — la remédiation du gate relance.
+
+    Écrit aussi un ARTEFACT dans le workspace monté (comme le ferait le
+    conteneur réel : __pycache__, node_modules, DB du smoke) — la recapture
+    post-remédiation ne doit PAS l'embarquer dans la PR (revue #481)."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self.calls = 0
+
+    def run_tests(self, workspace, command="pytest -q"):
+        self.calls += 1
+        import pathlib
+
+        artefacts = pathlib.Path(workspace, "node_modules")
+        artefacts.mkdir(exist_ok=True)
+        (artefacts / "artefact.js").write_text("// écrit par le conteneur du gate\n")
+        return self._results.pop(0) if len(self._results) > 1 else self._results[0]
+
+
+async def test_requirements_remediation_recaptures_diff_for_pr(repo):
+    """#481 : le gate a amendé requirements.txt — le diff autoritatif est
+    RECAPTURÉ, sinon la PR et la mémoire de retry (#436) partiraient sans le
+    correctif (récidive du bug livré)."""
+    red = SandboxResult(
+        exit_code=2,
+        stdout="E   ModuleNotFoundError: No module named 'httpx'\n",
+        stderr="",
+    )
+    green = SandboxResult(exit_code=0, stdout="2 passed", stderr="")
+    clients = _clients()
+    outcome = await execute_issue(
+        ISSUE,
+        repo,
+        ctx=None,
+        dry_run=False,
+        **_kwargs(
+            agent=FakeCodeAgent(files={"requirements.txt": "fastapi\n", "app.py": "import httpx\n"}),
+            sandbox=_SeqGateSandbox([red, green]),
+            clients=clients,
+        ),
+    )
+    assert outcome.success is True
+    assert outcome.quality_report.requirements_added == ("httpx",)
+    assert "+httpx" in outcome.execution.diff
+    assert "requirements.txt" in outcome.execution.files_changed
+    assert clients.prs.created  # la PR part AVEC le correctif
+    # Revue #481 : les artefacts écrits par le conteneur du gate restent hors PR.
+    assert not any("node_modules" in path for path in outcome.execution.files_changed)
+    assert "artefact.js" not in outcome.execution.diff
+
+
+async def test_remediation_failure_keeps_gate_red_and_diff_updated(repo):
+    """#481 : remédiation insuffisante (toujours rouge) → gate rouge fail-closed,
+    mais le diff recapturé porte l'ajout — cohérence de best_diff (#436)."""
+    red = SandboxResult(
+        exit_code=2,
+        stdout="E   ModuleNotFoundError: No module named 'httpx'\n",
+        stderr="",
+    )
+    outcome = await execute_issue(
+        ISSUE,
+        repo,
+        ctx=None,
+        dry_run=False,
+        **_kwargs(
+            agent=FakeCodeAgent(files={"requirements.txt": "fastapi\n", "app.py": "import httpx\n"}),
+            sandbox=_SeqGateSandbox([red]),
+        ),
+    )
+    assert outcome.success is False
+    assert outcome.reason == "gate_failed"
+    assert outcome.quality_report.requirements_added == ("httpx",)
+    assert "+httpx" in outcome.execution.diff

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -896,3 +896,220 @@ def test_reviewer_protocol_runtime_checkable():
     assert isinstance(FakeReviewer(), Reviewer)
     assert isinstance(ExpertReviewer(), Reviewer)
     assert not isinstance(object(), Reviewer)
+
+
+# --- remédiation déterministe des dépendances manquantes (#481) ---------------------
+
+
+class _SeqSandbox:
+    """Rend les résultats en séquence (le dernier se répète) — la remédiation
+    relance la même commande dans le même gate."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self.calls = []
+
+    def run_tests(self, workspace, command="pytest -q"):
+        self.calls.append((workspace, command))
+        return self._results.pop(0) if len(self._results) > 1 else self._results[0]
+
+
+def _missing(module):
+    return SandboxResult(
+        exit_code=2,
+        stdout=f"E   ModuleNotFoundError: No module named '{module}'\nERROR tests/test_x.py\n",
+        stderr="",
+    )
+
+
+def test_installability_command_continues_on_collection_errors(tmp_path):
+    """#481 : la collecte d'installabilité rapporte les erreurs de TOUS les
+    fichiers au lieu de s'interrompre (le flag ne couvre pas les chaînes
+    d'imports — c'est le rôle de la boucle de remédiation)."""
+    from collegue.executor import installability_command
+
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    assert "--continue-on-collection-errors" in installability_command(str(tmp_path))
+
+
+def test_missing_modules_parsed_and_deduplicated():
+    from collegue.executor.quality_gate import missing_modules
+
+    output = (
+        "E   ModuleNotFoundError: No module named 'httpx'\n"
+        "E   ModuleNotFoundError: No module named 'email_validator'\n"
+        "E   ModuleNotFoundError: No module named 'multipart'\n"
+        "E   ModuleNotFoundError: No module named 'httpx'\n"
+        "E   ModuleNotFoundError: No module named 'a.b'\n"
+    )
+    assert missing_modules(output) == ["httpx", "email_validator", "multipart", "a"]
+    assert missing_modules("") == []
+    assert missing_modules("FAILED tests/test_x.py - assert 1 == 2") == []
+
+
+def test_requirement_for_module_table_and_heuristic():
+    from collegue.executor.quality_gate import requirement_for_module
+
+    assert requirement_for_module("jose") == "python-jose[cryptography]"
+    assert requirement_for_module("email_validator") == "email-validator"
+    assert requirement_for_module("multipart") == "python-multipart"
+    assert requirement_for_module("httpx") == "httpx"
+    assert requirement_for_module("mon_module") == "mon-module"
+
+
+async def test_remediation_fixes_three_missing_packages_in_one_gate(tmp_path):
+    """LE test de l'issue #481 : 3 paquets manquants identifiés et réparés en UN
+    cycle (zéro LLM) — le run v4 brûlait un cycle LLM complet PAR paquet."""
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    red = SandboxResult(
+        exit_code=2,
+        stdout=(
+            "E   ModuleNotFoundError: No module named 'httpx'\n"
+            "E   ModuleNotFoundError: No module named 'email_validator'\n"
+            "E   ModuleNotFoundError: No module named 'multipart'\n"
+        ),
+        stderr="",
+    )
+    green = SandboxResult(exit_code=0, stdout="3 passed", stderr="")
+    sandbox = _SeqSandbox([red, green])
+    report = await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    assert report.passed is True
+    assert report.requirements_added == ("httpx", "email-validator", "python-multipart")
+    content = (tmp_path / "requirements.txt").read_text(encoding="utf-8")
+    assert all(pkg in content for pkg in ("fastapi", "httpx", "email-validator", "python-multipart"))
+    assert len(sandbox.calls) == 2  # un seul aller-retour de remédiation
+
+
+async def test_remediation_serial_import_chain_bounded(tmp_path):
+    """Cas FacNor exact : une chaîne d'imports ne révèle qu'un module manquant
+    par passage — la boucle bornée les égrène dans le même gate. Et un module
+    qui reste manquant après ajout (paquet cassé) ne boucle pas : fail-closed."""
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    green = SandboxResult(exit_code=0, stdout="3 passed", stderr="")
+    sandbox = _SeqSandbox([_missing("httpx"), _missing("email_validator"), _missing("multipart"), green])
+    report = await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    assert report.passed is True
+    assert report.requirements_added == ("httpx", "email-validator", "python-multipart")
+    assert len(sandbox.calls) == 4
+
+    # Toujours le même module manquant malgré l'ajout → un seul re-essai, gate
+    # rouge (le paquet ajouté reste visible dans le diff pour le cycle suivant).
+    (tmp_path / "requirements2").mkdir()
+    (tmp_path / "requirements2" / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    stuck = _SeqSandbox([_missing("httpx")])
+    report = await run_quality_gate(
+        str(tmp_path / "requirements2"), DIFF, ctx=None, sandbox=stuck, reviewer=FakeReviewer()
+    )
+    assert report.passed is False
+    assert report.requirements_added == ("httpx",)
+    assert len(stuck.calls) == 2
+
+
+async def test_remediation_skips_local_and_stdlib_modules(tmp_path):
+    """Garde-fous : un module LOCAL du projet (layout app/ ou src/) ou stdlib ne
+    devient jamais une dépendance PyPI (dependency confusion)."""
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    (tmp_path / "app").mkdir()
+    (tmp_path / "app" / "__init__.py").write_text("")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "pkg.py").write_text("")
+    red = SandboxResult(
+        exit_code=2,
+        stdout=(
+            "E   ModuleNotFoundError: No module named 'app'\n"
+            "E   ModuleNotFoundError: No module named 'pkg'\n"
+            "E   ModuleNotFoundError: No module named 'json'\n"
+        ),
+        stderr="",
+    )
+    sandbox = _SeqSandbox([red])
+    report = await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    assert report.requirements_added == ()
+    assert len(sandbox.calls) == 1
+    assert (tmp_path / "requirements.txt").read_text(encoding="utf-8") == "fastapi\n"
+
+
+async def test_remediation_skips_flat_import_inside_package(tmp_path):
+    """Revue #481 : ``app/main.py`` qui fait ``import utils`` pour ``app/utils.py``
+    lève le même ModuleNotFoundError qu'un paquet manquant — installer `utils`
+    depuis PyPI serait une dependency confusion (le gate pourrait même verdir
+    sur la sémantique d'un paquet étranger)."""
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    (tmp_path / "app").mkdir()
+    (tmp_path / "app" / "main.py").write_text("import utils\n")
+    (tmp_path / "app" / "utils.py").write_text("")
+    sandbox = _SeqSandbox([_missing("utils")])
+    report = await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    assert report.requirements_added == ()
+    assert len(sandbox.calls) == 1
+
+
+async def test_remediation_skips_unreadable_requirements(tmp_path):
+    """Revue #481 : un requirements.txt non-UTF8 n'est ni remédié ni corrompu —
+    et surtout ne détruit pas le diagnostic du gate (cycle LLM normal)."""
+    (tmp_path / "requirements.txt").write_bytes(b"# d\xe9pendances\nfastapi\n")  # latin-1
+    sandbox = _SeqSandbox([_missing("httpx")])
+    report = await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    assert report.requirements_added == ()
+    assert "ModuleNotFoundError" in report.test_output  # diagnostic réel préservé
+    assert (tmp_path / "requirements.txt").read_bytes() == b"# d\xe9pendances\nfastapi\n"
+
+
+async def test_remediation_requires_requirements_txt(tmp_path):
+    """Sans requirements.txt, la remédiation ne crée pas le contrat d'install."""
+    sandbox = _SeqSandbox([_missing("httpx")])
+    report = await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    assert report.requirements_added == ()
+    assert len(sandbox.calls) == 1
+
+
+async def test_remediation_never_duplicates_declared_package(tmp_path):
+    """Un paquet déjà déclaré (pin, extras) n'est jamais dupliqué — s'il manque
+    quand même, la cause est ailleurs (pin cassé) : cycle LLM normal."""
+    (tmp_path / "requirements.txt").write_text("httpx==0.27.0\npython-jose[cryptography]\n", encoding="utf-8")
+    red = SandboxResult(
+        exit_code=2,
+        stdout=("E   ModuleNotFoundError: No module named 'httpx'\nE   ModuleNotFoundError: No module named 'jose'\n"),
+        stderr="",
+    )
+    sandbox = _SeqSandbox([red])
+    report = await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    assert report.requirements_added == ()
+    assert len(sandbox.calls) == 1
+
+
+async def test_remediation_opt_out(tmp_path):
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    sandbox = _SeqSandbox([_missing("httpx")])
+    report = await run_quality_gate(
+        str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer(), fix_missing_requirements=False
+    )
+    assert report.requirements_added == ()
+    assert len(sandbox.calls) == 1
+    assert (tmp_path / "requirements.txt").read_text(encoding="utf-8") == "fastapi\n"
+
+
+def test_to_markdown_mentions_added_requirements():
+    report = QualityReport(
+        tests_passed=True,
+        test_exit_code=0,
+        test_output="ok",
+        review_summary="",
+        review_findings=(),
+        review_blocking=False,
+        passed=True,
+        requirements_added=("httpx", "python-multipart"),
+    )
+    markdown = report.to_markdown()
+    assert "ajoutées automatiquement" in markdown
+    assert "`httpx`" in markdown and "`python-multipart`" in markdown
+    report_clean = QualityReport(
+        tests_passed=True,
+        test_exit_code=0,
+        test_output="ok",
+        review_summary="",
+        review_findings=(),
+        review_blocking=False,
+        passed=True,
+    )
+    assert "ajoutées automatiquement" not in report_clean.to_markdown()

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -342,3 +342,16 @@ def test_importing_pilot_does_not_pull_openhands_runtime():
     import collegue.pilot  # noqa: F401
 
     assert not any(name == "openhands" or name.startswith("openhands.") for name in sys.modules)
+
+
+def test_gate_fix_requirements_opt_out_emitted_only_on_deviation():
+    """#481 : la remédiation requirements est ON par défaut côté gate — la clé
+    n'apparaît dans les options qu'en opt-out (les défauts restent inchangés,
+    cf. les assertions d'égalité stricte ci-dessus)."""
+    from types import SimpleNamespace
+
+    from collegue.pilot.runtime import _gate_options
+
+    assert "fix_missing_requirements" not in _gate_options(SimpleNamespace(GATE_TEST_COMMAND=""))
+    options = _gate_options(SimpleNamespace(GATE_FIX_REQUIREMENTS=False))
+    assert options["fix_missing_requirements"] is False


### PR DESCRIPTION
## Problème (#481 — MOYENNE)

La passe d'installabilité (#439) découvrait les dépendances manquantes **une par cycle LLM complet** (tâche 2 du run v4 : 3 cycles pour httpx → email-validator → python-multipart). Bilan : **77,6 % du budget tokens** consommé par des tentatives échouées, majoritairement sur cette classe d'échec mécanique.

## Correctif

1. **Boucle de remédiation déterministe** (bornée à 3 tours) dans `run_quality_gate` : sur `ModuleNotFoundError` en venv nu → mapper module→paquet (table des cas connus : `jose`→`python-jose[cryptography]`, `email_validator`→`email-validator`, `multipart`→`python-multipart`… + heuristique `_`→`-`) → ajouter à `requirements.txt` → **relancer la même commande**. Zéro LLM ; 3 tours couvrent le cas FacNor exact (une chaîne d'imports ne révèle qu'un module par passage — sémantique d'import Python, qu'aucun flag pytest ne change).
2. **Garde-fous indispensables** : modules **locaux** du projet exclus (racine, `src/` et sous-répertoires de 1er niveau — un `import utils` plat dans `app/` installerait le paquet PyPI `utils` : dependency confusion, le gate pourrait même verdir sur la sémantique d'un paquet étranger) ; stdlib exclue ; paquets déjà déclarés jamais dupliqués (PEP 503, extras/pins) ; fichier non-UTF8 → pas de remédiation, jamais corrompu.
3. **Recapture du diff autoritatif** quand le gate a amendé requirements.txt — sinon la PR et la mémoire de retry (#436, best_diff) partiraient **sans** le correctif. Stage **borné à requirements.txt** : le conteneur du gate écrit des artefacts dans le workspace monté (`node_modules`, `__pycache__`, fichiers du smoke) qu'un `add -A` global embarquerait dans la PR et qui feraient sauter best_diff (>200k chars).
4. `--continue-on-collection-errors` sur la collecte d'installabilité — honnêteté : le flag rapporte toutes les erreurs **par fichier** mais ne couvre pas les chaînes d'imports ; l'objectif « N paquets en un cycle » est atteint par la boucle.
5. `QualityReport.requirements_added` + bandeau 🔧 dans le corps de PR ; `GATE_FIX_REQUIREMENTS` (défaut ON, opt-out — clé runtime émise seulement en déviation).

## Tests (15 nouveaux)

- **Le test de l'issue** : 3 paquets manquants réparés en UN cycle (2 appels sandbox), et la chaîne d'imports série en 4 appels.
- Fail-closed : module toujours manquant après ajout → un seul re-essai, gate rouge ; verdict sur le DERNIER run (cohérent avec la grâce #477).
- Dependency confusion : layouts plat/src/app + `import utils` intra-package → jamais ajouté ; stdlib/locaux exclus ; pins/extras jamais dupliqués ; non-UTF8 intact.
- Recapture : la PR part AVEC `+httpx`, les artefacts du conteneur (node_modules simulé) restent HORS diff/PR ; gate rouge → diff recapturé quand même (best_diff #436 cohérent).
- Revue adversariale pré-PR : 3 défauts attrapés et corrigés (artefacts du gate dans la PR via add -A global — majeur ; UnicodeDecodeError destructrice du diagnostic ; import plat intra-package → dependency confusion prouvée avec le paquet PyPI `utils`).

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)