### PR TITLE
fix(pilot,executor): grâce + fail-fast crash-loop pour les agent_error d'import pré-LLM (#498)

### DIFF
--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -86,6 +86,16 @@ _INFRA_NOISE_SIGNATURES = (
     TIMEOUT_NOTE,
 )
 
+# #498 : un crash du process AGENT (coder OpenHands) AVANT tout appel LLM a une
+# signature nette — traceback d'import dans les logs (image/runner cassé, ex.
+# lmnr 0.7.53 incompatible au faux départ FacNor v5) ET 0 token consommé. C'est
+# un aléa d'INFRASTRUCTURE (cause globale, indépendante de la tâche), pas un
+# échec fonctionnel : il ne doit pas décompter le budget de tentatives.
+_IMPORT_CRASH_SIGNATURES = (
+    "ModuleNotFoundError",
+    "ImportError",
+)
+
 
 def is_infra_noise(feedback: str) -> bool:
     """Vrai si ``feedback`` ressemble à un aléa d'infrastructure (#459).
@@ -141,6 +151,50 @@ def is_infra_gate_failure(outcome: "ExecutionOutcome") -> bool:
         output = report.test_output or ""
         return any(signature in output for signature in _INFRA_NOISE_SIGNATURES)
     return False
+
+
+def is_infra_agent_crash(outcome: "ExecutionOutcome") -> bool:
+    """Vrai si un ``agent_error`` est un crash d'IMPORT pré-LLM (#498).
+
+    Signature : ``reason == agent_error`` ET 0 token consommé (aucun appel LLM
+    utile) ET un traceback d'import (``ModuleNotFoundError``/``ImportError``)
+    dans les logs de l'agent. C'est un aléa d'infrastructure GLOBAL (image/runner
+    sandbox cassé, ex. faux départ FacNor v5 : lmnr 0.7.53 incompatible) — gracié
+    comme un aléa de gate (#461), borné par ``MAX_INFRA_GATE_GRACE`` côté pilote.
+
+    Un ``agent_error`` FONCTIONNEL (l'agent a appelé le LLM puis échoué) consomme
+    des tokens → jamais classé crash d'infra.
+    """
+    if outcome.reason != REASON_AGENT_ERROR:
+        return False
+    result = getattr(outcome.execution, "agent_result", None)
+    if result is None:
+        return False
+    if int(getattr(result, "total_tokens", 0) or 0) > 0:
+        return False
+    logs = getattr(result, "logs", "") or ""
+    return any(sig in logs for sig in _IMPORT_CRASH_SIGNATURES)
+
+
+def agent_crash_signature(logs: str) -> str:
+    """Identité STABLE d'un crash d'import pour la détection de crash-loop (#498).
+
+    Hacher la queue brute des logs serait fragile : codes ANSI, bannière/version
+    OpenHands, warnings horodatés et chemins de workspace ``/tmp/collegue-exec-…``
+    randomisés font varier les octets à chaque crash → deux crashs de la MÊME
+    cause produiraient des hash différents et le fail-fast ne tirerait jamais. On
+    isole donc la (dernière) ligne d'exception d'import — ``ModuleNotFoundError:
+    No module named 'lmnr'`` — qui ne porte ni PID ni adresse ni chemin variable.
+    À défaut, repli sur les lignes d'import du traceback, sinon la queue bornée.
+    """
+    lines = [ln.strip() for ln in (logs or "").splitlines() if ln.strip()]
+    crash_lines = [ln for ln in lines if ln.startswith(_IMPORT_CRASH_SIGNATURES)]
+    if crash_lines:
+        return crash_lines[-1]
+    import_lines = [ln for ln in lines if any(sig in ln for sig in _IMPORT_CRASH_SIGNATURES)]
+    if import_lines:
+        return import_lines[-1]
+    return log_tail(logs, 1000)
 
 
 # #478 : marqueur de troncature du short summary pytest (ASCII « ... » — distinct

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -25,6 +25,7 @@ Module **isolé** : non importé par ``app.py`` (F4 câblera).
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import re
 from dataclasses import dataclass, field
@@ -33,8 +34,10 @@ from typing import List, Optional, Tuple
 from collegue.executor.agent import IssueSpec
 from collegue.executor.openhands_agent import estimate_cost_usd
 from collegue.executor.pipeline import (
+    agent_crash_signature,
     execute_issue,
     failure_feedback,
+    is_infra_agent_crash,
     is_infra_gate_failure,
     is_infra_noise,
     log_tail,
@@ -83,6 +86,7 @@ STOP_DEADLINE = "deadline_reached"
 STOP_BLOCKED = "blocked"  # graphe coincé (dépendance échouée)
 STOP_AWAITING_MERGE = "awaiting_merge"  # mode strict (#411) : tout est prêt SAUF des merges humains
 STOP_SAFETY_CAP = "safety_cap"  # garde-fou anti-boucle
+STOP_SANDBOX_BROKEN = "sandbox_broken"  # crash-loop d'import agent : image/runner cassé (#498)
 
 # Retry au niveau tâche (#420). Le défaut du MODULE reste 1 (= pas de retry,
 # comportement historique — module isolé, aucun changement sans opt-in) ; le
@@ -311,6 +315,12 @@ def reconcile_in_review_tasks(tasks, manager, clients, *, owner: str, repo: str,
 # tentatives FONCTIONNELLES, par tâche et par run. Borné : si l'infra reste
 # rouge, on recommence à décompter (pas de boucle infinie sur PyPI down).
 MAX_INFRA_GATE_GRACE = 2
+
+# #498 : N crashs agent CONSÉCUTIFS au traceback IDENTIQUE (hash des logs) =
+# image/runner sandbox cassé, cause GLOBALE — inutile de gracier puis brûler le
+# budget tâche par tâche. Fail-fast du run (stop_reason=sandbox_broken). Seuil
+# bas car la signature est sûre (crash d'import, 0 token consommé).
+MAX_AGENT_CRASH_LOOP = 3
 
 # #466 : statuts pour lesquels un workspace d'échec conservé (#443) ne sert
 # plus (la tâche a abouti) — purgé au balayage de démarrage, quel que soit le
@@ -573,6 +583,10 @@ async def run_project(
     # #461 : aléas infra du gate non décomptés (task_id → nombre), borné par
     # MAX_INFRA_GATE_GRACE — un timeout PyPI ne brûle plus une tentative saine.
     infra_gate_grace: dict = {}
+    # #498 : compteur de crashs agent au traceback IDENTIQUE (hash → nombre
+    # consécutif) — N d'affilée ⇒ fail-fast (image cassée). Réarmé dès qu'un
+    # hash change ou qu'une issue NON-crash survient.
+    agent_crash_loop: dict = {}
     # #484 : signal « coût inconnu » émis au plus UNE fois par run/segment
     # (anti-bruit — le flag en mémoire ne survit pas aux restarts, comme #443).
     cost_unknown_signaled = False
@@ -792,6 +806,7 @@ async def run_project(
         # et stockés dans tasks.last_error.
         if outcome.success:
             task.status = TASK_STATUS_IN_REVIEW
+            agent_crash_loop = {}  # #498 : un succès réarme la détection de crash-loop
         else:
             detail = {"task_id": task.id, "stage": outcome.stage, "reason": outcome.reason}
             if getattr(outcome, "error", None):  # exception d'infrastructure (#435)
@@ -805,6 +820,43 @@ async def run_project(
             # Synthèse CRISP (#424) : lignes FAILED/ERROR de pytest en priorité —
             # c'est ce qui sera ré-injecté dans le prompt de la tentative suivante.
             diagnostic = failure_feedback(outcome)
+
+            # #498 : détection de crash-loop agent. Un crash d'import pré-LLM
+            # (0 token, image/runner cassé) qui se rejoue à l'IDENTIQUE (même
+            # hash de logs) sur plusieurs tâches/tentatives = cause GLOBALE —
+            # inutile de gracier puis brûler tâche par tâche : on arrête le run
+            # avec un diagnostic clair (rebuild d'image). Le `break` sort AVANT
+            # d'incrémenter attempts/persister un échec : la tâche reste
+            # retentable au prochain run (après rebuild).
+            agent_crash = is_infra_agent_crash(outcome)
+            if agent_crash:
+                crash_logs = outcome.execution.agent_result.logs or ""
+                # Identité STABLE (ligne d'exception, pas la queue brute) : les
+                # logs réels portent ANSI/timestamps/chemins variables qui
+                # casseraient un hash de la queue → fail-fast jamais déclenché.
+                crash_sig = hashlib.sha1(agent_crash_signature(crash_logs).encode("utf-8")).hexdigest()
+                streak = agent_crash_loop.get(crash_sig, 0) + 1
+                agent_crash_loop = {crash_sig: streak}  # un hash différent réarme à zéro
+                if streak >= MAX_AGENT_CRASH_LOOP:
+                    stop_reason = STOP_SANDBOX_BROKEN
+                    audit.record(
+                        TASK_FAILED,
+                        iteration=iteration,
+                        attempt=int(getattr(task, "attempt_count", 0) or 0),
+                        max_attempts=max_task_attempts,
+                        sandbox_broken=True,
+                        crash_streak=streak,
+                        **detail,
+                    )
+                    logger.error(
+                        "crash-loop agent : %d crashs d'import IDENTIQUES (image/sandbox cassé ?) — "
+                        "arrêt du run (sandbox_broken). Reconstruire l'image puis relancer.",
+                        streak,
+                    )
+                    break
+            else:
+                agent_crash_loop = {}  # toute issue NON-crash réarme le compteur
+
             # #461 : « le livrable ne s'installe pas » (fonctionnel — le but de la
             # passe #439) et « PyPI n'a pas répondu » (infra transitoire)
             # produisaient le même gate_failed décompté du budget : chaque
@@ -813,7 +865,8 @@ async def run_project(
             # pas de tentative fonctionnelle (grâce bornée par tâche). La
             # classification (#477) couvre aussi la cascade « install en échec
             # réseau → ModuleNotFoundError de collecte » via deps_install_failed.
-            infra_gate_failure = is_infra_gate_failure(outcome)
+            # #498 : un crash d'import pré-LLM est gracié comme un aléa de gate.
+            infra_gate_failure = is_infra_gate_failure(outcome) or agent_crash
             grace_used = int(infra_gate_grace.get(task.id, 0))
             graced = infra_gate_failure and grace_used < MAX_INFRA_GATE_GRACE
             if graced:

--- a/tests/test_executor_pipeline.py
+++ b/tests/test_executor_pipeline.py
@@ -673,6 +673,76 @@ def test_is_infra_gate_failure_never_graces_green_tests():
     assert not is_infra_gate_failure(outcome)
 
 
+# --- crash d'import agent pré-LLM (#498) ---------------------------------------------
+
+
+def _agent_error_outcome(logs, *, prompt_tokens=0, completion_tokens=0, reason="agent_error"):
+    from collegue.executor import AgentResult, Workspace
+    from collegue.executor.pipeline import ExecutionOutcome
+    from collegue.executor.runner import ExecutionResult
+
+    return ExecutionOutcome(
+        success=False,
+        stage="run",
+        workspace=Workspace(path="/w", branch="b", base_commit="c"),
+        execution=ExecutionResult(
+            agent_result=AgentResult(
+                success=False, logs=logs, prompt_tokens=prompt_tokens, completion_tokens=completion_tokens
+            ),
+            changed=False,
+            diff="",
+            files_changed=(),
+            success=False,
+        ),
+        reason=reason,
+    )
+
+
+_IMPORT_CRASH_LOGS = (
+    "Traceback (most recent call last):\n"
+    '  File "/opt/oh_runner.py", line 31, in main\n'
+    "    from openhands.sdk import LLM, Conversation\n"
+    "ModuleNotFoundError: No module named 'lmnr'\n"
+)
+
+
+def test_is_infra_agent_crash_on_import_traceback():
+    """#498 : crash d'import pré-LLM (agent_error, 0 token, ModuleNotFoundError)
+    = aléa d'infra global (image cassée), pas un échec fonctionnel."""
+    from collegue.executor.pipeline import is_infra_agent_crash
+
+    assert is_infra_agent_crash(_agent_error_outcome(_IMPORT_CRASH_LOGS))
+
+
+def test_is_infra_agent_crash_requires_zero_tokens():
+    """L'agent a appelé le LLM (tokens > 0) puis échoué : échec FONCTIONNEL,
+    jamais classé crash d'infra — même si les logs mentionnent un import."""
+    from collegue.executor.pipeline import is_infra_agent_crash
+
+    assert not is_infra_agent_crash(_agent_error_outcome(_IMPORT_CRASH_LOGS, completion_tokens=50))
+
+
+def test_is_infra_agent_crash_requires_import_signature():
+    """0 token mais pas de traceback d'import (assertion, autre crash) → non classé."""
+    from collegue.executor.pipeline import is_infra_agent_crash
+
+    assert not is_infra_agent_crash(_agent_error_outcome("AssertionError: x != y\n"))
+
+
+def test_is_infra_agent_crash_handles_importerror():
+    from collegue.executor.pipeline import is_infra_agent_crash
+
+    assert is_infra_agent_crash(_agent_error_outcome("ImportError: cannot import name 'sdk' from 'openhands'\n"))
+
+
+def test_is_infra_agent_crash_only_on_agent_error():
+    """Un no_op ou un gate_failed avec les mêmes logs n'est pas un crash agent."""
+    from collegue.executor.pipeline import is_infra_agent_crash
+
+    assert not is_infra_agent_crash(_agent_error_outcome(_IMPORT_CRASH_LOGS, reason="no_op"))
+    assert not is_infra_agent_crash(_agent_error_outcome(_IMPORT_CRASH_LOGS, reason="gate_failed"))
+
+
 # --- remédiation requirements : recapture du diff (#481) -----------------------------
 
 
@@ -819,3 +889,29 @@ async def test_requirements_regeneration_stops_at_gate(repo):
     assert outcome.reason == "gate_failed"
     assert outcome.quality_report.requirements_removed == ("python-jose[cryptography]",)
     assert clients.prs.created == []
+
+
+def test_agent_crash_signature_is_stable_across_variable_preamble():
+    """#498 (revue) : deux crashs de la MÊME cause avec préambule variable (ANSI,
+    timestamps, chemin workspace randomisé) produisent la MÊME signature — sinon
+    le fail-fast crash-loop ne se déclencherait jamais en conditions réelles."""
+    from collegue.executor.pipeline import agent_crash_signature
+
+    crash_a = (
+        "\x1b[36m2026-06-12 01:00:01 WARNING litellm\x1b[0m\n"
+        "running in /tmp/collegue-exec-aAaAaA/workspace\n"
+        "Traceback (most recent call last):\n"
+        '  File "/opt/oh_runner.py", line 31, in main\n'
+        "ModuleNotFoundError: No module named 'lmnr'\n"
+    )
+    crash_b = (
+        "\x1b[36m2026-06-12 02:33:47 WARNING litellm\x1b[0m\n"
+        "running in /tmp/collegue-exec-zZzZzZ/workspace\n"
+        "Traceback (most recent call last):\n"
+        '  File "/opt/oh_runner.py", line 31, in main\n'
+        "ModuleNotFoundError: No module named 'lmnr'\n"
+    )
+    assert agent_crash_signature(crash_a) == agent_crash_signature(crash_b)
+    # Un paquet manquant DIFFÉRENT donne une signature différente.
+    crash_c = crash_b.replace("'lmnr'", "'httpx'")
+    assert agent_crash_signature(crash_c) != agent_crash_signature(crash_b)

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -1804,3 +1804,210 @@ async def test_no_cost_unknown_when_cost_reported(repo, manager):
     await _run(manager, repo, pid, dry_run=False, agent=_PaidAgent(), audit=audit)
     assert not [e for e in audit.events if e.kind == "cost_unknown"]
     assert audit.cost.usd == pytest.approx(0.002)
+
+
+# --- crash-loop agent : grâce + fail-fast (#498) ------------------------------------
+
+
+class _ImportCrashAgent:
+    """Crash d'import pré-LLM (image/runner cassé) : agent_error, 0 token,
+    traceback IDENTIQUE à chaque appel — le cas du faux départ FacNor v5."""
+
+    def __init__(self, logs="Traceback...\nModuleNotFoundError: No module named 'lmnr'"):
+        self._logs = logs
+        self.calls = 0
+
+    def implement_issue(self, workspace, issue):
+        self.calls += 1
+        return AgentResult(success=False, logs=self._logs)
+
+
+async def test_agent_import_crash_is_graced(repo, manager):
+    """#498 : un crash d'import pré-LLM est gracié comme un aléa de gate (#461) —
+    il ne décompte pas le budget fonctionnel de la tâche (events infra_grace)."""
+    from collegue.pilot.audit import RunAuditLog
+
+    async def _sleep(d):
+        pass
+
+    pid = _linear_project(manager, 1)
+    audit = RunAuditLog(pid)
+    await _run(
+        manager, repo, pid, dry_run=False, agent=_ImportCrashAgent(), max_task_attempts=1, audit=audit, sleep_fn=_sleep
+    )
+    graced = [e for e in audit.events if e.kind in ("task_retry", "task_failed") and e.detail.get("infra_grace")]
+    assert graced, "le crash d'import doit être gracié avant le fail-fast"
+
+
+async def test_agent_import_crash_loop_fail_fast(repo, manager):
+    """#498 : un crash d'import qui se rejoue à l'IDENTIQUE arrête le run en
+    sandbox_broken (cause globale) AVANT d'épuiser tout le budget — au run v5 le
+    run mourait blocked en abandonnant 11 tâches."""
+    from collegue.pilot.audit import RunAuditLog
+    from collegue.pilot.driver import MAX_AGENT_CRASH_LOOP
+
+    async def _sleep(d):
+        pass
+
+    pid = _sibling_project(manager, 5)
+    audit = RunAuditLog(pid)
+    result = await _run(
+        manager,
+        repo,
+        pid,
+        dry_run=False,
+        agent=_ImportCrashAgent(),
+        max_task_attempts=3,
+        audit=audit,
+        sleep_fn=_sleep,
+    )
+    assert result.stop_reason == "sandbox_broken"
+    broken = [e for e in audit.events if e.detail.get("sandbox_broken")]
+    assert len(broken) == 1
+    assert broken[0].detail["crash_streak"] >= MAX_AGENT_CRASH_LOOP
+    # Fail-fast : arrêt au MAX_AGENT_CRASH_LOOP-ième crash, bien avant le cap
+    # (5 tâches × 3 tentatives) ; aucune tâche n'a abouti.
+    assert result.iterations == MAX_AGENT_CRASH_LOOP
+    assert not any(o.success for o in result.processed)
+    assert all(t.status != "merged" for t in manager.get_tasks(pid))
+
+
+async def test_distinct_agent_crashes_rearm_loop(repo, manager):
+    """Contre-épreuve #498 : des tracebacks DIFFÉRENTS (hash qui change) ne
+    déclenchent pas le fail-fast — le compteur se réarme à chaque hash distinct."""
+
+    class _VaryingCrashAgent:
+        def __init__(self):
+            self.calls = 0
+
+        def implement_issue(self, workspace, issue):
+            self.calls += 1
+            return AgentResult(
+                success=False, logs=f"Traceback...\nModuleNotFoundError: No module named 'mod{self.calls}'"
+            )
+
+    async def _sleep(d):
+        pass
+
+    pid = _sibling_project(manager, 2)
+    result = await _run(
+        manager,
+        repo,
+        pid,
+        dry_run=False,
+        agent=_VaryingCrashAgent(),
+        max_task_attempts=1,
+        sleep_fn=_sleep,
+    )
+    assert result.stop_reason != "sandbox_broken"
+
+
+async def test_functional_agent_error_with_tokens_not_graced(repo, manager):
+    """Frontière #498 : un agent_error AVEC tokens (l'agent a appelé le LLM) est
+    fonctionnel — décompté normalement, jamais gracié ni traité en crash-loop."""
+    import dataclasses
+
+    from collegue.pilot.audit import RunAuditLog
+
+    class _FunctionalErrorAgent:
+        def implement_issue(self, workspace, issue):
+            return dataclasses.replace(
+                AgentResult(success=False, logs="Traceback...\nModuleNotFoundError: No module named 'x'"),
+                prompt_tokens=1000,
+                completion_tokens=200,
+            )
+
+    async def _sleep(d):
+        pass
+
+    pid = _linear_project(manager, 1)
+    audit = RunAuditLog(pid)
+    result = await _run(
+        manager,
+        repo,
+        pid,
+        dry_run=False,
+        agent=_FunctionalErrorAgent(),
+        max_task_attempts=1,
+        audit=audit,
+        sleep_fn=_sleep,
+    )
+    assert result.stop_reason != "sandbox_broken"
+    t = manager.get_tasks(pid)[0]
+    assert t.attempt_count == 1  # décompté, pas gracié
+
+
+async def test_agent_crash_loop_rearmed_by_success(repo, manager):
+    """#498 (revue) : un succès réarme la détection. 3 tâches qui crashent (1 fois
+    chacune, graciée) PUIS réussissent — sans réarmement-sur-succès, les 3 crashs
+    s'accumuleraient à streak=3 et déclencheraient le fail-fast à tort."""
+
+    class _CrashThenSucceedAgent:
+        """Crash d'import à la 1re tentative de CHAQUE tâche, succès ensuite."""
+
+        def __init__(self):
+            self.seen = {}
+            self._ok = FakeCodeAgent()
+
+        def implement_issue(self, workspace, issue):
+            self.seen[issue.title] = self.seen.get(issue.title, 0) + 1
+            if self.seen[issue.title] == 1:
+                return AgentResult(success=False, logs="Traceback...\nModuleNotFoundError: No module named 'lmnr'")
+            return self._ok.implement_issue(workspace, issue)
+
+    async def _sleep(d):
+        pass
+
+    pid = _sibling_project(manager, 3)
+    result = await _run(
+        manager,
+        repo,
+        pid,
+        dry_run=False,
+        agent=_CrashThenSucceedAgent(),
+        max_task_attempts=2,
+        sleep_fn=_sleep,
+    )
+    # Chaque succès a réarmé le compteur → jamais 3 crashs CONSÉCUTIFS.
+    assert result.stop_reason != "sandbox_broken"
+    assert all(t.status in ("in_review", "merged") for t in manager.get_tasks(pid))
+
+
+async def test_agent_crash_loop_fail_fast_survives_variable_preamble(repo, manager):
+    """#498 (revue) : le fail-fast tire même quand le préambule des logs varie
+    (timestamps/chemins) tant que la ligne d'exception est identique."""
+    from collegue.pilot.audit import RunAuditLog
+
+    class _NoisyImportCrashAgent:
+        def __init__(self):
+            self.calls = 0
+
+        def implement_issue(self, workspace, issue):
+            self.calls += 1
+            return AgentResult(
+                success=False,
+                logs=(
+                    f"2026-06-12 0{self.calls}:00:0{self.calls} WARNING litellm\n"
+                    f"running in /tmp/collegue-exec-rand{self.calls}/workspace\n"
+                    "Traceback (most recent call last):\n"
+                    "ModuleNotFoundError: No module named 'lmnr'\n"
+                ),
+            )
+
+    async def _sleep(d):
+        pass
+
+    pid = _sibling_project(manager, 5)
+    audit = RunAuditLog(pid)
+    result = await _run(
+        manager,
+        repo,
+        pid,
+        dry_run=False,
+        agent=_NoisyImportCrashAgent(),
+        max_task_attempts=3,
+        audit=audit,
+        sleep_fn=_sleep,
+    )
+    assert result.stop_reason == "sandbox_broken"
+    assert any(e.detail.get("sandbox_broken") for e in audit.events)


### PR DESCRIPTION
## Problème (#498 — HAUTE)

Le faux départ du run v5 : une image sandbox cassée (lmnr 0.7.53 incompatible) a fait crasher le process agent à l'import 3 fois en 95 s → budget de la tâche brûlé, `task_failed` terminal, run entier `blocked` (11 tâches abandonnées) pour une cause 100 % infra. La grâce #461 ne couvrait que `reason=gate_failed` — un `agent_error` n'était jamais gracié ni détecté comme boucle.

## Correctif (chemin réel, pas de knob de config inerte)

1. **`is_infra_agent_crash(outcome)`** (pipeline.py, pur/testable) : `reason==agent_error` ET 0 token consommé ET signature d'import (`ModuleNotFoundError`/`ImportError`) dans les logs ⇒ aléa d'infra global. Un `agent_error` AVEC tokens (l'agent a appelé le LLM puis échoué) reste **fonctionnel** — jamais gracié.
2. **Grâce** : `infra_gate_failure = is_infra_gate_failure(outcome) or agent_crash` → le crash d'import ne décompte pas le budget, borné par `MAX_INFRA_GATE_GRACE`.
3. **Fail-fast crash-loop** : N crashs CONSÉCUTIFS à la même signature ⇒ `stop_reason=sandbox_broken` + `break` AVANT de décompter/persister (la tâche reste retentable au prochain run, après rebuild). Robustesse (revue) : `agent_crash_signature` isole la **ligne d'exception** (`ModuleNotFoundError: No module named 'lmnr'`) — stable malgré ANSI/timestamps/chemins workspace randomisés, là où un hash de la queue brute ne se déclencherait jamais en réel. Un succès **ou** un hash différent réarme le compteur.
4. **Harness** (hors repo/CI) : sanity-check proactif `docker run … python -c "import openhands.sdk"` avant la boucle → abort immédiat, zéro budget, si l'image est cassée.

## Tests

- Prédicat pur : crash d'import → True ; tokens>0 → False ; pas de signature → False ; ImportError ; seulement sur agent_error.
- Signature stable : préambule variable (ANSI/timestamps/chemins) → même signature ; paquet différent → signature différente.
- Intégration : crash gracié (infra_grace) ; crash-loop identique → `sandbox_broken` à la 3e itération, 0 tâche aboutie ; **fail-fast survit au préambule variable** ; tracebacks différents → pas de fail-fast ; succès réarme (3 tâches crash-puis-succès → pas de fail-fast à tort) ; agent_error avec tokens → décompté normalement.
- Revue adversariale pré-PR : 2 défauts attrapés et corrigés (réarmement sur succès absent ; hash fragile aux logs non-déterministes).

**Base : `pre-main`** (nouvelle branche tampon pré-régression).

Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)