### PR TITLE
feat(executor): passe d'adéquation des TESTS — un critère chiffrable non asserté rend le gate rouge (#499)

### DIFF
--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -252,6 +252,17 @@ def failure_feedback(outcome: "ExecutionOutcome") -> str:
     if report is not None and getattr(report, "adequacy_implemented", None) is False:
         justification = getattr(report, "adequacy_justification", "") or "le diff n'implémente pas l'issue"
         return ("ADÉQUATION REFUSÉE — le diff ne réalise pas l'issue : " + justification)[:700]
+    if report is not None and getattr(report, "adequacy_tests_assert", None) is False:
+        # #499 : feature présente, tests VERTS, mais un critère chiffrable n'est
+        # asserté par aucun test. La sortie pytest (verte) serait un feedback
+        # trompeur — le motif UTILE est le critère non couvert, pour que l'agent
+        # ajoute l'assertion au lieu de boucler sans converger (cf. #424).
+        justification = getattr(report, "adequacy_tests_justification", "") or "un critère chiffrable n'est pas testé"
+        return (
+            "COUVERTURE DE TEST INSUFFISANTE (#499) — un critère chiffrable de l'issue n'est asserté par "
+            "aucun test : " + justification + ". Ajoute une assertion sur la VALEUR/le CALCUL attendu "
+            "(pas seulement un code HTTP 200)."
+        )[:700]
     removed = tuple(getattr(report, "requirements_removed", ()) or ()) if report is not None else ()
     if removed:
         # #482 : le motif utile est la liste NOMINATIVE des lignes perdues —

--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -27,7 +27,7 @@ import os
 import re
 import shlex
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Iterator, List, Optional, Protocol, Tuple, runtime_checkable
 
 from collegue.executor.agent import IssueSpec
@@ -582,10 +582,15 @@ class Reviewer(Protocol):
 
 @dataclass(frozen=True)
 class AdequacyOutcome:
-    """Verdict d'adéquation diff↔issue (#437)."""
+    """Verdict d'adéquation diff↔issue (#437) + couverture des critères (#499)."""
 
     implemented: bool
     justification: str = ""
+    # #499 : les critères CHIFFRABLES/observables de l'issue sont-ils ASSERTÉS par
+    # au moins un test du diff ? None = non évalué (rétrocompat #437 : un checker
+    # qui ne le renseigne pas ne bloque jamais sur ce volet).
+    tests_assert_criteria: Optional[bool] = None
+    tests_justification: str = ""
 
 
 @runtime_checkable
@@ -626,6 +631,11 @@ class QualityReport:
     # #482 : lignes de requirements.txt de la base supprimées sans que l'issue
     # le demande — requirements.txt est append-only ; non vide ⇒ gate rouge.
     requirements_removed: Tuple[str, ...] = ()
+    # #499 : les critères chiffrables de l'issue sont-ils assertés par les tests
+    # du diff ? None = non évalué (rétrocompat) ; False ⇒ gate rouge (un test qui
+    # n'asserte que « 200 » a livré la TVA ×100 du run v5 sans rien voir).
+    adequacy_tests_assert: Optional[bool] = None
+    adequacy_tests_justification: str = ""
 
     def to_markdown(self) -> str:
         """Rapport Markdown pour le corps de PR (texte de revue fencé, anti-injection)."""
@@ -685,6 +695,14 @@ class QualityReport:
             lines += ["", f"**Adéquation à l'issue (#437)** : {badge}"]
             if detail:
                 lines.append(f"> {_fence_safe_line(detail)}")
