### PR TITLE
feat(executor): le feedback d'échec distingue régression sur l'existant vs tests de la tâche (#507)

### DIFF
--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -228,6 +228,55 @@ def _detruncate_summary_line(line: str, output: str) -> str:
     return line
 
 
+def _summary_line_path(line: str) -> str:
+    """Chemin du fichier de test d'une ligne de short summary pytest (#507).
+
+    Forme : ``FAILED <path>::<test> - <msg>`` ou ``ERROR <path> - <msg>`` — le
+    path est le token qui suit ``FAILED ``/``ERROR ``, borné au premier ``::``
+    (nodeid) puis à l'espace (path nu « ERROR p - m »). Best-effort : chaîne vide
+    si non reconnaissable (le label sera alors omis).
+    """
+    for prefix in ("FAILED ", "ERROR "):
+        if line.startswith(prefix):
+            token = line[len(prefix) :].lstrip()
+            token = token.split("::", 1)[0].split(" ", 1)[0]
+            return token.strip()
+    return ""
+
+
+def _label_failure_line(line: str, changed: frozenset[str]) -> str:
+    """Étiquette une ligne FAILED/ERROR selon la PROVENANCE du test (#507).
+
+    Croise le fichier de test en échec avec le périmètre du diff de la tentative
+    (``files_changed``) : un test que le diff N'A PAS touché et qui casse = une
+    RÉGRESSION sur l'existant (le coder doit corriger SON code, pas le test).
+    Étiquette posée en SUFFIXE — jamais en préfixe : :func:`is_infra_noise` et
+    :func:`is_infra_gate_failure` testent ``startswith("FAILED "/"ERROR ")`` ;
+    un préfixe reclasserait à tort un échec fonctionnel en bruit infra et le
+    gracierait (#461). Best-effort : sans périmètre connu ou path illisible, la
+    ligne est relayée inchangée (pas de label spéculatif).
+    """
+    if not changed:
+        return line
+    path = _summary_line_path(line)
+    if not path:
+        return line
+    # Match tolérant au sous-répertoire : en monorepo, un GATE_TEST_COMMAND du type
+    # « cd backend && pytest » émet des nodeids relatifs au sous-dir (`tests/x.py`)
+    # alors que files_changed (git --name-only) est TOUJOURS racine-relatif
+    # (`backend/tests/x.py`). Le path pytest est donc un suffixe (frontière `/`) du
+    # path git. On n'autorise que ce sens (pytest plus court) : appeler une vraie
+    # régression « test de la tâche » est sans danger (la ligne FAILED reste
+    # relayée), tandis que l'inverse — étiqueter à tort RÉGRESSION un test que
+    # l'agent vient d'ajouter — lui ordonnerait de ne pas le corriger.
+    if path in changed or any(c.endswith("/" + path) for c in changed):
+        return f"{line} [tests de la tâche]"
+    return (
+        f"{line} [RÉGRESSION tests pré-existants — ton diff a cassé l'existant : "
+        "ne modifie pas ces tests, corrige ton code]"
+    )
+
+
 def failure_feedback(outcome: "ExecutionOutcome") -> str:
     """Synthèse **courte et actionnable** d'un échec, pour la tentative suivante (#424).
 
@@ -245,6 +294,11 @@ def failure_feedback(outcome: "ExecutionOutcome") -> str:
     Adéquation refusée (#437) : les tests sont VERTS — le motif utile est la
     justification du contrôle (« la feature n'est pas implémentée »), pas la
     sortie des tests.
+
+    Provenance (#507) : chaque ligne FAILED/ERROR est étiquetée selon que le
+    fichier de test appartient ou non au diff de la tentative (``files_changed``)
+    — le coder distingue ainsi une RÉGRESSION qu'il a introduite sur des tests
+    pré-existants d'un défaut de sa propre feature.
     """
     if outcome.error:
         return log_tail(outcome.error, 400)
@@ -284,7 +338,11 @@ def failure_feedback(outcome: "ExecutionOutcome") -> str:
         if fails:
             # #478 : filet — le diagnostic complet est repris du traceback quand
             # le short summary a été tronqué à la largeur du terminal.
-            return " ; ".join(_detruncate_summary_line(line, output) for line in fails[:6])[:700]
+            # #507 : ORDRE crucial — dé-troncature D'ABORD (son `.endswith("...")`
+            # doit voir la ligne brute), étiquetage de provenance ENSUITE.
+            changed = frozenset(getattr(outcome.execution, "files_changed", ()) or ())
+            labelled = (_label_failure_line(_detruncate_summary_line(line, output), changed) for line in fails[:6])
+            return " ; ".join(labelled)[:700]
         return log_tail(output, 400)
     return log_tail(outcome.execution.agent_result.logs, 400)
 

--- a/tests/test_executor_pipeline.py
+++ b/tests/test_executor_pipeline.py
@@ -251,7 +251,12 @@ def test_failure_feedback_is_crisp_and_actionable():
         quality_report=_report("bruit\nFAILED tests/a.py::t1 - boom\nencore du bruit\nERROR tests/b.py - setup\n"),
         reason="gate_failed",
     )
