### PR TITLE
feat(executor): la sonde smoke exerce la frontière front↔back (CORS) (#503)

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -139,6 +139,10 @@ class Settings(BaseSettings):
     # Budget d'attente de réponse (s) — à garder sous le timeout du conteneur
     # sandbox (120 s par défaut, partagé avec pip/pytest/npm).
     GATE_SMOKE_TIMEOUT: float = 30.0
+    # #503 : origine cross-origin des sondes smoke. Une route 2xx sans
+    # Access-Control-Allow-Origin compatible = rouge (l'UI serait bloquée au
+    # premier fetch). Vide = contrôle CORS désactivé (apps sans front).
+    GATE_SMOKE_CORS_ORIGIN: str = "http://localhost:5173"
     # DNS du sandbox (#485) : résolveurs passés en `--dns` aux conteneurs qui
     # ont besoin du réseau (installabilité #439, prélude #414, worker OpenHands).
     # Le résolveur Docker par défaut produisait des « Temporary failure in name

--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -101,6 +101,13 @@ _SMOKE_METHODS = frozenset({"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OP
 # bénéficie de la couverture — sinon le fix serait inerte au run réel, comme
 # #461 l'a été en v4. Coût nul sur une app sans ces routes (404/405 < 500).
 DEFAULT_SMOKE_PATHS = ("/", "POST:/auth/register", "POST:/auth/login")
+# #503 : origine cross-origin envoyée par chaque sonde — distincte de l'app
+# (127.0.0.1:8765). Un backend sans CORS ne renvoie pas d'Access-Control-Allow-
+# Origin couvrant cette origine → l'UI réelle serait bloquée au premier fetch
+# (run v5 : impossible de s'inscrire depuis l'interface). Défaut de SIGNATURE
+# (actif dès smoke_run, même si le harness bypasse _gate_options). Le port Vite
+# usuel des fronts générés. Vide = contrôle CORS désactivé (apps sans front).
+_SMOKE_DEFAULT_ORIGIN = "http://localhost:5173"
 # Payload générique des sondes à corps (#483) : champs usuels des routes d'auth.
 # Pydantic ignore les champs en trop par défaut → une route register/login VALIDE
 # ce corps et exécute son handler (le 500 passlib/bcrypt « out-of-the-box » de
@@ -136,6 +143,7 @@ command = %(command)r
 paths = %(paths)r  # paires (méthode, chemin) — cf. _smoke_probe_script (#483)
 payload = %(payload)r
 timeout = %(timeout)r
+origin = %(origin)r  # #503 : origine cross-origin (vide = contrôle CORS désactivé)
 log = open("/tmp/.collegue_smoke.log", "w+", encoding="utf-8", errors="replace")
 proc = subprocess.Popen(command, shell=True, stdout=log, stderr=subprocess.STDOUT)
 base = "http://127.0.0.1:%(port)d"
@@ -143,6 +151,7 @@ deadline = time.time() + timeout
 verdicts = []
 for method, path in paths:
     status = None
+    acao = None  # Access-Control-Allow-Origin renvoyé (#503)
     attempted = False
     # Au moins UNE tentative par chemin, même si le précédent a épuisé le délai
     # (sinon : faux rouge « sans réponse » sur un chemin jamais contacté).
@@ -152,20 +161,46 @@ for method, path in paths:
             break  # le serveur est mort avant de répondre
         try:
             data = payload if method not in ("GET", "HEAD") else None
-            headers = {"Content-Type": "application/json"} if data is not None else {}
+            headers = {"Origin": origin} if origin else {}
+            if data is not None:
+                headers["Content-Type"] = "application/json"
             req = urllib.request.Request(base + path, data=data, headers=headers, method=method)
-            status = urllib.request.urlopen(req, timeout=2).status
+            resp = urllib.request.urlopen(req, timeout=2)
+            status = resp.status
+            acao = resp.headers.get("Access-Control-Allow-Origin")
             break
         except urllib.error.HTTPError as exc:
             status = exc.code
+            acao = exc.headers.get("Access-Control-Allow-Origin") if exc.headers else None
             break
         except Exception:
             time.sleep(0.5)
-    verdicts.append((method, path, status))
+    verdicts.append((method, path, status, acao))
 time.sleep(0.3)  # resserre la fenêtre « répond une fois puis meurt »
-ok = proc.poll() is None and all(s is not None and s < 500 for _m, _p, s in verdicts)
-for method, path, status in verdicts:
+
+
+def _cors_ok(status, acao):
+    # #503 : CORS contrôlé seulement quand l'app A répondu et a ACCEPTÉ la requête
+    # (status < 400). Un 4xx de contrat est déjà signalé par le status ; un 401
+    # protégé n'a pas à exposer CORS. « * » ou écho exact de l'origine = OK.
+    if not origin or status is None or status >= 400:
+        return True
+    return acao in ("*", origin)
+
+
+cors_failures = [(m, p) for m, p, s, a in verdicts if not _cors_ok(s, a)]
+ok = (
+    proc.poll() is None
+    and all(s is not None and s < 500 for _m, _p, s, _a in verdicts)
+    and not cors_failures
+)
+for method, path, status, acao in verdicts:
     print("[gate] smoke run", method, path, "->", status if status is not None else "sans réponse")
+for method, path in cors_failures:
+    print(
+        "[gate] smoke run CORS ABSENT", method, path, "— l'origine", origin,
+        "n'est pas autorisée (Access-Control-Allow-Origin) ; l'UI serait bloquée au premier fetch (#503)",
+    )
 if proc.poll() is not None:
     print(
         "[gate] smoke run : le processus serveur s'est terminé (code", str(proc.poll()) + ")",
@@ -199,7 +234,14 @@ def _detect_asgi_app(workspace: str) -> Optional[str]:
     return None
 
 
-def _smoke_probe_script(command: str, paths: Tuple[str, ...], timeout: float, *, port: int = _SMOKE_PORT) -> str:
+def _smoke_probe_script(
+    command: str,
+    paths: Tuple[str, ...],
+    timeout: float,
+    *,
+    port: int = _SMOKE_PORT,
+    origin: str = _SMOKE_DEFAULT_ORIGIN,
+) -> str:
     """Source python de la sonde smoke-run (pur — testable par ``compile``)."""
     # #483 : préfixe « MÉTHODE: » optionnel (whitelist _SMOKE_METHODS) — sans
     # lui, GET (compat #458). Les méthodes à corps envoient le payload JSON
@@ -221,6 +263,7 @@ def _smoke_probe_script(command: str, paths: Tuple[str, ...], timeout: float, *,
         "payload": _SMOKE_PROBE_PAYLOAD,
         "timeout": float(timeout),
         "port": int(port),
+        "origin": str(origin),
     }
 
 
@@ -230,6 +273,7 @@ def smoke_run_command(
     command: Optional[str] = None,
     paths: Tuple[str, ...] = DEFAULT_SMOKE_PATHS,
     timeout: float = 30.0,
+    cors_origin: str = _SMOKE_DEFAULT_ORIGIN,
 ) -> Optional[str]:
     """Commande de la passe smoke-run (#458). Fail-closed une fois déclenchée.
 
@@ -262,7 +306,7 @@ def smoke_run_command(
         if target is None:
             return None
         command = f"python -m uvicorn {target} --host 127.0.0.1 --port {_SMOKE_PORT}"
-    script = _smoke_probe_script(command, paths, timeout)
+    script = _smoke_probe_script(command, paths, timeout, origin=cors_origin)
     return f"python - <<'{_SMOKE_HEREDOC}'\n{script}{_SMOKE_HEREDOC}"
 
 
@@ -1168,6 +1212,7 @@ async def run_quality_gate(
     smoke_command: Optional[str] = None,
     smoke_paths: Tuple[str, ...] = DEFAULT_SMOKE_PATHS,
     smoke_timeout: float = 30.0,
+    smoke_cors_origin: str = _SMOKE_DEFAULT_ORIGIN,
     fix_missing_requirements: bool = True,
     requirements_guard: bool = True,
     pin_guard: bool = True,
@@ -1261,7 +1306,13 @@ async def run_quality_gate(
                     installability = _tolerate_pytest_exit5(installability)
                 command = f"({command}) && echo '{_INSTALLABILITY_BANNER}' && ({installability})"
         if smoke_run:
-            smoke = smoke_run_command(workspace, command=smoke_command, paths=smoke_paths, timeout=smoke_timeout)
+            smoke = smoke_run_command(
+                workspace,
+                command=smoke_command,
+                paths=smoke_paths,
+                timeout=smoke_timeout,
+                cors_origin=smoke_cors_origin,
+            )
             if smoke is not None:
                 # Dernière passe (le heredoc doit clore la commande) : l'app est
                 # lancée dans le même conteneur, après install des deps (#414).

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -148,6 +148,15 @@ def _gate_options(settings_obj) -> dict:
         if smoke_paths:
             options["smoke_paths"] = smoke_paths
         options["smoke_timeout"] = float(getattr(settings_obj, "GATE_SMOKE_TIMEOUT", 30.0))
+        # #503 : le défaut vit dans la signature de run_quality_gate (actif même
+        # si le harness bypasse _gate_options) — n'émettre la clé qu'en OVERRIDE
+        # explicite (y compris "" pour désactiver), pour préserver l'égalité
+        # stricte de dict du test runtime sur le chemin par défaut.
+        from collegue.executor.quality_gate import _SMOKE_DEFAULT_ORIGIN
+
+        cors_origin = getattr(settings_obj, "GATE_SMOKE_CORS_ORIGIN", None)
+        if cors_origin is not None and str(cors_origin) != _SMOKE_DEFAULT_ORIGIN:
+            options["smoke_cors_origin"] = str(cors_origin)
     return options
 
 

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -428,13 +428,16 @@ def _free_port():
         return sock.getsockname()[1]
 
 
-def _run_probe(command, timeout=10.0, port=None, paths=("/",)):
+def _run_probe(command, timeout=10.0, port=None, paths=("/",), origin=""):
+    # origin="" par défaut : les tests #458/#483 sondent des serveurs sans CORS
+    # et ne doivent PAS rougir sur le contrôle #503 (qui est testé séparément
+    # avec une origine explicite).
     import subprocess
     import sys
 
     from collegue.executor.quality_gate import _smoke_probe_script
 
-    script = _smoke_probe_script(command, paths, timeout, port=port or _free_port())
+    script = _smoke_probe_script(command, paths, timeout, port=port or _free_port(), origin=origin)
     return subprocess.run([sys.executable, "-"], input=script, text=True, capture_output=True, timeout=60)
 
 
@@ -1761,3 +1764,94 @@ async def test_remediation_selfdiagnosed_skips_declared_and_local(tmp_path):
     red2 = SandboxResult(exit_code=1, stdout="E   RuntimeError: please install utils to continue\n", stderr="")
     report2 = await run_quality_gate(str(work2), DIFF, ctx=None, sandbox=_SeqSandbox([red2]), reviewer=FakeReviewer())
     assert report2.requirements_added == ()
+
+
+# --- intégration cross-origin / CORS (#503) -----------------------------------------
+
+
+def test_smoke_probe_script_embeds_origin():
+    """#503 : l'origine cross-origin est bakée par défaut (signature) et le
+    contrôle Access-Control-Allow-Origin est présent dans la sonde."""
+    from collegue.executor.quality_gate import _smoke_probe_script
+
+    script = _smoke_probe_script("python serve.py", ("/",), 5.0)
+    assert "localhost:5173" in script
+    assert "Access-Control-Allow-Origin" in script
+    compile(script, "<smoke>", "exec")
+
+
+def test_smoke_probe_script_origin_disabled_when_empty():
+    from collegue.executor.quality_gate import _smoke_probe_script
+
+    script = _smoke_probe_script("python serve.py", ("/",), 5.0, origin="")
+    assert "localhost:5173" not in script
+    compile(script, "<smoke>", "exec")
+
+
+def _cors_server(tmp_path, port, *, get_status=200, acao_header=None):
+    header = f'        self.send_header("Access-Control-Allow-Origin", "{acao_header}")\n' if acao_header else ""
+    body = (
+        "from http.server import BaseHTTPRequestHandler, HTTPServer\n"
+        "class H(BaseHTTPRequestHandler):\n"
+        "    def do_GET(self):\n"
+        f"        self.send_response({get_status})\n"
+        f"{header}"
+        "        self.end_headers(); self.wfile.write(b'ok')\n"
+        "    def log_message(self, *a): pass\n"
+        f"HTTPServer(('127.0.0.1', {port}), H).serve_forever()\n"
+    )
+    server = tmp_path / "serve.py"
+    server.write_text(body, encoding="utf-8")
+    return server
+
+
+def test_smoke_probe_red_when_cors_absent(tmp_path):
+    """#503 (le cas du run v5) : GET 200 mais aucun Access-Control-Allow-Origin
+    → l'UI serait bloquée → smoke ROUGE."""
+    import sys
+
+    port = _free_port()
+    server = _cors_server(tmp_path, port, get_status=200, acao_header=None)
+    result = _run_probe(f"{sys.executable} {server}", port=port, paths=("/",), origin="http://localhost:5173")
+    assert result.returncode == 1
+    assert "CORS ABSENT" in result.stdout
+
+
+def test_smoke_probe_green_when_cors_wildcard(tmp_path):
+    import sys
+
+    port = _free_port()
+    server = _cors_server(tmp_path, port, get_status=200, acao_header="*")
+    result = _run_probe(f"{sys.executable} {server}", port=port, paths=("/",), origin="http://localhost:5173")
+    assert result.returncode == 0
+
+
+def test_smoke_probe_green_when_cors_echoes_origin(tmp_path):
+    import sys
+
+    port = _free_port()
+    server = _cors_server(tmp_path, port, get_status=200, acao_header="http://localhost:5173")
+    result = _run_probe(f"{sys.executable} {server}", port=port, paths=("/",), origin="http://localhost:5173")
+    assert result.returncode == 0
+
+
+def test_smoke_probe_cors_ignored_on_4xx(tmp_path):
+    """#503 : une route protégée (401) sans CORS n'est PAS un faux rouge CORS —
+    le contrôle ne s'applique qu'aux réponses < 400."""
+    import sys
+
+    port = _free_port()
+    server = _cors_server(tmp_path, port, get_status=401, acao_header=None)
+    result = _run_probe(f"{sys.executable} {server}", port=port, paths=("/",), origin="http://localhost:5173")
+    assert result.returncode == 0  # 401 < 500 et CORS exempté sur >= 400
+
+
+async def test_gate_smoke_threads_cors_origin(tmp_path):
+    """#503 : le défaut de signature traverse run_quality_gate jusqu'à la commande
+    (même sans passer par _gate_options)."""
+    _write_fastapi_app(tmp_path)
+    sandbox = _green()
+    await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer(), smoke_run=True)
+    _ws, command = sandbox.calls[0]
+    assert "localhost:5173" in command
+    assert "Access-Control-Allow-Origin" in command

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -392,3 +392,17 @@ def test_gate_pin_guard_opt_out_emitted_only_on_deviation():
 
     assert "pin_guard" not in _gate_options(SimpleNamespace(GATE_TEST_COMMAND=""))
     assert _gate_options(SimpleNamespace(GATE_PIN_GUARD=False))["pin_guard"] is False
+
+
+def test_gate_smoke_cors_origin_emitted_only_on_override():
+    """#503 : le défaut CORS vit dans la signature du gate — la clé runtime n'est
+    émise qu'en override explicite (préserve l'égalité stricte du chemin défaut)."""
+    from types import SimpleNamespace
+
+    from collegue.pilot.runtime import _gate_options
+
+    assert "smoke_cors_origin" not in _gate_options(SimpleNamespace(GATE_SMOKE_RUN=True))
+    over = SimpleNamespace(GATE_SMOKE_RUN=True, GATE_SMOKE_CORS_ORIGIN="https://app.example")
+    assert _gate_options(over)["smoke_cors_origin"] == "https://app.example"
+    off = SimpleNamespace(GATE_SMOKE_RUN=True, GATE_SMOKE_CORS_ORIGIN="")
+    assert _gate_options(off)["smoke_cors_origin"] == ""


### PR DESCRIPTION
## Problème (#503 — MOYENNE)

Le gate frontend (#457) compile/teste l'UI, et le smoke (#458/#483) sonde le backend — mais **rien n'exerce l'UI CONTRE l'API**. Au run v5, le frontend était mort out-of-the-box : **CORS absent** (l'UI ne pouvait même pas s'inscrire), login JSON vs form-urlencoded → 422, PDF via préfixe `/api/` → 404 — tout passait le gate.

## Correctif (étend la sonde smoke, zéro dépendance)

1. Chaque sonde smoke envoie une **origine cross-origin** (`_SMOKE_DEFAULT_ORIGIN`, port Vite usuel) et vérifie l'`Access-Control-Allow-Origin` de la réponse : une route **2xx/3xx sans ACAO compatible** (`*` ou écho de l'origine) ⇒ **rouge `CORS ABSENT`** (l'UI serait bloquée au premier fetch).
2. Contrôle **exempté sur status ≥ 400** (un 401/404/405 est déjà signalé par le status ; une route protégée n'a pas à exposer CORS) → pas de faux rouge.
3. Défaut de **signature** (`smoke_cors_origin`/`cors_origin`/`origin`) → actif au run réel même si le harness bypasse `_gate_options` (anti-inertie). `GATE_SMOKE_CORS_ORIGIN` ; **vide = contrôle désactivé** (apps API-only). La clé runtime n'est émise qu'en override (égalité stricte de dict préservée).

Écart vs proposition #1 de l'issue (navigateur/node depuis le front) **assumé** : la sonde HTTP cross-origin capture le même défaut (CORS, contrats d'API) sans le chemin lourd. Limite documentée : un projet API-only qui active smoke verrait rouge sur ses GET publics → opt-in + `cors_origin=""`.

## Tests

- Sonde exécutée contre serveurs inline : CORS absent → rouge ; `*` / écho exact → vert ; 401 sans CORS → vert (exempté) ; `origin=""` → vert. Vrai FastAPI+CORSMiddleware validé en revue.
- `compile()` du template ; **déconstruction du tuple 3→4 vérifiée partout** (le risque de faux rouge généralisé).
- Non-régression #458/#483 : `_run_probe(origin="")` par défaut → les serveurs sans CORS restent verts.
- Défaut de signature traverse `run_quality_gate` ; runtime n'émet la clé qu'en override.
- Revue adversariale pré-PR : APPROUVÉ (tuple 3→4 couvert, sémantique CORS correcte, anti-inertie, opt-out) + déduplication d'un magic string appliquée.

**Base : `pre-main`.**

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)