### PR TITLE
fix(pilot,executor): respecter un coût 0 autoritaire (abonnement) vs prix de secours #484 (#504 suivi v6)

### DIFF
--- a/collegue/executor/agent.py
+++ b/collegue/executor/agent.py
@@ -87,6 +87,10 @@ class AgentResult:
     prompt_tokens: int = 0
     completion_tokens: int = 0
     cost_usd: float = 0.0
+    # #504 : True si le coût rapporté est AUTORITAIRE même nul (ex. abonnement,
+    # ``billable: false`` → coût réel 0) ; le pilote ne re-tarife alors PAS au prix
+    # de secours #484. Défaut False : un coût 0 = INCONNU (modèle non mappé) → #484.
+    cost_authoritative: bool = False
 
     @property
     def total_tokens(self) -> int:

--- a/collegue/executor/openhands_agent.py
+++ b/collegue/executor/openhands_agent.py
@@ -50,16 +50,24 @@ OPENHANDS_ENTRYPOINT = "openhands.core.main"
 USAGE_MARKER = "[collegue-usage]"
 
 
-def parse_usage_from_logs(logs: str) -> Tuple[int, int, float]:
-    """``(prompt_tokens, completion_tokens, cost_usd)`` sommés depuis les logs (#441).
+def parse_usage_from_logs(logs: str) -> Tuple[int, int, float, bool]:
+    """``(prompt_tokens, completion_tokens, cost_usd, cost_authoritative)`` (#441/#504).
 
     Best-effort : une ligne marquée mais illisible est ignorée (l'usage est une
-    télémétrie, jamais une cause d'échec). ``(0, 0, 0.0)`` si rien n'est rapporté
-    — le ledger distingue « zéro rapporté » de « gouvernance morte » par la
-    présence des événements ``cost_observed``.
+    télémétrie, jamais une cause d'échec). ``(0, 0, 0.0, False)`` si rien n'est
+    rapporté — le ledger distingue « zéro rapporté » de « gouvernance morte » par
+    la présence des événements ``cost_observed``.
+
+    ``cost_authoritative`` (#504) : ``True`` dès qu'une ligne porte ``billable:
+    false`` — le coder SAIT que le run n'est pas facturé (abonnement Codex/ChatGPT,
+    coût réel **0**). Le pilote ne doit alors PAS re-tarifer ce 0 au prix de secours
+    (#484) : ce serait un coût FANTÔME (run v6 : ledger ~$2 sur un run abonnement
+    pourtant gratuit). Absent / ``billable: true`` → un ``cost_usd`` nul reste un
+    coût INCONNU (modèle non mappé litellm) → re-tarification #484 légitime.
     """
     prompt = completion = 0
     cost = 0.0
+    cost_authoritative = False
     for line in (logs or "").splitlines():
         index = line.find(USAGE_MARKER)
         if index < 0:
@@ -72,9 +80,11 @@ def parse_usage_from_logs(logs: str) -> Tuple[int, int, float]:
             usd = float(data.get("cost_usd") or 0.0)
             if math.isfinite(usd) and usd > 0:
                 cost += usd
+            if data.get("billable") is False:
+                cost_authoritative = True  # #504 : 0 AUTORITAIRE (run non facturé)
         except (ValueError, TypeError, AttributeError):
             continue
-    return prompt, completion, cost
+    return prompt, completion, cost, cost_authoritative
 
 
 def estimate_cost_usd(prompt_tokens: int, completion_tokens: int, settings_obj=None) -> float:
@@ -263,7 +273,7 @@ class OpenHandsAgent:
         self._last_launch = self._clock()
         result = self._sandbox.run_command(self.build_command(issue), workspace)
         logs = "\n".join(part for part in (result.stdout, result.stderr) if part).strip()
-        prompt_tokens, completion_tokens, cost_usd = parse_usage_from_logs(logs)
+        prompt_tokens, completion_tokens, cost_usd, cost_authoritative = parse_usage_from_logs(logs)
         return AgentResult(
             success=result.ok,
             logs=logs,
@@ -271,4 +281,5 @@ class OpenHandsAgent:
             prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,
             cost_usd=cost_usd,
+            cost_authoritative=cost_authoritative,
         )

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -815,7 +815,11 @@ async def run_project(
         coder_completion = int(getattr(agent_result, "completion_tokens", 0) or 0)
         coder_tokens = coder_prompt + coder_completion
         coder_usd = float(getattr(agent_result, "cost_usd", 0.0) or 0.0)
-        if coder_tokens and coder_usd <= 0:
+        # #504 : un coût 0 AUTORITAIRE (abonnement, billable=false) n'est PAS un coût
+        # inconnu — ne pas le re-tarifer au prix de secours (#484), sinon le ledger
+        # porte un coût FANTÔME sur un run pourtant gratuit (run v6 : ~$2 fantômes).
+        coder_authoritative = bool(getattr(agent_result, "cost_authoritative", False))
+        if coder_tokens and coder_usd <= 0 and not coder_authoritative:
             # #484 : modèle non mappé litellm → cost_usd=0 malgré des tokens.
             # Prix de secours configurés (LLM_PRICE_*_PER_1M) : coût estimé ;
             # sinon coût INCONNU — signalé une fois par run/segment au lieu

--- a/tests/test_executor_agent.py
+++ b/tests/test_executor_agent.py
@@ -255,11 +255,23 @@ def test_parse_usage_from_logs_sums_marked_lines():
         "[collegue-usage] pas du json (ignoré, best-effort)\n"
         '[collegue-usage] {"prompt_tokens": -5, "cost_usd": "NaN"}\n'
     )
-    prompt, completion, cost = parse_usage_from_logs(logs)
+    prompt, completion, cost, authoritative = parse_usage_from_logs(logs)
     assert prompt == 2000
     assert completion == 500
     assert cost == pytest.approx(0.0021)
-    assert parse_usage_from_logs("") == (0, 0, 0.0)
+    assert authoritative is False  # #504 : aucune ligne billable=false → coût non autoritaire
+    assert parse_usage_from_logs("") == (0, 0, 0.0, False)
+
+
+def test_parse_usage_marks_authoritative_on_billable_false():
+    """#504 : une ligne ``billable: false`` (abonnement, non facturé) marque le coût
+    AUTORITAIRE même nul → le pilote ne re-tarifera pas au prix de secours #484."""
+    from collegue.executor.openhands_agent import parse_usage_from_logs
+
+    logs = '[collegue-usage] {"prompt_tokens": 5000, "completion_tokens": 800, "cost_usd": 0, "billable": false}\n'
+    prompt, completion, cost, authoritative = parse_usage_from_logs(logs)
+    assert (prompt, completion, cost) == (5000, 800, 0.0)
+    assert authoritative is True  # 0 AUTORITAIRE (run non facturé)
 
 
 def test_openhands_implement_issue_reports_usage():

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -1899,6 +1899,39 @@ async def test_no_cost_unknown_when_cost_reported(repo, manager):
     assert audit.cost.usd == pytest.approx(0.002)
 
 
+async def test_authoritative_zero_cost_not_repriced(repo, manager, monkeypatch):
+    """#504 : un coût 0 AUTORITAIRE (abonnement, cost_authoritative=True) n'est PAS
+    re-tarifé au prix de secours #484 — même AVEC des prix configurés — et n'émet
+    aucun cost_unknown. Le ledger $ reflète la réalité (run non facturé) ; les
+    tokens restent comptés. (Sans le flag, ce même cas serait estimé : cf.
+    test_coder_cost_estimated_when_litellm_unmapped.)"""
+    import dataclasses
+
+    from collegue import config
+    from collegue.pilot.audit import RunAuditLog
+
+    monkeypatch.setattr(config.settings, "LLM_PRICE_PROMPT_PER_1M", 1.5, raising=False)
+    monkeypatch.setattr(config.settings, "LLM_PRICE_COMPLETION_PER_1M", 9.0, raising=False)
+
+    class _SubscriptionAgent:
+        def __init__(self):
+            self._ok = FakeCodeAgent()
+
+        def implement_issue(self, workspace, issue):
+            result = self._ok.implement_issue(workspace, issue)
+            return dataclasses.replace(
+                result, prompt_tokens=1_000_000, completion_tokens=100_000, cost_usd=0.0, cost_authoritative=True
+            )
+
+    pid = _linear_project(manager, 1)
+    audit = RunAuditLog(pid)
+    result = await _run(manager, repo, pid, dry_run=False, agent=_SubscriptionAgent(), audit=audit)
+    assert result.stop_reason == "completed"
+    assert audit.cost.usd == 0.0  # PAS de coût fantôme malgré des prix configurés
+    assert audit.cost.tokens == 1_100_000  # tokens toujours comptés
+    assert not [e for e in audit.events if e.kind == "cost_unknown"]  # 0 autoritaire ≠ inconnu
+
+
 # --- crash-loop agent : grâce + fail-fast (#498) ------------------------------------
 
 


### PR DESCRIPTION
## Contexte — issue #504 / #484 (facette run v6)
En mode **abonnement** (Codex/ChatGPT), le coder rapporte `cost_usd=0` alors que le run n'est **pas facturé** (coût réel nul). Le pilote ne distinguait pas ce 0 d'un **coût inconnu** (modèle non mappé litellm) et appliquait le **prix de secours #484** → ledger $ **fantôme** (run v6 : ~$2,14 / 13,5M tokens sur un run pourtant gratuit).

## Correctif (générique)
Contrat étendu : une ligne `[collegue-usage]` peut porter **`billable: false`** → le coût 0 est **autoritaire** (à ne pas re-tarifer).
- `parse_usage_from_logs` retourne désormais `(prompt, completion, cost, cost_authoritative)` ; `cost_authoritative=True` dès qu'une ligne porte `billable: false`.
- `AgentResult.cost_authoritative: bool = False` (nouveau champ).
- `driver` : re-tarife (#484) **uniquement** si `coder_tokens and coder_usd <= 0 **and not cost_authoritative**`.

**Rétrocompat** : sans le flag (défaut `False`), le comportement #484 est **inchangé** (cost=0 + tokens → estimation / `cost_unknown`). Distingue proprement « 0 facturé » de « 0 inconnu ».

## Tests (3)
- `parse_usage_from_logs` : `billable:false` → `cost_authoritative=True` ; absence → `False` ; tuple à 4 (+ test existant mis à jour).
- driver : coût 0 **autoritaire** + prix de secours **configurés** → ledger `usd=0` (pas de fantôme), tokens comptés, **aucun** `cost_unknown` — alors que le même cas SANS flag est estimé (test #484 existant intact).

## Suivi (hors PR)
L'émission de `billable: false` par le coder d'abonnement est une bascule **harness** (gitignored) — ce PR pose le **contrat moteur** + la garde ; la bascule sera activée côté harness pour le prochain run.

Suite `test_executor_agent` / `test_pilot_driver` / `test_executor_pipeline` verte (ruff OK). Design pré-vété par workflow.

Refs #504 #484
