### PR TITLE
feat(executor,pilot): signal des dépendances directes non épinglées + consigne d'épinglage (#497)

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -112,6 +112,9 @@ class Settings(BaseSettings):
     # ROUGE (feedback nominatif). Analyse pure du diff, aucun coût d'infra ;
     # off → suppression silencieuse tolérée (comportement historique).
     GATE_REQUIREMENTS_APPEND_ONLY: bool = True
+    # #497 : signal (NON bloquant) des dépendances directes ajoutées sans
+    # contrainte de version dans requirements.txt (cause du register→500 v4).
+    GATE_PIN_GUARD: bool = True
     # Adéquation diff↔issue (#437) : contrôle LLM fail-closed « ce diff
     # implémente-t-il l'issue ? » lancé quand le reste du gate est vert — une
     # « livraison fantôme » (feature fermée par +1 ligne de requirements) ne

--- a/collegue/executor/__init__.py
+++ b/collegue/executor/__init__.py
@@ -36,6 +36,7 @@ from collegue.executor.quality_gate import (
     smoke_run_command,
     tests_touched,
     unjustified_requirement_removals,
+    unpinned_requirement_lines,
 )
 from collegue.executor.revert import (
     RevertError,
@@ -81,6 +82,7 @@ __all__ = [
     "frontend_gate_command",
     "installability_command",
     "removed_requirement_lines",
+    "unpinned_requirement_lines",
     "unjustified_requirement_removals",
     "smoke_run_command",
     "outcome_from_review",

--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -631,6 +631,10 @@ class QualityReport:
     # #482 : lignes de requirements.txt de la base supprimées sans que l'issue
     # le demande — requirements.txt est append-only ; non vide ⇒ gate rouge.
     requirements_removed: Tuple[str, ...] = ()
+    # #497 : lignes de paquet ajoutées à requirements.txt SANS contrainte de
+    # version (dépendances directes non épinglées) — signal NON bloquant ; cause
+    # racine du register→500 v4 (passlib figé + bcrypt résolu librement).
+    requirements_unpinned: Tuple[str, ...] = ()
     # #499 : les critères chiffrables de l'issue sont-ils assertés par les tests
     # du diff ? None = non évalué (rétrocompat) ; False ⇒ gate rouge (un test qui
     # n'asserte que « 200 » a livré la TVA ×100 du run v5 sans rien voir).
@@ -661,6 +665,13 @@ class QualityReport:
                 "> ⛔ **lignes de `requirements.txt` supprimées sans que l'issue le demande (#482)** — "
                 "`requirements.txt` est append-only. Lignes supprimées : "
                 + ", ".join(f"`{_fence_safe_line(line)}`" for line in self.requirements_removed)
+            )
+        if self.requirements_unpinned:
+            lines.append(
+                "> ⚠️ **dépendances directes non épinglées** ajoutées à `requirements.txt` (#497) — "
+                "une version résolue librement peut casser l'installation vierge (cause du register→500 v4). "
+                "Épingle-les (`==X.Y.Z` ou bornes `>=A,<B`) : "
+                + ", ".join(f"`{_fence_safe_line(line)}`" for line in self.requirements_unpinned)
             )
         lines += [
             "",
@@ -747,6 +758,10 @@ def issue_expects_code(issue: IssueSpec) -> bool:
 # Nom de paquet en tête d'une ligne de requirements ; les lignes d'option
 # (-r/-e/--index-url), commentaires et vides n'ont pas de nom.
 _REQ_LINE_NAME_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)\s*(\[[^\]]+\])?")
+# #497 : opérateurs de contrainte de version PEP 508. Une ligne qui en porte au
+# moins un (après le nom+extras) est « épinglée » ; « @ » (source figée,
+# `pkg @ https://…` / `pkg @ git+…`) vaut aussi épinglage.
+_REQ_PIN_RE = re.compile(r"(===|==|~=|!=|>=|<=|<|>|@)")
 
 
 def _requirement_name(line: str) -> Optional[str]:
