### PR TITLE
fix(executor): adéquation — strip lock files + avertissement de troncature (#526)

### DIFF
--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -1153,22 +1153,87 @@ def _parse_test_adequacy(text: str) -> Tuple[bool, str]:
     return False, f"réponse illisible du contrôle de couverture des tests : {raw[:300]}"
 
 
+# #526 : fichiers GÉNÉRÉS (verrous de dépendances) — volumineux, ~aucune info
+# d'adéquation, mais ils SATURENT la fenêtre du juge. Au run v6, un
+# ``package-lock.json`` de ~30k chars poussait ``package.json``/``vite.config``/``src/``
+# HORS de la fenêtre de 20k → le juge concluait « feature absente » sur un frontend
+# pourtant complet (faux rejets en cascade → run bloqué 4/15). On les retire du
+# diff soumis au juge (le diff autoritatif, lui, reste intact).
+_GENERATED_DIFF_FILES = (
+    "package-lock.json",
+    "npm-shrinkwrap.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "poetry.lock",
+    "Pipfile.lock",
+    "composer.lock",
+    "Cargo.lock",
+    "go.sum",
+)
+
+
+def strip_generated_from_diff(diff: str) -> str:
+    """Retire les blocs ``diff --git`` des fichiers GÉNÉRÉS (lock files) — #526.
+
+    Découpe le diff sur les frontières ``diff --git`` ; un bloc est retiré si le
+    BASENAME de son chemin de DESTINATION (``b/…``) est un fichier généré.
+    Comparaison par basename EXACT (pas sous-chaîne : ``src/go.sum.parser.ts`` ≠
+    ``go.sum``, conservé) et sur la cible ``b/`` (un rename d'un lock vers un
+    fichier source est conservé). Robuste : un diff sans ce format (ou vide) est
+    renvoyé tel quel.
+    """
+    if not diff:
+        return diff
+    blocks = re.split(r"(?=^diff --git )", diff, flags=re.M)
+    kept = []
+    for block in blocks:
+        header = block.split("\n", 1)[0]
+        is_generated = False
+        if header.startswith("diff --git ") and " b/" in header:
+            dest = header.split(" b/", 1)[1].strip()
+            is_generated = dest.rsplit("/", 1)[-1] in _GENERATED_DIFF_FILES
+        if not is_generated:
+            kept.append(block)
+    return "".join(kept)
+
+
 class LLMAdequacyChecker:
     """:class:`AdequacyChecker` par LLM (#437) — fail-closed.
 
     ``sample_fn`` : ``async (prompt, system_prompt) -> str``, injectable (mocké en
     CI) ; défaut = ``generate_text`` des providers LLM avec la config du serveur.
-    Le diff est borné (``max_diff_chars``) pour rester dans la fenêtre du modèle.
+    Le diff est borné (``max_diff_chars``) pour rester dans la fenêtre du modèle,
+    après retrait des fichiers générés (#526) ; une troncature résiduelle est
+    ANNONCÉE au juge (sinon il conclut à tort à l'absence d'un fichier non vu).
     """
 
-    def __init__(self, sample_fn=None, *, max_diff_chars: int = 20000):
+    def __init__(self, sample_fn=None, *, max_diff_chars: int = 60000):
         self._sample_fn = sample_fn or _default_adequacy_sample_fn()
         self._max_diff_chars = max_diff_chars
 
+    def _diff_for_judge(self, diff: str) -> str:
+        """Diff prêt pour le juge : fichiers générés retirés (#526), borné, et
+        troncature résiduelle EXPLICITEMENT signalée."""
+        cleaned = strip_generated_from_diff(diff or "")
+        if not cleaned:
+            # Distinguer « diff réellement vide » de « tout le diff était des
+            # fichiers générés » : sinon le juge hallucine « livrable absent » sur
+            # une tâche dont le livrable serait justement un fichier généré.
+            return "(diff = uniquement des fichiers générés/verrous)" if (diff or "").strip() else "(diff vide)"
+        if len(cleaned) <= self._max_diff_chars:
+            return cleaned
+        return (
+            cleaned[: self._max_diff_chars]
+            + f"\n\n[... DIFF TRONQUÉ à {self._max_diff_chars} chars sur {len(cleaned)} — "
+            "NE PAS conclure à l'absence d'un fichier qui n'apparaît pas ci-dessus, "
+            "il peut être dans la partie tronquée ...]"
+        )
+
     async def check(self, diff: str, issue: IssueSpec, ctx) -> AdequacyOutcome:
+        bounded = self._diff_for_judge(diff)
         prompt = (
             f"## Issue à fermer\n{issue.to_prompt()}\n\n"
-            f"## Diff livré\n```diff\n{(diff or '(diff vide)')[: self._max_diff_chars]}\n```\n\n"
+            f"## Diff livré\n```diff\n{bounded}\n```\n\n"
             "Ce diff implémente-t-il concrètement l'issue ?"
         )
         text = await self._sample_fn(prompt, _ADEQUACY_SYSTEM)
@@ -1181,7 +1246,7 @@ class LLMAdequacyChecker:
             return outcome
         test_prompt = (
             f"## Issue à fermer\n{issue.to_prompt()}\n\n"
-            f"## Diff livré\n```diff\n{(diff or '(diff vide)')[: self._max_diff_chars]}\n```\n\n"
+            f"## Diff livré\n```diff\n{bounded}\n```\n\n"
             "Les critères chiffrables/observables de l'issue sont-ils assertés par au moins un test du diff ?"
         )
         test_text = await self._sample_fn(test_prompt, _TEST_ADEQUACY_SYSTEM)

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -721,6 +721,106 @@ async def test_llm_adequacy_checker_round_trip():
     assert "JSON" in system
 
 
+# --- #526 : le diff soumis au juge retire les fichiers générés + signale la troncature ---
+
+
+def test_strip_generated_from_diff_removes_lockfiles():
+    from collegue.executor.quality_gate import strip_generated_from_diff
+
+    diff = (
+        'diff --git a/package.json b/package.json\n+ "name": "app"\n'
+        "diff --git a/package-lock.json b/package-lock.json\n"
+        + ('+    "dep": "1.0.0",\n' * 2000)
+        + "diff --git a/src/main.tsx b/src/main.tsx\n+console.log(1)\n"
+    )
+    stripped = strip_generated_from_diff(diff)
+    assert "package-lock.json" not in stripped  # bloc généré retiré
+    assert "b/package.json\n" in stripped  # le vrai fichier reste
+    assert "src/main.tsx" in stripped
+    # diff sans format git ou vide : renvoyé tel quel (robustesse)
+    assert strip_generated_from_diff("texte libre") == "texte libre"
+    assert strip_generated_from_diff("") == ""
+
+
+def test_strip_generated_matches_basename_not_substring():
+    """#526 (durcissement revue) : match par BASENAME exact du chemin b/, pas
+    sous-chaîne — un fichier applicatif nommé comme un lock est CONSERVÉ, et un
+    rename d'un lock vers un fichier source aussi."""
+    from collegue.executor.quality_gate import strip_generated_from_diff
+
+    diff = (
+        "diff --git a/src/go.sum.parser.ts b/src/go.sum.parser.ts\n+export const x = 1\n"
+        "diff --git a/docs/Cargo.lock.md b/docs/Cargo.lock.md\n+# notes\n"
+        "diff --git a/package-lock.json b/src/app.ts\n+// renommé vers un fichier source\n"
+    )
+    stripped = strip_generated_from_diff(diff)
+    assert "go.sum.parser.ts" in stripped  # faux match évité (basename ≠ go.sum)
+    assert "Cargo.lock.md" in stripped  # faux match évité
+    assert "b/src/app.ts" in stripped  # rename vers une cible source : conservé
+    # vrai lock : retiré
+    assert strip_generated_from_diff("diff --git a/go.sum b/go.sum\n+x\n") == ""
+
+
+async def test_adequacy_diff_strips_lockfile_so_real_files_reach_judge():
+    """#526 : un gros lock file ne doit plus pousser les vrais fichiers hors de la
+    fenêtre du juge (frontend complet faux-rejeté au run v6)."""
+    from collegue.executor import LLMAdequacyChecker
+
+    seen = {}
+
+    async def fake_sample(prompt, system_prompt):
+        seen["prompt"] = prompt
+        return '{"implemented": true, "justification": "frontend complet"}'
+
+    big_lock = "diff --git a/package-lock.json b/package-lock.json\n" + ('+      "dep": "1.0.0",\n' * 3000)
+    diff = (
+        "diff --git a/index.html b/index.html\n+<div id=root></div>\n"
+        + big_lock  # ~60k chars : sans le strip, pousse les fichiers suivants hors fenêtre
+        + 'diff --git a/package.json b/package.json\n+  "scripts": { "dev": "vite" }\n'
+        + "diff --git a/vite.config.ts b/vite.config.ts\n+export default defineConfig({})\n"
+    )
+    checker = LLMAdequacyChecker(fake_sample, max_diff_chars=2000)
+    outcome = await checker.check(diff, ISSUE, ctx=None)
+    assert outcome.implemented is True
+    assert "package-lock.json" not in seen["prompt"]  # lock retiré
+    assert "b/package.json\n" in seen["prompt"]  # vrai fichier VU par le juge
+    assert "vite.config.ts" in seen["prompt"]  # vrai fichier VU par le juge
+
+
+async def test_adequacy_warns_judge_on_residual_truncation():
+    """#526 : si le diff (lock retiré) dépasse encore la fenêtre, le juge est
+    PRÉVENU (sinon il conclut à tort à l'absence d'un fichier non vu)."""
+    from collegue.executor import LLMAdequacyChecker
+
+    seen = {}
+
+    async def fake_sample(prompt, system_prompt):
+        seen["prompt"] = prompt
+        return '{"implemented": true, "justification": "ok"}'
+
+    big_src = "diff --git a/app/big.py b/app/big.py\n" + ("+x = 1\n" * 2000)
+    checker = LLMAdequacyChecker(fake_sample, max_diff_chars=500)
+    await checker.check(big_src, ISSUE, ctx=None)
+    assert "DIFF TRONQUÉ" in seen["prompt"]
+
+
+async def test_adequacy_diff_only_generated_files_is_distinct_from_empty():
+    """#526 : un diff composé UNIQUEMENT de fichiers générés n'est pas présenté
+    comme « (diff vide) » (sinon faux « livrable absent »), mais distinctement."""
+    from collegue.executor import LLMAdequacyChecker
+
+    seen = {}
+
+    async def fake_sample(prompt, system_prompt):
+        seen["prompt"] = prompt
+        return '{"implemented": false, "justification": "..."}'
+
+    checker = LLMAdequacyChecker(fake_sample)
+    await checker.check("diff --git a/package-lock.json b/package-lock.json\n+x\n", ISSUE, ctx=None)
+    assert "uniquement des fichiers générés" in seen["prompt"]
+    assert "(diff vide)" not in seen["prompt"]
+
+
 # --- adéquation des TESTS : couverture des critères chiffrables (#499) ---------------
 
 


### PR DESCRIPTION
## Contexte — issue #526 (HAUTE)
Le juge d'adéquation `LLMAdequacyChecker` (#437) tronquait le diff à **20000 chars** avant de l'envoyer au LLM. Sur un gros diff (ex. scaffold frontend ~40k chars), un `package-lock.json` généré (~30k) **saturait la fenêtre** et poussait `package.json` / `vite.config.ts` / `src/` **hors du champ du juge** → verdict « feature absente » sur un livrable pourtant complet.

**Impact prouvé (run v6)** : faux rejets en cascade de task 2 (frontend) et task 6 (numérotation, dont le juge croyait un fichier « tronqué » alors que c'était la coupure du diff) → run bloqué **4/15**. Les **mêmes diffs passent** une fois la troncature corrigée → **13/15**.

## Correctif
- `strip_generated_from_diff()` : retire les blocs `diff --git` des fichiers générés (lock files) avant le juge. Match par **basename exact** du chemin `b/` (pas sous-chaîne → `src/go.sum.parser.ts` conservé ; un rename d'un lock vers un fichier source conservé).
- `_diff_for_judge()` : strip → borne → **ANNONCE la troncature résiduelle** au juge (« ne pas conclure à l'absence d'un fichier non vu ») ; distingue « diff = uniquement des fichiers générés » de « diff vide ».
- défaut `max_diff_chars` **20000 → 60000**.

Le **diff autoritatif** (commit/PR) reste intact : seul le diff *soumis au juge* est nettoyé.

## Tests (6 nouveaux)
- `strip_generated_from_diff` retire les lock files, conserve les vrais fichiers, robuste (texte libre / vide).
- **Régression #526** : avec `max_diff_chars=2000` et un lock de ~60k, `package.json`/`vite.config.ts` **atteignent** le prompt du juge (≠ tronqués).
- match par basename (faux match `go.sum.parser.ts` évité ; rename vers source conservé).
- avertissement de troncature présent quand un fichier non-lock dépasse encore la borne.
- diff 100% généré → note distincte (pas « diff vide »).

Suite executor/pipeline/runtime verte localement (ruff check + format OK).

## Revue
Revue adversariale (1 finding MINEUR : match sous-chaîne) → corrigé (basename exact) + tests de garde ajoutés.

Closes #526
