### PR TITLE
feat(pilot): CLI opérateur tracé (requeue/reset) — fin du trou d'audit des interventions hors-boucle (#506)

### DIFF
--- a/collegue/pilot/__init__.py
+++ b/collegue/pilot/__init__.py
@@ -35,6 +35,8 @@ from collegue.pilot.budget import (
 from collegue.pilot.driver import (
     ProjectRunResult,
     TaskOutcome,
+    operator_requeue_task,
+    operator_reset_task,
     reconcile_in_review_tasks,
     requeue_task_for_redo,
     run_project,
@@ -85,6 +87,8 @@ __all__ = [
     "TaskOutcome",
     "requeue_task_for_redo",
     "reconcile_in_review_tasks",
+    "operator_requeue_task",
+    "operator_reset_task",
     # F4 — câblage runtime
     "run_project_from_settings",
     "format_run_report",

--- a/collegue/pilot/__main__.py
+++ b/collegue/pilot/__main__.py
@@ -9,6 +9,10 @@ Exemple :
     python -m collegue.pilot --project-id 1 --repo-source /chemin/clone \\
         --owner moi --repo mon-app            # dry-run (aperçu)
     python -m collegue.pilot ... --execute    # écritures réelles
+
+Interventions opérateur tracées (#506) — hors-boucle, journalisées dans ``decisions`` :
+    python -m collegue.pilot task requeue <task_id> --message "motif"   # re-file (#460)
+    python -m collegue.pilot task reset <task_id> --message "motif" [--status todo]
 """
 
 from __future__ import annotations
@@ -23,15 +27,35 @@ from collegue.pilot.runtime import format_run_report, run_project_from_settings
 _OK_STOPS = {"completed", "paused_budget", "deadline_reached"}
 
 
+# Args requis du RUN par défaut (commande implicite). Validés à la main dans
+# ``main()`` quand aucune sous-commande n'est fournie — argparse ne sait pas
+# conditionner ``required`` sur l'absence de sous-commande (#506).
+_RUN_REQUIRED = ("project_id", "repo_source", "owner", "repo")
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="collegue.pilot",
         description="Pilote autonome : chaîne l'exécuteur d'issues sur le graphe de tâches sous budget-temps.",
     )
-    parser.add_argument("--project-id", type=int, required=True, help="Id du projet (état durable).")
-    parser.add_argument("--repo-source", required=True, help="Dépôt git source (repo-agnostique).")
-    parser.add_argument("--owner", required=True, help="Owner GitHub cible des PR.")
-    parser.add_argument("--repo", required=True, help="Repo GitHub cible des PR.")
+    # #506 : sous-commandes opérateur OPTIONNELLES. Sans sous-commande, on garde
+    # 100 % la rétro-compat (`python -m collegue.pilot --project-id ... --execute`) :
+    # les args du run restent au parseur RACINE, en `required=False`, validés dans main().
+    sub = parser.add_subparsers(dest="command")
+    task_p = sub.add_parser("task", help="Interventions opérateur tracées dans decisions (requeue/reset).")
+    task_sub = task_p.add_subparsers(dest="task_command", required=True)
+    rq = task_sub.add_parser("requeue", help="Re-file une tâche (motif → prompt de la tentative suivante, #460).")
+    rq.add_argument("task_id", type=int, help="Id de la tâche à re-filer.")
+    rq.add_argument("--message", required=True, help="Motif (atteint le prompt de la tentative suivante).")
+    rs = task_sub.add_parser("reset", help="Reset de statut post-incident, sans orienter de prompt (#506).")
+    rs.add_argument("task_id", type=int, help="Id de la tâche à réinitialiser.")
+    rs.add_argument("--status", default="todo", help="Statut cible (défaut: todo).")
+    rs.add_argument("--message", required=True, help="Motif du reset (tracé dans decisions).")
+    # --- args du RUN par défaut (required=False : validés dans main si pas de sous-commande) ---
+    parser.add_argument("--project-id", type=int, default=None, help="Id du projet (état durable).")
+    parser.add_argument("--repo-source", default=None, help="Dépôt git source (repo-agnostique).")
+    parser.add_argument("--owner", default=None, help="Owner GitHub cible des PR.")
+    parser.add_argument("--repo", default=None, help="Repo GitHub cible des PR.")
     parser.add_argument("--base", default="main", help="Branche de base des PR (défaut: main).")
     parser.add_argument(
         "--execute",
@@ -62,8 +86,42 @@ async def _run(args: argparse.Namespace) -> int:
     return 0 if result.stop_reason in _OK_STOPS else 1
 
 
+def _run_task_command(args: argparse.Namespace) -> int:
+    """Glue CLI des interventions opérateur (#506) : manager réel + audit persistant.
+
+    Branche la DB durable via la MÊME source de settings que ``run_project_from_settings``
+    (``runtime._settings``/``_build_manager``) — l'infra réelle est isolée dans ces deux
+    helpers (eux ``# pragma: no cover``) ; cette glue est testée par monkeypatch
+    (``test_main_task_command_*``). Le travail métier vit dans ``operator_*_task``.
+    """
+    from collegue.pilot.audit import RunAuditLog
+    from collegue.pilot.driver import operator_requeue_task, operator_reset_task
+    from collegue.pilot.runtime import _build_manager, _settings
+
+    manager = _build_manager(_settings())
+    task = manager.get_task(args.task_id)
+    if task is None:
+        print(f"Tâche {args.task_id} introuvable.")
+        return 1
+    audit = RunAuditLog(task.project_id, manager=manager, persist=True)
+    if args.task_command == "requeue":
+        fields = operator_requeue_task(manager, args.task_id, message=args.message, audit=audit)
+    else:
+        fields = operator_reset_task(manager, args.task_id, status=args.status, message=args.message, audit=audit)
+    print(f"Tâche {args.task_id} → {fields['status']} (motif tracé dans decisions).")
+    return 0
+
+
 def main(argv: Optional[List[str]] = None) -> int:
-    args = build_parser().parse_args(argv)
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "task":
+        return _run_task_command(args)
+    # Run par défaut : valider les args requis ici (argparse ne peut pas les
+    # conditionner sur l'absence de sous-commande). parser.error lève SystemExit.
+    missing = [name for name in _RUN_REQUIRED if getattr(args, name) is None]
+    if missing:
+        parser.error("arguments requis manquants : " + ", ".join("--" + m.replace("_", "-") for m in missing))
     return asyncio.run(_run(args))
 
 

--- a/collegue/pilot/audit.py
+++ b/collegue/pilot/audit.py
@@ -50,6 +50,11 @@ COST_UNKNOWN = "cost_unknown"
 # (avant la boucle), pour que l'opérateur sache que le ledger $ sera aveugle
 # sans attendre le post-mortem.
 COST_PRICING_UNRESOLVED = "cost_pricing_unresolved"
+# #506 : interventions OPÉRATEUR hors-boucle (CLI `python -m collegue.pilot task ...`).
+# Tracées dans `decisions` pour qu'un reset/requeue manuel ne soit plus invisible
+# au post-mortem (run v5 : reset failed→todo par UPDATE SQL direct = trou d'audit).
+OPERATOR_REQUEUE = "operator_requeue"  # tâche re-filée via requeue_task_for_redo (motif → prompt)
+OPERATOR_RESET = "operator_reset"  # reset de statut post-incident (état avant/après tracé)
 
 # Noms des métriques persistées pour le ledger de coût par run.
 METRIC_RUN_COST_USD = "run_cost_usd"

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -50,6 +50,8 @@ from collegue.pilot.audit import (
     COST_PRICING_UNRESOLVED,
     COST_UNKNOWN,
     GATE_DECISION,
+    OPERATOR_REQUEUE,
+    OPERATOR_RESET,
     OVERLAY_REFRESHED,
     PR_OPENED,
     RUN_STOP,
@@ -381,6 +383,58 @@ def requeue_task_for_redo(manager, task_id: int, *, message: str, attempt_count:
     else:
         fields["best_feedback"] = str(message)
     manager.update_task(task_id, **fields)
+    return fields
+
+
+def operator_requeue_task(manager, task_id: int, *, message: str, audit=None) -> dict:
+    """Intervention opérateur : re-file une tâche (#460) ET trace dans ``decisions`` (#506).
+
+    Wrappe :func:`requeue_task_for_redo` (chemin propre : le motif atteint le prompt
+    de la tentative suivante) puis journalise un événement ``OPERATOR_REQUEUE`` (état
+    avant/après) — sans ça, une reprise manuelle reste invisible au post-mortem
+    (run v5 : ``failed`` re-filé par ``UPDATE`` SQL direct, aucune trace). ``audit``
+    est injectable (défaut ``None``) : helper testable/utilisable sans DB d'audit,
+    no-op pur si absent (symétrie :class:`NullAuditLog`).
+    """
+    task = manager.get_task(task_id)
+    if task is None:
+        raise KeyError(f"tâche {task_id} introuvable")
+    before = task.status
+    fields = requeue_task_for_redo(manager, task_id, message=message)
+    if audit is not None:
+        audit.record(
+            OPERATOR_REQUEUE,
+            task_id=task_id,
+            status_before=before,
+            status_after=fields["status"],
+            message=str(message),
+        )
+    return fields
+
+
+def operator_reset_task(manager, task_id: int, *, status: str = TASK_STATUS_TODO, message: str, audit=None) -> dict:
+    """Reset de statut post-incident (#506) : pose ``status`` (défaut ``todo``) + trace.
+
+    Distinct du requeue : NE pose PAS de ``best_feedback`` (un reset n'oriente pas un
+    prompt, il rend juste une tâche terminale — ``failed`` — de nouveau éligible après
+    réparation d'infra ; cas run v5 : image sandbox HS). ``last_error`` horodaté garde
+    le motif lisible. Passe par ``manager.update_task`` (et non un ``UPDATE`` brut) pour
+    conserver le hook ORM ``updated_at``. ``audit`` injectable comme pour le requeue.
+    """
+    task = manager.get_task(task_id)
+    if task is None:
+        raise KeyError(f"tâche {task_id} introuvable")
+    before = task.status
+    fields = {"status": str(status), "last_error": f"[opérateur/reset] {message}"}
+    manager.update_task(task_id, **fields)
+    if audit is not None:
+        audit.record(
+            OPERATOR_RESET,
+            task_id=task_id,
+            status_before=before,
+            status_after=str(status),
+            message=str(message),
+        )
     return fields
 
 

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -949,6 +949,96 @@ def test_requeue_twice_replaces_redo_motive_not_stacks(manager):
     assert t.best_feedback.count("échecs connus") == 1  # jamais nidifié
 
 
+# --- interventions opérateur tracées (#506) ---------------------------------------
+
+
+def test_operator_requeue_task_traces_decision(manager):
+    """#506 : un requeue opérateur délègue à requeue_task_for_redo (#460) ET trace
+    un événement OPERATOR_REQUEUE persisté dans `decisions` — la reprise manuelle
+    n'est plus invisible au post-mortem."""
+    from collegue.pilot import operator_requeue_task
+    from collegue.pilot.audit import RunAuditLog
+
+    pid = _linear_project(manager, 1)
+    tid = manager.get_tasks(pid)[0].id
+    manager.update_task(tid, status="failed", attempt_count=3)
+    audit = RunAuditLog(pid, manager=manager, persist=True)
+
+    fields = operator_requeue_task(manager, tid, message="[opérateur] image sandbox réparée", audit=audit)
+
+    t = manager.get_tasks(pid)[0]
+    assert t.status == "todo" and fields["status"] == "todo"
+    assert "image sandbox" in t.last_error
+    assert "image sandbox" in t.best_feedback  # délègue à requeue_task_for_redo (#460)
+    evt = [e for e in audit.events if e.kind == "operator_requeue"]
+    assert len(evt) == 1
+    assert evt[0].detail["status_before"] == "failed"
+    assert evt[0].detail["status_after"] == "todo"
+    assert "image sandbox" in evt[0].detail["message"]
+    # trace PERSISTÉE dans decisions (cœur de l'issue) :
+    assert any(getattr(d, "summary", "") == "[run] operator_requeue" for d in manager.get_decisions(pid))
+
+
+def test_operator_reset_task_traces_before_after(manager):
+    """#506 : un reset pose le statut + trace l'état avant/après, SANS poser de
+    best_feedback (un reset n'oriente pas un prompt, distinct du requeue)."""
+    from collegue.pilot import operator_reset_task
+    from collegue.pilot.audit import RunAuditLog
+
+    pid = _linear_project(manager, 1)
+    tid = manager.get_tasks(pid)[0].id
+    manager.update_task(tid, status="failed")
+    audit = RunAuditLog(pid, manager=manager, persist=True)
+
+    operator_reset_task(manager, tid, message="reset post-incident sandbox", audit=audit)
+
+    t = manager.get_tasks(pid)[0]
+    assert t.status == "todo"
+    assert "reset post-incident" in t.last_error
+    assert not t.best_feedback  # distinct du requeue : aucun motif de réparation injecté
+    evt = [e for e in audit.events if e.kind == "operator_reset"]
+    assert len(evt) == 1
+    assert evt[0].detail["status_before"] == "failed"
+    assert evt[0].detail["status_after"] == "todo"
+    assert any(getattr(d, "summary", "") == "[run] operator_reset" for d in manager.get_decisions(pid))
+
+
+def test_operator_reset_task_custom_status(manager):
+    from collegue.pilot import operator_reset_task
+
+    pid = _linear_project(manager, 1)
+    tid = manager.get_tasks(pid)[0].id
+    manager.update_task(tid, status="failed")
+    fields = operator_reset_task(manager, tid, status="blocked", message="bloqué en attente d'arbitrage")
+    assert fields["status"] == "blocked"
+    assert manager.get_tasks(pid)[0].status == "blocked"
+
+
+def test_operator_helpers_unknown_task_raises(manager):
+    from collegue.pilot import operator_requeue_task, operator_reset_task
+
+    with pytest.raises(KeyError):
+        operator_reset_task(manager, 9999, message="x")
+    with pytest.raises(KeyError):
+        operator_requeue_task(manager, 9999, message="x")
+
+
+def test_operator_helpers_audit_none_is_noop_but_works(manager):
+    """audit=None : le travail manager est fait, aucune exception (helpers
+    utilisables/testables sans DB d'audit — symétrie NullAuditLog)."""
+    from collegue.pilot import operator_requeue_task, operator_reset_task
+
+    pid = _linear_project(manager, 2)
+    tids = [t.id for t in manager.get_tasks(pid)]
+    manager.update_task(tids[0], status="failed")
+    manager.update_task(tids[1], status="failed")
+    operator_reset_task(manager, tids[0], message="reset")  # audit défaut None
+    operator_requeue_task(manager, tids[1], message="redo")
+    statuses = {t.id: t.status for t in manager.get_tasks(pid)}
+    assert statuses[tids[0]] == "todo"
+    assert statuses[tids[1]] == "todo"
+
+
 # --- ré-injection du feedback d'échec au retry (#424) ------------------------------
 
 

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -247,8 +247,81 @@ def test_parser_execute_and_overrides():
 
 
 def test_parser_requires_mandatory_args():
+    # #506 : la validation des args du run a migré d'argparse vers main() pour
+    # cohabiter avec les sous-commandes opérateur (argparse ne peut pas conditionner
+    # `required` sur l'absence de sous-commande). parse_args réussit désormais ;
+    # le SystemExit est levé par main() (parser.error) quand un args requis manque.
+    import collegue.pilot.__main__ as cli
+
+    ns = build_parser().parse_args(["--owner", "o"])  # plus de SystemExit ici
+    assert ns.command is None and ns.project_id is None
     with pytest.raises(SystemExit):
-        build_parser().parse_args(["--owner", "o"])  # manque project-id/repo-source/repo
+        cli.main(["--owner", "o"])  # manque project-id/repo-source/repo
+
+
+# --- CLI sous-commandes opérateur (#506) ----------------------------------------
+
+
+def test_parser_task_requeue_subcommand():
+    ns = build_parser().parse_args(["task", "requeue", "42", "--message", "boom"])
+    assert ns.command == "task"
+    assert ns.task_command == "requeue"
+    assert ns.task_id == 42
+    assert ns.message == "boom"
+
+
+def test_parser_task_reset_subcommand_defaults_todo():
+    ns = build_parser().parse_args(["task", "reset", "7", "--message", "m"])
+    assert ns.task_command == "reset"
+    assert ns.task_id == 7
+    assert ns.status == "todo"
+    ns2 = build_parser().parse_args(["task", "reset", "7", "--message", "m", "--status", "blocked"])
+    assert ns2.status == "blocked"
+
+
+def test_parser_task_requeue_requires_message():
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["task", "requeue", "1"])  # --message obligatoire
+
+
+def test_parser_default_run_has_no_command():
+    # rétro-compat : sans sous-commande, command reste None (chemin run inchangé).
+    ns = build_parser().parse_args(["--project-id", "3", "--repo-source", "/r", "--owner", "o", "--repo", "app"])
+    assert ns.command is None
+
+
+def test_main_task_command_traces_decision(monkeypatch, tmp_path):
+    # Glue _run_task_command end-to-end SANS Docker/réseau : manager SQLite en mémoire,
+    # injecté via monkeypatch de runtime._build_manager + runtime._settings.
+    import collegue.pilot.__main__ as cli
+    import collegue.pilot.runtime as runtime
+    from collegue.state import ProjectStateManager
+
+    url = f"sqlite:///{tmp_path / 'state.db'}"
+    manager = ProjectStateManager.from_url(url, create=True)
+    pid = manager.create_project(name="p")
+    tid = manager.add_task(pid, title="T")
+    manager.update_task(tid, status="failed")
+
+    monkeypatch.setattr(runtime, "_settings", lambda: SimpleNamespace(STATE_DATABASE_URL=url))
+    monkeypatch.setattr(runtime, "_build_manager", lambda _s: manager)
+
+    rc = cli.main(["task", "reset", str(tid), "--message", "reset post-incident"])
+    assert rc == 0
+    assert manager.get_task(tid).status == "todo"
+    assert any(getattr(d, "summary", "") == "[run] operator_reset" for d in manager.get_decisions(pid))
+
+
+def test_main_task_command_unknown_task_returns_1(monkeypatch, tmp_path):
+    import collegue.pilot.__main__ as cli
+    import collegue.pilot.runtime as runtime
+    from collegue.state import ProjectStateManager
+
+    url = f"sqlite:///{tmp_path / 'state.db'}"
+    manager = ProjectStateManager.from_url(url, create=True)
+    monkeypatch.setattr(runtime, "_settings", lambda: SimpleNamespace(STATE_DATABASE_URL=url))
+    monkeypatch.setattr(runtime, "_build_manager", lambda _s: manager)
+    assert cli.main(["task", "reset", "9999", "--message", "x"]) == 1
 
 
 # --- CLI main (glue + codes de sortie) ------------------------------------------


### PR DESCRIPTION
## Contexte (#506)

Quand un opérateur intervenait **hors de la boucle** du pilote — re-filer une tâche, remettre un `failed` en `todo` après réparation d'infra — il le faisait par `UPDATE` SQL direct. Résultat : **aucune trace dans `decisions`**, intervention invisible au post-mortem (run v5 : reset d'une tâche après réparation de l'image sandbox, jamais journalisé).

## Correctif

Un **CLI opérateur explicite** qui journalise chaque intervention dans `decisions` via le journal d'audit du run.

```
python -m collegue.pilot task requeue <task_id> --message "motif"        # re-file (#460)
python -m collegue.pilot task reset   <task_id> --message "motif" [--status todo]
```

### Côté moteur (chemins réels, testables)
- **audit.py** : 2 types d'événements `OPERATOR_REQUEUE` / `OPERATOR_RESET`.
- **driver.py** : `operator_requeue_task` (délègue à `requeue_task_for_redo` #460 — le motif atteint le prompt suivant) et `operator_reset_task` (pose le statut + `last_error`, **sans** `best_feedback` : un reset n'oriente pas un prompt, il rend juste une tâche terminale de nouveau éligible). État avant/après tracé. `audit` **injectable** (défaut `None` = no-op) → helpers utilisables/testables sans DB.
- **__main__.py** : sous-commandes argparse `task requeue|reset`. **Rétro-compat 100 %** du run par défaut (`python -m collegue.pilot --project-id …`) : args racine en `required=False`, validés à la main dans `main()` (`parser.error`). Glue `_run_task_command` : construit manager + audit persistant via la **même source de settings** que `run_project_from_settings` (anti-inertie : pilote la bonne DB).
- **__init__.py** : exports.

## Tests
- Helpers : trace **PERSISTÉE** dans `decisions` (cœur de l'issue), reset sans `best_feedback`, statut cible custom, `KeyError` sur tâche absente, `audit=None` no-op fonctionnel.
- CLI : parsing des sous-commandes, `--message` obligatoire, `command is None` en run nominal, args requis adaptés (validation migrée argparse→`main()`), glue end-to-end avec SQLite injecté.
- Suite complète : **RC=0**. Ruff check + format : OK.

## Revue adversariale
VERDICT : **APPROUVÉ** (10 points de vigilance vérifiés : rétro-compat CLI, source des settings identique au run, ordre de capture `status_before`, persistance réelle, keyword-only `message`, etc.). Remarques mineures appliquées (docstring CLI, pragma de couverture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)