### PR TITLE
fix(executor): #499 — distinguer critère DÉFINITIONNEL de critère VALEUR (suivi v8)

### DIFF
--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -1298,19 +1298,27 @@ def _parse_adequacy(text: str) -> AdequacyOutcome:
 # test n'assertait les totaux (status 200 suffisait).
 _TEST_ADEQUACY_SYSTEM = (
     "Tu es un relecteur de COUVERTURE DE TEST (rôle REVIEWER). On te donne une issue "
-    "(critères d'acceptation chiffrables/observables) et le diff livré. Tu juges UNIQUEMENT "
-    "si CHAQUE critère chiffrable/observable de l'issue est ASSERTÉ par au moins un test du "
-    "diff (assertion sur la VALEUR/le CALCUL/le COMPORTEMENT, pas seulement un code HTTP 200). "
-    "EXCEPTION (#499) : un critère qui exige une MESURE RUNTIME non visible dans un diff "
-    "STATIQUE (ex. « couverture de tests > X% », « latence < Y ms », « débit/perf ») ne peut "
-    "PAS être vérifié par lecture du diff — NE bloque PAS dessus : réponds true s'il ajoute des "
-    "tests RÉELS et substantiels couvrant le domaine du critère (assertions véritables, jamais "
-    "des tests vides/triviaux), et NOMME ce critère comme non vérifiable statiquement dans la "
-    "justification. Continue de bloquer (false) sur tout critère de VALEUR vérifiable dans le "
-    "diff qui n'est asserté par aucun test. "
-    'Réponds STRICTEMENT en JSON : {"tests_assert_criteria": true|false, "justification": "..."}. '
-    "false si un critère chiffrable VÉRIFIABLE n'est couvert par aucune assertion (ex. : aucun "
-    "test n'asserte le montant TTC) — nomme alors le critère non couvert dans la justification."
+    "(critères d'acceptation) et le diff livré. Tu juges si les critères de VALEUR/CALCUL/"
+    "COMPORTEMENT de l'issue sont ASSERTÉS par au moins un test du diff (assertion sur la "
+    "VALEUR/le CALCUL/le COMPORTEMENT attendu — montant, total, compteur, numéro séquentiel, "
+    "unicité/déduplication EFFECTIVE, rejet d'une entrée invalide —, pas seulement un code HTTP 200). "
+    "EXCEPTION RUNTIME (#499) : un critère qui exige une MESURE RUNTIME non visible dans un diff "
+    "STATIQUE (ex. « couverture de tests > X% », « latence < Y ms », « débit/perf ») ne peut PAS "
+    "être vérifié par lecture du diff — NE bloque PAS dessus : réponds true s'il ajoute des tests "
+    "RÉELS et substantiels couvrant le domaine du critère (assertions véritables, jamais des tests "
+    "vides/triviaux), et NOMME ce critère comme non vérifiable statiquement dans la justification. "
+    "EXCEPTION STRUCTURELLE (#499 suivi v8) : un critère qui exige seulement qu'un élément soit "
+    "DÉFINI/PRÉSENT (ex. « le schéma DÉFINIT les tables X/Y avec leurs contraintes d'intégrité », "
+    "« le modèle/endpoint EXISTE ») est satisfait par sa PRÉSENCE dans le diff (visible statiquement) "
+    "DÈS LORS que des tests RÉELS couvrent le comportement central du critère (au moins une "
+    "contrainte/relation REPRÉSENTATIVE assertée). N'EXIGE PAS un test de rejet DÉDIÉ pour CHAQUE "
+    "contrainte/colonne sœur : si une contrainte représentative est testée et les autres sont "
+    "définies dans le diff, réponds true (« défini » n'est pas « testé »). "
+    "Continue de bloquer (false) UNIQUEMENT sur un critère de VALEUR/CALCUL/COMPORTEMENT vérifiable "
+    "dans le diff qu'AUCUN test n'asserte (ex. : aucun test n'asserte le montant TTC = somme des "
+    "lignes). Si false, COMMENCE la justification par le critère non couvert (concis, actionnable) "
+    "AVANT tout commentaire sur ce qui est déjà testé. "
+    'Réponds STRICTEMENT en JSON : {"tests_assert_criteria": true|false, "justification": "..."}.'
 )
 
 

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -1118,6 +1118,21 @@ def test_test_adequacy_prompt_tolerates_unmeasurable_runtime_criteria():
     assert "ttc" in prompt  # le verrou VALEUR (#499 origine) est conservé
 
 