-    assert failure_feedback(gate) == "FAILED tests/a.py::t1 - boom ; ERROR tests/b.py - setup"
+    # #507 : files_changed=("a.py",) ne couvre ni tests/a.py ni tests/b.py → les
+    # deux lignes sont étiquetées RÉGRESSION (suffixe ; format figé ici).
+    _regr = (
+        "[RÉGRESSION tests pré-existants — ton diff a cassé l'existant : ne modifie pas ces tests, corrige ton code]"
+    )
+    assert failure_feedback(gate) == (f"FAILED tests/a.py::t1 - boom {_regr} ; ERROR tests/b.py - setup {_regr}")
 
     # Pas de ligne FAILED → queue bornée de la sortie de tests.
     fuzzy = ExecutionOutcome(
@@ -267,6 +272,146 @@ def test_failure_feedback_is_crisp_and_actionable():
     # Échec au stage run (aucun rapport) → logs agent.
     run = ExecutionOutcome(success=False, stage="run", workspace=ws, execution=execution, reason="agent_error")
     assert failure_feedback(run) == "journal de l'agent"
+
+
+def test_failure_feedback_labels_regression_vs_task_tests():
+    """#507 : une ligne FAILED dont le fichier de test est dans le diff de la
+    tentative est étiquetée « tests de la tâche » ; un test pré-existant cassé
+    (hors diff) est étiqueté RÉGRESSION avec la consigne « ne modifie pas ces
+    tests »."""
+    from collegue.executor import AgentResult, QualityReport, Workspace
+    from collegue.executor.pipeline import ExecutionOutcome, failure_feedback
+    from collegue.executor.runner import ExecutionResult
+
+    execution = ExecutionResult(
+        agent_result=AgentResult(success=True, logs="journal"),
+        changed=True,
+        diff="",
+        files_changed=("collegue/pdf.py", "tests/test_pdf.py"),
+        success=True,
+    )
+    report = QualityReport(
+        tests_passed=False,
+        test_exit_code=1,
+        test_output=(
+            "FAILED tests/test_pdf.py::test_export - assert\n"  # touché par le diff
+            "FAILED tests/test_auth.py::test_login - KeyError\n"  # PAS touché → régression
+        ),
+        review_summary="",
+        review_findings=(),
+        review_blocking=False,
+        passed=False,
+    )
+    fb = failure_feedback(
+        ExecutionOutcome(
+            success=False,
+            stage="gate",
+            workspace=Workspace(path="/w", branch="b", base_commit="c"),
+            execution=execution,
+            quality_report=report,
+            reason="gate_failed",
+        )
+    )
+    # test de la tâche : étiqueté comme tel, jamais en régression
+    assert "tests/test_pdf.py::test_export - assert [tests de la tâche]" in fb
+    # test pré-existant cassé : étiqueté RÉGRESSION avec consigne « ne modifie pas ces tests »
+    assert "tests/test_auth.py::test_login" in fb
+    assert "RÉGRESSION tests pré-existants" in fb
+    assert "ne modifie pas ces tests" in fb
+
+
+def test_regression_label_preserves_infra_classification():
+    """#507 / non-régression #459/#461/#477 : étiqueter RÉGRESSION ne doit PAS
+    désarmer is_infra_noise — une ligne FAILED présente reste fonctionnelle
+    (jamais bruit infra graciable), car le label est en SUFFIXE."""
+    from collegue.executor.pipeline import failure_feedback, is_infra_noise
+
+    fb = failure_feedback(_gate_outcome("FAILED tests/test_x.py::t - requests.exceptions.ConnectionError: refusé\n"))
+    assert "RÉGRESSION" in fb  # _gate_outcome a files_changed=("a.py",) → hors diff
+    assert not is_infra_noise(fb)  # une ligne FAILED présente = jamais bruit infra
+
+
+def test_label_failure_line_best_effort():
+    """#507 : helpers purs — extraction du path et étiquetage best-effort."""
+    from collegue.executor.pipeline import _label_failure_line, _summary_line_path
+
+    assert _summary_line_path("FAILED tests/a.py::t - m") == "tests/a.py"
+    assert _summary_line_path("ERROR tests/b.py - setup") == "tests/b.py"
+    assert _summary_line_path("12 passed in 1.02s") == ""
+    # nodeid de classe et paramétré → path borné au premier ::
+    assert _summary_line_path("FAILED tests/a.py::TestC::test_m - msg") == "tests/a.py"
+    assert _summary_line_path("FAILED tests/a.py::test_x[a b] - msg") == "tests/a.py"
+    # ERROR avec nodeid (erreur de collecte sur un test précis) → path quand même
+    assert _summary_line_path("ERROR tests/x.py::TestC::test_m - boom") == "tests/x.py"
+    # périmètre vide → ligne inchangée (pas de label spéculatif)
+    assert _label_failure_line("FAILED tests/a.py::t - m", frozenset()) == "FAILED tests/a.py::t - m"
+    # path illisible → inchangé
+    assert _label_failure_line("12 passed", frozenset({"a.py"})) == "12 passed"
+    # path dans le diff → étiqueté « tests de la tâche »
+    assert _label_failure_line("FAILED a.py::t - m", frozenset({"a.py"})) == "FAILED a.py::t - m [tests de la tâche]"
+    # cas NOMINAL : path de test repo-relatif présent dans le diff (verrouille le
+    # bornage au :: — une régression qui renverrait "tests/test_pdf.py::t" casserait ici)
+    assert (
+        _label_failure_line("FAILED tests/test_pdf.py::t - m", frozenset({"tests/test_pdf.py", "collegue/pdf.py"}))
+        == "FAILED tests/test_pdf.py::t - m [tests de la tâche]"
+    )
+
+
+def test_label_failure_line_monorepo_subdir_match():
+    """#507 : en monorepo (GATE_TEST_COMMAND « cd backend && pytest »), le nodeid
+    pytest est relatif au sous-dir alors que files_changed est racine-relatif —
+    le match tolérant au suffixe évite un faux RÉGRESSION sur un test de la tâche."""
+    from collegue.executor.pipeline import _label_failure_line
+
+    # pytest émet "tests/test_x.py" ; git --name-only "backend/tests/test_x.py"
+    assert (
+        _label_failure_line("FAILED tests/test_x.py::t - m", frozenset({"backend/tests/test_x.py"}))
+        == "FAILED tests/test_x.py::t - m [tests de la tâche]"
+    )
+    # garde-fou : un sous-chemin DIFFÉRENT ne matche pas (pas de suffixe /)
+    assert "RÉGRESSION" in _label_failure_line("FAILED tests/test_x.py::t - m", frozenset({"backend/test_x.py"}))
+
+
+def test_failure_feedback_detruncation_then_label_same_line():
+    """#507 / #478 : dans un même feedback, la dé-troncature s'applique AVANT
+    l'étiquetage — une inversion casserait silencieusement le `.endswith("...")`
+    de #478. Le message dé-tronqué ET le label doivent coexister."""
+    from collegue.executor import AgentResult, QualityReport, Workspace
+    from collegue.executor.pipeline import ExecutionOutcome, failure_feedback
+    from collegue.executor.runner import ExecutionResult
+
+    output = (
+        "FAILED tests/test_pkg.py::t - ModuleNotFoundError: requires the httpx pack...\n"
+        "E   ModuleNotFoundError: requires the httpx package installed\n"
+    )
+    execution = ExecutionResult(
+        agent_result=AgentResult(success=True, logs="j"),
+        changed=True,
+        diff="",
+        files_changed=("tests/test_pkg.py", "src/pkg.py"),
+        success=True,
+    )
+    report = QualityReport(
+        tests_passed=False,
+        test_exit_code=1,
+        test_output=output,
+        review_summary="",
+        review_findings=(),
+        review_blocking=False,
+        passed=False,
+    )
+    fb = failure_feedback(
+        ExecutionOutcome(
+            success=False,
+            stage="gate",
+            workspace=Workspace(path="/w", branch="b", base_commit="c"),
+            execution=execution,
+            quality_report=report,
+            reason="gate_failed",
+        )
+    )
+    assert "ModuleNotFoundError: requires the httpx package installed" in fb  # dé-troncature #478
+    assert "[tests de la tâche]" in fb  # étiquetage #507 (test dans le diff)
 
 
 async def test_reviewer_error_is_contained_not_propagated(repo):


### PR DESCRIPTION
## Contexte (#507)

Quand le gate de qualité d'une tentative échoue, `failure_feedback` ré-injecte les lignes `FAILED`/`ERROR` de pytest dans le prompt suivant. Mais il ne distinguait pas un test que le diff de l'agent **a ajouté/modifié** d'un test **pré-existant** que son diff a **cassé** (régression). Le coder devait deviner — et corrigeait parfois le test au lieu de son propre code.

## Correctif (100 % côté moteur, chemin réel)

Deux helpers purs dans `collegue/executor/pipeline.py` :
- **`_summary_line_path(line)`** : extrait le fichier de test d'une ligne `FAILED <path>::<test> - …` / `ERROR <path> - …` (borné au premier `::` puis à l'espace).
- **`_label_failure_line(line, changed)`** : étiquette en **SUFFIXE** selon la provenance — `[tests de la tâche]` si le fichier est dans `files_changed`, sinon `[RÉGRESSION tests pré-existants — … ne modifie pas ces tests, corrige ton code]`.

