### PR TITLE
feat(executor): gate E2E navigateur actif par défaut (#503 suivi)

### DIFF
--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -1528,7 +1528,7 @@ async def run_quality_gate(
     smoke_paths: Tuple[str, ...] = DEFAULT_SMOKE_PATHS,
     smoke_timeout: float = 30.0,
     smoke_cors_origin: str = _SMOKE_DEFAULT_ORIGIN,
-    e2e_gate: bool = False,
+    e2e_gate: bool = True,
     e2e_timeout: float = 90.0,
     fix_missing_requirements: bool = True,
     requirements_guard: bool = True,
@@ -1568,6 +1568,15 @@ async def run_quality_gate(
     < 500), préfixe « MÉTHODE: » optionnel (#483, ex. ``POST:/auth/register`` —
     payload JSON générique, 4xx toléré, 5xx rouge). Skippée si aucune app n'est
     détectable et qu'aucune commande n'est fournie.
+    ``e2e_gate`` (#503 suivi, défaut VRAI) : passe E2E navigateur — démarre le
+    backend, build/sert le frontend (base d'URL backend injectée) et pilote
+    chromium (Playwright) sur l'UI RÉELLE pour attraper les ruptures front<->back
+    (contrat/préfixe/CORS/base d'URL) qu'aucune autre passe n'exerce. Insérée
+    AVANT le smoke (sonde écrite en fichier, chaînable). N'a d'effet que sur un
+    projet FULL-STACK (backend ASGI + frontend build+preview) — sinon
+    :func:`e2e_gate_command` renvoie ``None`` et la passe est inerte. EXIGE une
+    image sandbox avec Playwright + chromium (cf. ``docker/sandbox/Dockerfile``) ;
+    passer ``e2e_gate=False`` la désactive explicitement.
     """
     sandbox = sandbox or DockerSandbox()
     reviewer = reviewer or _default_reviewer()

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
 # pour que le gate dispose d'un runner même si le projet ne le déclare pas.
 RUN python -m pip install --no-cache-dir "pytest>=8.1,<9" "pytest-asyncio==0.23.6"
 
-# Navigateur headless pour le gate E2E opt-in (#503 suivi) : Playwright + chromium
+# Navigateur headless pour le gate E2E (actif par défaut, #503 suivi) : Playwright + chromium
 # + ses libs système (libnss3, libatk… via --with-deps, root). Le gate démarre le
 # backend, sert le frontend buildé (base d'URL backend injectée) et pilote l'UI
 # RÉELLE dans chromium pour attraper les ruptures front<->back (contrat/préfixe/

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -616,10 +616,31 @@ async def test_gate_e2e_appended_before_smoke_heredoc_last(tmp_path):
     assert command.rstrip().endswith("COLLEGUE_SMOKE_458")  # smoke heredoc en dernier
 
 
-async def test_gate_e2e_default_off(tmp_path):
-    """#503 : la passe E2E est opt-in (défaut OFF) — aucun impact si non activée."""
+async def test_gate_e2e_default_on_fullstack(tmp_path):
+    """#503 (suivi) : la passe E2E est désormais ACTIVE PAR DÉFAUT — sur un projet
+    full-stack elle s'insère sans avoir à l'activer explicitement."""
     _write_fastapi_app(tmp_path)
     _write_vite_front(tmp_path)
+    sandbox = _green()
+    await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
+    _ws, command = sandbox.calls[0]
+    assert "e2e navigateur" in command
+
+
+async def test_gate_e2e_explicit_off(tmp_path):
+    """#503 (suivi) : ``e2e_gate=False`` désactive explicitement la passe (opt-out)."""
+    _write_fastapi_app(tmp_path)
+    _write_vite_front(tmp_path)
+    sandbox = _green()
+    await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer(), e2e_gate=False)
+    _ws, command = sandbox.calls[0]
+    assert "e2e navigateur" not in command
+
+
+async def test_gate_e2e_default_inert_non_fullstack(tmp_path):
+    """#503 (suivi) : même par défaut, la passe reste INERTE hors full-stack (backend
+    seul, pas de frontend build+preview) — aucune régression sur les projets non-web."""
+    _write_fastapi_app(tmp_path)  # backend seul, pas de package.json
     sandbox = _green()
     await run_quality_gate(str(tmp_path), DIFF, ctx=None, sandbox=sandbox, reviewer=FakeReviewer())
     _ws, command = sandbox.calls[0]


### PR DESCRIPTION
## Quoi

La passe **E2E navigateur** (`e2e_gate`) passe de **opt-in** à **active par défaut** (`e2e_gate=True`).

La passe démarre le backend, build/sert le frontend (base d'URL backend injectée, port 5173 = origine CORS conventionnelle) et pilote **chromium headless** (Playwright) sur l'UI réelle pour attraper les ruptures front<->back (contrat/préfixe/CORS/base d'URL) qu'aucune autre passe n'exerce. Validée RED+GREEN en réel sur le MVP v7.

## Garde-fous (pas de régression)

- **Inerte hors full-stack** : `e2e_gate_command` renvoie `None` si pas de backend ASGI **+** frontend (build+preview) → la passe ne s'insère pas (test `test_gate_e2e_default_inert_non_fullstack`).
- **Opt-out explicite** : `e2e_gate=False` la désactive (test `test_gate_e2e_explicit_off`).
- **Exige Playwright+chromium** dans l'image sandbox (déjà baké, `docker/sandbox/Dockerfile`) ; documenté dans la docstring.

## Tests

- `run_quality_gate` : défaut `False` → `True` + docstring
- 3 tests (default-on full-stack, opt-out, inert non-full-stack)
- 240 passed (test_executor_quality_gate + test_pilot_driver), ruff check + format OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)