### PR TITLE
fix(executor): #437 — exception RÉSULTAT-RUNTIME pour l'adéquation (suivi v8)

### DIFF
--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -1309,9 +1309,19 @@ _ADEQUACY_SYSTEM = (
     "Tu es un relecteur d'ADÉQUATION (rôle REVIEWER). On te donne une issue (titre, "
     "critères d'acceptation) et le diff livré pour la fermer. Tu ne juges PAS le style : "
     "uniquement si le diff RÉALISE concrètement ce que l'issue demande. "
+    "EXCEPTION RÉSULTAT-RUNTIME (#437 suivi v8) : un critère qui exige un RÉSULTAT "
+    "D'EXÉCUTION non vérifiable par lecture d'un diff STATIQUE (ex. « la suite de tests "
+    "retourne 0 échec sur l'ensemble du code », « le pipeline CI passe », « l'application "
+    "démarre et répond ») est DÉJÀ exécuté et vérifié par le gate AVANT toi (tests + smoke + "
+    "e2e RÉELS, déjà verts à ce stade) — NE le juge donc PAS sur une preuve statique "
+    "impossible : réponds implemented=true dès que le diff MET EN PLACE de façon RÉELLE et "
+    "substantielle les ARTEFACTS de la feature (config CI, runner + suite de tests, "
+    "intégration), et NOMME ce critère comme vérifié à l'exécution (non statiquement) dans la "
+    "justification. "
     'Réponds STRICTEMENT en JSON : {"implemented": true|false, "justification": "..."}. '
-    "implemented=false si la feature est absente ou hors-spec (ex. : une seule ligne de "
-    "dépendance pour un service entier, un schéma sans la logique demandée)."
+    "implemented=false si la feature est ABSENTE ou hors-spec — verrou anti-livraison-fantôme "
+    "(ex. : une seule ligne de dépendance pour un service entier, un schéma sans la logique "
+    "demandée, des artefacts vides/triviaux)."
 )
 
 

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -1133,6 +1133,21 @@ def test_test_adequacy_prompt_distinguishes_structural_from_value_criteria():
     assert "commence la justification par le critère non couvert" in prompt  # gap-first (feedback actionnable)
 
 
+def test_adequacy_prompt_tolerates_runtime_outcome_criteria():
+    """#437 suivi v8 : le prompt d'ADÉQUATION (implemented?) instruit le juge de NE PAS
+    rejeter un critère de RÉSULTAT-RUNTIME (« la suite retourne 0 échec », « le pipeline CI
+    passe », « l'app démarre ») déjà exercé/vérifié par le gate — il accepte si le diff met
+    en place les ARTEFACTS réels (CI/runner/tests), tout en gardant le verrou anti-livraison-
+    fantôme (run v8 : tâche 12 CI/CD faussement rejetée, livrable pourtant substantiel + gate vert)."""
+    from collegue.executor.quality_gate import _ADEQUACY_SYSTEM
+
+    prompt = _ADEQUACY_SYSTEM.lower()
+    assert "runtime" in prompt  # l'exception runtime est explicite
+    assert "0 échec" in prompt or "pipeline ci" in prompt  # exemples du critère runtime
+    assert "artefacts" in prompt  # accepte dès que les artefacts réels sont là
+    assert "fantôme" in prompt  # verrou anti-livraison-fantôme conservé
+
+
 # --- signal « aucun test touché » (#437) --------------------------------------------
 
 


### PR DESCRIPTION
## Finding (run v8, tâche 12)

Le run v8 a bloqué sur la **tâche 12** (CI/CD + suite de tests). Le juge d'**adéquation #437** rejetait un livrable **pourtant substantiel** (workflow GitHub Actions + suite de tests frontend **Vitest** + intégration, ~3900 insertions) :

> *"Le diff met bien en place un workflow CI et ajoute des tests frontend (Vitest), mais le critère est plus fort : il faut que le pipeline retourne 0 échec sur l'ensemble du code"*

Le critère **« le pipeline de tests retourne 0 échec sur tout le code »** est un **résultat d'exécution** non prouvable en lisant un diff statique — **alors que le gate a déjà exécuté toute la suite en vert** (tests + smoke + e2e réels) **avant** d'appeler le juge. Faux-rejet : le critère est **mécaniquement satisfait**.

## Fix (parité avec l'exception RUNTIME de #499, déjà validée)

`_ADEQUACY_SYSTEM` (#437) ne bloque plus un critère de **résultat-runtime** (« suite 0 échec », « pipeline CI passe », « l'app démarre ») dès lors que le diff met en place les **artefacts réels et substantiels** de la feature (CI, runner, suite de tests).

**Verrou anti-livraison-fantôme intact** : feature absente / hors-spec (1 ligne de dépendance pour un service entier, schéma sans logique, artefacts triviaux) → toujours `implemented=false`.

## Validation empirique (juge gpt-5.4, abonnement)

| Cas | Résultat |
|---|---|
| Diff task 12 substantiel (CI + Vitest) | `implemented=True` ✅ (+ #499 `tests_assert=True`) |
| Fantôme `+pytest` (1 ligne) pour le même critère | `implemented=False` ✅ (verrou intact) |

## Tests
- `test_adequacy_prompt_tolerates_runtime_outcome_criteria` ; 155 passed ; ruff check + format OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)