### PR TITLE
feat(pilot,monitoring): MAX_COST_USD enforce enfin la dépense du canal coder (#495)

### DIFF
--- a/collegue/monitoring/metrics.py
+++ b/collegue/monitoring/metrics.py
@@ -334,6 +334,9 @@ class MetricsCollector:
         self,
         max_cost_usd: Optional[float] = None,
         max_tokens: Optional[int] = None,
+        *,
+        base_cost: float = 0.0,
+        base_tokens: int = 0,
     ) -> Optional[BudgetStatus]:
         """Retourne un :class:`BudgetStatus` si le budget dur est atteint, sinon ``None``.
 
@@ -341,6 +344,11 @@ class MetricsCollector:
         ``MAX_TOKENS_BUDGET``) s'ils ne sont pas fournis. Un plafond ``<= 0``
         (ou non défini) est désactivé. La comparaison est ``>=`` : on bloque
         l'appel suivant dès que la limite est atteinte.
+
+        ``base_cost``/``base_tokens`` (#495) : totaux d'un canal DISJOINT du
+        collector (le canal coder, invisible du MetricsCollector serveur) sommés
+        avant comparaison — sans eux le plafond $ ne mordait jamais sur la
+        dépense coder, pourtant majoritaire. Défaut 0 = comportement inchangé.
 
         Granularité (limitation connue, C4) : le coût cumulé est mis à jour à la
         **fin de chaque exécution d'outil** (``record_execution``), pas par appel
@@ -363,6 +371,8 @@ class MetricsCollector:
             except Exception:
                 pass
         total_cost, total_tokens = self._cumulative_totals()
+        total_cost = total_cost + float(base_cost or 0.0)
+        total_tokens = total_tokens + int(base_tokens or 0)
         # Fail-safe : un coût non fini (NaN/inf — ex. metrics.json corrompu) ne
         # doit pas aveugler le cap (NaN >= x est False), on le traite en dépassement.
         if max_cost_usd and max_cost_usd > 0 and (not math.isfinite(total_cost) or total_cost >= max_cost_usd):

--- a/collegue/pilot/budget.py
+++ b/collegue/pilot/budget.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Callable, Optional
+from typing import Callable, Optional, Tuple
 
 from collegue.monitoring.metrics import BudgetStatus, get_metrics_collector
 
@@ -72,11 +72,16 @@ class BudgetTimeController:
         collector=None,
         settings_obj: Optional[object] = None,
         clock: Optional[Callable[[], datetime]] = None,
+        extra_totals: Optional[Callable[[], Tuple[float, int]]] = None,
     ):
         self._clock = clock or _utcnow
         self._started_at = _aware(started_at) or _aware(self._clock())
         self._settings = settings_obj
         self._collector = collector
+        # #495 : source de totaux (usd, tokens) d'un canal DISJOINT du collector
+        # (le canal coder). Câblable post-construction via attach_extra_totals —
+        # le harness FacNor construit le controller AVANT run_project.
+        self._extra_totals = extra_totals
         if deadline_seconds is None:
             deadline_seconds = getattr(self._resolve_settings(), "COLLEGUE_RUN_DEADLINE_SECONDS", 0.0) or 0.0
         self._deadline_seconds = float(deadline_seconds)
@@ -94,6 +99,17 @@ class BudgetTimeController:
 
     def _collector_obj(self):
         return self._collector or get_metrics_collector()
+
+    def attach_extra_totals(self, source: Callable[[], Tuple[float, int]]) -> None:
+        """Câble une source de totaux (usd, tokens) d'un canal disjoint (#495).
+
+        Appelé par ``run_project`` pour brancher l'accumulateur CODER-SEUL — le
+        seul point en scope sur TOUS les chemins (runtime ET harness FacNor, qui
+        construit son propre controller). Ne jamais y brancher ``audit.cost`` ni
+        ``cost_source`` (qui incluent la portion process déjà dans le collector
+        → double comptage).
+        """
+        self._extra_totals = source
 
     def _now(self) -> datetime:
         """Heure courante *aware* (coercition UTC si l'horloge injectée est naïve)."""
@@ -130,10 +146,23 @@ class BudgetTimeController:
         # les settings injectés (cohérent avec la deadline), et on respecte
         # BUDGET_EXHAUSTED_ACTION : "warn" = non bloquant (comme enforce_budget).
         settings = self._resolve_settings()
-        status = self._collector_obj().would_exceed_budget(
-            max_cost_usd=getattr(settings, "MAX_COST_USD", None),
-            max_tokens=getattr(settings, "MAX_TOKENS_BUDGET", None),
-        )
+        kwargs = {
+            "max_cost_usd": getattr(settings, "MAX_COST_USD", None),
+            "max_tokens": getattr(settings, "MAX_TOKENS_BUDGET", None),
+        }
+        # #495 : somme du canal coder (disjoint du collector) avant comparaison.
+        # Émis SEULEMENT si non nul → l'appel par défaut reste à 2 kwargs (fakes
+        # à signature fixe + assertions d'égalité stricte préservés).
+        if self._extra_totals is not None:
+            try:
+                extra_usd, extra_tokens = self._extra_totals()
+                extra_usd, extra_tokens = float(extra_usd or 0.0), int(extra_tokens or 0)
+            except Exception:  # noqa: BLE001 - le budget ne casse jamais le run
+                extra_usd, extra_tokens = 0.0, 0
+            if extra_usd or extra_tokens:
+                kwargs["base_cost"] = extra_usd
+                kwargs["base_tokens"] = extra_tokens
+        status = self._collector_obj().would_exceed_budget(**kwargs)
         if status is not None:
             action = str(getattr(settings, "BUDGET_EXHAUSTED_ACTION", "pause") or "pause").strip().lower()
             reason = f"budget {status.limit_type} atteint : {status.current:.4f} >= {status.limit:.4f}"

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import math
 import re
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
@@ -515,6 +516,15 @@ async def run_project(
     """
     budget = budget or BudgetTimeController()
     audit = audit or NullAuditLog()
+    # #495 : accumulateur CODER-SEUL (disjoint du MetricsCollector serveur) câblé
+    # au budget — sans ça MAX_COST_USD ne mordait jamais sur la dépense coder,
+    # pourtant majoritaire (18 M tokens au v4). Câblé ici car run_project est le
+    # seul point où `budget` est en scope sur TOUS les chemins (runtime ET
+    # harness FacNor qui construit son propre controller).
+    coder_totals = {"usd": 0.0, "tokens": 0}
+    _attach = getattr(budget, "attach_extra_totals", None)
+    if callable(_attach):
+        _attach(lambda: (coder_totals["usd"], coder_totals["tokens"]))
     try:
         max_task_attempts = max(1, int(max_task_attempts))
     except (TypeError, ValueError):
@@ -745,6 +755,13 @@ async def run_project(
                 )
         if coder_tokens or coder_usd:
             audit.record_cost(usd=coder_usd, tokens=coder_tokens, iteration=iteration)
+            # #495 : alimente l'accumulateur coder-seul lu par le budget dur.
+            # Même garde que RunCostLedger.add — un coder_usd aberrant (négatif,
+            # NaN/inf) ne doit pas fausser ni empoisonner le total budgétaire.
+            if math.isfinite(coder_usd) and coder_usd > 0:
+                coder_totals["usd"] += coder_usd
+            if coder_tokens > 0:
+                coder_totals["tokens"] += coder_tokens
         elif TIMEOUT_NOTE in (getattr(agent_result, "logs", "") or ""):
             # #464 : tentative tuée de l'extérieur (timeout sandbox) AVANT toute
             # ligne [collegue-usage] — la dépense (la tentative la plus longue,

--- a/tests/test_pilot_budget.py
+++ b/tests/test_pilot_budget.py
@@ -162,3 +162,90 @@ def test_config_deadline_validator_neutralizes_bad_values():
     assert Settings(COLLEGUE_RUN_DEADLINE_SECONDS=-5).COLLEGUE_RUN_DEADLINE_SECONDS == 0.0
     assert Settings(COLLEGUE_RUN_DEADLINE_SECONDS=float("nan")).COLLEGUE_RUN_DEADLINE_SECONDS == 0.0
     assert Settings(COLLEGUE_RUN_DEADLINE_SECONDS=30).COLLEGUE_RUN_DEADLINE_SECONDS == 30.0
+
+
+# --- totaux externes (canal coder) repliés dans le budget (#495) --------------------
+
+
+def test_extra_totals_fold_into_budget_cost():
+    """#495 : un canal disjoint (coder) sommé avant comparaison déclenche le cap $."""
+    from collegue.monitoring.metrics import MetricsCollector
+
+    ctrl = BudgetTimeController(
+        started_at=T0,
+        deadline_seconds=0,
+        collector=MetricsCollector(),
+        settings_obj=SimpleNamespace(MAX_COST_USD=1.0, MAX_TOKENS_BUDGET=0, BUDGET_EXHAUSTED_ACTION="pause"),
+        clock=_clock(T0),
+        extra_totals=lambda: (1.5, 0),
+    )
+    assert ctrl.should_continue().action == "paused_budget"
+
+
+def test_extra_totals_fold_into_budget_tokens():
+    from collegue.monitoring.metrics import MetricsCollector
+
+    ctrl = BudgetTimeController(
+        started_at=T0,
+        deadline_seconds=0,
+        collector=MetricsCollector(),
+        settings_obj=SimpleNamespace(MAX_COST_USD=0, MAX_TOKENS_BUDGET=1000, BUDGET_EXHAUSTED_ACTION="pause"),
+        clock=_clock(T0),
+        extra_totals=lambda: (0.0, 2000),
+    )
+    assert ctrl.should_continue().action == "paused_budget"
+
+
+def test_extra_totals_source_raises_is_safe():
+    """Le budget ne casse jamais le run : une source qui lève retombe sur le
+    collector seul (continue)."""
+
+    def _boom():
+        raise RuntimeError("source cassée")
+
+    ctrl = BudgetTimeController(
+        started_at=T0,
+        deadline_seconds=0,
+        collector=_Collector(None),
+        settings_obj=SimpleNamespace(MAX_COST_USD=1.0, MAX_TOKENS_BUDGET=0, BUDGET_EXHAUSTED_ACTION="pause"),
+        clock=_clock(T0),
+        extra_totals=_boom,
+    )
+    assert ctrl.should_continue().ok is True
+
+
+def test_attach_extra_totals_setter():
+    """#495 : câblage post-construction (chemin harness — controller créé avant
+    run_project)."""
+    from collegue.monitoring.metrics import MetricsCollector
+
+    ctrl = BudgetTimeController(
+        started_at=T0,
+        deadline_seconds=0,
+        collector=MetricsCollector(),
+        settings_obj=SimpleNamespace(MAX_COST_USD=1.0, MAX_TOKENS_BUDGET=0, BUDGET_EXHAUSTED_ACTION="pause"),
+        clock=_clock(T0),
+    )
+    assert ctrl.should_continue().ok is True  # rien câblé → sous budget
+    ctrl.attach_extra_totals(lambda: (9.0, 0))
+    assert ctrl.should_continue().action == "paused_budget"
+
+
+def test_no_extra_totals_keeps_collector_call_two_kwargs():
+    """Sans extra_totals, l'appel à would_exceed_budget reste à 2 kwargs exactement
+    (fakes à signature fixe + assertions d'égalité stricte préservés)."""
+    seen = {}
+
+    class _Capturing:
+        def would_exceed_budget(self, max_cost_usd=None, max_tokens=None):
+            seen["keys"] = {"cost": max_cost_usd, "tokens": max_tokens}
+            return None
+
+    BudgetTimeController(
+        started_at=T0,
+        deadline_seconds=0,
+        collector=_Capturing(),
+        settings_obj=SimpleNamespace(MAX_COST_USD=5.0, MAX_TOKENS_BUDGET=10, BUDGET_EXHAUSTED_ACTION="pause"),
+        clock=_clock(T0),
+    ).should_continue()
+    assert seen["keys"] == {"cost": 5.0, "tokens": 10}

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -2011,3 +2011,52 @@ async def test_agent_crash_loop_fail_fast_survives_variable_preamble(repo, manag
     )
     assert result.stop_reason == "sandbox_broken"
     assert any(e.detail.get("sandbox_broken") for e in audit.events)
+
+
+# --- enforcement du plafond $ sur le canal coder (#495) -----------------------------
+
+
+async def test_coder_spend_enforces_max_cost(repo, manager):
+    """#495 (le test décisif) : la dépense CODER (invisible du MetricsCollector
+    serveur) compte enfin pour MAX_COST_USD — le run se met en pause au lieu de
+    dépenser sans limite dollar (18 M tokens à 0 $ « sous budget » au v4)."""
+    import dataclasses
+    from types import SimpleNamespace
+
+    from collegue.monitoring.metrics import MetricsCollector
+    from collegue.pilot.budget import BudgetTimeController
+
+    class _UsageAgent:
+        def __init__(self):
+            self._ok = FakeCodeAgent()
+
+        def implement_issue(self, workspace, issue):
+            result = self._ok.implement_issue(workspace, issue)
+            return dataclasses.replace(result, prompt_tokens=10000, completion_tokens=2000, cost_usd=5.0)
+
+    budget = BudgetTimeController(
+        collector=MetricsCollector(),  # collector serveur vide : seule la dépense coder compte
+        settings_obj=SimpleNamespace(MAX_COST_USD=1.0, MAX_TOKENS_BUDGET=0, BUDGET_EXHAUSTED_ACTION="pause"),
+    )
+    pid = _linear_project(manager, 2)
+    result = await _run(manager, repo, pid, dry_run=False, agent=_UsageAgent(), budget=budget)
+    assert result.stop_reason == "paused_budget"
+    statuses = {t.title: t.status for t in manager.get_tasks(pid)}
+    assert statuses["T0"] == "in_review"  # la 1re tâche a abouti
+    assert statuses["T1"] == "todo"  # la 2e n'a JAMAIS démarré (budget atteint)
+
+
+async def test_budget_unchanged_without_coder_spend(repo, manager):
+    """Sans dépense coder déclarée, comportement historique inchangé (pas de pause)."""
+    from types import SimpleNamespace
+
+    from collegue.monitoring.metrics import MetricsCollector
+    from collegue.pilot.budget import BudgetTimeController
+
+    budget = BudgetTimeController(
+        collector=MetricsCollector(),
+        settings_obj=SimpleNamespace(MAX_COST_USD=1.0, MAX_TOKENS_BUDGET=0, BUDGET_EXHAUSTED_ACTION="pause"),
+    )
+    pid = _linear_project(manager, 2)
+    result = await _run(manager, repo, pid, dry_run=False, agent=FakeCodeAgent(), budget=budget)
+    assert result.stop_reason == "completed"


### PR DESCRIPTION
## Problème (#495 — MOYENNE)

`BudgetTimeController.should_continue` ne lit que le `MetricsCollector` du process serveur (canal MCP). La dépense du **canal coder** — majoritaire (18 M tokens au v4) — alimente le `RunCostLedger` de l'audit, **jamais** le collector. Résultat : `MAX_COST_USD` ne mord pas sur le coder, même avec le ledger exact (#484).

## Correctif (côté moteur — anti-inertie)

1. **`would_exceed_budget(..., base_cost=0, base_tokens=0)`** : totaux d'un canal disjoint sommés avant comparaison (défaut 0 = inchangé).
2. **`BudgetTimeController`** : `extra_totals` + `attach_extra_totals(source)`. `should_continue` émet `base_cost`/`base_tokens` **seulement si non nuls** → l'appel par défaut reste à 2 kwargs (fakes à signature fixe + assertions d'égalité stricte préservés). Source qui lève → fail-safe (le budget ne casse jamais le run).
3. **`run_project`** : accumulateur **CODER-SEUL** câblé au budget via le setter — seul point en scope sur **tous** les chemins (runtime ET harness FacNor qui construit son propre controller). Garde anti-aberrant (`finite & >0`) alignée sur `RunCostLedger.add`. **Jamais** `audit.cost`/`cost_source` (qui incluent la portion process déjà dans le collector → pas de double comptage, caveat #441 respecté).

Complète #484 : le coût coder estimé (prix de secours) compte désormais réellement pour le plafond. Limitation connue conservée : le cap est évalué **entre tâches** (un run-away dans une seule tâche reste borné par le timeout sandbox).

## Tests

- Mécanisme : extra_totals replie le coût/les tokens → `paused_budget` ; source qui lève → safe (continue) ; setter post-construction (chemin harness) ; **sans** extra_totals → appel à 2 kwargs exactement (contrat préservé).
- **Intégration (décisif)** : un agent déclarant 5 $/tâche avec `MAX_COST_USD=1.0` → le run se met en pause **après la 1re tâche**, la 2e ne démarre jamais (échoue avant le fix : le run allait au bout).
- Pas de dépense coder → comportement historique (completed).
- Revue adversariale pré-PR : APPROUVÉ (double comptage nul, fail-safe, fakes intacts) + 1 durcissement appliqué (garde anti-négatif/NaN sur l'accumulateur).

**Base : `pre-main`.**

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)