### PR TITLE
feat(sandbox): résolveurs DNS explicites opt-in pour les conteneurs du gate et du coder (#485)

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -136,6 +136,13 @@ class Settings(BaseSettings):
     # Budget d'attente de réponse (s) — à garder sous le timeout du conteneur
     # sandbox (120 s par défaut, partagé avec pip/pytest/npm).
     GATE_SMOKE_TIMEOUT: float = 30.0
+    # DNS du sandbox (#485) : résolveurs passés en `--dns` aux conteneurs qui
+    # ont besoin du réseau (installabilité #439, prélude #414, worker OpenHands).
+    # Le résolveur Docker par défaut produisait des « Temporary failure in name
+    # resolution » en rafale, brûlant des tentatives (graciées par #477, mais
+    # autant réduire l'occurrence). Adresses IP séparées par des virgules
+    # (ex. "1.1.1.1,8.8.8.8") ; vide (défaut) = résolveur Docker.
+    SANDBOX_DNS: str = ""
 
     ENGINE_INIT_TIMEOUT: float = 10.0
     ENGINE_WAIT_TIMEOUT: float = 30.0

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -77,12 +77,20 @@ def _build_manager(settings_obj):  # pragma: no cover - infra réelle (integrati
     return ProjectStateManager.from_url(url)
 
 
+def _sandbox_dns(settings_obj) -> tuple:
+    """Résolveurs DNS du sandbox (#485) — ``SANDBOX_DNS``, IPs séparées par des virgules."""
+    raw = str(getattr(settings_obj, "SANDBOX_DNS", "") or "")
+    return tuple(server.strip() for server in raw.split(",") if server.strip())
+
+
 def _build_sandbox(settings_obj):  # pragma: no cover - infra réelle (integration)
     from collegue.sandbox import DockerSandbox
 
     # OpenHands appelle un LLM → le sandbox a besoin du réseau pour ce run précis
-    # (le défaut durci est ``network="none"``).
-    return DockerSandbox(network="bridge")
+    # (le défaut durci est ``network="none"``). #485 : résolveurs DNS explicites
+    # opt-in (SANDBOX_DNS) — le résolveur Docker par défaut était instable en
+    # run réel (gate ET coder, le sandbox est partagé).
+    return DockerSandbox(network="bridge", dns=_sandbox_dns(settings_obj))
 
 
 def _build_agent(sandbox, settings_obj):  # pragma: no cover - infra réelle (integration)

--- a/collegue/sandbox/executor.py
+++ b/collegue/sandbox/executor.py
@@ -79,6 +79,7 @@ class DockerSandbox:
         image: str = DEFAULT_SANDBOX_IMAGE,
         *,
         network: str = "none",
+        dns: Optional[Tuple[str, ...]] = None,
         memory: str = "512m",
         cpus: str = "1.0",
         pids_limit: int = 256,
@@ -93,6 +94,12 @@ class DockerSandbox:
     ):
         self.image = image
         self.network = network
+        # Résolveurs DNS explicites (#485) : le résolveur Docker par défaut
+        # produit des « Temporary failure in name resolution » en rafale sur
+        # les passes réseau du gate (#414/#439) — tentatives brûlées sur de
+        # l'infra. Vide (défaut) = comportement Docker inchangé. Une adresse
+        # invalide fait échouer `docker run` (stderr visible dans le gate).
+        self.dns = tuple(dns or ())
         self.memory = memory
         self.cpus = cpus
         self.pids_limit = pids_limit
@@ -155,6 +162,10 @@ class DockerSandbox:
             "--stop-timeout",
             "5",
         ]
