### PR TITLE
feat(executor): remédiation deps des messages auto-diagnostiqués Starlette/FastAPI (#501)

### DIFF
--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -312,6 +312,26 @@ _MODULE_TO_PACKAGE = {
     "fitz": "PyMuPDF",
 }
 _MISSING_MODULE_RE = re.compile(r"ModuleNotFoundError: No module named '([A-Za-z0-9_.]+)'")
+# #501 : formes « paquet auto-diagnostiqué » — Starlette/FastAPI/pydantic
+# interceptent l'import manquant et lèvent LEUR message ; le nom capturé est
+# DÉJÀ un paquet PyPI (pas un module). 4 alternatives couvrant les formes réelles
+# observées (run v5 + tests pipeline #478) — l'ancrage [A-Za-z0-9] exclut tout
+# flag pip (« -r », « --no-cache ») :
+#   - requires "X" to be installed   (python-multipart, guillemets)
+#   - requires the X package         (httpx via starlette.testclient, sans guillemets)
+#   - please install X               (générique)
+#   - pip install X                  (« You can install it with pip install X »)
+_SELFDIAGNOSED_PACKAGE_RE = re.compile(
+    r"""(?:requires|needs)\s+["']([A-Za-z0-9][A-Za-z0-9._-]*)["']\s+to\s+be\s+installed"""
+    r"""|requires\s+the\s+([A-Za-z0-9][A-Za-z0-9._-]*)\s+package\s+to\s+be\s+installed"""
+    r"""|please\s+install\s+([A-Za-z0-9][A-Za-z0-9._-]*)"""
+    r"""|pip\s+install\s+([A-Za-z0-9][A-Za-z0-9._-]*)"""
+)
+# #501 : mots génériques captés à tort par les formes larges (« please install
+# the dependency », « pip install git+… ») — un nom bidon échouerait de toute
+# façon à l'install (gate rouge, fail-closed), mais on évite la pollution de
+# requirements.txt en amont.
+_SELFDIAGNOSED_DENYLIST = frozenset({"the", "a", "an", "it", "this", "that", "your", "my", "git", "user", "package"})
 _REQ_NAME_RE = re.compile(r"^\s*([A-Za-z0-9._-]+)")
 # FacNor v4 tâche 2 : 3 paquets découverts en série (chaîne d'imports — Python ne
 # révèle que le PREMIER module manquant d'un fichier, quel que soit le flag pytest).
@@ -330,6 +350,29 @@ def missing_modules(output: str) -> List[str]:
         module = match.group(1).split(".")[0]
         if module and module not in seen:
             seen.append(module)
+    return seen
+
+
+def selfdiagnosed_packages(output: str) -> List[str]:
+    """Paquets PyPI nommés par les messages auto-diagnostiqués (#501).
+
+    Starlette/FastAPI/pydantic interceptent l'``ImportError`` et lèvent « X
+    requires "Y" to be installed » / « requires the Y package » / « please
+    install Y » : le nom capturé est DÉJÀ un paquet (pas un module), à ajouter
+    tel quel à ``requirements.txt``. Au run v5, « Form data requires
+    "python-multipart" » a brûlé une tentative car ce n'est pas une
+    ModuleNotFoundError. Dédupliqué (PEP 503), ordre stable.
+    """
+    seen: List[str] = []
+    seen_keys: set = set()
+    for match in _SELFDIAGNOSED_PACKAGE_RE.finditer(output or ""):
+        name = next((g for g in match.groups() if g), None)
+        if not name or name.lower() in _SELFDIAGNOSED_DENYLIST:
+            continue
+        key = _canonical(name)
+        if key not in seen_keys:
+            seen_keys.add(key)
+            seen.append(name)
     return seen
 
 
@@ -386,7 +429,11 @@ def remediate_missing_requirements(workspace: str, output: str) -> Tuple[str, ..
     if not os.path.isfile(req_path):
         return ()
     modules = missing_modules(output)
-    if not modules:
+    # #501 : les messages auto-diagnostiqués (Starlette « requires "X" ») ne sont
+    # PAS des ModuleNotFoundError — sans cette source, l'early-return ci-dessous
+    # raterait le cas multipart/httpx du run v5.
+    packages = selfdiagnosed_packages(output)
+    if not modules and not packages:
         return ()
     try:
         with open(req_path, encoding="utf-8") as handle:
@@ -412,6 +459,20 @@ def remediate_missing_requirements(workspace: str, output: str) -> Tuple[str, ..
             continue  # déjà déclaré : manquant pour une AUTRE raison (pin cassé…)
         additions.append(package)
         declared.add(_canonical(_REQ_NAME_RE.match(package).group(1)))
+    # #501 : paquets auto-diagnostiqués (déjà des noms PyPI — PAS de
+    # requirement_for_module, PAS de filtre stdlib). Mêmes gardes : dédup via
+    # `declared` (mis à jour ci-dessus, donc l'ordre modules-puis-paquets évite
+    # les doublons) et anti-module-local (« please install utils » pour un
+    # utils.py local = dependency confusion).
+    for package in packages:
+        base = _REQ_NAME_RE.match(package)
+        if base is None:
+            continue
+        key = _canonical(base.group(1))
+        if key in declared or _is_local_module(workspace, base.group(1)):
+            continue
+        additions.append(package)
+        declared.add(key)
     if not additions:
         return ()
     body = existing_text if existing_text.endswith("\n") or not existing_text else existing_text + "\n"

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -1131,6 +1131,25 @@ def test_missing_modules_parsed_and_deduplicated():
     assert missing_modules("FAILED tests/test_x.py - assert 1 == 2") == []
 
 
+def test_selfdiagnosed_packages_parsed():
+    """#501 : les messages auto-diagnostiqués nomment un PAQUET (pas un module)."""
+    from collegue.executor.quality_gate import selfdiagnosed_packages
+
+    multipart = (
+        'RuntimeError: Form data requires "python-multipart" to be installed. '
+        "You can install it with pip install python-multipart"
+    )
+    assert selfdiagnosed_packages(multipart) == ["python-multipart"]  # dédup guillemets + pip install
+    httpx = "RuntimeError: The starlette.testclient module requires the httpx package to be installed."
+    assert selfdiagnosed_packages(httpx) == ["httpx"]
+    assert selfdiagnosed_packages("RuntimeError: please install email-validator to enable this") == ["email-validator"]
+    assert selfdiagnosed_packages("pip install -r requirements.txt") == []  # flag jamais capturé
+    assert selfdiagnosed_packages("please install the dependency manually") == []  # mot générique (denylist)
+    assert selfdiagnosed_packages("pip install git+https://x/y.git") == []  # « git » en denylist
+    assert selfdiagnosed_packages("E   ModuleNotFoundError: No module named 'httpx'") == []  # autre chemin
+    assert selfdiagnosed_packages("") == []
+
+
 def test_requirement_for_module_table_and_heuristic():
     from collegue.executor.quality_gate import requirement_for_module
 
@@ -1688,3 +1707,57 @@ def test_to_markdown_mentions_unpinned_requirements():
         passed=True,
     )
     assert "non épinglées" not in clean.to_markdown()
+
+
+async def test_remediation_fixes_starlette_multipart_form(tmp_path):
+    """#501 (le cas du run v5 T2) : « Form data requires "python-multipart" » —
+    PAS une ModuleNotFoundError — réparé en un cycle, zéro LLM."""
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    red = SandboxResult(
+        exit_code=1,
+        stdout='E   RuntimeError: Form data requires "python-multipart" to be installed.\nERROR tests/test_auth.py\n',
+        stderr="",
+    )
+    green = SandboxResult(exit_code=0, stdout="3 passed", stderr="")
+    sandbox = _SeqSandbox([red, green])
+    report = await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    assert report.passed is True
+    assert report.requirements_added == ("python-multipart",)
+    assert "python-multipart" in (tmp_path / "requirements.txt").read_text(encoding="utf-8")
+    assert len(sandbox.calls) == 2  # un seul aller-retour, zéro cycle LLM
+
+
+async def test_remediation_fixes_starlette_httpx_package_form(tmp_path):
+    """#501 : forme SANS guillemets « requires the httpx package to be installed »."""
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    red = SandboxResult(
+        exit_code=1,
+        stdout="E   RuntimeError: The starlette.testclient module requires the httpx package to be installed.\n",
+        stderr="",
+    )
+    green = SandboxResult(exit_code=0, stdout="2 passed", stderr="")
+    sandbox = _SeqSandbox([red, green])
+    report = await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    assert report.requirements_added == ("httpx",)
+    assert report.passed is True
+    assert len(sandbox.calls) == 2
+
+
+async def test_remediation_selfdiagnosed_skips_declared_and_local(tmp_path):
+    """#501 : garde-fous — paquet déjà déclaré (dédup) et module local (dependency
+    confusion) ne sont jamais ajoutés."""
+    # déjà déclaré → pas de doublon
+    (tmp_path / "requirements.txt").write_text("fastapi\npython-multipart\n", encoding="utf-8")
+    red = SandboxResult(exit_code=1, stdout='E   RuntimeError: Form data requires "python-multipart"...\n', stderr="")
+    sandbox = _SeqSandbox([red])
+    report = await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    assert report.requirements_added == ()
+
+    # module local du projet → jamais installé depuis PyPI
+    work2 = tmp_path / "w2"
+    work2.mkdir()
+    (work2 / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    (work2 / "utils.py").write_text("")
+    red2 = SandboxResult(exit_code=1, stdout="E   RuntimeError: please install utils to continue\n", stderr="")
+    report2 = await run_quality_gate(str(work2), DIFF, ctx=None, sandbox=_SeqSandbox([red2]), reviewer=FakeReviewer())
+    assert report2.requirements_added == ()


### PR DESCRIPTION
## Problème (#501 — MOYENNE)

La remédiation déterministe #481 ne matchait que `ModuleNotFoundError: No module named 'X'`. Au run v5, l'échec réel était `RuntimeError: Form data requires "python-multipart" to be installed` (Starlette intercepte l'import et lève SON message) — pas une ModuleNotFoundError → la remédiation passait à côté et **brûlait une tentative LLM complète**. Ironie : `_MODULE_TO_PACKAGE` connaissait déjà `multipart → python-multipart`, seul le regex ne voyait pas le message.

## Correctif (entièrement dans quality_gate.py, étend #481)

1. **`_SELFDIAGNOSED_PACKAGE_RE` + `selfdiagnosed_packages(output)`** : 4 formes réelles — `requires "X" to be installed` (python-multipart), `requires the X package to be installed` (httpx via starlette.testclient, **sans guillemets**, prouvée par les tests #478), `please install X`, `pip install X`. Le nom capturé est **déjà un paquet PyPI**. Ancrage `[A-Za-z0-9]` → un flag pip (`-r`, `--no-cache`) n'est jamais capturé.
2. **Intégration** dans `remediate_missing_requirements` en 2e source (pas de `requirement_for_module`, pas de filtre stdlib — le nom est canonique), mêmes gardes que #481 : dédup `declared` partagée (ordre modules-puis-paquets → pas de doublon), anti-module-local (dependency confusion), borne 3 rounds. L'early-return couvre désormais « 0 ModuleNotFoundError mais 1 message Starlette ».
3. **Denylist** de mots génériques (`the`/`git`/`user`/`package`…) — coupe les faux positifs des formes larges ; un nom bidon échouerait de toute façon à l'install (fail-closed), mais on évite la pollution de `requirements.txt`.

Interactions : #481 intact (le regex ne matche aucun ModuleNotFoundError) ; #497 (pas de faux signal croisé — la remédiation écrit après recapture). Défaut de signature `fix_missing_requirements=True` → actif au run réel (anti-inertie).

## Tests

- Extraction : multipart (guillemets) + httpx (sans guillemets) + email-validator ; `pip install -r requirements.txt` → `[]` ; mots génériques (`the`, `git`) → `[]` ; ModuleNotFoundError → `[]` (autre chemin).
- Intégration : multipart et httpx réparés **en un cycle, zéro LLM** (2 appels sandbox) ; gardes (déjà déclaré, module local) → aucun ajout.
- Non-régression #481 conservée.
- Revue adversariale pré-PR : APPROUVÉ (faux positifs bornés par fail-closed) + denylist appliquée en durcissement.

**Base : `pre-main`.**

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)