### PR TITLE
feat(executor,review): volet ownership/IDOR dans la revue de sécurité du gate (#500)

### DIFF
--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -1285,6 +1285,45 @@ def _diff_paths(diff: str) -> Iterator[str]:
         yield path
 
 
+# #500 : un diff qui touche de l'AUTH (routes d'auth, « utilisateur courant ») est
+# le terrain de l'IDOR — la fuite cross-user la plus probable d'une app CRUD
+# générée par LLM (run v5 : clients lisibles/modifiables par tout compte). La
+# détection vit sur le DIFF (pas la config) → active au run réel même si le
+# harness bypasse _gate_options.
+_AUTH_DIFF_MARKERS = (
+    "get_current_user",
+    "current_user",
+    "oauth2passwordbearer",
+    "/auth/",
+    "httpbearer",
+    "import jwt",
+    "from jwt",
+    "jwt.encode",
+    "jwt.decode",
+    "depends(get_current",
+)
+
+# Consigne de revue ciblée, injectée quand le diff touche l'auth. Heuristique
+# best-effort : elle peut RATER une auth maison sans marqueur idiomatique (le
+# standard `security` mentionne alors l'IDOR de façon inconditionnelle comme
+# filet) ; un faux positif ne coûte qu'une consigne en trop — on erre du bon
+# côté en sécurité.
+_OWNERSHIP_REVIEW_CONSIGNE = (
+    "REVUE SÉCURITÉ — ISOLATION PAR PROPRIÉTAIRE (IDOR) : cette app a de "
+    "l'authentification. Toute ressource créée par un utilisateur DOIT être "
+    "filtrée par son propriétaire en lecture, écriture ET suppression. Signale "
+    "en `critical` (catégorie `security`) tout endpoint CRUD (GET/PUT/PATCH/"
+    "DELETE d'une ressource par id) qui n'applique aucun filtre owner — un "
+    "autre utilisateur authentifié pourrait y accéder."
+)
+
+
+def _diff_touches_auth(diff: str) -> bool:
+    """Le diff introduit-il de l'authentification ? (heuristique, insensible casse, #500)."""
+    haystack = (diff or "").lower()
+    return any(marker in haystack for marker in _AUTH_DIFF_MARKERS)
+
+
 def _detect_review_language(diff: str) -> Optional[str]:
     """Langage dominant d'un diff parmi ceux que ``code_review`` sait reviewer.
 
@@ -1357,11 +1396,15 @@ class ExpertReviewer:
             )
 
         tool = self._tool or self._build_tool()
-        request = CodeReviewRequest(
-            code=diff or "(diff vide)",
-            language=language,
-            context=issue.to_prompt() if issue is not None else None,
-        )
+        base_context = issue.to_prompt() if issue is not None else None
+        # #500 : si le diff touche l'auth, injecter la consigne ownership/IDOR —
+        # le diff complet (modèle + routes) est déjà envoyé en `code`, seul le
+        # prompt manquait la consigne (run v5 : IDOR clients non détecté).
+        if _diff_touches_auth(diff):
+            base_context = (
+                f"{base_context}\n\n{_OWNERSHIP_REVIEW_CONSIGNE}" if base_context else _OWNERSHIP_REVIEW_CONSIGNE
+            )
+        request = CodeReviewRequest(code=diff or "(diff vide)", language=language, context=base_context)
         response = await tool.execute_async(request, ctx=ctx)
         return outcome_from_review(response, min_quality=self._min_quality)
 

--- a/collegue/tools/code_review/config.py
+++ b/collegue/tools/code_review/config.py
@@ -12,7 +12,10 @@ REVIEW_STANDARDS = {
         "hachage de mot de passe faible ou non salé (MD5, SHA1, SHA-256 nu), "
         "comparaison de mots de passe/jetons non à temps constant, "
         "jetons d'authentification falsifiables (base64/JSON non signés), "
-        "validation des entrées manquante, contrôle d'autorisation absent"
+        "validation des entrées manquante, contrôle d'autorisation absent, "
+        "isolation par propriétaire absente sur une ressource multi-utilisateurs "
+        "(IDOR : un endpoint CRUD qui lit/modifie/supprime une ressource sans la "
+        "filtrer par l'utilisateur courant)"
     ),
     "performance": "Patterns inefficaces (boucles O(n²), allocations inutiles)",
     "dry": "Duplication de code (Don't Repeat Yourself)",

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -1002,6 +1002,55 @@ async def test_expert_reviewer_maps_tool_response():
     assert request.language == "python"
 
 
+def test_diff_touches_auth_heuristic():
+    """#500 : détection (insensible casse) d'un diff qui touche l'auth."""
+    from collegue.executor.quality_gate import _diff_touches_auth
+
+    assert _diff_touches_auth("diff --git a/api.py b/api.py\n+user = Depends(get_current_user)\n")
+    assert _diff_touches_auth("diff --git a/auth.py b/auth.py\n+@app.post('/auth/login')\n")
+    assert _diff_touches_auth("+OAuth2PasswordBearer(tokenUrl='token')")
+    assert _diff_touches_auth("+import JWT")  # insensible à la casse
+    assert not _diff_touches_auth("diff --git a/calc.py b/calc.py\n+def add(a, b): return a + b\n")
+    assert not _diff_touches_auth("")
+
+
+def test_security_standard_mentions_idor():
+    """#500 : le standard `security` de la revue nomme désormais l'IDOR/ownership."""
+    from collegue.tools.code_review.config import REVIEW_STANDARDS
+
+    assert "IDOR" in REVIEW_STANDARDS["security"]
+    assert "propriétaire" in REVIEW_STANDARDS["security"]
+
+
+async def test_review_injects_ownership_consigne_when_diff_touches_auth():
+    """#500 : un diff auth déclenche l'injection de la consigne ownership dans le
+    contexte de revue — le diff complet (modèle + routes) est déjà envoyé, seul
+    le prompt manquait la consigne (IDOR clients non détecté au run v5)."""
+    auth_diff = (
+        "diff --git a/app/api/clients.py b/app/api/clients.py\n"
+        "+def list_clients(user = Depends(get_current_user)):\n+    return db.query(Client).all()\n"
+    )
+    tool = _FakeTool(_response(0.9))
+    reviewer = ExpertReviewer(tool=tool)
+    await reviewer.review(auth_diff, ctx=None, issue=ISSUE)
+    context = tool.calls[0][0].context
+    assert context.startswith(ISSUE.to_prompt())
+    assert "IDOR" in context and "propriétaire" in context
+
+
+async def test_review_no_ownership_consigne_without_auth():
+    """Pas de bruit : un diff sans auth n'injecte aucune consigne ownership."""
+    neutral = "diff --git a/calc.py b/calc.py\n+def add(a, b):\n+    return a + b\n"
+    tool = _FakeTool(_response(0.9))
+    reviewer = ExpertReviewer(tool=tool)
+    await reviewer.review(neutral, ctx=None, issue=ISSUE)
+    assert tool.calls[0][0].context == ISSUE.to_prompt()
+    # Sans issue ET sans auth → contexte None (inchangé).
+    tool2 = _FakeTool(_response(0.9))
+    await ExpertReviewer(tool=tool2).review(neutral, ctx=None, issue=None)
+    assert tool2.calls[0][0].context is None
+
+
 async def test_review_skipped_for_unsupported_language_diff():
     """#409 : un diff sans fichier de code supporté (SQL seul) → revue IGNORÉE et
     NON bloquante ; l'outil n'est PAS appelé (plus de faux 0.00 sur du non-code).


### PR DESCRIPTION
## Problème (#500 — HAUTE)

Au run v5, les clients FacNor n'avaient aucune notion de propriétaire : n'importe quel compte authentifié lisait/modifiait/supprimait les clients de tout le monde (IDOR cross-user prouvé). La revue de sécurité du gate n'a rien bloqué — aucun volet ownership/multi-tenancy.

## Correctif — FIX #1 (le verrou principal)

1. **Standard `security`** (code_review) nomme désormais l'**IDOR / isolation par propriétaire** — critère inconditionnel de toute revue sécurité.
2. **Consigne ciblée** : si le diff touche l'auth (`_diff_touches_auth`, heuristique best-effort insensible à la casse), `ExpertReviewer` injecte une consigne ownership dans le contexte de revue. Le diff complet (modèle + routes) part déjà au LLM en `code` — seul le prompt manquait la consigne. Un endpoint CRUD sans filtre owner doit sortir en `security`/`critical`.
3. **Blocage effectif au run réel** (corrigé en revue — point d'inertie) : le moteur (`outcome_from_review`) rend déjà les findings `critical` bloquants, mais le harness wrappait le reviewer en `_AdvisoryReviewer` qui forçait `blocking=False`. Désormais un finding **security/critical** (IDOR, injection, secret) reste **bloquant** malgré l'advisory ; le reste de la revue demeure consultatif (les tests sont le gate dur). Sans ce verrou, FIX #1 aurait été inerte au prochain run.

## Choix de périmètre

**FIX #2** (sonde smoke cross-user dynamique : créer ressource avec compte A, prouver l'accès par B) est **différé en follow-up** : l'issue dit « ou », la consigne LLM + le blocage critical sont le verrou robuste qui aurait stoppé les 12 PRs v5 ; la sonde générique est fragile (fail-open sur schéma inconnu) et mérite sa propre PR. Limite documentée : une auth maison sans marqueur idiomatique peut échapper à l'heuristique — le standard `security` inconditionnel reste alors le filet.

## Tests

- `_diff_touches_auth` : détecte Depends(get_current…), /auth/, OAuth2PasswordBearer, import jwt… ; faux sur diff neutre.
- Standard `security` mentionne IDOR/propriétaire.
- Injection : diff auth → consigne ownership appendée au contexte (commence par `issue.to_prompt()`) ; diff neutre → contexte inchangé ; sans issue ni auth → None.
- Rétrocompat : `test_expert_reviewer_maps_tool_response` (DIFF sans marqueur) intact ; chemins #437/#409 (early-return) non perturbés.
- Revue adversariale pré-PR : 1 défaut bloquant attrapé (inertie : advisory neutralisait le blocage) → corrigé ; marqueurs `depends(`/`jwt` resserrés pour limiter les faux positifs ; commentaire rendu honnête.

**Base : `pre-main`.**

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)