@@ -846,6 +861,51 @@ def unjustified_requirement_removals(diff: str, issue: Optional[IssueSpec] = Non
             continue  # suppression demandée par l'issue
         kept.append(line)
     return tuple(kept)
+
+
+def unpinned_requirement_lines(diff: str) -> Tuple[str, ...]:
+    """Lignes de paquet AJOUTÉES à ``requirements.txt`` sans contrainte de version (#497).
+
+    Cause racine du register→500 du run v4 : ``passlib`` 1.7.4 figé + ``bcrypt``
+    résolu librement (≥ 5) → incompatible sur installation vierge. Une dépendance
+    directe nue (``fastapi``) laisse pip résoudre n'importe quelle version future,
+    cassant la reproductibilité. Signal **NON bloquant** : on liste les lignes
+    pour la PR (le smoke POST #483 reste le filet aval qui attrape le 500).
+
+    Analyse les lignes ``+`` de ``requirements.txt`` (monorepo-aware, basename) :
+    paquet nu → retenu ; paquet contraint (``==``/``>=,<``/``~=``/``pkg @ url``)
+    → silencieux ; lignes d'option (``-r``, ``--index-url``), commentaires, vides
+    → ignorés. N'analyse que l'argument ``diff`` (= diff de l'agent) : les ajouts
+    nus de la remédiation déterministe (#481, ``httpx``) sont écrits APRÈS et
+    re-capturés ailleurs — jamais dans ce diff.
+    """
+    unpinned: List[str] = []
+    seen: set = set()
+    in_requirements = False
+    for line in (diff or "").splitlines():
+        if line.startswith("diff --git "):
+            parts = line.split(" b/", 1)
+            path = parts[1].strip() if len(parts) == 2 else ""
+            in_requirements = os.path.basename(path) == "requirements.txt"
+            continue
+        if line.startswith(("--- ", "+++ ")) or not in_requirements or not line.startswith("+"):
+            continue
+        text = line[1:].strip()
+        name = _requirement_name(text)  # None pour option/commentaire/vide
+        if name is None or name in seen:
+            continue
+        # Retirer le nom+extras en tête : ce qui reste porte les contraintes.
+        # `passlib[bcrypt]==1.7.4` épinglé ; `passlib[bcrypt]` non (l'extra n'est
+        # pas une contrainte de version). Le marqueur d'environnement (après
+        # « ; », ex. `; python_version<'3.8'`) est retiré : son `<`/`==` n'est
+        # pas une contrainte de version du paquet.
+        match = _REQ_LINE_NAME_RE.match(text)
+        remainder = (text[match.end() :] if match else text).split(";", 1)[0]
+        if _REQ_PIN_RE.search(remainder):
+            continue
+        seen.add(name)
+        unpinned.append(text)
+    return tuple(unpinned)
 
 
 _TEST_PATH_RE = re.compile(r"(^|/)(tests?|__tests__)(/|$)|(^|/)test_[^/]+$|[^/]+[._]test\.[a-z]+$|[^/]+\.spec\.[a-z]+$")
@@ -1049,6 +1109,7 @@ async def run_quality_gate(
     smoke_timeout: float = 30.0,
     fix_missing_requirements: bool = True,
     requirements_guard: bool = True,
+    pin_guard: bool = True,
 ) -> QualityReport:
     """Exécute les tests (sandbox) + la revue (reviewer) sur un diff. Fail-closed.
 
@@ -1092,6 +1153,12 @@ async def run_quality_gate(
     requirements_removed: Tuple[str, ...] = ()
     if requirements_guard:
         requirements_removed = unjustified_requirement_removals(diff, issue)
+    # #497 : signal NON bloquant des dépendances directes non épinglées — analyse
+    # PURE du diff de l'agent (les ajouts #481 arrivent après, re-capturés
+    # ailleurs). N'entre PAS dans would_pass (signal seulement, par défaut).
+    requirements_unpinned: Tuple[str, ...] = ()
+    if pin_guard:
+        requirements_unpinned = unpinned_requirement_lines(diff)
 
     # 1. Tests dans le sandbox. Une incapacité à les exécuter = non passé
     #    (fail-closed), pas une exception qui remonterait.
@@ -1227,6 +1294,7 @@ async def run_quality_gate(
         tests_touched=touched,
         requirements_added=tuple(requirements_added),
         requirements_removed=requirements_removed,
+        requirements_unpinned=requirements_unpinned,
         adequacy_tests_assert=adequacy_tests_assert,
         adequacy_tests_justification=adequacy_tests_justification,
     )

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -113,7 +113,9 @@ MAX_BEST_DIFF_CHARS = 200_000
 # venv nu, 12 tests verts par ailleurs).
 REQUIREMENTS_APPEND_ONLY_RULE = (
     "Règle stricte : requirements.txt est APPEND-ONLY — ne le régénère jamais, ne supprime "
-    "ni ne remplace AUCUNE ligne existante ; ajoute uniquement les dépendances manquantes."
+    "ni ne remplace AUCUNE ligne existante ; ajoute uniquement les dépendances manquantes, "
+    "chacune ÉPINGLÉE à une version (== X.Y.Z, ou bornes >=A,<B) — une dépendance nue casse "
+    "l'installation vierge (passlib non contraint + bcrypt résolu librement → register en 500)."
 )
 _PASSED_RE = re.compile(r"(\d+) passed")
 _FAILED_RE = re.compile(r"(\d+) failed")

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -129,6 +129,9 @@ def _gate_options(settings_obj) -> dict:
     # #482 : garde append-only requirements — même convention (défaut ON).
     if not bool(getattr(settings_obj, "GATE_REQUIREMENTS_APPEND_ONLY", True)):
         options["requirements_guard"] = False
+    # #497 : signal deps non épinglées (défaut ON) — clé émise seulement en opt-out.
+    if not bool(getattr(settings_obj, "GATE_PIN_GUARD", True)):
+        options["pin_guard"] = False
     test_command = getattr(settings_obj, "GATE_TEST_COMMAND", None)
     if test_command:
         options["test_command"] = str(test_command)

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -1578,3 +1578,113 @@ def test_smoke_probe_green_when_post_4xx(tmp_path):
     result = _run_probe(f"{sys.executable} {server}", port=port, paths=("/", "POST:/auth/register"))
     assert result.returncode == 0
     assert "POST /auth/register -> 422" in result.stdout
+
+
+# --- signal dépendances non épinglées (#497) ----------------------------------------
+
+
+def test_unpinned_requirement_lines_detects_bare_deps():
+    """#497 : les dépendances directes nues sont signalées ; contraintes ⇒ silencieux."""
+    from collegue.executor import unpinned_requirement_lines
+
+    diff = (
+        "diff --git a/requirements.txt b/requirements.txt\n--- a/requirements.txt\n+++ b/requirements.txt\n"
+        "+fastapi\n+passlib\n+bcrypt==5.0.0\n+uvicorn>=0.20,<1\n+httpx~=0.27\n"
+    )
+    assert unpinned_requirement_lines(diff) == ("fastapi", "passlib")
+
+
+def test_unpinned_requirement_lines_ignores_options_and_comments():
+    from collegue.executor import unpinned_requirement_lines
+
+    diff = (
+        "diff --git a/requirements.txt b/requirements.txt\n--- a/requirements.txt\n+++ b/requirements.txt\n"
+        "+# commentaire\n+-r base.txt\n+--index-url https://x\n+\n+rich\n"
+    )
+    assert unpinned_requirement_lines(diff) == ("rich",)
+
+
+def test_unpinned_requirement_lines_extras_and_url():
+    from collegue.executor import unpinned_requirement_lines
+
+    # extra nu → signalé ; extra + pin → silencieux ; URL (source figée) → silencieux ; dédup.
+    diff = (
+        "diff --git a/requirements.txt b/requirements.txt\n--- a/requirements.txt\n+++ b/requirements.txt\n"
+        "+passlib[bcrypt]\n+python-jose[cryptography]==3.3.0\n+pkg @ https://files/pkg.whl\n+fastapi\n+fastapi\n"
+    )
+    assert unpinned_requirement_lines(diff) == ("passlib[bcrypt]", "fastapi")
+
+
+def test_unpinned_requirement_lines_env_marker_not_a_pin():
+    """#497 (revue) : un marqueur d'environnement (`; python_version<'3.8'`)
+    n'est PAS une contrainte de version du paquet — un paquet nu avec marqueur
+    reste signalé."""
+    from collegue.executor import unpinned_requirement_lines
+
+    diff = (
+        "diff --git a/requirements.txt b/requirements.txt\n--- a/requirements.txt\n+++ b/requirements.txt\n"
+        "+importlib-metadata; python_version<'3.8'\n+typing-extensions==4.0; python_version<'3.10'\n"
+    )
+    assert unpinned_requirement_lines(diff) == ("importlib-metadata; python_version<'3.8'",)
+
+
+def test_unpinned_requirement_lines_monorepo_and_noise():
+    from collegue.executor import unpinned_requirement_lines
+
+    nested = (
+        "diff --git a/backend/requirements.txt b/backend/requirements.txt\n"
+        "--- a/backend/requirements.txt\n+++ b/backend/requirements.txt\n+fastapi\n"
+    )
+    assert unpinned_requirement_lines(nested) == ("fastapi",)
+    code = "diff --git a/app/x.py b/app/x.py\n--- a/app/x.py\n+++ b/app/x.py\n+fastapi\n"
+    assert unpinned_requirement_lines(code) == ()
+    assert unpinned_requirement_lines("") == ()
+
+
+async def test_unpinned_signal_is_not_blocking(tmp_path):
+    """#497 : signal NON bloquant par défaut — le gate reste vert, la PR liste."""
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    diff = (
+        "diff --git a/requirements.txt b/requirements.txt\n--- a/requirements.txt\n+++ b/requirements.txt\n+fastapi\n"
+    )
+    report = await run_quality_gate(
+        str(tmp_path), diff, ctx=None, sandbox=_green(), reviewer=FakeReviewer(), issue=ISSUE
+    )
+    assert report.passed is True
+    assert report.requirements_unpinned == ("fastapi",)
+    assert "non épinglées" in report.to_markdown()
+
+
+async def test_pin_guard_opt_out(tmp_path):
+    diff = (
+        "diff --git a/requirements.txt b/requirements.txt\n--- a/requirements.txt\n+++ b/requirements.txt\n+fastapi\n"
+    )
+    report = await run_quality_gate(
+        str(tmp_path), diff, ctx=None, sandbox=_green(), reviewer=FakeReviewer(), issue=ISSUE, pin_guard=False
+    )
+    assert report.requirements_unpinned == ()
+
+
+def test_to_markdown_mentions_unpinned_requirements():
+    report = QualityReport(
+        tests_passed=True,
+        test_exit_code=0,
+        test_output="ok",
+        review_summary="",
+        review_findings=(),
+        review_blocking=False,
+        passed=True,
+        requirements_unpinned=("fastapi", "passlib"),
+    )
+    markdown = report.to_markdown()
+    assert "non épinglées" in markdown and "`fastapi`" in markdown and "`passlib`" in markdown
+    clean = QualityReport(
+        tests_passed=True,
+        test_exit_code=0,
+        test_output="ok",
+        review_summary="",
+        review_findings=(),
+        review_blocking=False,
+        passed=True,
+    )
+    assert "non épinglées" not in clean.to_markdown()

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -1701,6 +1701,7 @@ def test_repair_prompt_carries_requirements_append_only_rule():
         id=1, title="T", acceptance="", issue_number=None, depends_on=[], attempt_count=0, last_error=None
     )
     assert "APPEND-ONLY" not in _issue_from_task(fresh).context
