### PR TITLE
feat(pilot,executor): prix de secours du canal coder + signal cost_unknown — le ledger $ n'est plus aveugle aux modèles non mappés (#484)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,6 +135,8 @@ LLM_API_KEY="votre_clé_api_gemini"
 # 0 = désactivé. À l'atteinte du plafond, les appels LLM sont stoppés.
 # MAX_COST_USD=0.0
 # MAX_TOKENS_BUDGET=0
+# LLM_PRICE_PROMPT_PER_1M=0.0         # prix de secours $/1M tokens prompt (modèle non mappé litellm, #484)
+# LLM_PRICE_COMPLETION_PER_1M=0.0     # idem completion ; 0 = désactivé -> événement d'audit cost_unknown
 # BUDGET_EXHAUSTED_ACTION=pause       # pause (défaut) | warn
 # COLLEGUE_RUN_DEADLINE_SECONDS=0     # durée mur max d'un run (0 = pas de deadline)
 # LLM_CALL_TIMEOUT=0                  # timeout par appel LLM, s (0 = off)

--- a/collegue/config.py
+++ b/collegue/config.py
@@ -173,6 +173,8 @@ class Settings(BaseSettings):
     # 0 (ou non défini) = plafond désactivé (opt-in ; défaut = aucun changement).
     # Portée : compteur cumulé du process serveur (le moteur autonome = 1 process ;
     # le dashboard est un lecteur séparé). En multi-worker, le cap est par-worker.
+    # Modèles non mappés litellm : cost_usd=0 côté runner → configurer
+    # LLM_PRICE_*_PER_1M, sinon le ledger $ reste à 0 (événement cost_unknown).
     # Providers locaux (LM Studio/Ollama/Unsloth) : coût = 0 → MAX_COST_USD inerte,
     # seul MAX_TOKENS_BUDGET les protège.
     MAX_COST_USD: float = 0.0
@@ -189,6 +191,18 @@ class Settings(BaseSettings):
             return "pause"
         action = str(v).strip().lower()
         return action if action in ("pause", "warn") else "pause"
+
+    # #484 : prix de secours du canal coder (USD par MILLION de tokens). Quand
+    # litellm ne mappe pas le modèle (« Cost calculation failed: This model isn't
+    # mapped yet », ex. gemma-4-31b-it), le runner émet cost_usd=0 malgré des
+    # millions de tokens : run_cost_usd reste à 0. Si l'un de ces prix est > 0,
+    # le moteur estime coût = tokens × prix pour le ledger. 0 (défaut) =
+    # désactivé : un événement d'audit `cost_unknown` signale alors le coût
+    # inconnu (une fois par run/segment) au lieu d'un 0 silencieux. NB : un
+    # provider coder réellement gratuit (LM Studio/Ollama local) déclenchera
+    # aussi le signal — factuellement exact, le cap $ ne protège pas ce canal.
+    LLM_PRICE_PROMPT_PER_1M: float = 0.0
+    LLM_PRICE_COMPLETION_PER_1M: float = 0.0
 
     # ── Auto-merge progressif (Phase 5, H2) ──────────────────────────────────
     # §6 reste le DÉFAUT : approbation humaine avant chaque merge dans main.

--- a/collegue/executor/openhands_agent.py
+++ b/collegue/executor/openhands_agent.py
@@ -77,6 +77,37 @@ def parse_usage_from_logs(logs: str) -> Tuple[int, int, float]:
     return prompt, completion, cost
 
 