`failure_feedback` applique le label **après** la dé-troncature #478 (ordre crucial : `_detruncate` doit voir la ligne brute terminée par `...`), sur chaque ligne FAILED/ERROR (max 6, borné `[:700]`).

### Invariants préservés
- **SUFFIXE jamais préfixe** → le `startswith("FAILED "/"ERROR ")` de `is_infra_noise`/`is_infra_gate_failure` reste vrai : la **grâce infra #461 n'est pas désarmée** (un échec fonctionnel à message réseau, étiqueté RÉGRESSION, reste fonctionnel).
- **Pas de nouvelle config / `_gate_options`** : aucune clé pydantic, donc aucune inertie possible au run réel FacNor (le harness consomme `failure_feedback` via `execute_issue → driver → best_feedback/last_error` ré-injectés au prompt — chemin non bypassable).
- **Match tolérant au sous-répertoire** : en monorepo (`GATE_TEST_COMMAND="cd backend && pytest"`), pytest émet un nodeid relatif au sous-dir alors que `git --name-only` est racine-relatif ; on matche au suffixe `/` (sens pytest-plus-court uniquement) pour ne pas étiqueter à tort RÉGRESSION un test que l'agent vient d'ajouter.

## Tests
Cas mixte régression+tâche, invariant infra verrouillé (`assert not is_infra_noise`), helpers purs (nodeid de classe/paramétré, `ERROR`+nodeid, périmètre vide, path illisible, cas nominal repo-relatif), **match monorepo** + garde-fou, **interaction ordre dé-troncature #478 + étiquetage** dans le même feedback, et l'égalité stricte existante adaptée (format figé). Suite complète : **RC=0**. Ruff check + format : OK.

## Revue adversariale (Workflow, 5 lentilles + synthèse)
VERDICT : **APPROUVÉ**. Lentilles : invariant de classification infra, anti-inertie, ordre #478, extraction/matching de chemin, complétude des tests. Le seul défaut réel signalé (mismatch monorepo opt-in) **a été corrigé** dans ce diff (match tolérant au suffixe) ; améliorations de tests recommandées **appliquées**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)