### PR TITLE
fix(pilot): cost_unknown dédupliqué par run/projet, restarts inclus (#504)

### DIFF
--- a/collegue/pilot/audit.py
+++ b/collegue/pilot/audit.py
@@ -204,6 +204,45 @@ class RunAuditLog:
                 pass  # l'audit ne doit jamais casser le run
         return event
 
+    def record_once(self, kind: str, *, iteration: Optional[int] = None, **detail: Any) -> Optional[RunEvent]:
+        """Émet ``kind`` au plus UNE fois par PROJET/run, restarts inclus (#504).
+
+        Anti-bruit pour les signaux à portée « run » (ex. ``cost_unknown``) : en
+        mode sériel strict (#434), le pilote est rappelé après chaque merge — un
+        garde-fou en mémoire repartirait à zéro à chaque segment (×N événements
+        au lieu d'un, run v5 : 12 ``cost_unknown``). On déduplique sur l'état
+        DURABLE (décisions persistées, comme le ledger #462) : si un événement de
+        ce ``kind`` existe déjà pour le projet, on n'émet rien. Sans persistance
+        (dry_run/tests mémoire), portée « segment » via :attr:`events`. Renvoie
+        l'événement émis, ou ``None`` si déjà signalé.
+        """
+        if self._already_recorded(kind):
+            return None
+        return self.record(kind, iteration=iteration, **detail)
+
+    def _already_recorded(self, kind: str) -> bool:
+        """Vrai si ``kind`` a déjà été émis pour ce projet (mémoire + décisions persistées)."""
+        if any(e.kind == kind for e in self.events):
+            return True
+        if not self._persist:
+            return False
+        getter = getattr(self._manager, "get_decision_journal", None) or getattr(self._manager, "get_decisions", None)
+        if getter is None:
+            return False
+        # Best-effort : l'audit ne casse jamais le run — une lecture en échec
+        # retombe sur « pas encore signalé » (au pire un doublon, jamais une
+        # exception). Égalité STRICTE du summary (le filtre query n'est qu'une
+        # présélection ilike, à revérifier en Python).
+        summary = f"[run] {kind}"
+        try:
+            try:
+                rows = getter(self.project_id, summary)
+            except TypeError:
+                rows = getter(self.project_id)
+            return any(getattr(d, "summary", "") == summary for d in rows)
+        except Exception:
+            return False
+
     def record_cost(self, *, usd: float = 0.0, tokens: int = 0, iteration: Optional[int] = None) -> None:
         """Ajoute au ledger de coût du run + trace l'événement (et persiste si activé).
 
@@ -254,6 +293,9 @@ class NullAuditLog(RunAuditLog):
     def record(self, kind: str, *, iteration: Optional[int] = None, **detail: Any) -> RunEvent:
         # Ne rien stocker ni horodater : retour symbolique pour respecter la signature.
         return RunEvent(kind=kind, ts="", iteration=iteration, detail=detail)
+
+    def record_once(self, kind: str, *, iteration: Optional[int] = None, **detail: Any) -> Optional[RunEvent]:
+        return None
 
     def record_cost(self, *, usd: float = 0.0, tokens: int = 0, iteration: Optional[int] = None) -> None:
         return None

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -606,9 +606,6 @@ async def run_project(
     # consécutif) — N d'affilée ⇒ fail-fast (image cassée). Réarmé dès qu'un
     # hash change ou qu'une issue NON-crash survient.
     agent_crash_loop: dict = {}
-    # #484 : signal « coût inconnu » émis au plus UNE fois par run/segment
-    # (anti-bruit — le flag en mémoire ne survit pas aux restarts, comme #443).
-    cost_unknown_signaled = False
 
     # #466 : balayage de démarrage. (a) Les workspaces conservés PERSISTÉS des
     # tâches désormais abouties — le dict en mémoire de #443 repartait vide à
@@ -770,9 +767,11 @@ async def run_project(
             # sinon coût INCONNU — signalé une fois par run/segment au lieu
             # d'un 0 silencieux qui ressemble à un run gratuit.
             coder_usd = estimate_cost_usd(coder_prompt, coder_completion)
-            if coder_usd <= 0 and not cost_unknown_signaled:
-                cost_unknown_signaled = True
-                audit.record(
+            if coder_usd <= 0:
+                # #484/#504 : au plus UNE fois par run/projet — la dédup vit dans
+                # l'audit persistant (décisions), donc elle survit aux restarts du
+                # mode sériel strict (#434, run v5 : 12 cost_unknown → 1).
+                audit.record_once(
                     COST_UNKNOWN,
                     iteration=iteration,
                     task_id=task.id,

--- a/tests/test_pilot_audit.py
+++ b/tests/test_pilot_audit.py
@@ -309,3 +309,72 @@ async def test_driver_default_audit_is_noop(repo, manager):
         dry_run=True,
     )
     assert result.stop_reason == "completed"
+
+
+# --- record_once : dédup d'un signal à portée run, restarts inclus (#504) ------------
+
+
+def test_record_once_emits_once_per_log_in_memory():
+    """#504 : un signal « run » n'est émis qu'une fois dans un même log (mémoire)."""
+    from collegue.pilot.audit import COST_UNKNOWN
+
+    log = RunAuditLog(project_id=1, clock=_fixed_clock)
+    e1 = log.record_once(COST_UNKNOWN, iteration=1, tokens=10)
+    e2 = log.record_once(COST_UNKNOWN, iteration=2, tokens=20)
+    assert e1 is not None and e2 is None
+    assert len([e for e in log.events if e.kind == COST_UNKNOWN]) == 1
+
+
+def test_record_once_dedups_across_persistent_restarts(manager):
+    """#504 (le cas du run v5) : en mode sériel strict le pilote est ré-appelé
+    après chaque merge — la dédup doit survivre aux restarts (état persisté),
+    pas un flag mémoire (12 cost_unknown → 1)."""
+    from collegue.pilot.audit import COST_UNKNOWN
+
+    pid = manager.create_project(name="once")
+    seg1 = RunAuditLog(pid, manager=manager, clock=_fixed_clock, persist=True)
+    assert seg1.record_once(COST_UNKNOWN, iteration=1, tokens=100) is not None
+    # « restart » : nouveau log persistant, même DB.
+    seg2 = RunAuditLog(pid, manager=manager, clock=_fixed_clock, persist=True)
+    assert seg2.record_once(COST_UNKNOWN, iteration=2, tokens=100) is None
+    seg3 = RunAuditLog(pid, manager=manager, clock=_fixed_clock, persist=True)
+    assert seg3.record_once(COST_UNKNOWN, iteration=3, tokens=100) is None
+    cu = [d for d in manager.get_decisions(pid) if d.summary == "[run] cost_unknown"]
+    assert len(cu) == 1
+
+
+def test_record_once_isolated_per_project(manager):
+    from collegue.pilot.audit import COST_UNKNOWN
+
+    pid_a = manager.create_project(name="a")
+    pid_b = manager.create_project(name="b")
+    assert RunAuditLog(pid_a, manager=manager, persist=True).record_once(COST_UNKNOWN, tokens=1) is not None
+    # pid_b n'est pas affecté par le signal de pid_a.
+    assert RunAuditLog(pid_b, manager=manager, persist=True).record_once(COST_UNKNOWN, tokens=1) is not None
+
+
+def test_record_once_tolerates_manager_read_failure():
+    """Best-effort : une lecture en échec ne casse pas le run (au pire un doublon)."""
+    from types import SimpleNamespace
+
+    from collegue.pilot.audit import COST_UNKNOWN
+
+    class _BrokenManager:
+        def record_decision(self, *a, **k):
+            return 1
+
+        def add_metric(self, *a, **k):
+            return None
+
+        def get_decision_journal(self, *a, **k):
+            raise RuntimeError("DB indispo")
+
+    log = RunAuditLog(project_id=1, manager=_BrokenManager(), persist=True)
+    # Ne lève pas ; émet (retombe sur « pas encore signalé »).
+    assert log.record_once(COST_UNKNOWN, tokens=1) is not None
+
+
+def test_null_audit_record_once_noop():
+    from collegue.pilot.audit import COST_UNKNOWN
+
+    assert NullAuditLog().record_once(COST_UNKNOWN, tokens=1) is None

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -2130,3 +2130,25 @@ async def test_require_cost_pricing_passes_when_price_set(repo, manager, monkeyp
     pid = _linear_project(manager, 1)
     result = await _run(manager, repo, pid, dry_run=False, agent=FakeCodeAgent(), require_cost_pricing=True)
     assert result.stop_reason == "completed"
+
+
+async def test_cost_unknown_deduped_across_serial_segments(repo, manager, monkeypatch):
+    """#504 : en mode sériel strict le pilote est ré-appelé après chaque merge
+    (nouvel audit persistant à chaque segment) — le signal cost_unknown ne doit
+    être persisté qu'UNE fois pour tout le run (run v5 : 12 → 1)."""
+    from collegue import config
+    from collegue.pilot.audit import RunAuditLog
+
+    monkeypatch.setattr(config.settings, "LLM_PRICE_PROMPT_PER_1M", 0.0, raising=False)
+    monkeypatch.setattr(config.settings, "LLM_PRICE_COMPLETION_PER_1M", 0.0, raising=False)
+    pid = _linear_project(manager, 1)
+    # Segment 1 : audit persistant → émet cost_unknown (persisté en décisions).
+    audit1 = RunAuditLog(pid, manager=manager, persist=True)
+    await _run(manager, repo, pid, dry_run=False, agent=_UnmappedModelAgent(), audit=audit1)
+    # Nouvelle tâche todo + « restart » (nouvel audit persistant) = 2e segment.
+    manager.add_task(pid, title="T-seg2")
+    audit2 = RunAuditLog(pid, manager=manager, persist=True)
+    await _run(manager, repo, pid, dry_run=False, agent=_UnmappedModelAgent(), audit=audit2)
+    # Au plus UN cost_unknown persisté pour tout le run, malgré 2 segments.
+    cu = [d for d in manager.get_decisions(pid) if d.summary == "[run] cost_unknown"]
+    assert len(cu) == 1


### PR DESCRIPTION
## Problème (#504 — BASSE)

Le garde-fou anti-bruit de #484 (`cost_unknown_signaled`) était une variable **locale** à `run_project`. En mode sériel strict (#434), le pilote est ré-appelé après chaque merge → le flag repart à zéro → **12 événements `cost_unknown`** au run v5 au lieu d'un.

## Correctif (couche audit, pas un knob — aucun risque d'inertie)

1. **`RunAuditLog.record_once(kind, …)`** : émet au plus une fois par **projet/run**. `_already_recorded` : court-circuit mémoire (`self.events`) puis, si persistant, vérifie qu'une décision `[run] {kind}` n'existe pas déjà en base (best-effort `try/except` — l'audit ne casse jamais le run ; **égalité stricte** du summary, le filtre `ilike` n'étant qu'une présélection). Même pattern que le ledger #462 (dédup sur l'état durable, survit aux restarts). `NullAuditLog.record_once` → no-op.
2. **driver** : flag local supprimé ; `audit.record(COST_UNKNOWN)` → `audit.record_once`. Le **ledger tokens** (`record_cost`) reste **inconditionnel** — les tokens sont toujours comptés, seul l'event est dédupliqué.

Le fix vit dans la couche audit traversée par tous les chemins (le harness passe son propre audit mais appelle `record_once`) — pas de config, pas de `_gate_options`, pas de signature à propager.

## Tests

- `record_once` : 1× en mémoire ; **dédup cross-restart persistant** (3 segments → 1 décision) ; isolation par projet ; lecture DB en échec → pas de crash (best-effort) ; NullAuditLog no-op.
- Driver : **cross-segment** (2 audits persistants successifs → 1 seule décision `[run] cost_unknown`, le cas du run v5).
- Non-régression #484 : 1 run / 2 tâches / persist=False → 1 event (dédup mémoire), 2 `cost_observed`, tokens comptés. #502 (`cost_pricing_unresolved`) non affecté (kind distinct).
- Revue adversariale pré-PR : APPROUVÉ, aucun défaut.

**Base : `pre-main`.**

Closes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)