### PR TITLE
feat(sandbox): montage opt-in des creds d'abonnement (Codex/ChatGPT) dans le worker

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -162,6 +162,11 @@ class Settings(BaseSettings):
     # dossier (writable par l'uid hôte). Vide (défaut) = aucun cache. N'enlève
     # --no-cache-dir QUE si le volume est monté (sinon cache dans le tmpfs /tmp).
     SANDBOX_PIP_CACHE_DIR: str = ""
+    # Creds d'abonnement OpenHands (Codex via ChatGPT, subscription_login). Chemin
+    # HÔTE (ex. ~/.openhands) monté en LECTURE-ÉCRITURE sur /home/sandbox/.openhands
+    # du worker : permet au coder d'utiliser l'abo (sans coût API) et de persister le
+    # token rafraîchi. Vide (défaut) = aucun montage (mode clé API inchangé).
+    SANDBOX_SUBSCRIPTION_AUTH_DIR: str = ""
 
     ENGINE_INIT_TIMEOUT: float = 10.0
     ENGINE_WAIT_TIMEOUT: float = 30.0

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -97,6 +97,19 @@ def _sandbox_pip_cache(settings_obj):
     return path
 
 
+def _sandbox_subscription_auth(settings_obj):
+    """Creds d'abonnement OpenHands (Codex/ChatGPT) — ``SANDBOX_SUBSCRIPTION_AUTH_DIR``.
+
+    Chemin HÔTE (ex. ``~/.openhands``) monté en RW dans le worker pour utiliser
+    l'abonnement (sans coût API). Vide/absent → ``None`` (mode clé API inchangé).
+    Ne crée PAS le dossier : il doit contenir des creds valides (login fait en amont).
+    """
+    raw = str(getattr(settings_obj, "SANDBOX_SUBSCRIPTION_AUTH_DIR", "") or "").strip()
+    if not raw:
+        return None
+    return os.path.expanduser(raw)
+
+
 def _build_sandbox(settings_obj):  # pragma: no cover - infra réelle (integration)
     from collegue.sandbox import DockerSandbox
 
@@ -108,6 +121,7 @@ def _build_sandbox(settings_obj):  # pragma: no cover - infra réelle (integrati
         network="bridge",
         dns=_sandbox_dns(settings_obj),
         pip_cache_dir=_sandbox_pip_cache(settings_obj),  # #496 : cache pip persistant opt-in
+        subscription_auth_dir=_sandbox_subscription_auth(settings_obj),  # creds abo Codex/ChatGPT
     )
 
 

--- a/collegue/sandbox/executor.py
+++ b/collegue/sandbox/executor.py
@@ -41,6 +41,12 @@ from typing import List, Mapping, Optional, Tuple, Union
 DEFAULT_SANDBOX_IMAGE = "collegue-sandbox:latest"
 # #496 : point de montage du cache pip persistant dans le conteneur.
 SANDBOX_PIP_CACHE_MOUNT = "/tmp/.pip_cache"
+# Sous-chemin (relatif au HOME du worker) où OpenHands lit/écrit ses creds
+# d'abonnement (Codex/ChatGPT, subscription_login). La cible RÉELLE du montage est
+# dérivée du HOME effectif du conteneur (``env['HOME']``), pas codée en dur : les
+# creds NE peuvent PAS vivre sous /tmp (le ``--tmpfs /tmp`` les masquerait), d'où
+# le fail-loud si HOME pointe sous /tmp (cf. _build_run_argv).
+SANDBOX_OPENHANDS_AUTH_SUBPATH = ".openhands"
 
 # Code de sortie conventionnel pour un dépassement de délai (cf. coreutils timeout).
 TIMEOUT_EXIT_CODE = 124
@@ -85,6 +91,7 @@ class DockerSandbox:
         network: str = "none",
         dns: Optional[Tuple[str, ...]] = None,
         pip_cache_dir: Optional[str] = None,
+        subscription_auth_dir: Optional[str] = None,
         memory: str = "512m",
         cpus: str = "1.0",
         pids_limit: int = 256,
@@ -111,6 +118,11 @@ class DockerSandbox:
         # réduits, temps mur amorti — jusqu'à 4 passes avec la remédiation #481).
         # Vide (défaut) = aucun montage, argv inchangé. Validé comme un -v.
         self.pip_cache_dir = pip_cache_dir or None
