### PR TITLE
feat(pilot): avertissement au démarrage quand le prix coder n'est pas résolvable (#502)

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -213,6 +213,10 @@ class Settings(BaseSettings):
     # aussi le signal — factuellement exact, le cap $ ne protège pas ce canal.
     LLM_PRICE_PROMPT_PER_1M: float = 0.0
     LLM_PRICE_COMPLETION_PER_1M: float = 0.0
+    # #502 : refuser de DÉMARRER un run réel si aucun prix de secours coder n'est
+    # résolvable (litellm non mappé + LLM_PRICE_* absents → ledger $ aveugle).
+    # Off par défaut : avertissement seulement. Opt-in pour un échec net.
+    REQUIRE_COST_PRICING: bool = False
 
     # ── Auto-merge progressif (Phase 5, H2) ──────────────────────────────────
     # §6 reste le DÉFAUT : approbation humaine avant chaque merge dans main.

--- a/collegue/executor/openhands_agent.py
+++ b/collegue/executor/openhands_agent.py
@@ -108,6 +108,28 @@ def estimate_cost_usd(prompt_tokens: int, completion_tokens: int, settings_obj=N
     return total / 1_000_000.0 if math.isfinite(total) else 0.0
 
 
+def coder_pricing_resolvable(settings_obj=None) -> bool:
+    """Vrai si un prix de secours coder (``LLM_PRICE_*_PER_1M``) est configuré (#502).
+
+    Quand litellm ne mappe pas le modèle coder ET qu'aucun prix n'est configuré,
+    le ledger $ reste à 0 et ``MAX_COST_USD`` est inopérant côté coder (3 runs
+    consécutifs aveugles). Ce prédicat permet de l'AVERTIR au démarrage du run
+    plutôt que de le découvrir en post-mortem. Même robustesse que
+    :func:`estimate_cost_usd` (prix absent/non numérique/négatif/non fini → 0).
+    """
+    if settings_obj is None:
+        from collegue.config import settings as settings_obj
+
+    def _price(name: str) -> float:
+        try:
+            value = float(getattr(settings_obj, name, 0.0) or 0.0)
+        except (TypeError, ValueError):
+            return 0.0
+        return value if math.isfinite(value) and value > 0 else 0.0
+
+    return _price("LLM_PRICE_PROMPT_PER_1M") > 0 or _price("LLM_PRICE_COMPLETION_PER_1M") > 0
+
+
 # Politique retries/backoff par défaut du canal coder (#422) — alignée sur les
 # settings ``CODER_LLM_*`` de ``collegue.config``.
 DEFAULT_CODER_NUM_RETRIES = 8

--- a/collegue/pilot/audit.py
+++ b/collegue/pilot/audit.py
@@ -46,6 +46,10 @@ USAGE_LOST = "usage_lost"
 # plafond MAX_COST_USD est aveugle en dollars sur ce canal ; on le signale au
 # lieu de laisser un 0 ressembler à un run gratuit.
 COST_UNKNOWN = "cost_unknown"
+# #502 : aucun prix de secours coder configuré — signalé AU DÉMARRAGE du run
+# (avant la boucle), pour que l'opérateur sache que le ledger $ sera aveugle
+# sans attendre le post-mortem.
+COST_PRICING_UNRESOLVED = "cost_pricing_unresolved"
 
 # Noms des métriques persistées pour le ledger de coût par run.
 METRIC_RUN_COST_USD = "run_cost_usd"

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -33,7 +33,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
 from collegue.executor.agent import IssueSpec
-from collegue.executor.openhands_agent import estimate_cost_usd
+from collegue.executor.openhands_agent import coder_pricing_resolvable, estimate_cost_usd
 from collegue.executor.pipeline import (
     agent_crash_signature,
     execute_issue,
@@ -47,6 +47,7 @@ from collegue.executor.workspace import branch_for_issue, cleanup_workspace, swe
 from collegue.pilot.audit import (
     BUDGET_EVENT,
     CHECKPOINT_SAVED,
+    COST_PRICING_UNRESOLVED,
     COST_UNKNOWN,
     GATE_DECISION,
     OVERLAY_REFRESHED,
@@ -88,6 +89,11 @@ STOP_BLOCKED = "blocked"  # graphe coincé (dépendance échouée)
 STOP_AWAITING_MERGE = "awaiting_merge"  # mode strict (#411) : tout est prêt SAUF des merges humains
 STOP_SAFETY_CAP = "safety_cap"  # garde-fou anti-boucle
 STOP_SANDBOX_BROKEN = "sandbox_broken"  # crash-loop d'import agent : image/runner cassé (#498)
+
+
+class CostPricingUnresolvedError(RuntimeError):
+    """Refus de démarrer : prix coder non résolvable et REQUIRE_COST_PRICING (#502)."""
+
 
 # Retry au niveau tâche (#420). Le défaut du MODULE reste 1 (= pas de retry,
 # comportement historique — module isolé, aucun changement sans opt-in) ; le
@@ -457,6 +463,7 @@ async def run_project(
     gate_options=None,
     reconcile_reviews: bool = True,
     cleanup_workspaces: bool = True,
+    require_cost_pricing: bool = False,
 ) -> ProjectRunResult:
     """Pilote un projet : chaîne ``execute_issue`` sur les tâches prêtes sous budget.
 
@@ -617,6 +624,24 @@ async def run_project(
         swept = sweep_stale_temp_clones()
         if swept:
             logger.info("balayage démarrage : %d clone(s) collegue-revert-* périmé(s) supprimé(s)", swept)
+
+    # #502 : visibilité du coût AU DÉMARRAGE (avant la boucle, en réel seulement).
+    # Si aucun prix de secours coder n'est configuré et que litellm ne mappe pas
+    # le modèle, le ledger $ restera à 0 et MAX_COST_USD sera inopérant côté
+    # coder — l'opérateur doit le savoir maintenant, pas en post-mortem.
+    if not dry_run and not coder_pricing_resolvable():
+        logger.warning(
+            "COÛT $ DU RUN POTENTIELLEMENT INCONNU : aucun prix de secours coder "
+            "(LLM_PRICE_PROMPT_PER_1M / LLM_PRICE_COMPLETION_PER_1M). Si litellm ne mappe pas le "
+            "modèle coder, le ledger $ restera à 0 et MAX_COST_USD sera INOPÉRANT côté coder. "
+            "Configurez LLM_PRICE_*_PER_1M, ou REQUIRE_COST_PRICING=true pour refuser de démarrer."
+        )
+        audit.record(COST_PRICING_UNRESOLVED, iteration=iteration, dry_run=dry_run)
+        if require_cost_pricing:
+            raise CostPricingUnresolvedError(
+                "REQUIRE_COST_PRICING=true et aucun prix coder (LLM_PRICE_*_PER_1M) résolvable : "
+                "run refusé (ledger $ aveugle)."
+            )
 
     while True:
         if len(processed) >= cap:

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -253,6 +253,8 @@ async def run_project_from_settings(
         # Gouvernance de coût (#441) : ledger + source process branchés en réel.
         audit=audit,
         cost_source=cost_source,
+        # #502 : refus opt-in de démarrer si le prix coder n'est pas résolvable.
+        require_cost_pricing=bool(getattr(settings_obj, "REQUIRE_COST_PRICING", False)),
     )
 
     # Reporting (journal de décisions) — réel uniquement (dry_run n'écrit rien).
@@ -269,6 +271,11 @@ async def run_project_from_settings(
         if audit is not None:
             ledger = audit.cost_summary()
             cost_note = f" ; coût≈{ledger.get('usd', 0.0)}$ / {ledger.get('tokens', 0)} tokens"
+            # #502 : un coût à 0 sans prix coder configuré est suspect — le dire.
+            from collegue.executor.openhands_agent import coder_pricing_resolvable
+
+            if not coder_pricing_resolvable(settings_obj):
+                cost_note += " [PRIX CODER NON CONFIGURÉS — coût $ possiblement INCONNU]"
         manager.record_decision(
             project_id,
             f"Run pilote: {result.stop_reason} — {result.iterations} tâche(s), PR {prs}{drain}{cost_note}",

--- a/tests/test_executor_agent.py
+++ b/tests/test_executor_agent.py
@@ -328,3 +328,14 @@ def test_estimate_cost_usd_survives_poisoned_token_counts():
 
     prices = _settings(LLM_PRICE_PROMPT_PER_1M=1.5)
     assert estimate_cost_usd(10**400, 0, prices) == 0.0
+
+
+def test_coder_pricing_resolvable():
+    """#502 : vrai si un prix de secours coder est configuré (>0)."""
+    from collegue.executor.openhands_agent import coder_pricing_resolvable
+
+    assert coder_pricing_resolvable(_settings(LLM_PRICE_PROMPT_PER_1M=1.5)) is True
+    assert coder_pricing_resolvable(_settings(LLM_PRICE_COMPLETION_PER_1M=9.0)) is True
+    assert coder_pricing_resolvable(_settings()) is False
+    for bad in (0.0, -3.0, "n/a", float("nan")):
+        assert coder_pricing_resolvable(_settings(LLM_PRICE_PROMPT_PER_1M=bad)) is False

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -2063,3 +2063,70 @@ async def test_budget_unchanged_without_coder_spend(repo, manager):
     pid = _linear_project(manager, 2)
     result = await _run(manager, repo, pid, dry_run=False, agent=FakeCodeAgent(), budget=budget)
     assert result.stop_reason == "completed"
+
+
+# --- visibilité du prix coder au démarrage (#502) -----------------------------------
+
+
+async def test_cost_pricing_unresolved_event_at_startup(repo, manager, monkeypatch):
+    """#502 : sans prix coder configuré, un event est émis AU DÉMARRAGE (avant la
+    boucle) — l'opérateur sait que le ledger $ sera aveugle sans post-mortem."""
+    from collegue import config
+    from collegue.pilot.audit import RunAuditLog
+
+    monkeypatch.setattr(config.settings, "LLM_PRICE_PROMPT_PER_1M", 0.0, raising=False)
+    monkeypatch.setattr(config.settings, "LLM_PRICE_COMPLETION_PER_1M", 0.0, raising=False)
+    pid = _linear_project(manager, 2)
+    audit = RunAuditLog(pid)
+    await _run(manager, repo, pid, dry_run=False, agent=FakeCodeAgent(), audit=audit)
+    kinds = [e.kind for e in audit.events]
+    assert kinds.count("cost_pricing_unresolved") == 1
+    # Émis AVANT toute tâche (visibilité de démarrage).
+    assert kinds.index("cost_pricing_unresolved") < kinds.index("task_started")
+
+
+async def test_no_cost_pricing_event_when_price_configured(repo, manager, monkeypatch):
+    from collegue import config
+    from collegue.pilot.audit import RunAuditLog
+
+    monkeypatch.setattr(config.settings, "LLM_PRICE_PROMPT_PER_1M", 1.5, raising=False)
+    pid = _linear_project(manager, 1)
+    audit = RunAuditLog(pid)
+    await _run(manager, repo, pid, dry_run=False, agent=FakeCodeAgent(), audit=audit)
+    assert not [e for e in audit.events if e.kind == "cost_pricing_unresolved"]
+
+
+async def test_no_cost_pricing_event_in_dry_run(repo, manager, monkeypatch):
+    from collegue import config
+    from collegue.pilot.audit import RunAuditLog
+
+    monkeypatch.setattr(config.settings, "LLM_PRICE_PROMPT_PER_1M", 0.0, raising=False)
+    monkeypatch.setattr(config.settings, "LLM_PRICE_COMPLETION_PER_1M", 0.0, raising=False)
+    pid = _linear_project(manager, 1)
+    audit = RunAuditLog(pid)
+    await _run(manager, repo, pid, dry_run=True, agent=FakeCodeAgent(), audit=audit)
+    assert not [e for e in audit.events if e.kind == "cost_pricing_unresolved"]
+
+
+async def test_require_cost_pricing_blocks_start(repo, manager, monkeypatch):
+    """#502 (opt-in) : REQUIRE_COST_PRICING refuse de démarrer si prix aveugle."""
+    import pytest
+
+    from collegue import config
+    from collegue.pilot.driver import CostPricingUnresolvedError
+
+    monkeypatch.setattr(config.settings, "LLM_PRICE_PROMPT_PER_1M", 0.0, raising=False)
+    monkeypatch.setattr(config.settings, "LLM_PRICE_COMPLETION_PER_1M", 0.0, raising=False)
+    pid = _linear_project(manager, 2)
+    with pytest.raises(CostPricingUnresolvedError):
+        await _run(manager, repo, pid, dry_run=False, agent=FakeCodeAgent(), require_cost_pricing=True)
+    assert all(t.status == "todo" for t in manager.get_tasks(pid))  # rien démarré
+
+
+async def test_require_cost_pricing_passes_when_price_set(repo, manager, monkeypatch):
+    from collegue import config
+
+    monkeypatch.setattr(config.settings, "LLM_PRICE_PROMPT_PER_1M", 1.5, raising=False)
+    pid = _linear_project(manager, 1)
+    result = await _run(manager, repo, pid, dry_run=False, agent=FakeCodeAgent(), require_cost_pricing=True)
+    assert result.stop_reason == "completed"


### PR DESCRIPTION
## Problème (#502 — MOYENNE)

Quand litellm ne mappe pas le modèle coder ET qu'aucun prix de secours n'est configuré, le ledger $ reste à 0 et `MAX_COST_USD` est inopérant côté coder — **3 runs consécutifs aveugles**, découverts en post-mortem.

## Correctif (anti-inertie : ancré dans run_project, visible au run réel)

1. **`coder_pricing_resolvable(settings)`** : vrai si `LLM_PRICE_PROMPT_PER_1M` ou `LLM_PRICE_COMPLETION_PER_1M` > 0 (robuste : absent/NaN/négatif → 0).
2. **`run_project`** : AVANT la boucle (en réel uniquement), si le prix n'est pas résolvable → `logger.warning` + event d'audit `cost_pricing_unresolved` (émis **avant** toute tâche). Ancré dans `run_project` (pas `runtime`) → l'avertissement et l'event apparaissent au run FacNor réel qui appelle `run_project` directement.
3. **`REQUIRE_COST_PRICING`** (opt-in, défaut False) → `CostPricingUnresolvedError` : refus net de démarrer plutôt qu'un run au coût aveugle. Passe par la **signature** (`require_cost_pricing`), pas `_gate_options` (égalité stricte préservée).
4. **runtime** : forward du flag + suffixe « PRIX CODER NON CONFIGURÉS » au bilan de fin.
5. **dry_run** : aucun avertissement ni refus (rien n'y est dépensé).

Complète #484 (signal `cost_unknown` par tâche) et #495 (enforcement) : on sait **dès le départ** si le plafond $ sera opérant. Double signal assumé (démarrage = prédictif, par-tâche = constaté).

## Tests

- `coder_pricing_resolvable` : prix configuré → True ; absent/aberrant → False.
- Event émis au démarrage **avant** `task_started` ; absent si prix configuré ; absent en dry_run.
- `REQUIRE_COST_PRICING` opt-in : refus (`CostPricingUnresolvedError`, rien démarré) sans prix / run complété avec prix.
- Non-régression #484 (filtre par kind) ; `_gate_options` intact.
- Revue adversariale pré-PR : APPROUVÉ, aucun défaut (monkeypatch du bon singleton, ordre/visibilité, dry_run, pas de cycle d'import).

**Base : `pre-main`.**

Closes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)