### PR TITLE
fix(executor): feedback actionnable quand la garde fichiers parasites bloque le gate (#508, finding run v6)

### DIFF
--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -295,6 +295,11 @@ def failure_feedback(outcome: "ExecutionOutcome") -> str:
     justification du contrôle (« la feature n'est pas implémentée »), pas la
     sortie des tests.
 
+    Fichiers parasites bloquants (#508) : quand la garde bloquante a fait rougir le
+    gate, le motif utile est la liste des fichiers à RETIRER — la sortie des tests
+    (souvent verte) masquerait cette consigne (run v6 : `server.log` jamais signalé,
+    tâche racine bloquée 3 tentatives).
+
     Provenance (#507) : chaque ligne FAILED/ERROR est étiquetée selon que le
     fichier de test appartient ou non au diff de la tentative (``files_changed``)
     — le coder distingue ainsi une RÉGRESSION qu'il a introduite sur des tests
@@ -326,6 +331,19 @@ def failure_feedback(outcome: "ExecutionOutcome") -> str:
             "REQUIREMENTS APPEND-ONLY (#482) — lignes de requirements.txt présentes sur la base et "
             "SUPPRIMÉES par ton diff : " + " ; ".join(removed[:10]) + ". Ré-ajoute-les telles quelles "
             "(n'en supprime aucune) et conserve le reste de ton travail."
+        )[:700]
+    if report is not None and getattr(report, "forbidden_files_blocking", False):
+        # #508 : le gate est rouge PARCE QUE le diff committe des fichiers parasites
+        # (garde bloquante opt-in). Sans cette branche, failure_feedback retombait
+        # sur la sortie des tests — souvent VERTE, terminée par du bruit pip — et
+        # l'agent ne savait JAMAIS qu'il fallait retirer ces fichiers (run v6 : la
+        # tâche racine a brûlé ses 3 tentatives sur un `server.log` jamais signalé).
+        forbidden = tuple(getattr(report, "forbidden_files", ()) or ())
+        return (
+            "FICHIERS PARASITES COMMITTÉS (#508) — ton diff ajoute des fichiers qui n'ont rien à "
+            "faire dans le livrable (artefacts d'exécution / secrets / bases locales / dépendances "
+            "vendorées) et le gate les REFUSE : " + " ; ".join(forbidden[:10]) + ". Retire-les du "
+            "commit (git rm --cached) et ajoute leurs motifs au .gitignore ; conserve le reste de ton travail."
         )[:700]
     if outcome.quality_report is not None and outcome.quality_report.test_output:
         output = outcome.quality_report.test_output

--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -754,6 +754,12 @@ class QualityReport:
     # __pycache__) — signal NON bloquant par défaut ; rouge seulement si
     # forbidden_files_block (opt-in). Récidive v4→v5 : `server.log` livré.
     forbidden_files: Tuple[str, ...] = ()
+    # Vrai quand forbidden_files a RÉELLEMENT fait rougir le gate (block opt-in actif
+    # ET liste non vide) — distinct du simple signal. Permet à failure_feedback de ne
+    # surfacer la consigne « retire ces fichiers » que lorsqu'elle est la cause du
+    # rejet (sinon, en mode signal, elle masquerait le vrai motif d'échec). Run v6 :
+    # `server.log` bloquait le gate mais le feedback montrait du bruit pip trompeur.
+    forbidden_files_blocking: bool = False
 
     def to_markdown(self) -> str:
         """Rapport Markdown pour le corps de PR (texte de revue fencé, anti-injection)."""
@@ -1473,7 +1479,8 @@ async def run_quality_gate(
     # #508 : signal par défaut, bloquant seulement en opt-in. Appliqué APRÈS le
     # calcul de `passed` (n'entre pas dans would_pass : ne change pas l'économie
     # d'appels d'adéquation #437).
-    if forbidden_files_block and forbidden_files:
+    forbidden_blocked = bool(forbidden_files_block and forbidden_files)
+    if forbidden_blocked:
         passed = False
     return QualityReport(
         tests_passed=tests_passed,
@@ -1495,6 +1502,7 @@ async def run_quality_gate(
         adequacy_tests_assert=adequacy_tests_assert,
         adequacy_tests_justification=adequacy_tests_justification,
         forbidden_files=forbidden_files,
+        forbidden_files_blocking=forbidden_blocked,
     )
 
 

--- a/tests/test_executor_pipeline.py
+++ b/tests/test_executor_pipeline.py
@@ -320,6 +320,88 @@ def test_failure_feedback_labels_regression_vs_task_tests():
     assert "ne modifie pas ces tests" in fb
 
 
+def test_failure_feedback_surfaces_forbidden_files_when_blocking():
+    """#508 (suite v6) : quand la garde fichiers parasites a fait rougir le gate,
+    le feedback DOIT dire à l'agent de retirer ces fichiers — même si les tests
+    sont verts (sinon il reçoit la sortie de test trompeuse et boucle, cas réel
+    v6 : server.log jamais signalé, tâche racine bloquée 3 tentatives)."""
+    from collegue.executor import AgentResult, QualityReport, Workspace
+    from collegue.executor.pipeline import ExecutionOutcome, failure_feedback
+    from collegue.executor.runner import ExecutionResult
+
+    execution = ExecutionResult(
+        agent_result=AgentResult(success=True, logs="j"),
+        changed=True,
+        diff="",
+        files_changed=("server.log", "app/x.py"),
+        success=True,
+    )
+    report = QualityReport(
+        tests_passed=True,  # tests VERTS
+        test_exit_code=0,
+        test_output="6 passed\nsse-starlette 3.4.4 requires starlette>=0.49.1 ... incompatible.",  # bruit pip
+        review_summary="",
+        review_findings=(),
+        review_blocking=False,
+        passed=False,  # rouge à cause de #508
+        forbidden_files=("server.log",),
+        forbidden_files_blocking=True,
+    )
+    fb = failure_feedback(
+        ExecutionOutcome(
+            success=False,
+            stage="gate",
+            workspace=Workspace(path="/w", branch="b", base_commit="c"),
+            execution=execution,
+            quality_report=report,
+            reason="gate_failed",
+        )
+    )
+    assert "#508" in fb
+    assert "server.log" in fb
+    assert "git rm --cached" in fb or "gitignore" in fb
+    assert "incompatible" not in fb  # le bruit pip ne doit PAS être le diagnostic
+
+
+def test_failure_feedback_ignores_forbidden_files_when_signal_only():
+    """#508 (suite v6) : en mode SIGNAL (non bloquant), forbidden_files ne doit PAS
+    masquer la vraie cause d'échec — le feedback reste le diagnostic des tests."""
+    from collegue.executor import AgentResult, QualityReport, Workspace
+    from collegue.executor.pipeline import ExecutionOutcome, failure_feedback
+    from collegue.executor.runner import ExecutionResult
+
+    execution = ExecutionResult(
+        agent_result=AgentResult(success=True, logs="j"),
+        changed=True,
+        diff="",
+        files_changed=("tests/test_app.py", "server.log"),
+        success=True,
+    )
+    report = QualityReport(
+        tests_passed=False,
+        test_exit_code=1,
+        test_output="FAILED tests/test_app.py::test_login - AssertionError",
+        review_summary="",
+        review_findings=(),
+        review_blocking=False,
+        passed=False,
+        forbidden_files=("server.log",),
+        forbidden_files_blocking=False,  # signal seulement
+    )
+    fb = failure_feedback(
+        ExecutionOutcome(
+            success=False,
+            stage="gate",
+            workspace=Workspace(path="/w", branch="b", base_commit="c"),
+            execution=execution,
+            quality_report=report,
+            reason="gate_failed",
+        )
+    )
+    assert "test_login" in fb  # la vraie cause (échec de test) est relayée
+    assert "#508" not in fb  # le signal parasite ne prend pas le dessus
+
+
 def test_regression_label_preserves_infra_classification():
     """#507 / non-régression #459/#461/#477 : étiqueter RÉGRESSION ne doit PAS
     désarmer is_infra_noise — une ligne FAILED présente reste fonctionnelle

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -1611,6 +1611,7 @@ async def test_forbidden_files_signals_but_does_not_block_by_default():
     report = await run_quality_gate("/ws", diff, ctx=None, sandbox=_green(), reviewer=FakeReviewer())
     assert report.forbidden_files == ("server.log",)
     assert report.passed is True  # signal, pas rouge
+    assert report.forbidden_files_blocking is False  # mode signal → pas la cause d'un rejet
     md = report.to_markdown()
     assert "#508" in md and "server.log" in md
 
@@ -1626,6 +1627,7 @@ async def test_forbidden_files_blocks_when_opt_in():
     )
     assert report.forbidden_files == ("server.log",)
     assert report.passed is False
+    assert report.forbidden_files_blocking is True  # le flag permet à failure_feedback de surfacer la consigne
 
 
 async def test_forbidden_files_guard_opt_out():


### PR DESCRIPTION
## Contexte — finding du run de validation FacNor v6

La tâche racine (schéma BDD) a échoué ses **3 tentatives** → run `blocked` dès la première tâche. Diagnostic confirmé **par reproduction** (et non les deps OpenHands soupçonnées au départ — vérifié inoffensives : `pip install --user` exit 0, pytest 6/0, installabilité venv-propre OK) :

- #508 était en mode **bloquant** (`forbidden_files_block=True`, opt-in) et a rejeté le gate parce que le diff committait `server.log`.
- **MAIS** `failure_feedback` (le diagnostic réinjecté à l'agent) n'avait **aucune branche #508** → il retombait sur la sortie des tests (verte, terminée par des warnings pip trompeurs « starlette incompatible »).
- → l'agent n'a **jamais su** qu'il fallait retirer `server.log`, a « corrigé » des deps déjà bonnes, brûlé ses itérations → échec terminal.

**Leçon : un gate bloquant sans feedback actionnable = un piège.**

## Correctif

- **quality_gate.py** : champ `QualityReport.forbidden_files_blocking`, vrai **uniquement** quand le block opt-in est actif ET la liste non vide (`forbidden_blocked = bool(forbidden_files_block and forbidden_files)`), utilisé pour `passed=False` ET propagé au rapport. En mode **signal** (défaut), reste `False` → ne masque jamais la vraie cause d'un échec concomitant.
- **pipeline.py** : `failure_feedback` gagne une branche #508 (placée **après** #482, **avant** le fallback sortie de tests) qui nomme les fichiers et dit à l'agent de les **retirer** (`git rm --cached` + `.gitignore`). Bornée `[:700]`, liste `[:10]`.
- **tests** : surface quand blocking (cas réel v6 : tests verts + bruit pip → message #508, et `"incompatible" not in fb`) ; **ignore en mode signal** (la vraie cause d'échec prime) ; assertions `forbidden_files_blocking` dans les tests de gate.

## Garanties
- **Non-régression mode signal** : `forbidden_files_block=False` + vrai échec de test → feedback = diagnostic des tests, pas #508.
- **Invariant infra #459/#461/#477 préservé** : le message #508 ne matche aucune signature réseau (is_infra_noise=False) et `is_infra_gate_failure` court-circuite déjà sur `tests_passed`.
- Verdict inchangé hors `would_pass` (économie d'appels d'adéquation #437 intacte).

Suite complète : **RC=0**. Ruff check + format : OK. Revue adversariale (8 points de vigilance) : **APPROUVÉ**.

NB : ce PR ne relance PAS le run v6 (demande explicite). Il corrige le moteur ; un run ultérieur en bénéficiera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)