### PR TITLE
fix(executor): adéquation — ne pas bloquer sur un critère runtime non mesurable statiquement (#499 suivi v6)

### DIFF
--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -1132,9 +1132,16 @@ _TEST_ADEQUACY_SYSTEM = (
     "(critères d'acceptation chiffrables/observables) et le diff livré. Tu juges UNIQUEMENT "
     "si CHAQUE critère chiffrable/observable de l'issue est ASSERTÉ par au moins un test du "
     "diff (assertion sur la VALEUR/le CALCUL/le COMPORTEMENT, pas seulement un code HTTP 200). "
+    "EXCEPTION (#499) : un critère qui exige une MESURE RUNTIME non visible dans un diff "
+    "STATIQUE (ex. « couverture de tests > X% », « latence < Y ms », « débit/perf ») ne peut "
+    "PAS être vérifié par lecture du diff — NE bloque PAS dessus : réponds true s'il ajoute des "
+    "tests RÉELS et substantiels couvrant le domaine du critère (assertions véritables, jamais "
+    "des tests vides/triviaux), et NOMME ce critère comme non vérifiable statiquement dans la "
+    "justification. Continue de bloquer (false) sur tout critère de VALEUR vérifiable dans le "
+    "diff qui n'est asserté par aucun test. "
     'Réponds STRICTEMENT en JSON : {"tests_assert_criteria": true|false, "justification": "..."}. '
-    "false si un critère chiffrable n'est couvert par aucune assertion (ex. : aucun test "
-    "n'asserte le montant TTC) — nomme alors le critère non couvert dans la justification."
+    "false si un critère chiffrable VÉRIFIABLE n'est couvert par aucune assertion (ex. : aucun "
+    "test n'asserte le montant TTC) — nomme alors le critère non couvert dans la justification."
 )
 
 

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -999,6 +999,21 @@ def test_parse_test_adequacy_is_fail_closed():
     assert _parse_test_adequacy("")[0] is False
 
 
+def test_test_adequacy_prompt_tolerates_unmeasurable_runtime_criteria():
+    """#499 (suivi v6) : le prompt de couverture instruit le juge de NE PAS bloquer
+    sur un critère RUNTIME non vérifiable dans un diff statique (couverture %,
+    latence) — il accepte alors des tests réels substantiels (task 13 faux-rejetée
+    au run v6), tout en gardant le verrou anti-tests-vides ET le blocage des
+    critères de VALEUR vérifiables (cas TVA ×100)."""
+    from collegue.executor.quality_gate import _TEST_ADEQUACY_SYSTEM
+
+    prompt = _TEST_ADEQUACY_SYSTEM.lower()
+    assert "runtime" in prompt and "couverture de tests > x%" in prompt
+    assert "ne bloque pas" in prompt  # l'exception est explicite
+    assert "vides" in prompt or "triviaux" in prompt  # anti-rubber-stamp
+    assert "ttc" in prompt  # le verrou VALEUR (#499 origine) est conservé
+
+
 # --- signal « aucun test touché » (#437) --------------------------------------------
 
 


### PR DESCRIPTION
## Contexte — issue #499 (facette run v6)
Le contrôle de couverture #499 (juge LLM, revue **statique** du diff via `_TEST_ADEQUACY_SYSTEM`) rejetait un critère de type **mesure RUNTIME** — « couverture de tests > 80% », latence, perf — qu'il **ne peut pas mesurer** en lisant le diff. Au run v6, **task 13** (48 tests réels ajoutés, diff 14,5k) a été rejetée 3/3 → **#15 E2E bloqué en cascade**.

## Correctif (générique)
On instruit le juge à **NE PAS bloquer** sur un critère non vérifiable statiquement :
- répond `true` si le diff ajoute des **tests réels et substantiels** couvrant le domaine du critère — **jamais des tests vides/triviaux** (garde anti-rubber-stamp) — et **nomme** le critère non mesurable dans la justification ;
- **continue de bloquer** (`false`) sur tout critère de **VALEUR vérifiable** non asserté (verrou #499 d'origine — cas TVA ×100 préservé).

Pas de regex de domaine ni d'override mécanique (tous deux fragiles / risque de faux positifs) : la décision « mesurable ou non » revient au **juge** (gpt-5.4, capable), conforme au modèle LLM-as-judge. La logique de parsing/gate est **inchangée** (rétrocompat totale).

## Tests
- garde de prompt : présence de l'exception runtime (couverture %, « ne bloque pas »), de la garde anti-tests-vides, ET du verrou VALEUR (TTC) ;
- tous les tests d'adéquation existants (parsing fail-closed, blocage critère-valeur, pass) restent verts.

Suite `test_executor_quality_gate` verte (ruff OK). Design pré-vété par workflow (option « tolérance » retenue plutôt que l'override heuristique, jugé risqué).

Refs #499
