### PR TITLE
fix(sandbox): épingle pytest<9 dans l'image de référence (finding run v6)

### DIFF
--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -15,6 +15,15 @@ RUN apt-get update \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
+# Runner de tests du gate qualité, ÉPINGLÉ (pytest<9). pytest 9.0 a retiré
+# `FixtureDef` du namespace top-level, ce qui casse `from pytest import FixtureDef`
+# de pytest-asyncio<0.24 (que les projets générés pinnent couramment, ex. 0.23.6) :
+# ImportError à la collecte → toute tâche à tests échoue au gate (constaté run v6
+# après un rebuild qui a tiré pytest 9.x). On fige le runner sur 8.x + un
+# pytest-asyncio aligné sur l'écosystème projet. Pré-installé (vs deps du projet)
+# pour que le gate dispose d'un runner même si le projet ne le déclare pas.
+RUN python -m pip install --no-cache-dir "pytest>=8.1,<9" "pytest-asyncio==0.23.6"
+
 # Utilisateur non-root par défaut (le `docker run` peut surcharger --user pour
 # matcher l'UID hôte et garder le workspace écrivable/persisté).
 RUN useradd --create-home --uid 1000 sandbox


### PR DESCRIPTION
## Contexte — finding du run v6 rendu durable

L'image sandbox **suivie** (`docker/sandbox/Dockerfile`) n'avait **aucun runner de tests pré-installé** ; le seul pin pytest vivait dans `docker/sandbox/Dockerfile.openhands` (gitignoré, donc local et non durable).

**pytest 9.0** a retiré `FixtureDef` du namespace top-level → casse `from pytest import FixtureDef` de **pytest-asyncio<0.24** (que les projets générés pinnent couramment, ex. `0.23.6`) → `ImportError` à la collecte → **toute tâche à tests échoue au gate**. Constaté au run v6 après un rebuild `--no-cache` qui a tiré pytest 9.x.

## Correctif

Pré-installer le runner **épinglé** dans l'image de référence :
```dockerfile
RUN python -m pip install --no-cache-dir "pytest>=8.1,<9" "pytest-asyncio==0.23.6"
```
- Le pin devient **durable / tracké** (plus seulement dans le `.openhands` local).
- Comble un trou : le gate dispose d'un runner compatible même si un projet ne déclare pas pytest.

## Validation
Build local de `docker/sandbox/Dockerfile` : **OK**, `pytest 8.4.2` + `pytest-asyncio 0.23.6`, `from pytest import FixtureDef` OK. (La CI ne build pas l'image sandbox — elle build `docker/collegue/Dockerfile` — d'où la validation manuelle.)

NB : ne relance pas v6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)