+        # Creds d'abonnement (Codex via ChatGPT, subscription_login) montées en
+        # LECTURE-ÉCRITURE (OpenHands rafraîchit le token et le réécrit → persistance
+        # hors-run). Opt-in : vide (défaut) = aucun montage, argv inchangé. Validé
+        # comme un -v (realpath + refus ':'/racine) ; hors confinement workspace_root.
+        self.subscription_auth_dir = subscription_auth_dir or None
         self.memory = memory
         self.cpus = cpus
         self.pids_limit = pids_limit
@@ -187,6 +199,24 @@ class DockerSandbox:
             if ":" in cache or cache == os.path.sep:
                 raise ValueError(f"pip_cache_dir invalide (':' ou racine): {cache}")
             argv += ["-v", f"{cache}:{SANDBOX_PIP_CACHE_MOUNT}", "-e", f"PIP_CACHE_DIR={SANDBOX_PIP_CACHE_MOUNT}"]
+        # Creds d'abonnement (Codex/ChatGPT) : montage RW, cible fixe (HOME du worker).
+        # Même validation que le cache pip ; hors confinement workspace_root (les creds
+        # vivent hors du workspace). RW car OpenHands réécrit le token rafraîchi.
+        if self.subscription_auth_dir:
+            auth = os.path.realpath(os.path.abspath(self.subscription_auth_dir))
+            if ":" in auth or auth == os.path.sep:
+                raise ValueError(f"subscription_auth_dir invalide (':' ou racine): {auth}")
+            # Cible = $HOME/.openhands du worker. HOME effectif = override ``env['HOME']``
+            # (sinon le défaut /tmp injecté plus bas). Les creds NE peuvent PAS vivre sous
+            # /tmp (le ``--tmpfs /tmp`` masquerait le bind) → fail-loud, sinon le montage
+            # serait inerte silencieusement (le coder ne verrait jamais l'auth abo).
+            home = (self.env.get("HOME") or "/tmp").rstrip("/")
+            if home == "/tmp" or home.startswith("/tmp/"):
+                raise ValueError(
+                    "subscription_auth_dir exige env['HOME'] hors /tmp "
+                    "(le tmpfs /tmp masquerait le montage des creds d'abonnement)"
+                )
+            argv += ["-v", f"{auth}:{home}/{SANDBOX_OPENHANDS_AUTH_SUBPATH}"]
         if self.read_only:
             argv += ["--read-only"]  # root FS en lecture seule
         argv += [

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -508,3 +508,17 @@ def test_sandbox_pip_cache_parsed_from_settings(tmp_path):
     assert target.is_dir()  # créé (writable par l'uid hôte)
     assert _sandbox_pip_cache(SimpleNamespace(SANDBOX_PIP_CACHE_DIR="")) is None
     assert _sandbox_pip_cache(SimpleNamespace()) is None
+
+
+def test_sandbox_subscription_auth_parsed_from_settings(tmp_path):
+    """Creds d'abonnement : SANDBOX_SUBSCRIPTION_AUTH_DIR → chemin (NON créé) ; vide → None."""
+    from types import SimpleNamespace
+
+    from collegue.pilot.runtime import _sandbox_subscription_auth
+
+    target = tmp_path / "openhands"
+    # ne crée PAS le dossier (creds doivent préexister, login fait en amont)
+    assert _sandbox_subscription_auth(SimpleNamespace(SANDBOX_SUBSCRIPTION_AUTH_DIR=str(target))) == str(target)
+    assert not target.exists()
+    assert _sandbox_subscription_auth(SimpleNamespace(SANDBOX_SUBSCRIPTION_AUTH_DIR="")) is None
+    assert _sandbox_subscription_auth(SimpleNamespace()) is None

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -318,3 +318,46 @@ def test_build_argv_pip_cache_validated(tmp_path):
     sb = DockerSandbox(image="img", pip_cache_dir="/bad:path")
     with pytest.raises(ValueError):
         sb._build_run_argv("x", str(tmp_path))
+
+
+def test_build_argv_subscription_auth_mount(tmp_path):
+    """Creds d'abonnement opt-in → montage RW sur $HOME/.openhands (HOME dérivé de env)."""
+    auth = tmp_path / "openhands"
+    auth.mkdir()
+    sb = DockerSandbox(image="img", subscription_auth_dir=str(auth), env={"HOME": "/home/sandbox"})
+    argv = sb._build_run_argv("echo hi", str(tmp_path / "ws"))
+    import os as _os
+
+    auth_real = _os.path.realpath(str(auth))
+    assert f"{auth_real}:/home/sandbox/.openhands" in _mounts(argv)
+
+
+def test_build_argv_subscription_auth_requires_home_outside_tmp(tmp_path):
+    """Fail-loud : sans HOME hors /tmp, le tmpfs masquerait les creds → ValueError."""
+    import pytest
+
+    auth = tmp_path / "openhands"
+    auth.mkdir()
+    # HOME non fourni → défaut /tmp (masqué par le tmpfs) → refus explicite
+    sb = DockerSandbox(image="img", subscription_auth_dir=str(auth))
+    with pytest.raises(ValueError):
+        sb._build_run_argv("x", str(tmp_path))
+    # HOME explicitement sous /tmp → refus aussi
+    sb2 = DockerSandbox(image="img", subscription_auth_dir=str(auth), env={"HOME": "/tmp/x"})
+    with pytest.raises(ValueError):
+        sb2._build_run_argv("x", str(tmp_path))
+
+
+def test_build_argv_no_subscription_auth_by_default(tmp_path):
+    """Défaut : aucun montage de creds abo (argv = workspace seul)."""
+    argv = DockerSandbox(image="img")._build_run_argv("x", str(tmp_path))
+    assert _mounts(argv) == [f"{tmp_path}:/workspace"]
+
+
+def test_build_argv_subscription_auth_validated(tmp_path):
+    """Un chemin de creds contenant ':' est refusé (devient un -v)."""
+    import pytest
+
+    sb = DockerSandbox(image="img", subscription_auth_dir="/bad:path", env={"HOME": "/home/sandbox"})
+    with pytest.raises(ValueError):
+        sb._build_run_argv("x", str(tmp_path))


### PR DESCRIPTION
## Contexte

Objectif : faire tourner le **coder** via un **abonnement ChatGPT Plus/Pro** (OpenHands `LLM.subscription_login`, modèles **GPT-5.x**) — **sans coût API**. OpenHands lit ses creds dans `$HOME/.openhands` ; il faut donc **monter ce dossier hôte** dans le conteneur sandbox du worker. Ce PR ajoute la **capacité moteur** (le câblage d'activation vit dans le harness FacNor local).

## Changements (calqués sur `pip_cache_dir` #496)

- **`DockerSandbox.subscription_auth_dir`** : chemin hôte (ex. `~/.openhands`) monté en **lecture-écriture** (le token rafraîchi est réécrit → persistance hors-run). **Opt-in strict** (vide = aucun montage, argv inchangé). Validé comme le cache pip (realpath + refus `':'`/racine), hors confinement `workspace_root`.
- **Cible du montage DÉRIVÉE du HOME effectif** (`env['HOME']`), pas codée en dur, avec **fail-loud** si HOME pointe sous `/tmp` : le `--tmpfs /tmp` y masquerait le bind → le montage serait **inerte silencieusement** (leçon « vérifier le chemin réel »). Le harness met `HOME=/home/sandbox` → cible `/home/sandbox/.openhands`.
- **config** : `SANDBOX_SUBSCRIPTION_AUTH_DIR`. **runtime** : `_sandbox_subscription_auth` (ne **crée pas** le dossier — les creds doivent préexister, login fait en amont) + câblage `_build_sandbox`.
- **tests** : montage dérivé du HOME, fail-loud `HOME=/tmp`, validation `':'` refusée, défaut absent, parsing settings.

## Validation

- Suite complète : **RC=0**. Ruff check + format : OK.
- **Smoke end-to-end** (manuel, hors run 7h) : `gpt-5.5` via l'abonnement génère du code correct (`calc.py` + `test_calc.py`) en **~38 s**, auth **headless** via creds montées. Découverte au smoke : le backend ChatGPT sert les modèles **généraux** (gpt-5.5/gpt-5.4), **pas** les SKU `*-codex` (l'allow-list cliente d'OpenHands est désynchronisée — gérée côté harness).
- Revue adversariale : a relevé le couplage HOME (cible codée en dur) → **corrigé** (dérivation + fail-loud). Le 2e point (propagation `LLM_SUBSCRIPTION`) concerne le **harness** (oh_runner/run.py local), pas ce PR moteur.

Ne relance pas le run v6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)