+def estimate_cost_usd(prompt_tokens: int, completion_tokens: int, settings_obj=None) -> float:
+    """Coût USD estimé via les prix configurés ``LLM_PRICE_*_PER_1M`` (#484).
+
+    Filet quand litellm ne mappe pas le modèle : le runner émet ``cost_usd: 0``
+    malgré des tokens — sans prix configurés on retourne 0.0 (l'appelant signale
+    alors un coût INCONNU au lieu d'un zéro silencieux). Robuste : prix absent /
+    non numérique / négatif / non fini → 0 (désactivé).
+    """
+    if settings_obj is None:
+        from collegue.config import settings as settings_obj
+
+    def _price(name: str) -> float:
+        try:
+            value = float(getattr(settings_obj, name, 0.0) or 0.0)
+        except (TypeError, ValueError):
+            return 0.0
+        return value if math.isfinite(value) and value > 0 else 0.0
+
+    prompt_price = _price("LLM_PRICE_PROMPT_PER_1M")
+    completion_price = _price("LLM_PRICE_COMPLETION_PER_1M")
+    if prompt_price <= 0 and completion_price <= 0:
+        return 0.0
+    try:
+        total = max(0, int(prompt_tokens)) * prompt_price + max(0, int(completion_tokens)) * completion_price
+    except OverflowError:
+        # Ligne d'usage empoisonnée (int JSON géant) : estimer 0 plutôt que de
+        # tuer le run — l'audit ne casse jamais le run.
+        return 0.0
+    return total / 1_000_000.0 if math.isfinite(total) else 0.0
+
+
 # Politique retries/backoff par défaut du canal coder (#422) — alignée sur les
 # settings ``CODER_LLM_*`` de ``collegue.config``.
 DEFAULT_CODER_NUM_RETRIES = 8

--- a/collegue/pilot/audit.py
+++ b/collegue/pilot/audit.py
@@ -41,6 +41,11 @@ COST_OBSERVED = "cost_observed"
 # ligne d'usage — la dépense de la tentative est invisible du ledger ; on
 # journalise la perte au lieu de laisser un trou silencieux.
 USAGE_LOST = "usage_lost"
+# #484 : des tokens coder sont comptés mais leur coût ne l'est pas (modèle non
+# mappé litellm → cost_usd=0, aucun prix LLM_PRICE_*_PER_1M configuré) — le
+# plafond MAX_COST_USD est aveugle en dollars sur ce canal ; on le signale au
+# lieu de laisser un 0 ressembler à un run gratuit.
+COST_UNKNOWN = "cost_unknown"
 
 # Noms des métriques persistées pour le ledger de coût par run.
 METRIC_RUN_COST_USD = "run_cost_usd"

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
 from collegue.executor.agent import IssueSpec