+def test_test_adequacy_prompt_distinguishes_structural_from_value_criteria():
+    """#499 (suivi v8) : le prompt instruit le juge qu'un critère DÉFINITIONNEL/structurel
+    (« le schéma DÉFINIT les tables avec contraintes ») est satisfait par sa PRÉSENCE +
+    une contrainte REPRÉSENTATIVE testée — sans exiger un test de rejet DÉDIÉ pour CHAQUE
+    contrainte sœur (root task v8 bloquée : schéma complet rejeté car la contrainte TVA
+    n'avait pas son propre test alors que SIREN l'avait). Le verrou VALEUR reste intact."""
+    from collegue.executor.quality_gate import _TEST_ADEQUACY_SYSTEM
+
+    prompt = _TEST_ADEQUACY_SYSTEM.lower()
+    assert "structurel" in prompt  # l'exception structurelle est explicite
+    assert "défini" in prompt and "présent" in prompt  # défini/présent vs testé
+    assert "représentative" in prompt  # une contrainte représentative suffit
+    assert "commence la justification par le critère non couvert" in prompt  # gap-first (feedback actionnable)
+
+
 # --- signal « aucun test touché » (#437) --------------------------------------------
 
 


### PR DESCRIPTION
## Finding (run v8, tâche racine)

Le run v8 a **bloqué dès la tâche racine** (#211, conception du schéma BDD). Le juge de couverture **#499** (gpt-5.4) rejetait un schéma **objectivement complet** (5 tables, FK, contraintes CHECK SIREN/TVA, numérotation séquentielle + UNIQUE, montants en centimes) accompagné de **tests substantiels** (présence des tables, rejet FK, rejet SIREN invalide, séquence FAC-000001/2, TTC=somme) — au **seul** motif qu'aucun test **dédié** n'assertait la contrainte **TVA** (`vat_number`), alors que **SIREN** (représentative) l'était.

Cause racine : le juge lisait « contraintes d'intégrité **définies** » comme « contraintes **testées** » et exigeait un test de rejet **par contrainte**. Le coder (gpt-5.5) n'a pas convergé en 3 essais → `task_failed` → **run blocked**, avant même d'exercer le gate e2e (objet du run).

## Fix (prompt #499, validé empiriquement)

- **EXCEPTION STRUCTURELLE** : un critère **définitionnel** (« le schéma DÉFINIT X avec ses contraintes », « le modèle/endpoint EXISTE ») est satisfait par sa **PRÉSENCE** dans le diff + **une** contrainte/relation **représentative** testée — pas un test de rejet dédié par contrainte sœur. *« défini » ≠ « testé »*.
- **Verrou VALEUR intact** : bloque toujours (`false`) un critère de **VALEUR/CALCUL/COMPORTEMENT** non asserté — c'est le cas **TVA ×100 du run v5** que #499 existe pour attraper.
- **Justification GAP-FIRST** : si `false`, nommer le critère non couvert **en premier** (le feedback #424 plafonné à 700 car tronquait l'ask actionnable, noyé sous l'éloge des tests existants par le juge).

## Validation empirique (juge gpt-5.4, abonnement)

| Cas | Avant | Après |
|---|---|---|
| Schéma task 1 complet (SIREN testé, TVA défini-non-testé) | `tests_assert=False` (bloqué ×3) | **`True`** ✅ |
| Critère VALEUR (TTC=somme) testé seulement par `status==200` | `False` | **`False`** ✅ (verrou v5 intact) |

## Tests
- Nouveau test prompt (`test_test_adequacy_prompt_distinguishes_structural_from_value_criteria`)
- 150 passed (`test_executor_quality_gate`), ruff check + format OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)