### PR TITLE
feat(executor): sondes smoke à méthode — POST /auth/register en 500 ne passe plus le gate (#483)

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -124,11 +124,15 @@ class Settings(BaseSettings):
     # conteneur du gate et vérifie qu'elle répond (< 500) — détecte les
     # divergences d'init tests/prod (tests verts via create_all, prod en 500
     # sur schema.sql incomplet). SMOKE_COMMAND : démarrage explicite (doit
-    # écouter sur 127.0.0.1:8765) ; vide → auto-détection FastAPI. SMOKE_PATHS :
-    # chemins sondés, séparés par des virgules.
+    # écouter sur 127.0.0.1:8765) ; vide → auto-détection FastAPI.
     GATE_SMOKE_RUN: bool = False
     GATE_SMOKE_COMMAND: str = ""
-    GATE_SMOKE_PATHS: str = "/"
+    # Chemins sondés, séparés par des virgules ; préfixe optionnel « MÉTHODE: »
+    # (#483, ex. POST:/auth/register — payload JSON générique, 4xx toléré /
+    # 5xx rouge). Défaut : racine + routes d'auth (le flux d'écriture central,
+    # mort out-of-the-box deux runs de suite avec un smoke GET-only) — coût nul
+    # sur une app sans ces routes (404 < 500, toléré).
+    GATE_SMOKE_PATHS: str = "/, POST:/auth/register, POST:/auth/login"
     # Budget d'attente de réponse (s) — à garder sous le timeout du conteneur
     # sandbox (120 s par défaut, partagé avec pip/pytest/npm).
     GATE_SMOKE_TIMEOUT: float = 30.0

--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -91,6 +91,30 @@ _SMOKE_BANNER = "[gate] smoke run : l'app démarre et répond (#458)"
 _SMOKE_PORT = 8765
 _SMOKE_HEREDOC = "COLLEGUE_SMOKE_458"
 
+# Méthodes HTTP reconnues dans la syntaxe enrichie des chemins sondés (#483) :
+# « POST:/auth/register ». Sans préfixe reconnu → GET (compat #458).
+_SMOKE_METHODS = frozenset({"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"})
+# Chemins sondés par défaut (#483) : racine + routes d'auth — le flux d'écriture
+# central, mort « out-of-the-box » deux runs de suite avec un smoke GET-only.
+# Défaut de SIGNATURE (et pas seulement de config) : un appelant qui active
+# smoke_run sans fournir de chemins (ex. harness qui bypasse _gate_options)
+# bénéficie de la couverture — sinon le fix serait inerte au run réel, comme
+# #461 l'a été en v4. Coût nul sur une app sans ces routes (404/405 < 500).
+DEFAULT_SMOKE_PATHS = ("/", "POST:/auth/register", "POST:/auth/login")
+# Payload générique des sondes à corps (#483) : champs usuels des routes d'auth.
+# Pydantic ignore les champs en trop par défaut → une route register/login VALIDE
+# ce corps et exécute son handler (le 500 passlib/bcrypt « out-of-the-box » de
+# FacNor v4 devient visible) ; un modèle strict répond 422 — toléré, l'app a répondu.
+_SMOKE_PROBE_PAYLOAD = json.dumps(
+    {
+        "email": "smoke-458@example.com",
+        "username": "smoke458",
+        "password": "Smoke-Run-458!",
+        "full_name": "Smoke Run",
+        "name": "Smoke Run",
+    }
+).encode()
+
 # Entrées FastAPI usuelles : (chemin relatif, cible uvicorn). Détection
 # délibérément conservatrice — sans entrée reconnue, la passe est SKIPPÉE
 # (pas de faux rouge sur un projet non-web), sauf commande explicite.
@@ -109,14 +133,15 @@ _SMOKE_PROBE_TEMPLATE = """\
 import subprocess, sys, time, urllib.error, urllib.request
 
 command = %(command)r
-paths = %(paths)r
+paths = %(paths)r  # paires (méthode, chemin) — cf. _smoke_probe_script (#483)
+payload = %(payload)r
 timeout = %(timeout)r
 log = open("/tmp/.collegue_smoke.log", "w+", encoding="utf-8", errors="replace")
 proc = subprocess.Popen(command, shell=True, stdout=log, stderr=subprocess.STDOUT)
 base = "http://127.0.0.1:%(port)d"
 deadline = time.time() + timeout
 verdicts = []
-for path in paths:
+for method, path in paths:
     status = None
     attempted = False
     # Au moins UNE tentative par chemin, même si le précédent a épuisé le délai
@@ -126,18 +151,21 @@ for path in paths:
         if proc.poll() is not None:
             break  # le serveur est mort avant de répondre
         try:
-            status = urllib.request.urlopen(base + path, timeout=2).status
+            data = payload if method not in ("GET", "HEAD") else None
+            headers = {"Content-Type": "application/json"} if data is not None else {}
+            req = urllib.request.Request(base + path, data=data, headers=headers, method=method)
+            status = urllib.request.urlopen(req, timeout=2).status
             break
         except urllib.error.HTTPError as exc:
             status = exc.code
             break
         except Exception:
             time.sleep(0.5)
-    verdicts.append((path, status))
+    verdicts.append((method, path, status))
 time.sleep(0.3)  # resserre la fenêtre « répond une fois puis meurt »
-ok = proc.poll() is None and all(s is not None and s < 500 for _p, s in verdicts)
-for path, status in verdicts:
-    print("[gate] smoke run", path, "->", status if status is not None else "sans réponse")
+ok = proc.poll() is None and all(s is not None and s < 500 for _m, _p, s in verdicts)
+for method, path, status in verdicts:
+    print("[gate] smoke run", method, path, "->", status if status is not None else "sans réponse")
 if proc.poll() is not None:
     print(
         "[gate] smoke run : le processus serveur s'est terminé (code", str(proc.poll()) + ")",
@@ -173,12 +201,24 @@ def _detect_asgi_app(workspace: str) -> Optional[str]:
 
 def _smoke_probe_script(command: str, paths: Tuple[str, ...], timeout: float, *, port: int = _SMOKE_PORT) -> str:
     """Source python de la sonde smoke-run (pur — testable par ``compile``)."""
+    # #483 : préfixe « MÉTHODE: » optionnel (whitelist _SMOKE_METHODS) — sans
+    # lui, GET (compat #458). Les méthodes à corps envoient le payload JSON
+    # générique : 4xx toléré (validation — l'app A répondu), 5xx rouge.
     # `/` de tête normalisé : sans lui, urlopen("…:8765health") lèverait à
     # chaque tentative et brûlerait tout le délai en silence.
-    normalized = tuple(path if path.startswith("/") else "/" + path for path in paths) or ("/",)
+    probes = []
+    for raw in paths:
+        method, sep, rest = raw.partition(":")
+        if sep and method.strip().upper() in _SMOKE_METHODS:
+            method, path = method.strip().upper(), rest.strip()
+        else:
+            method, path = "GET", raw
+        probes.append((method, path if path.startswith("/") else "/" + path))
+    normalized = tuple(probes) or (("GET", "/"),)
     return _SMOKE_PROBE_TEMPLATE % {
         "command": command,
         "paths": normalized,
+        "payload": _SMOKE_PROBE_PAYLOAD,
         "timeout": float(timeout),
         "port": int(port),
     }
@@ -188,7 +228,7 @@ def smoke_run_command(
     workspace: str,
     *,
     command: Optional[str] = None,
-    paths: Tuple[str, ...] = ("/",),
+    paths: Tuple[str, ...] = DEFAULT_SMOKE_PATHS,
     timeout: float = 30.0,
 ) -> Optional[str]:
     """Commande de la passe smoke-run (#458). Fail-closed une fois déclenchée.
@@ -204,7 +244,10 @@ def smoke_run_command(
       daemonise est vu comme « serveur mort ») ; sinon auto-détection FastAPI
       (cf. :data:`_ASGI_APP_CANDIDATES`) → ``python -m uvicorn`` ;
     - ``paths`` : chemins sondés — chacun doit répondre **< 500** (4xx toléré :
-      l'app a répondu ; 5xx ou silence = rouge) ;
+      l'app a répondu ; 5xx ou silence = rouge). Préfixe « MÉTHODE: » optionnel
+      (#483, ex. ``POST:/auth/register``) : les méthodes à corps envoient un
+      payload JSON générique (champs usuels d'auth) — un register qui crashe à
+      l'exécution (500 out-of-the-box) ne passe plus avec un simple GET vert ;
     - ``timeout`` : budget total d'attente de réponse (secondes) — à garder
       sous le timeout du conteneur sandbox (120 s par défaut, partagé avec
       pip/pytest/npm) ;
@@ -927,7 +970,7 @@ async def run_quality_gate(
     require_test_changes: bool = False,
     smoke_run: bool = False,
     smoke_command: Optional[str] = None,
-    smoke_paths: Tuple[str, ...] = ("/",),
+    smoke_paths: Tuple[str, ...] = DEFAULT_SMOKE_PATHS,
     smoke_timeout: float = 30.0,
     fix_missing_requirements: bool = True,
     requirements_guard: bool = True,
@@ -961,8 +1004,9 @@ async def run_quality_gate(
     elle, une divergence d'init tests/prod livre un produit en 500 avec tous
     les gates verts. ``smoke_command`` : démarrage explicite (écoute sur
     127.0.0.1:8765) ; ``smoke_paths`` : chemins sondés (chacun doit répondre
-    < 500). Skippée si aucune app n'est détectable et qu'aucune commande n'est
-    fournie.
+    < 500), préfixe « MÉTHODE: » optionnel (#483, ex. ``POST:/auth/register`` —
+    payload JSON générique, 4xx toléré, 5xx rouge). Skippée si aucune app n'est
+    détectable et qu'aucune commande n'est fournie.
     """
     sandbox = sandbox or DockerSandbox()
     reviewer = reviewer or _default_reviewer()

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -428,13 +428,13 @@ def _free_port():
         return sock.getsockname()[1]
 
 
-def _run_probe(command, timeout=10.0, port=None):
+def _run_probe(command, timeout=10.0, port=None, paths=("/",)):
     import subprocess
     import sys
 
     from collegue.executor.quality_gate import _smoke_probe_script
 
-    script = _smoke_probe_script(command, ("/",), timeout, port=port or _free_port())
+    script = _smoke_probe_script(command, paths, timeout, port=port or _free_port())
     return subprocess.run([sys.executable, "-"], input=script, text=True, capture_output=True, timeout=60)
 
 
@@ -1312,3 +1312,85 @@ def test_requirements_removed_markdown_neutralizes_injection():
     )
     markdown = report.to_markdown()
     assert "```" not in markdown.split("Lignes supprimées : ", 1)[1].splitlines()[0]
+
+
+# --- sondes smoke à méthode (#483) ---------------------------------------------------
+
+
+def test_smoke_probe_script_parses_method_prefix():
+    """#483 : préfixe « MÉTHODE: » optionnel — GET par défaut (compat #458),
+    payload JSON générique embarqué pour les méthodes à corps."""
+    from collegue.executor.quality_gate import _smoke_probe_script
+
+    script = _smoke_probe_script("python serve.py", ("POST:/auth/register", "health", "/"), 5.0)
+    assert "('POST', '/auth/register')" in script
+    assert "('GET', '/health')" in script
+    assert "('GET', '/')" in script
+    assert "Content-Type" in script
+    assert "smoke-458@example.com" in script
+    compile(script, "<smoke>", "exec")  # anti-SyntaxError du template %-formaté
+
+
+async def test_smoke_default_paths_cover_auth_posts(tmp_path):
+    """Revue #483 (anti-inertie, leçon #461-v4) : le défaut de SIGNATURE — pas
+    seulement de config — couvre les POST d'auth. Un appelant qui active
+    smoke_run sans fournir de chemins (harness qui bypasse _gate_options)
+    sonde quand même le flux d'écriture central."""
+    from collegue.executor.quality_gate import DEFAULT_SMOKE_PATHS
+
+    assert "POST:/auth/register" in DEFAULT_SMOKE_PATHS
+    assert "POST:/auth/login" in DEFAULT_SMOKE_PATHS
+    _write_fastapi_app(tmp_path)
+    sandbox = _green()
+    await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer(), smoke_run=True)
+    _ws, command = sandbox.calls[0]
+    assert "('POST', '/auth/register')" in command
+    assert "('POST', '/auth/login')" in command
+
+
+def test_smoke_probe_red_when_post_500_but_get_200(tmp_path):
+    """LE cas de l'issue #483 (répété v3 puis v4) : GET / → 200 mais
+    POST /auth/register → 500 out-of-the-box — le smoke doit être ROUGE."""
+    import sys
+
+    port = _free_port()
+    server = tmp_path / "serve.py"
+    server.write_text(
+        "from http.server import BaseHTTPRequestHandler, HTTPServer\n"
+        "class H(BaseHTTPRequestHandler):\n"
+        "    def do_GET(self):\n"
+        "        self.send_response(200); self.end_headers(); self.wfile.write(b'ok')\n"
+        "    def do_POST(self):\n"
+        "        # simule le crash passlib/bcrypt à l'exécution du handler\n"
+        "        self.send_response(500); self.end_headers()\n"
+        "    def log_message(self, *a): pass\n"
+        f"HTTPServer(('127.0.0.1', {port}), H).serve_forever()\n",
+        encoding="utf-8",
+    )
+    result = _run_probe(f"{sys.executable} {server}", port=port, paths=("/", "POST:/auth/register"))
+    assert result.returncode == 1
+    assert "GET / -> 200" in result.stdout
+    assert "POST /auth/register -> 500" in result.stdout
+
+
+def test_smoke_probe_green_when_post_4xx(tmp_path):
+    """#483 : un 4xx sur POST (validation du payload, modèle strict) reste
+    toléré — même sémantique que les GET (#458) : l'app A répondu."""
+    import sys
+
+    port = _free_port()
+    server = tmp_path / "serve.py"
+    server.write_text(
+        "from http.server import BaseHTTPRequestHandler, HTTPServer\n"
+        "class H(BaseHTTPRequestHandler):\n"
+        "    def do_GET(self):\n"
+        "        self.send_response(200); self.end_headers(); self.wfile.write(b'ok')\n"
+        "    def do_POST(self):\n"
+        "        self.send_response(422); self.end_headers()\n"
+        "    def log_message(self, *a): pass\n"
+        f"HTTPServer(('127.0.0.1', {port}), H).serve_forever()\n",
+        encoding="utf-8",
+    )
+    result = _run_probe(f"{sys.executable} {server}", port=port, paths=("/", "POST:/auth/register"))
+    assert result.returncode == 0
+    assert "POST /auth/register -> 422" in result.stdout

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -321,6 +321,11 @@ def test_gate_options_built_from_settings():
     assert options["smoke_command"] == "python serve.py"
     assert options["smoke_paths"] == ("/health", "/factures/")
     assert options["smoke_timeout"] == 30.0
+
+    # #483 : le préfixe « MÉTHODE: » traverse le mapping config sans altération
+    # (le parsing vit dans la sonde, pas ici).
+    with_post = SimpleNamespace(GATE_SMOKE_RUN=True, GATE_SMOKE_PATHS="/, POST:/auth/register")
+    assert _gate_options(with_post)["smoke_paths"] == ("/", "POST:/auth/register")
     assert "smoke_run" not in _gate_options(SimpleNamespace())  # défaut : off
 
 


### PR DESCRIPTION
## Problème (#483 — MOYENNE)

La sonde smoke-run (#458) n'émettait que des **GET** : le produit v4 livré répondait `GET / → 200` (smoke vert) mais `POST /auth/register → 500` out-of-the-box (passlib 1.7.4 incompatible bcrypt 5.0.0, non épinglés) — produit inutilisable à la livraison. **Répétition exacte du pattern v3** : 2 campagnes de suite où le flux d'écriture central échappe au gate.

## Correctif

1. **Syntaxe enrichie** des chemins sondés : préfixe `MÉTHODE:` optionnel (`POST:/auth/register`) — sans préfixe, GET (compat #458 totale). Méthodes à corps → **payload JSON générique** (champs usuels d'auth) avec `Content-Type: application/json` : pydantic ignore les champs en trop par défaut, le handler s'exécute réellement ; modèle strict → 422 **toléré** (l'app a répondu) ; 5xx/silence = rouge — sémantique de verdict inchangée.
2. **`DEFAULT_SMOKE_PATHS = ("/", "POST:/auth/register", "POST:/auth/login")` en défaut de signature** (`run_quality_gate`, `smoke_run_command`) et de config — la revue adversariale a montré que le harness du run réel bypasse `_gate_options` : un défaut config seul aurait rendu ce fix **inerte au run v5, exactement comme #461 l'a été en v4**. Coût nul sur une app sans ces routes (404/405 < 500, toléré — vérifié sur FastAPI réel).
3. Parsing centralisé dans la sonde : config/runtime transmettent les chaînes telles quelles (zéro changement de mapping).

Vérifications adversariales : aucun `%` littéral dans le template %-formaté ; redirections urllib (302→GET suivi, 307/308 non suivis → statut <500 toléré) ; effets de bord inter-sondes (register 201 puis login 200, re-run #481 en conteneur neuf → 409 toléré) ; chemins avec `:` littéral intacts ; `get:` minuscules normalisé ; la recapture #481 reste bornée à requirements.txt (la DB créée par le smoke n'entre pas dans la PR).

## Tests

- **LE cas de l'issue, exécuté contre un serveur réel** : GET / → 200 + POST /auth/register → 500 ⇒ sonde rouge (vérifié rouge AVANT le fix : l'ancienne sonde faisait `GET /POST:/auth/register` → 200 → vert).
- POST → 422 ⇒ vert (validation tolérée, contrat #458 conservé).
- Anti-inertie : le défaut de **signature** atteint le script de sonde sans aucune option fournie.
- Parsing pur + `compile()` (anti-SyntaxError du template) ; pass-through runtime ; non-régressions #458 inchangées (marqueurs `-> 200`, « premier plan », heredoc final).
- Revue adversariale pré-PR : 1 bloquant attrapé (fix inerte côté harness — corrigé par le défaut de signature + patch harness opérateur), 3 limites documentées (slash-redirect 307, 501 sur serveurs sans do_POST, redirects absolus — préexistantes ou marginales).

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)