### PR TITLE
feat(sandbox,executor): cache pip persistant opt-in pour les passes réseau du gate (#496)

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -150,6 +150,12 @@ class Settings(BaseSettings):
     # autant réduire l'occurrence). Adresses IP séparées par des virgules
     # (ex. "1.1.1.1,8.8.8.8") ; vide (défaut) = résolveur Docker.
     SANDBOX_DNS: str = ""
+    # #496 : cache pip persistant du sandbox (partie 2 de #485). Chemin HÔTE
+    # monté sur /tmp/.pip_cache (+ PIP_CACHE_DIR) pour les passes réseau du gate
+    # (#414/#439) : évite de retélécharger PyPI à chaque run. Le runtime crée le
+    # dossier (writable par l'uid hôte). Vide (défaut) = aucun cache. N'enlève
+    # --no-cache-dir QUE si le volume est monté (sinon cache dans le tmpfs /tmp).
+    SANDBOX_PIP_CACHE_DIR: str = ""
 
     ENGINE_INIT_TIMEOUT: float = 10.0
     ENGINE_WAIT_TIMEOUT: float = 30.0

--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -50,7 +50,7 @@ DEFAULT_TEST_COMMAND = f"{_PYTEST_WIDE_COLUMNS} python -m pytest -q"
 _INSTALL_FAILED_NOTE = "[gate] installation des dépendances en échec — tests lancés quand même (#414)"
 
 
-def deps_install_prelude(workspace: str, *, strict: bool = False) -> Optional[str]:
+def deps_install_prelude(workspace: str, *, strict: bool = False, use_cache: bool = False) -> Optional[str]:
     """Préambule shell installant les dépendances du projet avant les tests (#414).
 
     Le conteneur de tests est **éphémère** et distinct de celui où l'agent a
@@ -70,11 +70,15 @@ def deps_install_prelude(workspace: str, *, strict: bool = False) -> Optional[st
       l'installabilité des dépendances déclarées fait partie du contrat ;
     - ``None`` si le workspace ne déclare aucune dépendance installable.
     """
+    # #496 : ``use_cache=True`` retire ``--no-cache-dir`` — réservé au cas où le
+    # sandbox monte un cache pip persistant (sinon le cache irait dans le tmpfs
+    # /tmp, compté dans --memory). Dérivé du sandbox côté run_quality_gate.
+    no_cache = "" if use_cache else "--no-cache-dir "
     parts: List[str] = []
     if os.path.isfile(os.path.join(workspace, "requirements.txt")):
-        parts.append("python -m pip install --user --no-cache-dir -q -r requirements.txt")
+        parts.append(f"python -m pip install --user {no_cache}-q -r requirements.txt")
     if os.path.isfile(os.path.join(workspace, "pyproject.toml")) or os.path.isfile(os.path.join(workspace, "setup.py")):
-        parts.append("python -m pip install --user --no-cache-dir -q -e .")
+        parts.append(f"python -m pip install --user {no_cache}-q -e .")
     if not parts:
         return None
     if strict:
@@ -310,7 +314,7 @@ def smoke_run_command(
     return f"python - <<'{_SMOKE_HEREDOC}'\n{script}{_SMOKE_HEREDOC}"
 
 
-def installability_command(workspace: str) -> Optional[str]:
+def installability_command(workspace: str, *, use_cache: bool = False) -> Optional[str]:
     """Passe d'installabilité en environnement NU (#439). Fail-closed.
 
     L'image sandbox pré-installe une stack web pour servir l'**agent** (#414) :
@@ -331,7 +335,8 @@ def installability_command(workspace: str) -> Optional[str]:
     # --timeout 30 (pas plus) : le conteneur du gate a un budget TOTAL de
     # 120 s — un timeout socket long plus un retry le dépasserait (kill du
     # conteneur, le pire diagnostic possible).
-    pip_flags = "--no-cache-dir -q --retries 5 --timeout 30"
+    # #496 : --no-cache-dir retiré si un cache pip est monté (use_cache).
+    pip_flags = f"{'' if use_cache else '--no-cache-dir '}-q --retries 5 --timeout 30"
     return (
         f"python -m venv --clear {_GATE_VENV}"
         f" && {_GATE_VENV}/bin/python -m pip install {pip_flags} -r requirements.txt"
@@ -1252,6 +1257,11 @@ async def run_quality_gate(
     """
     sandbox = sandbox or DockerSandbox()
     reviewer = reviewer or _default_reviewer()
+    # #496 : le cache pip n'est utilisé que si le sandbox monte effectivement le
+    # volume — sinon le cache irait dans le tmpfs /tmp, compté dans --memory.
+    # Source de vérité UNIQUE = l'attribut du sandbox (pas un kwarg
+    # désynchronisable) ; getattr → tout double de test sans l'attribut → False.
+    use_pip_cache = bool(getattr(sandbox, "pip_cache_dir", None))
 
     # #482 : garde append-only sur requirements.txt — analyse PURE du diff,
     # AVANT les passes d'infra. Les tests tournent quand même : la mémoire de
@@ -1273,7 +1283,7 @@ async def run_quality_gate(
     try:
         command = test_command
         if install_deps:
-            prelude = deps_install_prelude(workspace, strict=require_deps_install)
+            prelude = deps_install_prelude(workspace, strict=require_deps_install, use_cache=use_pip_cache)
             if prelude is not None:
                 # Strict (#439) : install bloquante. Toléré (#414) : les tests
                 # tournent quand même, l'échec laisse sa note dans la sortie.
@@ -1298,7 +1308,7 @@ async def run_quality_gate(
             # gate rouge.
             command = f"({command}) && {front}"
         if check_installability:
-            installability = installability_command(workspace)
+            installability = installability_command(workspace, use_cache=use_pip_cache)
             if installability is not None:
                 if front_commands:
                     # La collecte de la passe d'installabilité (#439) renvoie

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -83,6 +83,20 @@ def _sandbox_dns(settings_obj) -> tuple:
     return tuple(server.strip() for server in raw.split(",") if server.strip())
 
 
+def _sandbox_pip_cache(settings_obj):
+    """Cache pip persistant du sandbox (#496) — ``SANDBOX_PIP_CACHE_DIR`` (chemin hôte).
+
+    Crée le dossier (le conteneur tourne en ``--user`` uid:gid hôte → writable
+    requis). Vide/absent → ``None`` (aucun cache).
+    """
+    raw = str(getattr(settings_obj, "SANDBOX_PIP_CACHE_DIR", "") or "").strip()
+    if not raw:
+        return None
+    path = os.path.expanduser(raw)
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
 def _build_sandbox(settings_obj):  # pragma: no cover - infra réelle (integration)
     from collegue.sandbox import DockerSandbox
 
@@ -90,7 +104,11 @@ def _build_sandbox(settings_obj):  # pragma: no cover - infra réelle (integrati
     # (le défaut durci est ``network="none"``). #485 : résolveurs DNS explicites
     # opt-in (SANDBOX_DNS) — le résolveur Docker par défaut était instable en
     # run réel (gate ET coder, le sandbox est partagé).
-    return DockerSandbox(network="bridge", dns=_sandbox_dns(settings_obj))
+    return DockerSandbox(
+        network="bridge",
+        dns=_sandbox_dns(settings_obj),
+        pip_cache_dir=_sandbox_pip_cache(settings_obj),  # #496 : cache pip persistant opt-in
+    )
 
 
 def _build_agent(sandbox, settings_obj):  # pragma: no cover - infra réelle (integration)

--- a/collegue/sandbox/executor.py
+++ b/collegue/sandbox/executor.py
@@ -39,6 +39,8 @@ from dataclasses import dataclass
 from typing import List, Mapping, Optional, Tuple, Union
 
 DEFAULT_SANDBOX_IMAGE = "collegue-sandbox:latest"
+# #496 : point de montage du cache pip persistant dans le conteneur.
+SANDBOX_PIP_CACHE_MOUNT = "/tmp/.pip_cache"
 
 # Code de sortie conventionnel pour un dépassement de délai (cf. coreutils timeout).
 TIMEOUT_EXIT_CODE = 124
@@ -70,8 +72,10 @@ class DockerSandbox:
     """Exécute des commandes dans un conteneur Docker isolé et durci.
 
     Isolation (AC#1 « ne peut pas lire le FS hôte ») : seul ``workspace`` est monté
-    (sur ``/workspace``) ; aucun autre chemin hôte n'est exposé. Persistance (AC#2) :
-    ``workspace`` est un répertoire réel réutilisé d'une exécution à l'autre.
+    (sur ``/workspace``) ; aucun autre chemin hôte n'est exposé — sauf un cache pip
+    OPT-IN sur ``/tmp/.pip_cache`` si ``pip_cache_dir`` est fourni (#496).
+    Persistance (AC#2) : ``workspace`` est un répertoire réel réutilisé d'une
+    exécution à l'autre.
     """
 
     def __init__(
@@ -80,6 +84,7 @@ class DockerSandbox:
         *,
         network: str = "none",
         dns: Optional[Tuple[str, ...]] = None,
+        pip_cache_dir: Optional[str] = None,
         memory: str = "512m",
         cpus: str = "1.0",
         pids_limit: int = 256,
@@ -100,6 +105,12 @@ class DockerSandbox:
         # l'infra. Vide (défaut) = comportement Docker inchangé. Une adresse
         # invalide fait échouer `docker run` (stderr visible dans le gate).
         self.dns = tuple(dns or ())
+        # Cache pip persistant opt-in (#496, partie 2 de #485). Monté sur
+        # /tmp/.pip_cache + PIP_CACHE_DIR : les passes réseau du gate (#414/#439)
+        # ne retéléchargent plus tout PyPI à chaque run (aléas DNS/timeout
+        # réduits, temps mur amorti — jusqu'à 4 passes avec la remédiation #481).
+        # Vide (défaut) = aucun montage, argv inchangé. Validé comme un -v.
+        self.pip_cache_dir = pip_cache_dir or None
         self.memory = memory
         self.cpus = cpus
         self.pids_limit = pids_limit
@@ -166,6 +177,16 @@ class DockerSandbox:
         # défaut strictement inchangé).
         for server in self.dns:
             argv += ["--dns", server]
+        # #496 : cache pip persistant — 2e montage hôte opt-in (cf. docstring
+        # d'isolation). Le bind sur /tmp/.pip_cache MASQUE le tmpfs à ce
+        # sous-chemin → les pages du cache ne comptent pas dans --memory. Validé
+        # (realpath + refus ':'/racine) car il devient un -v ; le confinement
+        # workspace_root NE s'applique PAS (le cache vit hors du workspace).
+        if self.pip_cache_dir:
+            cache = os.path.realpath(os.path.abspath(self.pip_cache_dir))
+            if ":" in cache or cache == os.path.sep:
+                raise ValueError(f"pip_cache_dir invalide (':' ou racine): {cache}")
+            argv += ["-v", f"{cache}:{SANDBOX_PIP_CACHE_MOUNT}", "-e", f"PIP_CACHE_DIR={SANDBOX_PIP_CACHE_MOUNT}"]
         if self.read_only:
             argv += ["--read-only"]  # root FS en lecture seule
         argv += [

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -1855,3 +1855,52 @@ async def test_gate_smoke_threads_cors_origin(tmp_path):
     _ws, command = sandbox.calls[0]
     assert "localhost:5173" in command
     assert "Access-Control-Allow-Origin" in command
+
+
+# --- cache pip persistant opt-in (#496) ---------------------------------------------
+
+
+def test_deps_install_prelude_use_cache_drops_no_cache_dir(tmp_path):
+    from collegue.executor.quality_gate import deps_install_prelude
+
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    default = deps_install_prelude(str(tmp_path))
+    assert "--no-cache-dir" in default
+    cached = deps_install_prelude(str(tmp_path), use_cache=True)
+    assert "--no-cache-dir" not in cached
+    assert "pip install --user" in cached  # l'install ne disparaît pas
+
+
+def test_installability_command_use_cache(tmp_path):
+    from collegue.executor import installability_command
+
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    cmd = installability_command(str(tmp_path), use_cache=True)
+    assert "--no-cache-dir" not in cmd
+    assert cmd.count("--retries 5") == 2 and cmd.count("--timeout 30") == 2  # retries #461 intacts
+
+
+class _CacheSandbox(_FakeSandbox):
+    """FakeSandbox qui annonce un cache pip monté (dérivation run_quality_gate)."""
+
+    def __init__(self, result=None):
+        super().__init__(result or SandboxResult(exit_code=0, stdout="2 passed", stderr=""))
+        self.pip_cache_dir = "/host/cache"
+
+
+async def test_gate_keeps_no_cache_dir_without_sandbox_cache(tmp_path):
+    """Défaut (sandbox sans cache) : --no-cache-dir conservé (comportement #414)."""
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    sandbox = _green()  # pas d'attribut pip_cache_dir
+    await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    _ws, command = sandbox.calls[0]
+    assert "--no-cache-dir" in command
+
+
+async def test_gate_uses_cache_when_sandbox_mounts_it(tmp_path):
+    """#496 : si le sandbox monte un cache, le gate retire --no-cache-dir."""
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+    sandbox = _CacheSandbox()
+    await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    _ws, command = sandbox.calls[0]
+    assert "--no-cache-dir" not in command

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -406,3 +406,16 @@ def test_gate_smoke_cors_origin_emitted_only_on_override():
     assert _gate_options(over)["smoke_cors_origin"] == "https://app.example"
     off = SimpleNamespace(GATE_SMOKE_RUN=True, GATE_SMOKE_CORS_ORIGIN="")
     assert _gate_options(off)["smoke_cors_origin"] == ""
+
+
+def test_sandbox_pip_cache_parsed_from_settings(tmp_path):
+    """#496 : SANDBOX_PIP_CACHE_DIR → chemin créé ; vide/absent → None."""
+    from types import SimpleNamespace
+
+    from collegue.pilot.runtime import _sandbox_pip_cache
+
+    target = tmp_path / "pipcache"
+    assert _sandbox_pip_cache(SimpleNamespace(SANDBOX_PIP_CACHE_DIR=str(target))) == str(target)
+    assert target.is_dir()  # créé (writable par l'uid hôte)
+    assert _sandbox_pip_cache(SimpleNamespace(SANDBOX_PIP_CACHE_DIR="")) is None
+    assert _sandbox_pip_cache(SimpleNamespace()) is None

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -289,3 +289,32 @@ def test_build_argv_dns_flags(tmp_path):
 def test_build_argv_no_dns_by_default(tmp_path):
     """Défaut : aucun --dns — argv identique au comportement historique durci."""
     assert "--dns" not in DockerSandbox(image="img")._build_run_argv("x", str(tmp_path))
+
+
+def test_build_argv_pip_cache_mount(tmp_path):
+    """#496 : cache pip persistant opt-in → 2e montage + PIP_CACHE_DIR."""
+    cache = tmp_path / "pipcache"
+    cache.mkdir()
+    sb = DockerSandbox(image="img", pip_cache_dir=str(cache))
+    argv = sb._build_run_argv("echo hi", str(tmp_path / "ws"))
+    import os as _os
+
+    cache_real = _os.path.realpath(str(cache))
+    assert f"{cache_real}:/tmp/.pip_cache" in _mounts(argv)
+    assert "PIP_CACHE_DIR=/tmp/.pip_cache" in " ".join(argv)
+
+
+def test_build_argv_no_pip_cache_by_default(tmp_path):
+    """Défaut : aucun cache → argv inchangé (un seul montage workspace)."""
+    argv = DockerSandbox(image="img")._build_run_argv("x", str(tmp_path))
+    assert "PIP_CACHE_DIR" not in " ".join(argv)
+    assert _mounts(argv) == [f"{tmp_path}:/workspace"]
+
+
+def test_build_argv_pip_cache_validated(tmp_path):
+    """#496 : un chemin de cache contenant ':' est refusé (devient un -v)."""
+    import pytest
+
+    sb = DockerSandbox(image="img", pip_cache_dir="/bad:path")
+    with pytest.raises(ValueError):
+        sb._build_run_argv("x", str(tmp_path))


### PR DESCRIPTION
## Problème (#496 — BASSE, partie 2 de #485)

Les passes réseau du gate (#414/#439) forcent `--no-cache-dir` → chaque run retélécharge tout PyPI : exposition aux rafales DNS/timeout multipliée, temps mur amorti (jusqu'à 4 passes avec la remédiation #481).

## Correctif (déviation assumée du design de l'issue — source de vérité unique)

1. **`DockerSandbox(pip_cache_dir=…)`** → 2e montage opt-in `-v cache:/tmp/.pip_cache -e PIP_CACHE_DIR` (calque #485 dns). Le **bind masque le tmpfs** à ce sous-chemin → les pages du cache ne comptent pas dans `--memory` (le point #4 de l'issue). Validation inline (realpath + refus `:`/racine, **sans** confinement `workspace_root` car le cache vit hors workspace). Argv par défaut **strictement inchangé**.
2. **`use_cache`** sur `deps_install_prelude`/`installability_command` retire `--no-cache-dir`. **`run_quality_gate` DÉRIVE `use_cache` de `sandbox.pip_cache_dir`** — source de vérité **unique** (pas de kwarg `pip_cache` séparé comme proposé par l'issue, qui serait désynchronisable). Conséquence : impossible d'avoir un cache sans montage effectif → le point #4 est **structurellement** garanti.
3. **runtime** : `_sandbox_pip_cache` (os.makedirs — conteneur `--user` uid hôte, point #3) câblé dans `_build_sandbox` ; `SANDBOX_PIP_CACHE_DIR`. Défaut de signature → activable au run réel (le harness n'a qu'à ajouter `pip_cache_dir` à son sandbox). `_gate_options` **intact** (le cache passe par le sandbox).

Contrat venv-nu #439 **préservé** : `python -m venv --clear` reste vierge — le cache n'évite que le re-téléchargement, l'installabilité depuis requirements.txt reste prouvée.

## Tests

- Montage : cache → `-v …:/tmp/.pip_cache` + `PIP_CACHE_DIR` ; défaut → 1 seul montage workspace (invariant `mounts_only_workspace` étendu) ; chemin `:` → ValueError.
- Builders : `use_cache` retire `--no-cache-dir`, garde l'install et les retries #461.
- Dérivation : sandbox sans cache → `--no-cache-dir` conservé ; sandbox avec cache → retiré.
- runtime : `SANDBOX_PIP_CACHE_DIR` crée le dossier ; vide/absent → None.
- Revue adversariale pré-PR : APPROUVÉ, aucun défaut (ordre des montages Docker vérifié, validation équivalente, _gate_options intact).

**Base : `pre-main`.**

Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)