+    assert "ÉPINGLÉE" not in _issue_from_task(fresh).context  # #497 : pas sur le prompt initial
 
     retry = SimpleNamespace(
         id=1,
@@ -1711,7 +1712,9 @@ def test_repair_prompt_carries_requirements_append_only_rule():
         attempt_count=1,
         last_error="[gate/gate_failed] tentative 1/3 — FAILED tests/test_x.py",
     )
-    assert REQUIREMENTS_APPEND_ONLY_RULE in _issue_from_task(retry).context
+    retry_ctx = _issue_from_task(retry).context
+    assert REQUIREMENTS_APPEND_ONLY_RULE in retry_ctx
+    assert "ÉPINGLÉE" in retry_ctx  # #497 : consigne d'épinglage sur le retry
 
     repair = SimpleNamespace(
         id=1,

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -382,3 +382,13 @@ def test_sandbox_dns_parsed_from_settings():
     assert _sandbox_dns(SimpleNamespace(SANDBOX_DNS="1.1.1.1, 8.8.8.8")) == ("1.1.1.1", "8.8.8.8")
     assert _sandbox_dns(SimpleNamespace(SANDBOX_DNS="")) == ()
     assert _sandbox_dns(SimpleNamespace()) == ()  # setting absent → défaut Docker
+
+
+def test_gate_pin_guard_opt_out_emitted_only_on_deviation():
+    """#497 : signal deps non épinglées ON par défaut — clé émise seulement en opt-out."""
+    from types import SimpleNamespace
+
+    from collegue.pilot.runtime import _gate_options
+
+    assert "pin_guard" not in _gate_options(SimpleNamespace(GATE_TEST_COMMAND=""))
+    assert _gate_options(SimpleNamespace(GATE_PIN_GUARD=False))["pin_guard"] is False


### PR DESCRIPTION
## Problème (#497 — MOYENNE)

Cause racine du register→500 livré aux runs v4 ET v5 : `requirements.txt` sans aucune contrainte de version. `passlib` 1.7.4 (figé) devient incompatible avec `bcrypt` résolu librement (≥5) → 500 sur installation vierge. Le smoke POST #483 attrape le symptôme en aval ; cette issue attrape la cause en amont.

## Correctif (proposition 1 : signal NON bloquant + consigne)

1. **`unpinned_requirement_lines(diff)`** : lignes `+` de `requirements.txt` ajoutant un paquet **sans contrainte de version** (`==`/`>=,<`/`~=`/`pkg @ url` = épinglé ; paquet nu = signalé). Monorepo-aware (basename), dédup, **marqueur d'environnement** (`; python_version<…`) exclu de la détection (son `<` n'est pas un pin — corrigé en revue).
2. **`QualityReport.requirements_unpinned`** + bandeau ⚠️ dans le corps de PR (anti-injection `_fence_safe_line`). **NON bloquant par défaut** : n'entre pas dans `would_pass` (le smoke POST #483 reste le filet aval).
3. **`run_quality_gate(pin_guard=True)`** en défaut de **signature** (anti-inertie : le harness bypasse `_gate_options`) ; `GATE_PIN_GUARD` + opt-out runtime.
4. **`REQUIREMENTS_APPEND_ONLY_RULE`** étendue avec la consigne d'épinglage (injectée sur les retries seulement, pas le prompt initial).

Interactions vérifiées : #481 (le signal analyse le diff de l'agent → ignore les ajouts nus de la remédiation, recapturés après) ; #482 (helpers réutilisés en lecture seule, pas de changement de comportement).

## Tests

- Parsing : paquet nu signalé / pin·extras+pin·URL silencieux ; options/commentaires/vides ignorés ; monorepo ; dédup ; marqueur d'environnement non pris pour un pin.
- Non-bloquant : diff 100 % non épinglé → `passed=True` + bandeau ; opt-out `pin_guard=False`.
- Markdown (présence + neutralisation injection) ; consigne d'épinglage injectée sur retry, absente du prompt initial.
- Revue adversariale pré-PR : APPROUVÉ ; 1 faux négatif (marqueur d'environnement) corrigé + testé bien qu'il fût sans impact (signal non bloquant).

**Base : `pre-main`.**

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)