### PR TITLE
fix(executor): smoke — CORS conditionnel à la présence d'un frontend (#503 suivi v6)

### DIFF
--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -1457,12 +1457,21 @@ async def run_quality_gate(
                     installability = _tolerate_pytest_exit5(installability)
                 command = f"({command}) && echo '{_INSTALLABILITY_BANNER}' && ({installability})"
         if smoke_run:
+            # #503 (suivi v6) : le contrôle CORS du smoke n'a de sens QUE si un
+            # frontend existe — un backend ISOLÉ n'a légitimement pas de middleware
+            # CORS et était faussement rejeté (run v6, tâche d'init backend). On
+            # n'exige donc le CORS par DÉFAUT que si un frontend est détecté dans le
+            # workspace ; un ``smoke_cors_origin`` EXPLICITE (≠ défaut) reste toujours
+            # respecté (override opérateur), et "" garde le contrôle désactivé.
+            cors = smoke_cors_origin
+            if cors == _SMOKE_DEFAULT_ORIGIN and not _frontend_dirs(workspace):
+                cors = ""
             smoke = smoke_run_command(
                 workspace,
                 command=smoke_command,
                 paths=smoke_paths,
                 timeout=smoke_timeout,
-                cors_origin=smoke_cors_origin,
+                cors_origin=cors,
             )
             if smoke is not None:
                 # Dernière passe (le heredoc doit clore la commande) : l'app est

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -500,6 +500,49 @@ async def test_gate_smoke_run_default_off_and_skipped_without_app(tmp_path):
     assert "smoke" not in command2  # aucune app détectable → passe skippée
 
 
+# --- #503 (suivi v6) : CORS du smoke CONDITIONNEL à la présence d'un frontend -------
+
+
+async def test_gate_smoke_cors_disabled_without_frontend(tmp_path):
+    """#503 v6 : un backend ISOLÉ (sans frontend) ne se voit PAS exiger de CORS —
+    sinon une tâche d'init backend (app pourtant parfaite) rouge à tort."""
+    _write_fastapi_app(tmp_path)
+    sandbox = _green()
+    await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer(), smoke_run=True)
+    _ws, command = sandbox.calls[0]
+    assert "smoke run" in command  # la passe smoke est bien générée
+    assert "origin = ''" in command  # CORS désactivé (aucun frontend détecté)
+
+
+async def test_gate_smoke_cors_enforced_with_frontend(tmp_path):
+    """#503 v6 : dès qu'un frontend existe, le CORS reste EXIGÉ sur le backend
+    (intention d'origine de #503 préservée)."""
+    _write_fastapi_app(tmp_path)
+    (tmp_path / "package.json").write_text('{"name": "f", "scripts": {"build": "vite build"}}', encoding="utf-8")
+    sandbox = _green()
+    await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer(), smoke_run=True)
+    _ws, command = sandbox.calls[0]
+    assert "origin = 'http://localhost:5173'" in command  # CORS exigé (frontend présent)
+
+
+async def test_gate_smoke_cors_explicit_origin_respected_without_frontend(tmp_path):
+    """#503 v6 : un cors_origin EXPLICITE (override opérateur) est respecté même
+    sans frontend détecté — on ne désactive que la valeur PAR DÉFAUT."""
+    _write_fastapi_app(tmp_path)
+    sandbox = _green()
+    await run_quality_gate(
+        str(tmp_path),
+        DIFF,
+        ctx=None,
+        sandbox=sandbox,
+        reviewer=FakeReviewer(),
+        smoke_run=True,
+        smoke_cors_origin="http://custom:1234",
+    )
+    _ws, command = sandbox.calls[0]
+    assert "origin = 'http://custom:1234'" in command  # override respecté
+
+
 # --- installabilité du livrable (#439) ---------------------------------------------
 
 
@@ -2088,8 +2131,10 @@ def test_smoke_probe_cors_ignored_on_4xx(tmp_path):
 
 async def test_gate_smoke_threads_cors_origin(tmp_path):
     """#503 : le défaut de signature traverse run_quality_gate jusqu'à la commande
-    (même sans passer par _gate_options)."""
+    (même sans passer par _gate_options) — DÈS LORS qu'un frontend est présent
+    (#503 suivi v6 : le CORS n'est exigé que si un frontend existe)."""
     _write_fastapi_app(tmp_path)
+    (tmp_path / "package.json").write_text('{"name": "f", "scripts": {"build": "vite build"}}', encoding="utf-8")
     sandbox = _green()
     await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer(), smoke_run=True)
     _ws, command = sandbox.calls[0]


### PR DESCRIPTION
## Contexte — issue #503 (suivi run v6)
Le contrôle CORS du smoke (ajouté pour #503) envoie un header `Origin: http://localhost:5173` et rougit dès qu'une réponse <400 n'expose pas `Access-Control-Allow-Origin`. Problème prouvé au run v6 : une tâche d'**INIT BACKEND isolée** (pas encore de frontend → pas de middleware CORS) est rejetée 3/3 **alors que l'app est parfaite** (`/health` 200, tests verts, installable, adéquation OK). Le check CORS était une **hypothèse produit** (front Vite présent) appliquée à tout backend.

## Correctif (générique)
Le CORS ne concerne qu'un client navigateur → on n'exige le header **par défaut** que si un **frontend est détecté** dans le workspace (`_frontend_dirs()`, déjà existant). 
- Backend isolé (aucun `package.json`) → CORS **non exigé** (plus de faux rouge).
- Frontend présent (monorepo / front déjà mergé) → CORS **exigé** sur le backend → l'intention d'origine de #503 est **préservée** (et c'est plus fin que le workaround harness v6 qui désactivait CORS partout).
- `smoke_cors_origin` **explicite** (≠ défaut) → toujours respecté (override opérateur) ; `""` garde le contrôle désactivé.

Un seul point de décision ajouté dans `run_quality_gate` avant `smoke_run_command` :
```python
cors = smoke_cors_origin
if cors == _SMOKE_DEFAULT_ORIGIN and not _frontend_dirs(workspace):
    cors = ""
```

## Tests (3 nouveaux + 1 réconcilié)
- backend sans frontend → `origin = ''` (CORS off) ;
- frontend présent → `origin = 'http://localhost:5173'` (CORS exigé) ;
- override explicite respecté sans frontend ;
- `test_gate_smoke_threads_cors_origin` mis à jour (ajout d'un `package.json` : le défaut traverse quand il a du sens).

Suite executor/pipeline/runtime verte localement (ruff check + format OK).

Design pré-vété par un workflow de cartographie (lecture seule).

Refs #503