+from collegue.executor.openhands_agent import estimate_cost_usd
 from collegue.executor.pipeline import (
     execute_issue,
     failure_feedback,
@@ -42,6 +43,7 @@ from collegue.executor.workspace import branch_for_issue, cleanup_workspace, swe
 from collegue.pilot.audit import (
     BUDGET_EVENT,
     CHECKPOINT_SAVED,
+    COST_UNKNOWN,
     GATE_DECISION,
     OVERLAY_REFRESHED,
     PR_OPENED,
@@ -571,6 +573,9 @@ async def run_project(
     # #461 : aléas infra du gate non décomptés (task_id → nombre), borné par
     # MAX_INFRA_GATE_GRACE — un timeout PyPI ne brûle plus une tentative saine.
     infra_gate_grace: dict = {}
+    # #484 : signal « coût inconnu » émis au plus UNE fois par run/segment
+    # (anti-bruit — le flag en mémoire ne survit pas aux restarts, comme #443).
+    cost_unknown_signaled = False
 
     # #466 : balayage de démarrage. (a) Les workspaces conservés PERSISTÉS des
     # tâches désormais abouties — le dict en mémoire de #443 repartait vide à
@@ -704,10 +709,26 @@ async def run_project(
         # auto-déclaré par l'agent alimente le même ledger (les deux canaux
         # s'additionnent : ils ne comptent jamais les mêmes appels).
         agent_result = outcome.execution.agent_result
-        coder_tokens = int(getattr(agent_result, "prompt_tokens", 0) or 0) + int(
-            getattr(agent_result, "completion_tokens", 0) or 0
-        )
+        coder_prompt = int(getattr(agent_result, "prompt_tokens", 0) or 0)
+        coder_completion = int(getattr(agent_result, "completion_tokens", 0) or 0)
+        coder_tokens = coder_prompt + coder_completion
         coder_usd = float(getattr(agent_result, "cost_usd", 0.0) or 0.0)
+        if coder_tokens and coder_usd <= 0:
+            # #484 : modèle non mappé litellm → cost_usd=0 malgré des tokens.
+            # Prix de secours configurés (LLM_PRICE_*_PER_1M) : coût estimé ;
+            # sinon coût INCONNU — signalé une fois par run/segment au lieu
+            # d'un 0 silencieux qui ressemble à un run gratuit.
+            coder_usd = estimate_cost_usd(coder_prompt, coder_completion)
+            if coder_usd <= 0 and not cost_unknown_signaled:
+                cost_unknown_signaled = True
+                audit.record(
+                    COST_UNKNOWN,
+                    iteration=iteration,
+                    task_id=task.id,
+                    tokens=coder_tokens,
+                    reason="cost_usd nul malgré des tokens (modèle non mappé litellm ?) et aucun prix "
+                    "LLM_PRICE_*_PER_1M configuré — plafond MAX_COST_USD inopérant pour le canal coder",
+                )
         if coder_tokens or coder_usd:
             audit.record_cost(usd=coder_usd, tokens=coder_tokens, iteration=iteration)
         elif TIMEOUT_NOTE in (getattr(agent_result, "logs", "") or ""):

--- a/docs/moteur_autonome.md
+++ b/docs/moteur_autonome.md
@@ -155,7 +155,9 @@ lit :
 |----------|-------------|--------|
 | `STATE_DATABASE_URL` | État durable (Postgres ou SQLite). Requis pour un run réel. | — |
 | `LLM_MODEL_CODER` / `_QA` / `_PLANNER` / `_REVIEWER` | Modèle par **rôle** (codeur fort, QA économique, planificateur, revue). Retombe sur `LLM_MODEL` si absent. | `LLM_MODEL` |
-| `MAX_COST_USD` | Plafond dur de dépense cumulée (`0` = désactivé). | `0` |
+| `MAX_COST_USD` | Plafond dur de dépense cumulée (`0` = désactivé). NB : son enforcement lit le MetricsCollector serveur et ne voit PAS le canal coder (gap structurel) ; les prix `LLM_PRICE_*` ne corrigent que le ledger/reporting du run — sans eux, un modèle non mappé litellm laisse `run_cost_usd=0` (événement d'audit `cost_unknown`, #484). | `0` |
+| `LLM_PRICE_PROMPT_PER_1M` | Prix de secours du canal coder, $/1M tokens prompt — utilisé quand le runner émet `cost_usd=0` malgré des tokens (#484). | `0` |
+| `LLM_PRICE_COMPLETION_PER_1M` | Idem, $/1M tokens completion. `0` = désactivé. | `0` |
 | `MAX_TOKENS_BUDGET` | Plafond dur de tokens cumulés (`0` = désactivé). | `0` |
 | `BUDGET_EXHAUSTED_ACTION` | `pause` (refuse les appels LLM) ou `warn` (journalise seulement). | `pause` |
 | `COLLEGUE_RUN_DEADLINE_SECONDS` | Durée mur max d'un run (`0` = pas de deadline). | `0` |

--- a/tests/test_executor_agent.py
+++ b/tests/test_executor_agent.py
@@ -292,3 +292,39 @@ def test_app_does_not_wire_executor():
     app_src = (Path(__file__).resolve().parent.parent / "collegue" / "app.py").read_text(encoding="utf-8")
     assert "collegue.executor" not in app_src
     assert "from collegue.executor" not in app_src
+
+
+# --- prix de secours du canal coder (#484) -------------------------------------------
+
+
+def test_estimate_cost_usd_uses_configured_prices():
+    """#484 : modèle non mappé litellm → cost_usd=0 du runner ; les prix
+    LLM_PRICE_*_PER_1M permettent au moteur d'estimer le coût."""
+    from collegue.executor.openhands_agent import estimate_cost_usd
+
+    prices = _settings(LLM_PRICE_PROMPT_PER_1M=1.5, LLM_PRICE_COMPLETION_PER_1M=9.0)
+    assert estimate_cost_usd(1_000_000, 2_000_000, prices) == pytest.approx(1.5 + 18.0)
+    # Un seul prix configuré : seul ce côté compte.
+    prompt_only = _settings(LLM_PRICE_PROMPT_PER_1M=1.5)
+    assert estimate_cost_usd(1_000_000, 500_000, prompt_only) == pytest.approx(1.5)
+
+
+def test_estimate_cost_usd_disabled_or_aberrant_returns_zero():
+    """Sans prix configurés (ou aberrants), 0.0 — l'appelant signale alors un
+    coût INCONNU au lieu d'un zéro silencieux."""
+    from collegue.executor.openhands_agent import estimate_cost_usd
+
+    assert estimate_cost_usd(1_000_000, 1_000_000, _settings()) == 0.0
+    for bad in (0.0, -3.0, "n/a", float("nan"), float("inf"), None):
+        assert estimate_cost_usd(1_000_000, 0, _settings(LLM_PRICE_PROMPT_PER_1M=bad)) == 0.0
+    # Tokens négatifs neutralisés.
+    assert estimate_cost_usd(-100, -100, _settings(LLM_PRICE_PROMPT_PER_1M=1.0)) == 0.0
+
+
+def test_estimate_cost_usd_survives_poisoned_token_counts():
+    """Revue #484 : un int JSON géant dans la ligne d'usage ne tue pas le run —
+    OverflowError rattrapée, estimation 0 (l'audit ne casse jamais le run)."""
+    from collegue.executor.openhands_agent import estimate_cost_usd
+
+    prices = _settings(LLM_PRICE_PROMPT_PER_1M=1.5)
+    assert estimate_cost_usd(10**400, 0, prices) == 0.0

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -1727,3 +1727,80 @@ def test_repair_prompt_carries_requirements_append_only_rule():
         best_feedback=None,
     )
     assert REQUIREMENTS_APPEND_ONLY_RULE in _issue_from_task(repair).context
+
+
+# --- coût inconnu / prix de secours du canal coder (#484) ----------------------------
+
+
+class _UnmappedModelAgent:
+    """Agent dont le runner déclare des tokens mais cost_usd=0 (litellm sans
+    mapping du modèle — cas gemma-4-31b-it du run v4)."""
+
+    def __init__(self):
+        self._ok = FakeCodeAgent()
+
+    def implement_issue(self, workspace, issue):
+        import dataclasses
+
+        result = self._ok.implement_issue(workspace, issue)
+        return dataclasses.replace(result, prompt_tokens=1_000_000, completion_tokens=100_000, cost_usd=0.0)
+
+
+async def test_coder_cost_estimated_when_litellm_unmapped(repo, manager, monkeypatch):
+    """#484 : prix de secours configurés → le ledger porte le coût ESTIMÉ
+    (tokens × prix), aucun signal cost_unknown."""
+    from collegue import config
+    from collegue.pilot.audit import RunAuditLog
+
+    monkeypatch.setattr(config.settings, "LLM_PRICE_PROMPT_PER_1M", 1.5, raising=False)
+    monkeypatch.setattr(config.settings, "LLM_PRICE_COMPLETION_PER_1M", 9.0, raising=False)
+    pid = _linear_project(manager, 1)
+    audit = RunAuditLog(pid)
+    result = await _run(manager, repo, pid, dry_run=False, agent=_UnmappedModelAgent(), audit=audit)
+    assert result.stop_reason == "completed"
+    assert audit.cost.tokens == 1_100_000
+    assert audit.cost.usd == pytest.approx(1.5 + 0.9)
+    assert not [e for e in audit.events if e.kind == "cost_unknown"]
+
+
+async def test_cost_unknown_event_when_tokens_without_price(repo, manager, monkeypatch):
+    """#484 : tokens comptés, coût inconnu, aucun prix configuré → UN événement
+    cost_unknown par run (anti-bruit), tokens toujours comptés au ledger."""
+    from collegue import config
+    from collegue.pilot.audit import RunAuditLog
+
+    # Herméticité : un .env développeur définissant des prix fausserait le test.
+    monkeypatch.setattr(config.settings, "LLM_PRICE_PROMPT_PER_1M", 0.0, raising=False)
+    monkeypatch.setattr(config.settings, "LLM_PRICE_COMPLETION_PER_1M", 0.0, raising=False)
+    pid = _linear_project(manager, 2)
+    audit = RunAuditLog(pid)
+    result = await _run(manager, repo, pid, dry_run=False, agent=_UnmappedModelAgent(), audit=audit)
+    assert result.stop_reason == "completed"
+    assert audit.cost.usd == 0.0
+    assert audit.cost.tokens == 2 * 1_100_000
+    unknown = [e for e in audit.events if e.kind == "cost_unknown"]
+    assert len(unknown) == 1  # une seule fois par run, malgré 2 tâches
+    assert unknown[0].detail["tokens"] == 1_100_000
+    assert "MAX_COST_USD" in unknown[0].detail["reason"]
+    assert len([e for e in audit.events if e.kind == "cost_observed"]) == 2
+
+
+async def test_no_cost_unknown_when_cost_reported(repo, manager):
+    """#441 préservé : un coût déclaré par le runner ne déclenche aucun signal."""
+    import dataclasses
+
+    from collegue.pilot.audit import RunAuditLog
+
+    class _PaidAgent:
+        def __init__(self):
+            self._ok = FakeCodeAgent()
+
+        def implement_issue(self, workspace, issue):
+            result = self._ok.implement_issue(workspace, issue)
+            return dataclasses.replace(result, prompt_tokens=1200, completion_tokens=300, cost_usd=0.002)
+
+    pid = _linear_project(manager, 1)
+    audit = RunAuditLog(pid)
+    await _run(manager, repo, pid, dry_run=False, agent=_PaidAgent(), audit=audit)
+    assert not [e for e in audit.events if e.kind == "cost_unknown"]
+    assert audit.cost.usd == pytest.approx(0.002)


### PR DESCRIPTION
## Problème (#484 — MOYENNE)

« Cost calculation failed: This model isn't mapped yet » dans tous les tails du run v4 (gemma-4-31b-it non mappé litellm) → `run_cost_usd = 0.0` pour **18,2 M tokens**. Le moteur ne distingue pas « coût nul » de « coût inconnu » : les métriques $ des runs sont fausses et le plafond dollar ne peut pas mordre.

## Correctif

1. **`LLM_PRICE_PROMPT_PER_1M` / `LLM_PRICE_COMPLETION_PER_1M`** (défaut 0 = off) : quand le runner déclare des tokens avec `cost_usd ≤ 0`, le driver estime `coût = tokens × prix` — au **site unique** d'enregistrement du canal coder. Découverte d'analyse : le run réel passe par les agents du harness, pas par `OpenHandsAgent` — un fallback placé dans la seule localisation citée par l'issue aurait été **inerte en réel** (la leçon #461-v4).
2. **Signal d'invalidité `cost_unknown`** (événement d'audit, une fois par run/segment) quand des tokens sont comptés sans coût ni prix configurés — au lieu d'un 0 silencieux qui ressemble à un run gratuit. Les tokens restent comptés au ledger.
3. `estimate_cost_usd` robuste : prix absents/non numériques/négatifs/nan/inf → 0 ; tokens négatifs neutralisés ; `OverflowError` (ligne d'usage empoisonnée) rattrapée — l'audit ne casse jamais le run.
4. **Honnêteté** (point 3 de l'issue, documenté `.env.example` + `docs/moteur_autonome.md`) : les prix ne corrigent que le **ledger/reporting**. L'enforcement de `MAX_COST_USD` lit le MetricsCollector serveur et ne voit structurellement pas le canal coder — gap distinct découvert pendant l'analyse, à ponter via `BudgetTimeController` (issue de suite recommandée).

Invariants vérifiés : pas de double comptage (canaux serveur/coder disjoints) ; reseed multi-segments #462 cohérent ; branche `USAGE_LOST` #464 atteignable à l'identique ; un coût déclaré par le runner n'est jamais écrasé.

## Tests

- Prix configurés → ledger porte le coût estimé (1,1 M tokens → 2,40 $), zéro signal.
- Sans prix → `cost_unknown` exactement UNE fois sur un run de 2 tâches (anti-bruit), tokens comptés, raison nommant MAX_COST_USD ; herméticité monkeypatchée.
- Coût déclaré → zéro signal (#441 préservé).
- Robustesse : prix aberrants (0/négatif/« n/a »/nan/inf) → 0 ; int géant → pas de crash.
- Revue adversariale pré-PR : 3 corrections appliquées (doc qui sous-entendait l'enforcement réparé — reformulée ; OverflowError ; herméticité d'un test). Contre-épreuve : les nouveaux tests échouent tous sur HEAD.

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)