### PR TITLE
fix(tools): le 404 du client GitHub part en debug, plus en error (#505)

### DIFF
--- a/collegue/tools/base.py
+++ b/collegue/tools/base.py
@@ -38,7 +38,17 @@ class ToolValidationError(ToolError):
 
 
 class ToolExecutionError(ToolError):
-    pass
+    """Erreur d'exécution d'un outil.
+
+    ``status_code`` (optionnel) porte le code HTTP d'origine quand l'erreur naît
+    d'un appel API : le wrapper retry des clients (``_execute_with_retry``) le
+    relit via ``getattr(e, "status_code", 0)`` pour rétrograder en ``debug`` les
+    404 ATTENDUS (sondes d'existence) au lieu de les logger en ``error`` (#465/#505).
+    """
+
+    def __init__(self, message: str = "", status_code: int = 0):
+        super().__init__(message)
+        self.status_code = status_code
 
 
 class ToolConfigurationError(ToolError):

--- a/collegue/tools/clients/github.py
+++ b/collegue/tools/clients/github.py
@@ -78,13 +78,18 @@ class GitHubClient(APIClient):
                 timeout=self.timeout,
             )
             if response.status_code == 404:
-                raise ToolExecutionError(f"Ressource introuvable: {endpoint}")
+                # #505 : statut porté → _execute_with_retry rétrograde en debug
+                # (sonde d'existence : contents/<fichier> sur branche fraîche =
+                # 404 ATTENDU, ~60 lignes de bruit console au run v5).
+                raise ToolExecutionError(f"Ressource introuvable: {endpoint}", status_code=404)
             if response.status_code == 401:
-                raise ToolExecutionError("Token GitHub invalide ou expiré, ou authentification requise")
+                raise ToolExecutionError(
+                    "Token GitHub invalide ou expiré, ou authentification requise", status_code=401
+                )
             if response.status_code == 403:
                 remaining = response.headers.get("X-RateLimit-Remaining", "?")
                 raise ToolExecutionError(
-                    f"Rate limit GitHub atteint ou permissions insuffisantes. Restant: {remaining}"
+                    f"Rate limit GitHub atteint ou permissions insuffisantes. Restant: {remaining}", status_code=403
                 )
             response.raise_for_status()
             return response

--- a/tests/test_clients_retry_logging.py
+++ b/tests/test_clients_retry_logging.py
@@ -78,3 +78,44 @@ def test_success_after_transient_failure_no_final_log(caplog):
     with caplog.at_level("DEBUG", logger=client.logger.name):
         assert client._execute_with_retry(_op, "GET ref") == "ok"
     assert not [r for r in caplog.records if "failed after" in r.message]
+
+
+def test_tool_execution_error_404_logs_at_debug(caplog):
+    """#505 : un ToolExecutionError porteur de status_code=404 (cas GitHubClient,
+    qui convertit le 404 HTTP en exception métier) part en debug, plus en error —
+    le rétrogradage #465 atteint enfin ce chemin (~60 lignes de bruit au run v5)."""
+    from collegue.tools.base import ToolExecutionError
+
+    client = _Client()
+    with caplog.at_level("DEBUG", logger=client.logger.name):
+        with pytest.raises(APIError):
+            client._execute_with_retry(
+                _always_raise(ToolExecutionError("Ressource introuvable: contents/x", status_code=404)),
+                "GET contents/x",
+            )
+    records = [r for r in caplog.records if "failed after" in r.message]
+    assert records and all(r.levelname == "DEBUG" for r in records)
+
+
+def test_tool_execution_error_401_stays_error(caplog):
+    """401 reste une vraie erreur (console) — auth invalide, pas du bruit attendu."""
+    from collegue.tools.base import ToolExecutionError
+
+    client = _Client()
+    with caplog.at_level("DEBUG", logger=client.logger.name):
+        with pytest.raises(APIError):
+            client._execute_with_retry(
+                _always_raise(ToolExecutionError("Token invalide", status_code=401)),
+                "GET user",
+            )
+    records = [r for r in caplog.records if "failed after" in r.message]
+    assert records and all(r.levelname == "ERROR" for r in records)
+
+
+def test_tool_execution_error_default_status_is_zero():
+    """Compat signature : message seul → status_code défaut 0 (sous-classes incluses)."""
+    from collegue.tools.base import ToolExecutionError, ToolQuotaError, ToolRateLimitError
+
+    assert ToolExecutionError("x").status_code == 0
+    assert ToolRateLimitError("x").status_code == 0
+    assert ToolQuotaError("x").status_code == 0


### PR DESCRIPTION
## Problème (#505 — BASSE)

Le rétrogradage 404→debug de #465 ne s'appliquait jamais au client GitHub : `github.py` convertit le 404 HTTP en `ToolExecutionError` **sans statut**, donc `_execute_with_retry` voyait `last_status=0 ≠ 404` → `logger.error`. Au run v5, ~60 lignes « failed after 1 attempt(s): Ressource introuvable » (sondes d'existence `contents/<fichier>`) polluaient la console.

## Correctif (chemin réel — défaut de signature)

1. **`ToolExecutionError.__init__(message, status_code=0)`** : le wrapper retry relit `getattr(e, "status_code", 0)` → 404 → `logger.debug`.
2. **`github.py`** : les 3 raises HTTP (404/401/403) portent leur statut. 404 (attendu, sonde d'existence) → debug ; **401/403 restent en error** (vraies anomalies d'auth/rate-limit).

Scoping : Sentry inchangé (`raise_for_status` porte déjà `e.response.status_code`). Compat : les ~90 appelants de `ToolExecutionError(message)` passent un seul argument → `status_code` défaut 0 (sous-classes `ToolRateLimitError`/`ToolQuotaError` incluses, vérifié).

## Tests

- `ToolExecutionError(status_code=404)` → `failed after` en DEBUG ; `status_code=401` → ERROR.
- Compat signature : message seul → status_code 0 (3 classes).
- Revue adversariale pré-PR : APPROUVÉ (~90 appelants vérifiés, aucun 2e positionnel ; Sentry non régressé ; 246 tests tools verts).

**Base : `pre-main`.**

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)