### PR TITLE
feat(executor,pilot): garde append-only sur requirements.txt — les lignes de la base ne se perdent plus en silence (#482)

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -107,6 +107,11 @@ class Settings(BaseSettings):
     # #481 : remédiation déterministe des dépendances manquantes pendant le gate
     # (table module→paquet + relance bornée, sans LLM). Défaut ON — opt-out.
     GATE_FIX_REQUIREMENTS: bool = True
+    # Garde append-only sur requirements.txt (#482) : des lignes présentes sur la
+    # base SUPPRIMÉES par le diff sans que l'issue nomme le paquet rendent le gate
+    # ROUGE (feedback nominatif). Analyse pure du diff, aucun coût d'infra ;
+    # off → suppression silencieuse tolérée (comportement historique).
+    GATE_REQUIREMENTS_APPEND_ONLY: bool = True
     # Adéquation diff↔issue (#437) : contrôle LLM fail-closed « ce diff
     # implémente-t-il l'issue ? » lancé quand le reste du gate est vert — une
     # « livraison fantôme » (feature fermée par +1 ligne de requirements) ne

--- a/collegue/executor/__init__.py
+++ b/collegue/executor/__init__.py
@@ -31,9 +31,11 @@ from collegue.executor.quality_gate import (
     installability_command,
     issue_expects_code,
     outcome_from_review,
+    removed_requirement_lines,
     run_quality_gate,
     smoke_run_command,
     tests_touched,
+    unjustified_requirement_removals,
 )
 from collegue.executor.revert import (
     RevertError,
@@ -78,6 +80,8 @@ __all__ = [
     "run_quality_gate",
     "frontend_gate_command",
     "installability_command",
+    "removed_requirement_lines",
+    "unjustified_requirement_removals",
     "smoke_run_command",
     "outcome_from_review",
     "AdequacyChecker",

--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -198,6 +198,16 @@ def failure_feedback(outcome: "ExecutionOutcome") -> str:
     if report is not None and getattr(report, "adequacy_implemented", None) is False:
         justification = getattr(report, "adequacy_justification", "") or "le diff n'implémente pas l'issue"
         return ("ADÉQUATION REFUSÉE — le diff ne réalise pas l'issue : " + justification)[:700]
+    removed = tuple(getattr(report, "requirements_removed", ()) or ()) if report is not None else ()
+    if removed:
+        # #482 : le motif utile est la liste NOMINATIVE des lignes perdues —
+        # c'est elle que la tentative suivante doit ré-ajouter telles quelles
+        # (la sortie des tests, souvent VERTE ici, serait un feedback trompeur).
+        return (
+            "REQUIREMENTS APPEND-ONLY (#482) — lignes de requirements.txt présentes sur la base et "
+            "SUPPRIMÉES par ton diff : " + " ; ".join(removed[:10]) + ". Ré-ajoute-les telles quelles "
+            "(n'en supprime aucune) et conserve le reste de ton travail."
+        )[:700]
     if outcome.quality_report is not None and outcome.quality_report.test_output:
         output = outcome.quality_report.test_output
         # « FAILED  » / « ERROR  » avec espace : les formes du short summary

--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -580,6 +580,9 @@ class QualityReport:
     # #481 : paquets ajoutés à requirements.txt par la remédiation déterministe
     # du gate (modules manquants) — visibles dans la PR et l'audit.
     requirements_added: Tuple[str, ...] = ()
+    # #482 : lignes de requirements.txt de la base supprimées sans que l'issue
+    # le demande — requirements.txt est append-only ; non vide ⇒ gate rouge.
+    requirements_removed: Tuple[str, ...] = ()
 
     def to_markdown(self) -> str:
         """Rapport Markdown pour le corps de PR (texte de revue fencé, anti-injection)."""
@@ -599,6 +602,12 @@ class QualityReport:
             lines.append(
                 "> 🔧 **dépendances manquantes ajoutées automatiquement** à `requirements.txt` (#481) : "
                 + ", ".join(f"`{p}`" for p in self.requirements_added)
+            )
+        if self.requirements_removed:
+            lines.append(
+                "> ⛔ **lignes de `requirements.txt` supprimées sans que l'issue le demande (#482)** — "
+                "`requirements.txt` est append-only. Lignes supprimées : "
+                + ", ".join(f"`{_fence_safe_line(line)}`" for line in self.requirements_removed)
             )
         lines += [
             "",
@@ -673,6 +682,111 @@ def issue_expects_code(issue: IssueSpec) -> bool:
 
 
 # Fichiers de test : tests/, __tests__/, test_x.py, x_test.go, x.test.ts, x.spec.ts…
+# --- garde append-only requirements.txt (#482) ---------------------------------
+# Nom de paquet en tête d'une ligne de requirements ; les lignes d'option
+# (-r/-e/--index-url), commentaires et vides n'ont pas de nom.
+_REQ_LINE_NAME_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)\s*(\[[^\]]+\])?")
+
+
+def _requirement_name(line: str) -> Optional[str]:
+    """Nom normalisé (PEP 503) d'une ligne de requirements, ``None`` si non-paquet."""
+    text = line.strip()
+    if not text or text.startswith(("#", "-")):
+        return None
+    match = _REQ_LINE_NAME_RE.match(text)
+    return _canonical(match.group(1)) if match else None
+
+
+def _requirement_key(line: str) -> Optional[str]:
+    """Clé d'identité d'une ligne de requirements pour la garde #482.
+
+    - paquet : nom PEP 503 **+ extras normalisés** — ``passlib[bcrypt]`` ≠
+      ``passlib`` : perdre un extra prive le venv nu de la dépendance réelle,
+      invisible à la collecte #439 (les backends lazy ne sont importés qu'à
+      l'exécution) ;
+    - ligne d'option (``-r base.txt``, ``--extra-index-url …``) : la ligne
+      normalisée — perdre un ``-r`` jette tout un fichier de dépendances ;
+    - commentaire/vide : ``None`` (pas une dépendance).
+    """
+    text = line.strip()
+    if not text or text.startswith("#"):
+        return None
+    if text.startswith("-"):
+        return " ".join(text.split())
+    match = _REQ_LINE_NAME_RE.match(text)
+    if not match:
+        return None
+    name = _canonical(match.group(1))
+    extras = match.group(2)
+    if extras:
+        items = sorted(item.strip().lower() for item in extras[1:-1].split(","))
+        return f"{name}[{','.join(items)}]"
+    return name
+
+
+def removed_requirement_lines(diff: str) -> Tuple[str, ...]:
+    """Lignes de ``requirements.txt`` de la BASE supprimées par le diff (#482).
+
+    Comparaison par NOM : un changement de pin ou un réordonnancement n'est pas
+    une suppression — seule une dépendance qui DISPARAÎT est retenue (cas réel
+    FacNor v4, tâche 5 : ``python-jose[cryptography]``/``passlib[bcrypt]``
+    perdus à la régénération → « No module named 'jose' » en venv nu, alors que
+    12 tests étaient verts).
+    """
+    removed: dict = {}  # nom → ligne d'origine
+    added: set = set()
+    in_requirements = False
+    for line in (diff or "").splitlines():
+        if line.startswith("diff --git "):
+            parts = line.split(" b/", 1)
+            path = parts[1].strip() if len(parts) == 2 else ""
+            in_requirements = os.path.basename(path) == "requirements.txt"
+            continue
+        if line.startswith(("--- ", "+++ ")) or not in_requirements:
+            continue
+        if line.startswith("-"):
+            key = _requirement_key(line[1:])
+            if key is not None:
+                removed.setdefault(key, line[1:].strip())
+        elif line.startswith("+"):
+            key = _requirement_key(line[1:])
+            if key is not None:
+                added.add(key)
+    return tuple(text for key, text in removed.items() if key not in added)
+
+
+def unjustified_requirement_removals(diff: str, issue: Optional[IssueSpec] = None) -> Tuple[str, ...]:
+    """Suppressions de requirements NON demandées par l'issue (#482).
+
+    Fail-closed : une suppression est « demandée » si le nom du paquet (ou le
+    fichier d'une ligne d'option) apparaît — en MOT ENTIER — dans le texte
+    OPÉRATEUR de l'issue (titre, corps, critères). ``issue.context`` est EXCLU :
+    machine-généré, il porte le feedback de la tentative précédente, qui NOMME
+    précisément les lignes perdues — l'y chercher désarmerait la garde dès la
+    tentative 2 (boomerang du feedback). Sans issue, toute suppression bloque.
+
+    Trou connu (documenté) : un RENOMMAGE du fichier (``requirements.txt`` →
+    autre nom) évade la garde — mais il évade aussi l'install sandbox et la
+    passe #439, donc le gate échoue ailleurs.
+    """
+    removed = removed_requirement_lines(diff)
+    if not removed or issue is None:
+        return removed
+    text = " ".join((issue.title or "", issue.body or "", *issue.acceptance_criteria))
+    normalized = re.sub(r"[-_.]+", "-", text.lower())
+    kept = []
+    for line in removed:
+        token = _requirement_name(line)
+        if token is None:
+            # Ligne d'option : le fichier/URL référencé (dernier mot) fait foi.
+            parts = line.split()
+            token = re.sub(r"[-_.]+", "-", parts[-1].lower()) if len(parts) > 1 else None
+        if token and re.search(rf"(?<![a-z0-9-]){re.escape(token)}(?![a-z0-9-])", normalized):
+            continue  # suppression demandée par l'issue
+        kept.append(line)
+    return tuple(kept)
+
+
 _TEST_PATH_RE = re.compile(r"(^|/)(tests?|__tests__)(/|$)|(^|/)test_[^/]+$|[^/]+[._]test\.[a-z]+$|[^/]+\.spec\.[a-z]+$")
 
 
@@ -816,6 +930,7 @@ async def run_quality_gate(
     smoke_paths: Tuple[str, ...] = ("/",),
     smoke_timeout: float = 30.0,
     fix_missing_requirements: bool = True,
+    requirements_guard: bool = True,
 ) -> QualityReport:
     """Exécute les tests (sandbox) + la revue (reviewer) sur un diff. Fail-closed.
 
@@ -851,6 +966,13 @@ async def run_quality_gate(
     """
     sandbox = sandbox or DockerSandbox()
     reviewer = reviewer or _default_reviewer()
+
+    # #482 : garde append-only sur requirements.txt — analyse PURE du diff,
+    # AVANT les passes d'infra. Les tests tournent quand même : la mémoire de
+    # retry (#436) garde son score, et le feedback nominatif part avec.
+    requirements_removed: Tuple[str, ...] = ()
+    if requirements_guard:
+        requirements_removed = unjustified_requirement_removals(diff, issue)
 
     # 1. Tests dans le sandbox. Une incapacité à les exécuter = non passé
     #    (fail-closed), pas une exception qui remonterait.
@@ -941,7 +1063,7 @@ async def run_quality_gate(
     # 3. Adéquation diff↔issue (#437) — lancée seulement si le reste est vert
     #    (économie d'appels LLM : un gate déjà rouge n'a pas besoin du verdict).
     #    Fail-closed : non conforme OU erreur du checker ⇒ non passé.
-    would_pass = bool(tests_passed and not review_blocking and review_error is None)
+    would_pass = bool(tests_passed and not review_blocking and review_error is None and not requirements_removed)
     adequacy_implemented: Optional[bool] = None
     adequacy_justification = ""
     adequacy_error: Optional[str] = None
@@ -972,6 +1094,7 @@ async def run_quality_gate(
         adequacy_error=adequacy_error,
         tests_touched=touched,
         requirements_added=tuple(requirements_added),
+        requirements_removed=requirements_removed,
     )
 
 

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -99,6 +99,15 @@ DEFAULT_MAX_INFLIGHT_REVIEWS = 1
 # Mémoire de la meilleure tentative (#436). Un diff tronqué ne s'appliquerait
 # plus (git apply échouerait) : au-delà de ce plafond, on ne mémorise pas.
 MAX_BEST_DIFF_CHARS = 200_000
+
+# #482 : consigne append-only sur requirements.txt, injectée dans tout prompt de
+# nouvelle tentative — en réparation, l'agent a déjà RÉGÉNÉRÉ le fichier au moins
+# une fois (cas réel v4 : lignes de main perdues → « No module named 'jose' » en
+# venv nu, 12 tests verts par ailleurs).
+REQUIREMENTS_APPEND_ONLY_RULE = (
+    "Règle stricte : requirements.txt est APPEND-ONLY — ne le régénère jamais, ne supprime "
+    "ni ne remplace AUCUNE ligne existante ; ajoute uniquement les dépendances manquantes."
+)
 _PASSED_RE = re.compile(r"(\d+) passed")
 _FAILED_RE = re.compile(r"(\d+) failed")
 
@@ -233,6 +242,9 @@ def _issue_from_task(task, by_id=None) -> IssueSpec:
             f"Détail de l'échec : {last_error}. "
             "Analyse et corrige d'abord cette cause précise au lieu de régénérer le même code."
         )
+    if best_diff or attempts > 0:
+        # #482 : prompts de réparation/retry seulement — le prompt initial reste inchangé.
+        parts.append(REQUIREMENTS_APPEND_ONLY_RULE)
     return IssueSpec(
         number=task.issue_number or task.id,
         title=task.title,

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -118,6 +118,9 @@ def _gate_options(settings_obj) -> dict:
     # seulement en opt-out, pour ne pas grossir les options par défaut.
     if not bool(getattr(settings_obj, "GATE_FIX_REQUIREMENTS", True)):
         options["fix_missing_requirements"] = False
+    # #482 : garde append-only requirements — même convention (défaut ON).
+    if not bool(getattr(settings_obj, "GATE_REQUIREMENTS_APPEND_ONLY", True)):
+        options["requirements_guard"] = False
     test_command = getattr(settings_obj, "GATE_TEST_COMMAND", None)
     if test_command:
         options["test_command"] = str(test_command)

--- a/tests/test_executor_pipeline.py
+++ b/tests/test_executor_pipeline.py
@@ -751,3 +751,71 @@ async def test_remediation_failure_keeps_gate_red_and_diff_updated(repo):
     assert outcome.reason == "gate_failed"
     assert outcome.quality_report.requirements_added == ("httpx",)
     assert "+httpx" in outcome.execution.diff
+
+
+# --- garde append-only requirements : feedback nominatif (#482) ----------------------
+
+
+def test_failure_feedback_names_removed_requirements():
+    """#482 : tests VERTS mais lignes de requirements perdues — le feedback est
+    la liste NOMINATIVE des lignes (la sortie verte serait un feedback trompeur)."""
+    from collegue.executor import AgentResult, QualityReport, Workspace
+    from collegue.executor.pipeline import ExecutionOutcome, failure_feedback
+    from collegue.executor.runner import ExecutionResult
+
+    outcome = ExecutionOutcome(
+        success=False,
+        stage="gate",
+        workspace=Workspace(path="/w", branch="b", base_commit="c"),
+        execution=ExecutionResult(
+            agent_result=AgentResult(success=True, logs="journal"),
+            changed=True,
+            diff="",
+            files_changed=("requirements.txt",),
+            success=True,
+        ),
+        quality_report=QualityReport(
+            tests_passed=True,
+            test_exit_code=0,
+            test_output="12 passed in 1.02s",
+            review_summary="",
+            review_findings=(),
+            review_blocking=False,
+            passed=False,
+            requirements_removed=("python-jose[cryptography]", "passlib[bcrypt]"),
+        ),
+        reason="gate_failed",
+    )
+    feedback = failure_feedback(outcome)
+    assert "APPEND-ONLY" in feedback
+    assert "python-jose[cryptography]" in feedback and "passlib[bcrypt]" in feedback
+    assert "12 passed" not in feedback
+    assert len(feedback) <= 700
+
+
+async def test_requirements_regeneration_stops_at_gate(repo):
+    """#482 bout en bout : l'agent régénère requirements.txt en perdant une ligne
+    de la base → gate rouge, aucune PR."""
+    import pathlib
+
+    src = pathlib.Path(repo)
+    (src / "requirements.txt").write_text("fastapi\npython-jose[cryptography]\n")
+    _git(src, "add", "-A")
+    _git(src, "commit", "-q", "-m", "deps de base")
+
+    clients = _clients()
+    outcome = await execute_issue(
+        ISSUE,
+        repo,
+        ctx=None,
+        dry_run=False,
+        **_kwargs(
+            agent=FakeCodeAgent(files={"requirements.txt": "fastapi\nhttpx\n"}),
+            clients=clients,
+        ),
+    )
+    assert outcome.success is False
+    assert outcome.stage == "gate"
+    assert outcome.reason == "gate_failed"
+    assert outcome.quality_report.requirements_removed == ("python-jose[cryptography]",)
+    assert clients.prs.created == []

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -1113,3 +1113,202 @@ def test_to_markdown_mentions_added_requirements():
         passed=True,
     )
     assert "ajoutées automatiquement" not in report_clean.to_markdown()
+
+
+# --- garde append-only requirements.txt (#482) --------------------------------------
+
+
+REQ_REMOVAL_DIFF = (
+    "diff --git a/requirements.txt b/requirements.txt\n"
+    "--- a/requirements.txt\n"
+    "+++ b/requirements.txt\n"
+    "@@ -1,4 +1,2 @@\n"
+    " fastapi\n"
+    "-python-jose[cryptography]\n"
+    "-passlib[bcrypt]\n"
+    "+httpx\n"
+)
+
+
+def test_removed_requirement_lines_net_removals():
+    """#482 : seules les dépendances qui DISPARAISSENT comptent — pin changé,
+    réordonnancement, commentaires, options et autres fichiers sont ignorés."""
+    from collegue.executor import removed_requirement_lines
+
+    assert removed_requirement_lines(REQ_REMOVAL_DIFF) == ("python-jose[cryptography]", "passlib[bcrypt]")
+    # Changement de pin : le NOM survit → pas une suppression.
+    pin = (
+        "diff --git a/requirements.txt b/requirements.txt\n"
+        "--- a/requirements.txt\n+++ b/requirements.txt\n"
+        "-fastapi==0.100\n+fastapi==0.110\n"
+    )
+    assert removed_requirement_lines(pin) == ()
+    # Commentaires et lignes vides n'ont pas de nom.
+    noise = (
+        "diff --git a/requirements.txt b/requirements.txt\n"
+        "--- a/requirements.txt\n+++ b/requirements.txt\n"
+        "-# anciennes deps\n-\n"
+    )
+    assert removed_requirement_lines(noise) == ()
+    # Un fichier python qui perd un import n'est PAS requirements.txt.
+    code = "diff --git a/app/x.py b/app/x.py\n--- a/app/x.py\n+++ b/app/x.py\n-import jose\n"
+    assert removed_requirement_lines(code) == ()
+    assert removed_requirement_lines("") == ()
+    # Monorepo (#457) : backend/requirements.txt compte aussi (basename).
+    nested = (
+        "diff --git a/backend/requirements.txt b/backend/requirements.txt\n"
+        "--- a/backend/requirements.txt\n+++ b/backend/requirements.txt\n"
+        "-python-jose[cryptography]\n"
+    )
+    assert removed_requirement_lines(nested) == ("python-jose[cryptography]",)
+
+
+async def test_requirements_removal_blocks_gate_with_named_lines():
+    """#482 (le symptôme exact) : 12 tests verts n'achètent plus le gate quand
+    des lignes de requirements de la base ont été perdues — gate rouge avec les
+    lignes NOMMÉES dans le rapport."""
+    report = await run_quality_gate(
+        "/ws", REQ_REMOVAL_DIFF, ctx=None, sandbox=_green(), reviewer=FakeReviewer(), issue=ISSUE
+    )
+    assert report.tests_passed is True
+    assert report.passed is False
+    assert report.requirements_removed == ("python-jose[cryptography]", "passlib[bcrypt]")
+    markdown = report.to_markdown()
+    assert "append-only" in markdown
+    assert "python-jose[cryptography]" in markdown
+
+
+async def test_requirements_removal_allowed_when_issue_names_package():
+    """« Sans que l'issue le demande » : si l'issue nomme le paquet, la
+    suppression est légitime."""
+    issue = IssueSpec(number=7, title="Retirer les dépendances python-jose et passlib devenues inutiles")
+    report = await run_quality_gate(
+        "/ws", REQ_REMOVAL_DIFF, ctx=None, sandbox=_green(), reviewer=FakeReviewer(), issue=issue
+    )
+    assert report.requirements_removed == ()
+    assert report.passed is True
+
+
+async def test_requirements_guard_opt_out():
+    report = await run_quality_gate(
+        "/ws",
+        REQ_REMOVAL_DIFF,
+        ctx=None,
+        sandbox=_green(),
+        reviewer=FakeReviewer(),
+        issue=ISSUE,
+        requirements_guard=False,
+    )
+    assert report.requirements_removed == ()
+    assert report.passed is True
+
+
+async def test_requirements_removal_skips_adequacy_call():
+    """Économie LLM : la garde rouge saute l'appel d'adéquation (#437), comme
+    tout gate déjà rouge."""
+
+    class _CountingChecker:
+        def __init__(self):
+            self.calls = 0
+
+        async def check(self, diff, issue, ctx):
+            self.calls += 1
+            raise AssertionError("ne doit pas être appelé")
+
+    checker = _CountingChecker()
+    report = await run_quality_gate(
+        "/ws",
+        REQ_REMOVAL_DIFF,
+        ctx=None,
+        sandbox=_green(),
+        reviewer=FakeReviewer(),
+        issue=ISSUE,
+        adequacy_checker=checker,
+    )
+    assert report.passed is False
+    assert checker.calls == 0
+
+
+def test_removed_requirement_lines_flags_extras_downgrade():
+    """Revue #482 : perdre un extra (`passlib[bcrypt]` → `passlib`) prive le venv
+    nu de la dépendance réelle — invisible à la collecte #439 (backends lazy) :
+    c'est une suppression."""
+    from collegue.executor import removed_requirement_lines
+
+    downgrade = (
+        "diff --git a/requirements.txt b/requirements.txt\n"
+        "--- a/requirements.txt\n+++ b/requirements.txt\n"
+        "-passlib[bcrypt]\n+passlib\n"
+    )
+    assert removed_requirement_lines(downgrade) == ("passlib[bcrypt]",)
+    # Pin changé, extras conservés → pas une suppression.
+    pin = (
+        "diff --git a/requirements.txt b/requirements.txt\n"
+        "--- a/requirements.txt\n+++ b/requirements.txt\n"
+        "-passlib[bcrypt]==1.7.4\n+passlib[bcrypt]==1.7.5\n"
+    )
+    assert removed_requirement_lines(pin) == ()
+
+
+def test_removed_requirement_lines_flags_option_lines():
+    """Revue #482 : perdre `-r base.txt` jette tout un fichier de dépendances —
+    les lignes d'option comptent ; l'issue peut les justifier en nommant le
+    fichier."""
+    from collegue.executor import removed_requirement_lines, unjustified_requirement_removals
+
+    option = (
+        "diff --git a/requirements.txt b/requirements.txt\n"
+        "--- a/requirements.txt\n+++ b/requirements.txt\n"
+        "--r base.txt\n+httpx\n"
+    )
+    assert removed_requirement_lines(option) == ("-r base.txt",)
+    issue = IssueSpec(number=7, title="Fusionner base.txt dans requirements.txt")
+    assert unjustified_requirement_removals(option, issue) == ()
+
+
+async def test_requirements_removal_not_justified_by_machine_context():
+    """Revue #482 (boomerang) : le feedback nominatif de la tentative 1 revient
+    dans issue.context à la tentative 2 — il ne doit JAMAIS « justifier » la
+    suppression, sinon la garde se désarme avec ses propres mots."""
+    issue = IssueSpec(
+        number=7,
+        title="Auth JWT",
+        context=(
+            "ATTENTION : ta tentative précédente a ÉCHOUÉ. REQUIREMENTS APPEND-ONLY (#482) — "
+            "lignes supprimées : python-jose[cryptography] ; passlib[bcrypt]. Ré-ajoute-les."
+        ),
+    )
+    report = await run_quality_gate(
+        "/ws", REQ_REMOVAL_DIFF, ctx=None, sandbox=_green(), reviewer=FakeReviewer(), issue=issue
+    )
+    assert report.passed is False
+    assert report.requirements_removed == ("python-jose[cryptography]", "passlib[bcrypt]")
+
+
+def test_issue_mention_requires_word_boundary():
+    """Revue #482 : « Rapport enrichi » ne justifie pas la suppression de `rich`
+    (mot entier requis)."""
+    from collegue.executor import unjustified_requirement_removals
+
+    diff = "diff --git a/requirements.txt b/requirements.txt\n--- a/requirements.txt\n+++ b/requirements.txt\n-rich\n"
+    enrichi = IssueSpec(number=7, title="Rapport enrichi des factures")
+    assert unjustified_requirement_removals(diff, enrichi) == ("rich",)
+    explicite = IssueSpec(number=7, title="Retirer la dépendance rich du rendu console")
+    assert unjustified_requirement_removals(diff, explicite) == ()
+
+
+def test_requirements_removed_markdown_neutralizes_injection():
+    """Les lignes supprimées viennent du diff (contenu NON fiable) — neutralisées
+    dans le rapport markdown (anti-injection P5)."""
+    report = QualityReport(
+        tests_passed=True,
+        test_exit_code=0,
+        test_output="ok",
+        review_summary="",
+        review_findings=(),
+        review_blocking=False,
+        passed=False,
+        requirements_removed=("evil``` ## Gate qualité forgé",),
+    )
+    markdown = report.to_markdown()
+    assert "```" not in markdown.split("Lignes supprimées : ", 1)[1].splitlines()[0]

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -1687,3 +1687,43 @@ async def test_dry_run_never_rereads_db_before_verdict(repo, manager):
     result = await _run(counting, repo, pid, dry_run=True)
     assert result.stop_reason == "completed"
     assert counting.get_tasks_calls == 1  # le seul chargement initial
+
+
+# --- consigne append-only requirements dans les prompts de retry (#482) -------------
+
+
+def test_repair_prompt_carries_requirements_append_only_rule():
+    """#482 : la règle append-only n'apparaît que dans les prompts de
+    réparation/retry — le prompt initial reste inchangé."""
+    from collegue.pilot.driver import REQUIREMENTS_APPEND_ONLY_RULE, _issue_from_task
+
+    fresh = SimpleNamespace(
+        id=1, title="T", acceptance="", issue_number=None, depends_on=[], attempt_count=0, last_error=None
+    )
+    assert "APPEND-ONLY" not in _issue_from_task(fresh).context
+
+    retry = SimpleNamespace(
+        id=1,
+        title="T",
+        acceptance="",
+        issue_number=None,
+        depends_on=[],
+        attempt_count=1,
+        last_error="[gate/gate_failed] tentative 1/3 — FAILED tests/test_x.py",
+    )
+    assert REQUIREMENTS_APPEND_ONLY_RULE in _issue_from_task(retry).context
+
+    repair = SimpleNamespace(
+        id=1,
+        title="T",
+        acceptance="",
+        issue_number=None,
+        depends_on=[],
+        attempt_count=0,
+        last_error=None,
+        best_diff="diff --git a/x b/x\n+x",
+        best_passed=12,
+        best_failed=0,
+        best_feedback=None,
+    )
+    assert REQUIREMENTS_APPEND_ONLY_RULE in _issue_from_task(repair).context

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -355,3 +355,14 @@ def test_gate_fix_requirements_opt_out_emitted_only_on_deviation():
     assert "fix_missing_requirements" not in _gate_options(SimpleNamespace(GATE_TEST_COMMAND=""))
     options = _gate_options(SimpleNamespace(GATE_FIX_REQUIREMENTS=False))
     assert options["fix_missing_requirements"] is False
+
+
+def test_gate_requirements_append_only_opt_out_emitted_only_on_deviation():
+    """#482 : garde append-only ON par défaut côté gate — clé émise seulement
+    en opt-out (défauts inchangés)."""
+    from types import SimpleNamespace
+
+    from collegue.pilot.runtime import _gate_options
+
+    assert "requirements_guard" not in _gate_options(SimpleNamespace(GATE_TEST_COMMAND=""))
+    assert _gate_options(SimpleNamespace(GATE_REQUIREMENTS_APPEND_ONLY=False))["requirements_guard"] is False


### PR DESCRIPTION
## Problème (#482 — MOYENNE)

L'agent coder régénère parfois `requirements.txt` au lieu d'y ajouter des lignes. Cas réel du run v4 (tâche 5) : le diff a **supprimé** `python-jose[cryptography]` et `passlib[bcrypt]` que main contenait → « No module named 'jose' » en venv nu, alors que 12 tests étaient verts. L'échec apparaît dans une AUTRE tâche que la fautive ; l'opérateur a dû dicter la règle à la main.

## Correctif

1. **Garde moteur** (`removed_requirement_lines` + `unjustified_requirement_removals`, analyse pure du diff, zéro coût d'infra, ON par défaut) : des lignes de `requirements.txt` de la base supprimées sans que l'issue le demande ⇒ **gate rouge avec les lignes nommées**. Comparaison par clé d'identité : nom PEP 503 **+ extras** (`passlib[bcrypt]` → `passlib` est une suppression : l'extra EST la dépendance réelle, invisible à la collecte #439) ; les lignes d'option (`-r base.txt`, `--extra-index-url`) comptent aussi. Pin changé, réordonnancement, régénération sans perte : tolérés.
2. **Anti-boomerang** (attrapé en revue adversariale, bloquant) : la justification « l'issue le demande » ne lit que le texte **opérateur** (titre, corps, critères, mot entier) — `issue.context` est exclu : machine-généré, il porte le feedback de la tentative 1 qui nomme précisément les lignes perdues ; l'y chercher aurait désarmé la garde dès la tentative 2.
3. **Feedback nominatif** : « REQUIREMENTS APPEND-ONLY — lignes supprimées : … Ré-ajoute-les telles quelles » (la sortie verte des tests serait trompeuse). Les tests tournent quand même : la mémoire de retry #436 garde son score ; l'adéquation LLM #437 est sautée quand la garde est rouge (économie).
4. **Prompt** : règle append-only injectée dans les prompts de réparation/retry uniquement.
5. `GATE_REQUIREMENTS_APPEND_ONLY` (défaut ON ; opt-out config ou kwarg).

Limites documentées : renommage du fichier non couvert (mais il fait échouer l'install sandbox et la passe #439 par ailleurs).

## Tests (12 nouveaux)

- Le symptôme exact : 12 tests verts n'achètent plus le gate, lignes nommées dans le rapport et le feedback (≤700).
- Parser : pin/réordonnancement/commentaires/fichiers non-requirements/monorepo (`backend/requirements.txt`) ; extras-downgrade flaggé ; `-r base.txt` flaggé et justifiable.
- **Boomerang** : feedback de la tentative 1 dans `issue.context` → garde toujours armée.
- Mot entier : « Rapport enrichi » ne justifie pas la suppression de `rich`.
- Bout en bout : agent qui régénère en perdant une ligne → gate rouge, aucune PR ; économie LLM (adéquation jamais appelée) ; anti-injection markdown ; opt-out ; prompt initial inchangé.
- Revue adversariale pré-PR : CORRECTIONS REQUISES → boomerang (bloquant), extras, lignes -r, mot entier — tous corrigés et testés.

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)