### PR TITLE
fix(executor): surfacer les findings d'une revue bloquante dans le feedback (suivi v8)

### DIFF
--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -383,6 +383,23 @@ def failure_feedback(outcome: "ExecutionOutcome") -> str:
             "vendorées) et le gate les REFUSE : " + " ; ".join(forbidden[:10]) + ". Retire-les du "
             "commit (git rm --cached) et ajoute leurs motifs au .gitignore ; conserve le reste de ton travail."
         )[:700]
+    if report is not None and getattr(report, "review_blocking", False):
+        # #503 suivi v8 : le gate est rouge PARCE QUE la revue experte a HARD-BLOQUÉ
+        # (findings CRITIQUES de sécurité — ex. IDOR, jetons falsifiables). Sans cette
+        # branche, failure_feedback retombait sur la sortie des tests — souvent VERTE —
+        # et le coder ne savait JAMAIS pourquoi le gate échouait (run v8, tâche 1 : 1
+        # tentative perdue, le verdict critical-security du reviewer étant invisible).
+        # On NOMME les failles pour que la tentative suivante les corrige (cf. #508/#482).
+        findings = tuple(getattr(report, "review_findings", ()) or ())
+        blockers = [
+            f for f in findings if getattr(f, "severity", "") == "critical" and getattr(f, "category", "") == "security"
+        ] or list(findings)[:6]
+        named = " ; ".join(f"[{f.severity}/{f.category}] {f.title}" for f in blockers[:6])
+        return (
+            "REVUE EXPERTE BLOQUANTE — la revue a trouvé des failles que le gate REFUSE "
+            "(les tests sont VERTS mais ne les couvrent pas) : " + named + ". Corrige ces "
+            "failles dans le code livré (n'ignore pas la sécurité) ; conserve le reste de ton travail."
+        )[:700]
     if outcome.quality_report is not None and outcome.quality_report.test_output:
         output = outcome.quality_report.test_output
         # « FAILED  » / « ERROR  » avec espace : les formes du short summary

--- a/tests/test_executor_pipeline.py
+++ b/tests/test_executor_pipeline.py
@@ -363,6 +363,50 @@ def test_failure_feedback_surfaces_forbidden_files_when_blocking():
     assert "incompatible" not in fb  # le bruit pip ne doit PAS être le diagnostic
 
 
+def test_failure_feedback_surfaces_blocking_review_findings():
+    """#503 suivi v8 : quand la revue experte HARD-BLOQUE (findings critical+security),
+    le feedback DOIT nommer les failles — sinon le coder reçoit la sortie de tests VERTE
+    et ne peut pas converger (run v8, tâche 1 : 1 tentative perdue sur un verdict
+    critical-security invisible). Le verdict bloquant prime sur la sortie de tests verte."""
+    from collegue.executor import AgentResult, QualityReport, ReviewFindingLite, Workspace
+    from collegue.executor.pipeline import ExecutionOutcome, failure_feedback
+    from collegue.executor.runner import ExecutionResult
+
+    execution = ExecutionResult(
+        agent_result=AgentResult(success=True, logs="j"), changed=True, diff="", files_changed=(), success=True
+    )
+    report = QualityReport(
+        tests_passed=True,  # tests VERTS
+        test_exit_code=0,
+        test_output="6 passed in 0.4s",
+        review_summary="",
+        review_findings=(
+            ReviewFindingLite(
+                category="security",
+                severity="critical",
+                title="Absence d'isolation par propriétaire (IDOR) sur /clients",
+            ),
+            ReviewFindingLite(category="dry", severity="warning", title="Code dupliqué"),
+        ),
+        review_blocking=True,  # rouge à cause de la revue bloquante
+        passed=False,
+    )
+    fb = failure_feedback(
+        ExecutionOutcome(
+            success=False,
+            stage="gate",
+            workspace=Workspace(path="/w", branch="b", base_commit="c"),
+            execution=execution,
+            quality_report=report,
+            reason="gate_failed",
+        )
+    )
+    assert "REVUE EXPERTE BLOQUANTE" in fb
+    assert "IDOR" in fb  # la faille critique de sécurité est nommée
+    assert "Code dupliqué" not in fb  # seuls les findings critical+security sont surfacés
+    assert "6 passed" not in fb  # la sortie de tests verte ne doit PAS être le diagnostic
+
+
 def test_failure_feedback_ignores_forbidden_files_when_signal_only():
     """#508 (suite v6) : en mode SIGNAL (non bloquant), forbidden_files ne doit PAS
     masquer la vraie cause d'échec — le feedback reste le diagnostic des tests."""


### PR DESCRIPTION
## Finding v8 #2 — blind-spot reviewer

Quand la revue experte **hard-bloque** le gate (findings `critical`+`security` — IDOR, jetons falsifiables), `failure_feedback` n'avait **pas de branche dédiée** → il retombait sur la **sortie de tests VERTE** → le coder ne savait **jamais** pourquoi le gate échouait.

Constaté au run v8 (tâche 1) : 1 tentative perdue sur un verdict critical-security **invisible** et non-déterministe (gemma-4). Même classe de bug que #508 (`server.log` jamais signalé) et #482.

## Fix

Nouvelle branche dans `failure_feedback` (avant le repli `test_output`) : quand `report.review_blocking`, **nommer les failles** `critical`+`security` (à défaut, les premiers findings) pour que la tentative suivante les corrige. Le verdict bloquant prime sur la sortie de tests verte.

## Tests
- `test_failure_feedback_surfaces_blocking_review_findings` : faille critique nommée, sortie verte écartée, findings non-critiques filtrés.
- Suite pipeline verte ; ruff check + format OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)