+        if self.adequacy_tests_assert is False:
+            lines += [
+                "",
+                "> ⛔ **couverture des critères par les tests insuffisante (#499)** — un critère "
+                "chiffrable/observable de l'issue n'est asserté par aucun test du diff.",
+            ]
+            if self.adequacy_tests_justification:
+                lines.append(f"> {_fence_safe_line(self.adequacy_tests_justification)}")
         if not self.tests_touched:
             lines += [
                 "",
@@ -866,6 +884,36 @@ def _parse_adequacy(text: str) -> AdequacyOutcome:
     return AdequacyOutcome(False, f"réponse illisible du contrôle d'adéquation : {raw[:300]}")
 
 
+# #499 : contrôle de COUVERTURE DES TESTS — distinct de l'adéquation #437 (la
+# feature est-elle là ?). Ici : les critères chiffrables de l'issue sont-ils
+# ASSERTÉS par les tests ? Au run v5, la TVA ×100 a été livrée 12/12 car aucun
+# test n'assertait les totaux (status 200 suffisait).
+_TEST_ADEQUACY_SYSTEM = (
+    "Tu es un relecteur de COUVERTURE DE TEST (rôle REVIEWER). On te donne une issue "
+    "(critères d'acceptation chiffrables/observables) et le diff livré. Tu juges UNIQUEMENT "
+    "si CHAQUE critère chiffrable/observable de l'issue est ASSERTÉ par au moins un test du "
+    "diff (assertion sur la VALEUR/le CALCUL/le COMPORTEMENT, pas seulement un code HTTP 200). "
+    'Réponds STRICTEMENT en JSON : {"tests_assert_criteria": true|false, "justification": "..."}. '
+    "false si un critère chiffrable n'est couvert par aucune assertion (ex. : aucun test "
+    "n'asserte le montant TTC) — nomme alors le critère non couvert dans la justification."
+)
+
+
+def _parse_test_adequacy(text: str) -> Tuple[bool, str]:
+    """Parsing tolérant du verdict de couverture des tests (#499) — fail-closed."""
+    raw = (text or "").strip()
+    match = re.search(r"\{.*\}", raw, flags=re.S)
+    if match:
+        try:
+            data = json.loads(match.group(0))
+            return bool(data.get("tests_assert_criteria")), str(data.get("justification") or "")[:500]
+        except ValueError:
+            pass
+    if not raw:
+        return False, "réponse vide du contrôle de couverture des tests"
+    return False, f"réponse illisible du contrôle de couverture des tests : {raw[:300]}"
+
+
 class LLMAdequacyChecker:
     """:class:`AdequacyChecker` par LLM (#437) — fail-closed.
 
@@ -885,7 +933,21 @@ class LLMAdequacyChecker:
             "Ce diff implémente-t-il concrètement l'issue ?"
         )
         text = await self._sample_fn(prompt, _ADEQUACY_SYSTEM)
-        return _parse_adequacy(text)
+        outcome = _parse_adequacy(text)
+        # #499 : ne contrôler la COUVERTURE des critères que si l'adéquation est
+        # OK (sinon déjà rouge), que le diff touche des tests (sinon
+        # tests_touched/require_test_changes gère) ET que l'issue porte des
+        # critères chiffrables — borne le coût LLM et les faux rouges.
+        if not outcome.implemented or not tests_touched(diff) or not issue.acceptance_criteria:
+            return outcome
+        test_prompt = (
+            f"## Issue à fermer\n{issue.to_prompt()}\n\n"
+            f"## Diff livré\n```diff\n{(diff or '(diff vide)')[: self._max_diff_chars]}\n```\n\n"
+            "Les critères chiffrables/observables de l'issue sont-ils assertés par au moins un test du diff ?"
+        )
+        test_text = await self._sample_fn(test_prompt, _TEST_ADEQUACY_SYSTEM)
+        asserts, justif = _parse_test_adequacy(test_text)
+        return replace(outcome, tests_assert_criteria=asserts, tests_justification=justif)
 
 
 def _default_adequacy_sample_fn():  # pragma: no cover - chemin réel (integration)
@@ -910,18 +972,31 @@ class FakeAdequacyChecker:
     """:class:`AdequacyChecker` déterministe pour la CI (aucun LLM)."""
 
     def __init__(
-        self, *, implemented: bool = True, justification: str = "conforme", raises: Optional[Exception] = None
+        self,
+        *,
+        implemented: bool = True,
+        justification: str = "conforme",
+        raises: Optional[Exception] = None,
+        tests_assert_criteria: Optional[bool] = None,
+        tests_justification: str = "",
     ):
         self._implemented = implemented
         self._justification = justification
         self._raises = raises
+        self._tests_assert_criteria = tests_assert_criteria
+        self._tests_justification = tests_justification
         self.calls: List[int] = []
 
     async def check(self, diff: str, issue: IssueSpec, ctx) -> AdequacyOutcome:
         self.calls.append(issue.number)
         if self._raises is not None:
             raise self._raises
-        return AdequacyOutcome(implemented=self._implemented, justification=self._justification)
+        return AdequacyOutcome(
+            implemented=self._implemented,
+            justification=self._justification,
+            tests_assert_criteria=self._tests_assert_criteria,
+            tests_justification=self._tests_justification,
+        )
 
 
 class FakeReviewer:
@@ -1111,16 +1186,29 @@ async def run_quality_gate(
     adequacy_implemented: Optional[bool] = None
     adequacy_justification = ""
     adequacy_error: Optional[str] = None
+    adequacy_tests_assert: Optional[bool] = None
+    adequacy_tests_justification = ""
     if adequacy_checker is not None and issue is not None and would_pass:
         try:
             adequacy = await adequacy_checker.check(diff, issue, ctx)
             adequacy_implemented = bool(adequacy.implemented)
             adequacy_justification = adequacy.justification
+            # #499 : couverture des critères par les tests (None = non évalué).
+            adequacy_tests_assert = adequacy.tests_assert_criteria
+            adequacy_tests_justification = adequacy.tests_justification
         except Exception as exc:  # noqa: BLE001 - fail-closed ; BaseException (budget) remonte
             adequacy_error = str(exc) or repr(exc)
 
     touched = tests_touched(diff)
-    passed = would_pass and adequacy_implemented is not False and adequacy_error is None
+    # #499 : `is not False` — None (non évalué) et True passent ; seul False
+    # bloque (rétrocompat #437 : un checker qui n'évalue pas la couverture ne
+    # rend jamais le gate rouge sur ce volet).
+    passed = (
+        would_pass
+        and adequacy_implemented is not False
+        and adequacy_tests_assert is not False
+        and adequacy_error is None
+    )
     if require_test_changes and not touched:
         passed = False
     return QualityReport(
@@ -1139,6 +1227,8 @@ async def run_quality_gate(
         tests_touched=touched,
         requirements_added=tuple(requirements_added),
         requirements_removed=requirements_removed,
+        adequacy_tests_assert=adequacy_tests_assert,
+        adequacy_tests_justification=adequacy_tests_justification,
     )
 
 

--- a/tests/test_executor_pipeline.py
+++ b/tests/test_executor_pipeline.py
@@ -863,6 +863,46 @@ def test_failure_feedback_names_removed_requirements():
     assert len(feedback) <= 700
 
 
+def test_failure_feedback_names_uncovered_criterion():
+    """#499 (revue) : feature présente, tests VERTS, mais un critère chiffrable
+    n'est asserté par aucun test — le feedback de retry doit NOMMER le critère
+    non couvert, sinon l'agent reçoit la sortie verte et boucle sans converger."""
+    from collegue.executor import AgentResult, QualityReport, Workspace
+    from collegue.executor.pipeline import ExecutionOutcome, failure_feedback
+    from collegue.executor.runner import ExecutionResult
+
+    outcome = ExecutionOutcome(
+        success=False,
+        stage="gate",
+        workspace=Workspace(path="/w", branch="b", base_commit="c"),
+        execution=ExecutionResult(
+            agent_result=AgentResult(success=True, logs="journal"),
+            changed=True,
+            diff="",
+            files_changed=("tests/test_api.py",),
+            success=True,
+        ),
+        quality_report=QualityReport(
+            tests_passed=True,
+            test_exit_code=0,
+            test_output="12 passed in 1.02s",
+            review_summary="",
+            review_findings=(),
+            review_blocking=False,
+            passed=False,
+            adequacy_implemented=True,
+            adequacy_tests_assert=False,
+            adequacy_tests_justification="aucun test n'asserte le montant TTC",
+        ),
+        reason="gate_failed",
+    )
+    feedback = failure_feedback(outcome)
+    assert "#499" in feedback
+    assert "montant TTC" in feedback
+    assert "12 passed" not in feedback  # la sortie verte ne doit PAS être le feedback
+    assert len(feedback) <= 700
+
+
 async def test_requirements_regeneration_stops_at_gate(repo):
     """#482 bout en bout : l'agent régénère requirements.txt en perdant une ligne
     de la base → gate rouge, aucune PR."""

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -718,6 +718,141 @@ async def test_llm_adequacy_checker_round_trip():
     assert "JSON" in system
 
 
+# --- adéquation des TESTS : couverture des critères chiffrables (#499) ---------------
+
+
+_ISSUE_TVA = IssueSpec(
+    number=7,
+    title="Calcul des totaux TVA/TTC",
+    acceptance_criteria=("Le total TTC doit être calculé correctement (HT + TVA).",),
+)
+# Diff qui TOUCHE un test (tests_touched True) — le cas du run v5 : un test qui
+# n'asserte que le code HTTP, jamais les montants.
+_DIFF_WITH_TEST = (
+    "diff --git a/app/tax.py b/app/tax.py\n+def compute(...): ...\n"
+    "diff --git a/tests/test_api.py b/tests/test_api.py\n+    assert resp.status_code == 200\n"
+)
+
+
+async def test_test_adequacy_blocks_when_criteria_not_asserted(tmp_path):
+    """#499 (le cas TVA ×100 du run v5) : feature présente, tests verts, MAIS
+    aucun test n'asserte le critère chiffrable → gate ROUGE."""
+    from collegue.executor import FakeAdequacyChecker
+
+    checker = FakeAdequacyChecker(
+        implemented=True, tests_assert_criteria=False, tests_justification="aucun test n'asserte le montant TTC"
+    )
+    report = await run_quality_gate(
+        str(tmp_path),
+        _DIFF_WITH_TEST,
+        ctx=None,
+        sandbox=_green(),
+        reviewer=FakeReviewer(),
+        issue=_ISSUE_TVA,
+        adequacy_checker=checker,
+    )
+    assert report.tests_passed is True
+    assert report.adequacy_implemented is True
+    assert report.adequacy_tests_assert is False
+    assert report.passed is False  # fail-closed
+    markdown = report.to_markdown()
+    assert "#499" in markdown and "montant TTC" in markdown
+
+
+async def test_test_adequacy_pass_keeps_gate_green(tmp_path):
+    from collegue.executor import FakeAdequacyChecker
+
+    checker = FakeAdequacyChecker(
+        implemented=True, tests_assert_criteria=True, tests_justification="le test asserte le TTC à 0.01 près"
+    )
+    report = await run_quality_gate(
+        str(tmp_path),
+        _DIFF_WITH_TEST,
+        ctx=None,
+        sandbox=_green(),
+        reviewer=FakeReviewer(),
+        issue=_ISSUE_TVA,
+        adequacy_checker=checker,
+    )
+    assert report.adequacy_tests_assert is True
+    assert report.passed is True
+
+
+async def test_test_adequacy_none_is_non_blocking(tmp_path):
+    """Rétrocompat #437 : un checker qui n'évalue pas la couverture (None) ne rend
+    jamais le gate rouge sur ce volet, et l'encart #499 est absent du rapport."""
+    from collegue.executor import FakeAdequacyChecker
+
+    checker = FakeAdequacyChecker(implemented=True)  # tests_assert_criteria laissé à None
+    report = await run_quality_gate(
+        str(tmp_path),
+        _DIFF_WITH_TEST,
+        ctx=None,
+        sandbox=_green(),
+        reviewer=FakeReviewer(),
+        issue=_ISSUE_TVA,
+        adequacy_checker=checker,
+    )
+    assert report.adequacy_tests_assert is None
+    assert report.passed is True
+    assert "#499" not in report.to_markdown()
+
+
+async def test_llm_test_adequacy_round_trip():
+    """#499 : LLMAdequacyChecker émet un 2e verdict (couverture) quand l'adéquation
+    est OK ET le diff touche des tests ET l'issue porte des critères."""
+    from collegue.executor import LLMAdequacyChecker
+
+    prompts = []
+
+    async def fake_sample(prompt, system_prompt):
+        prompts.append((prompt, system_prompt))
+        if "COUVERTURE DE TEST" in system_prompt:
+            return '{"tests_assert_criteria": false, "justification": "aucun test n\'asserte le montant TTC"}'
+        return '{"implemented": true, "justification": "service livré"}'
+
+    checker = LLMAdequacyChecker(fake_sample)
+    outcome = await checker.check(_DIFF_WITH_TEST, _ISSUE_TVA, ctx=None)
+    assert outcome.implemented is True
+    assert outcome.tests_assert_criteria is False
+    assert len(prompts) == 2  # adéquation puis couverture
+    assert "COUVERTURE DE TEST" in prompts[1][1]
+    assert _ISSUE_TVA.title in prompts[1][0]
+
+
+async def test_llm_test_adequacy_skipped_without_criteria_or_tests():
+    """Borne du coût : pas de 2e appel si le diff ne touche pas de test, ou si
+    l'issue n'a pas de critères chiffrables."""
+    from collegue.executor import LLMAdequacyChecker
+
+    calls = {"n": 0}
+
+    async def fake_sample(prompt, system_prompt):
+        calls["n"] += 1
+        return '{"implemented": true, "justification": "ok"}'
+
+    # 5a : diff SANS test → un seul appel, tests_assert reste None.
+    checker = LLMAdequacyChecker(fake_sample)
+    out_a = await checker.check("diff --git a/app/tax.py b/app/tax.py\n+x\n", _ISSUE_TVA, ctx=None)
+    assert calls["n"] == 1 and out_a.tests_assert_criteria is None
+
+    # 5b : issue SANS acceptance_criteria → un seul appel.
+    calls["n"] = 0
+    out_b = await checker.check(_DIFF_WITH_TEST, IssueSpec(number=8, title="X"), ctx=None)
+    assert calls["n"] == 1 and out_b.tests_assert_criteria is None
+
+
+def test_parse_test_adequacy_is_fail_closed():
+    from collegue.executor.quality_gate import _parse_test_adequacy
+
+    ok, _ = _parse_test_adequacy('{"tests_assert_criteria": true, "justification": "asserte le TTC"}')
+    assert ok is True
+    fenced, just = _parse_test_adequacy('```json\n{"tests_assert_criteria": false, "justification": "rien"}\n```')
+    assert fenced is False and "rien" in just
+    assert _parse_test_adequacy("blabla")[0] is False  # illisible ⇒ fail-closed
+    assert _parse_test_adequacy("")[0] is False
+
+
 # --- signal « aucun test touché » (#437) --------------------------------------------
 
 


### PR DESCRIPTION
## Problème (#499 — HAUTE)

Au run v5, les totaux TVA/TTC du produit FacNor étaient faux **×100** — et livrés 12/12 parce qu'**aucun test n'assertait les montants** (`status_code == 200` suffisait). L'adéquation #437 vérifie « la feature est-elle là ? » mais pas « les TESTS vérifient-ils les critères chiffrables de l'issue ? ».

## Correctif

1. **2e verdict d'adéquation** dans `LLMAdequacyChecker` : après #437, si la feature est présente ET le diff touche des tests ET l'issue porte des critères chiffrables → un appel LLM distinct (`_TEST_ADEQUACY_SYSTEM`) juge si chaque critère est **asserté sur une VALEUR/un CALCUL**, pas un simple code HTTP. Borné (pas d'appel ni de faux rouge sinon).
2. **Gate fail-closed** : `adequacy_tests_assert is False` ⇒ `passed=False`. `None`/`True` passent → **rétrocompat #437 stricte** (un checker qui n'évalue pas la couverture ne bloque jamais sur ce volet ; champs `AdequacyOutcome` ajoutés en fin avec défaut neutre).
3. **Feedback de retry** (corrigé en revue) : le motif #499 est réinjecté via `failure_feedback` — il NOMME le critère non couvert (« ajoute une assertion sur le montant TTC ») au lieu de relayer la sortie pytest VERTE. Sans cela, le gate bloquait mais l'agent bouclait sans converger (#424).
4. **Harness** (hors repo/CI) : `adequacy_checker` câblé dans `gate_options` — sans ce câblage #437 ET #499 étaient **inertes au run réel** (le harness construit ses options en dur ; c'est pourquoi la TVA ×100 est passée).
5. `QualityReport` + encart `to_markdown` (#499) neutralisé anti-injection.

## Tests

- Gate : critère non asserté → rouge avec le motif nommé ; asserté → vert ; None → non bloquant (rétrocompat #437) ; encart #499 absent quand non évalué.
- `LLMAdequacyChecker` : 2 verdicts (round-trip) ; 2e appel sauté sans test/critères (borne du coût).
- `_parse_test_adequacy` fail-closed (vide/illisible/fencé).
- **Propagation** (angle mort de la 1re passe, ajouté en revue) : `failure_feedback` porte « #499 » + le critère, jamais la sortie verte.
- Revue adversariale pré-PR : 1 défaut bloquant attrapé (le verdict #499 n'atteignait pas l'agent au retry) → corrigé + testé. Rétrocompat #437, parsing, harness : RAS.

**Base : `pre-main`.**

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)