+        # #485 : résolveurs DNS explicites — uniquement si configurés (argv par
+        # défaut strictement inchangé).
+        for server in self.dns:
+            argv += ["--dns", server]
         if self.read_only:
             argv += ["--read-only"]  # root FS en lecture seule
         argv += [

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -371,3 +371,14 @@ def test_gate_requirements_append_only_opt_out_emitted_only_on_deviation():
 
     assert "requirements_guard" not in _gate_options(SimpleNamespace(GATE_TEST_COMMAND=""))
     assert _gate_options(SimpleNamespace(GATE_REQUIREMENTS_APPEND_ONLY=False))["requirements_guard"] is False
+
+
+def test_sandbox_dns_parsed_from_settings():
+    """#485 : SANDBOX_DNS (IPs séparées par des virgules) → tuple pour DockerSandbox."""
+    from types import SimpleNamespace
+
+    from collegue.pilot.runtime import _sandbox_dns
+
+    assert _sandbox_dns(SimpleNamespace(SANDBOX_DNS="1.1.1.1, 8.8.8.8")) == ("1.1.1.1", "8.8.8.8")
+    assert _sandbox_dns(SimpleNamespace(SANDBOX_DNS="")) == ()
+    assert _sandbox_dns(SimpleNamespace()) == ()  # setting absent → défaut Docker

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -275,3 +275,17 @@ def test_sandbox_workspace_persists(tmp_path):
     sb.run_command("echo persisted > marker.txt", str(tmp_path))
     res = sb.run_command("cat marker.txt", str(tmp_path))
     assert "persisted" in res.stdout
+
+
+def test_build_argv_dns_flags(tmp_path):
+    """#485 : résolveurs DNS explicites traduits en --dns (un flag par serveur)."""
+    sb = DockerSandbox(image="img", network="bridge", dns=("1.1.1.1", "8.8.8.8"))
+    argv = sb._build_run_argv("echo hi", str(tmp_path))
+    joined = " ".join(argv)
+    assert "--dns 1.1.1.1" in joined
+    assert "--dns 8.8.8.8" in joined
+
+
+def test_build_argv_no_dns_by_default(tmp_path):
+    """Défaut : aucun --dns — argv identique au comportement historique durci."""
+    assert "--dns" not in DockerSandbox(image="img")._build_run_argv("x", str(tmp_path))


### PR DESCRIPTION
## Problème (#485 — BASSE)

Les passes réseau du gate (installabilité #439, prélude #414) et le worker coder tournent dans `DockerSandbox` avec le résolveur DNS par défaut de Docker — qui a produit des rafales « Temporary failure in name resolution » sur le run v4, brûlant des tentatives (l'opérateur a dû baker une image à la main pour finir le run).

## Correctif (partie 1 de l'issue — minimale)

1. **`DockerSandbox(dns=("1.1.1.1", "8.8.8.8"))`** → flags `--dns` dans l'argv durci, insérés sans toucher au reste (argv par défaut **strictement inchangé**, invariants d'isolation préservés — tests existants verts sans modification).
2. **`SANDBOX_DNS`** (chaîne CSV — un `List[str]` pydantic-settings exigerait du JSON dans la variable d'env, convention `GATE_SMOKE_PATHS`) ; parsing pur `_sandbox_dns` ; câblé sur le sandbox **partagé** gate + coder (les mêmes pannes DNS frappent les deux).
3. Sécurité tranchée empiriquement : argv en liste (aucun shell), et le CLI docker valide chaque valeur `--dns` comme adresse IP (`--dns --privileged` → rejet « IP address is not correctly formatted ») — pas d'injection possible ; une valeur invalide fait échouer `docker run` en exit 125 avec stderr explicite (fail-fast).

**Partie 2 (cache pip) différée** : les deux commandes pip du gate forcent `--no-cache-dir` (le flag CLI écrase `PIP_CACHE_DIR`) — un volume monté côté sandbox seul serait du code mort. Un correctif complet doit traverser les builders purs de quality_gate + préserver le contrat venv-nu #439 et l'invariant « seul le workspace est monté » : candidate à une issue dédiée si le besoin persiste après ce fix.

Note : les échecs DNS restent **graciés** par #477 (signature déjà dans `_INFRA_NOISE_SIGNATURES`) — ce fix réduit l'occurrence, la grâce reste le filet.

## Tests

- Argv avec DNS : un flag `--dns` par serveur ; argv par défaut : aucun `--dns` (garde d'invariant).
- Parsing settings : CSV avec espaces → tuple ; vide/absent → () (résolveur Docker).
- Revue adversariale pré-PR : APPROUVÉ (injection docker testée contre le vrai CLI, chaîne de câblage runtime→driver→gate vérifiée de bout en bout, ~25 instanciations existantes compatibles).

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)