### PR TITLE
fix(executor): feedback — filtrer le bruit pip non-fatal (#507 suivi v6)

### DIFF
--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -277,6 +277,44 @@ def _label_failure_line(line: str, changed: frozenset[str]) -> str:
     )
 
 
+# #507 (suivi v6) : bruit pip NON-fatal (exit 0). Un conflit de version avec une
+# dépendance de l'IMAGE sandbox (openhands & co — hors périmètre du livrable) est
+# signalé par pip SANS bloquer ; ce bruit NOIE le feedback de repli (run v6 : la
+# tâche racine a brûlé 3 tentatives, le coder empilant des pins inutiles au lieu de
+# voir le vrai motif). On le retire du diagnostic RELAYÉ au coder. Sûr vis-à-vis de
+# la grâce #461 : AUCUNE de ces signatures n'est une signature réseau
+# (_INFRA_NOISE_SIGNATURES), et on ne touche JAMAIS ``report.test_output``.
+_PIP_NOISE_SIGNATURES = (
+    "pip's dependency resolver does not currently take into account",
+    "[notice] A new release of pip is available",
+    "[notice] To update, run:",
+    "WARNING: The script ",
+    "Consider adding this directory to PATH",
+    "Defaulting to user installation because normal site-packages is not writeable",
+)
+
+
+def filter_pip_noise(output: str) -> str:
+    """Retire les lignes de bruit pip NON-fatal d'un diagnostic (#507).
+
+    Cible : avertissements du resolver, notices de mise à jour pip, warnings de
+    PATH, et la ligne de conflit ``X requires Y, but you have Z which is
+    incompatible.`` (deps de l'image, hors livrable). Ne retire AUCUNE signature
+    réseau (#461) ni ligne pytest ``FAILED``/``ERROR``.
+    """
+    if not output:
+        return output
+    kept = []
+    for line in output.splitlines():
+        stripped = line.strip()
+        if any(sig in stripped for sig in _PIP_NOISE_SIGNATURES):
+            continue
+        if "but you have" in stripped and "incompatible" in stripped:  # conflit de version pip
+            continue
+        kept.append(line)
+    return "\n".join(kept)
+
+
 def failure_feedback(outcome: "ExecutionOutcome") -> str:
     """Synthèse **courte et actionnable** d'un échec, pour la tentative suivante (#424).
 
@@ -361,7 +399,17 @@ def failure_feedback(outcome: "ExecutionOutcome") -> str:
             changed = frozenset(getattr(outcome.execution, "files_changed", ()) or ())
             labelled = (_label_failure_line(_detruncate_summary_line(line, output), changed) for line in fails[:6])
             return " ; ".join(labelled)[:700]
-        return log_tail(output, 400)
+        # #507 : pas de ligne pytest exploitable → on relaie la queue, MAIS nettoyée
+        # du bruit pip non-fatal (conflit avec les deps de l'image, notices). Si tout
+        # était du bruit, on le DIT au lieu de relayer un diagnostic trompeur. La
+        # signature réseau (#461) survit au filtre → la grâce reste armée.
+        cleaned = filter_pip_noise(output)
+        if not cleaned.strip():
+            return (
+                "Gate rouge sans diagnostic pytest exploitable — la sortie ne contenait que du bruit "
+                "d'installation pip non bloquant (conflit avec des dépendances de l'image, hors livrable)."
+            )
+        return log_tail(cleaned, 400)
     return log_tail(outcome.execution.agent_result.logs, 400)
 
 

--- a/tests/test_executor_pipeline.py
+++ b/tests/test_executor_pipeline.py
@@ -454,6 +454,59 @@ def test_label_failure_line_monorepo_subdir_match():
     assert "RÉGRESSION" in _label_failure_line("FAILED tests/test_x.py::t - m", frozenset({"backend/test_x.py"}))
 
 
+def test_filter_pip_noise_keeps_network_and_real_content():
+    """#507 : le filtre retire le bruit pip NON-fatal (conflit deps image, notices,
+    PATH) mais PRÉSERVE les signatures réseau (#461) et le contenu légitime."""
+    from collegue.executor.pipeline import filter_pip_noise
+
+    raw = (
+        "Collecting fastapi\n"
+        "ERROR: pip's dependency resolver does not currently take into account all the packages\n"
+        "openhands-ai 1.7.0 requires starlette>=0.49.1, but you have starlette 0.41.3 which is incompatible.\n"
+        "[notice] A new release of pip is available: 25.0.1 -> 26.1.2\n"
+        "WARNING: The script fastapi is installed in '/home/sandbox/.local/bin' which is not on PATH.\n"
+        "pip._vendor.urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='x'): Read timed out.\n"
+    )
+    out = filter_pip_noise(raw)
+    assert "incompatible" not in out  # conflit de version retiré
+    assert "dependency resolver" not in out  # warning resolver retiré
+    assert "[notice]" not in out and "is not on PATH" not in out  # notices/PATH retirés
+    assert "ReadTimeoutError" in out  # signature réseau PRÉSERVÉE (#461)
+    assert "Collecting fastapi" in out  # contenu légitime conservé
+
+
+def test_failure_feedback_replaces_pure_pip_noise_with_note():
+    """#507 : une queue UNIQUEMENT composée de bruit pip non-fatal (pas de FAILED)
+    n'est plus relayée telle quelle — le coder reçoit une note explicite (run v6 :
+    3 tentatives brûlées à empiler des pins sur ce bruit)."""
+    from collegue.executor.pipeline import failure_feedback
+
+    noise = (
+        "ERROR: pip's dependency resolver does not currently take into account all the packages\n"
+        "openhands-ai 1.7.0 requires starlette>=0.49.1, but you have starlette 0.41.3 which is incompatible.\n"
+        "[notice] A new release of pip is available: 25.0.1 -> 26.1.2\n"
+    )
+    fb = failure_feedback(_gate_outcome(noise))
+    assert "incompatible" not in fb  # le bruit ne fuit plus
+    assert "bruit d'installation pip" in fb  # note explicite à la place
+
+
+def test_failure_feedback_pip_noise_preserves_infra_grace():
+    """#507 / #461 : bruit pip + un ReadTimeout (sans FAILED) → le feedback garde la
+    signature réseau → is_infra_gate_failure gracie toujours l'aléa."""
+    from collegue.executor.pipeline import failure_feedback, is_infra_gate_failure
+
+    out = (
+        "[notice] A new release of pip is available: 25.0.1 -> 26.1.2\n"
+        "openhands-ai 1.7.0 requires starlette>=0.49.1, but you have starlette 0.41.3 which is incompatible.\n"
+        "pip._vendor.urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='files'): Read timed out.\n"
+    )
+    outcome = _gate_outcome(out)
+    fb = failure_feedback(outcome)
+    assert "ReadTimeoutError" in fb  # signature réseau survit au filtre
+    assert is_infra_gate_failure(outcome) is True  # grâce #461 toujours armée
+
+
 def test_failure_feedback_detruncation_then_label_same_line():
     """#507 / #478 : dans un même feedback, la dé-troncature s'applique AVANT
     l'étiquetage — une inversion casserait silencieusement le `.endswith("...")`


### PR DESCRIPTION
## Contexte — issue #507 (facette run v6)
Quand le gate échoue **sans ligne pytest `FAILED`/`ERROR` exploitable**, `failure_feedback` retombait sur `log_tail(output, 400)` — souvent saturé par le **bruit pip NON-fatal** (exit 0) : conflit de version avec une dépendance de l'**image sandbox** (`openhands-ai` & co, hors périmètre du livrable), notices `[notice] A new release of pip…`, warnings de PATH.

Au run v6, la tâche racine a **brûlé ses 3 tentatives** : le coder voyait `openhands-ai requires starlette>=0.49.1 but you have 0.41.3 which is incompatible` et empilait des pins starlette inutiles, sans jamais voir le vrai motif.

## Correctif (générique)
- `filter_pip_noise(output)` retire du **diagnostic relayé** : l'avertissement du resolver, la ligne de conflit `… but you have … incompatible.`, les notices pip, les warnings de PATH.
- Si après filtrage il ne reste **rien d'exploitable**, le feedback le **dit explicitement** au lieu de relayer le bruit.

## Sûreté (non-régression grâce réseau #461)
- **Aucune** signature filtrée n'est une signature réseau (`_INFRA_NOISE_SIGNATURES` = ReadTimeout/ConnectTimeout/name resolution/5xx…). Les `ReadTimeoutError` & co **survivent** au filtre → `is_infra_gate_failure` (qui lit `failure_feedback`) **gracie toujours** l'aléa.
- `report.test_output` n'est **jamais** modifié (la détection infra qui le lit directement est intacte).
- La voie « lignes FAILED/ERROR présentes » est inchangée (étiquetage de provenance #507 conservé).

## Tests (3 nouveaux)
- `filter_pip_noise` retire le bruit, **préserve** `ReadTimeoutError` + le contenu légitime ;
- queue 100% bruit pip → note explicite (plus de fuite du conflit) ;
- bruit pip + `ReadTimeout` → feedback garde la signature réseau ET `is_infra_gate_failure` reste `True`.

Suite `test_executor_pipeline` verte localement (ruff check + format OK). Design pré-vété par workflow.

Refs #507
