### PR TITLE
fix(executor): borner la lecture de requirements.txt dans #482 (revue v8)

### DIFF
--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -1117,10 +1117,15 @@ def requirement_keys_present(workspace: str) -> frozenset:
     for root in roots:
         try:
             with open(os.path.join(root, "requirements.txt"), encoding="utf-8") as fh:
-                for line in fh:
-                    key = _requirement_key(line)
-                    if key is not None:
-                        keys.add(key)
+                # Lecture BORNÉE (#482 suivi v8, revue) : requirements.txt est écrit par
+                # l'agent (non fiable, comme dans :func:`_detect_asgi_app`) — un fichier
+                # adverse de plusieurs Mo ne doit pas charger le gate. 256 Ko couvre très
+                # largement tout requirements.txt légitime.
+                blob = fh.read(262144)
+            for line in blob.splitlines():
+                key = _requirement_key(line)
+                if key is not None:
+                    keys.add(key)
         except (OSError, UnicodeDecodeError):
             continue
     return frozenset(keys)

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -1834,6 +1834,19 @@ def test_requirement_keys_present_reads_workspace(tmp_path):
     assert requirement_keys_present(str(tmp_path / "inexistant")) == frozenset()
 
 
+def test_requirement_keys_present_reads_are_bounded(tmp_path):
+    """#482 suivi v8 (revue) : requirements.txt est écrit par l'agent (non fiable) —
+    la lecture est BORNÉE (256 Ko) pour qu'un fichier adverse de plusieurs Mo ne
+    charge pas le gate. Un paquet placé AU-DELÀ de la borne n'est pas lu."""
+    from collegue.executor import requirement_keys_present
+
+    padding = "# pad\n" * 50000  # ~300 Ko, > borne de 256 Ko
+    (tmp_path / "requirements.txt").write_text("fastapi==0.137.1\n" + padding + "tarpit==9.9.9\n", encoding="utf-8")
+    keys = requirement_keys_present(str(tmp_path))
+    assert "fastapi" in keys  # début du fichier, lu
+    assert "tarpit" not in keys  # au-delà de la borne, non lu
+
+
 async def test_requirements_removal_not_justified_by_machine_context():
     """Revue #482 (boomerang) : le feedback nominatif de la tentative 1 revient
     dans issue.context à la tentative 2 — il ne doit JAMAIS « justifier » la


### PR DESCRIPTION
## Finding (revue pre-main → main)

`requirement_keys_present` (#482 suivi v8) lisait le `requirements.txt` — fichier **écrit par l'agent, non fiable** — ligne par ligne **sans borne**, contrairement à `_detect_asgi_app` qui borne explicitement (`read(65536)`). Un `requirements.txt` adverse de plusieurs Mo chargeait inutilement le gate. Faible exploitabilité (l'agent se sabote lui-même), mais incohérent avec la prudence du reste du module.

## Fix

Lecture **bornée à 256 Ko** (couvre très largement tout `requirements.txt` légitime — les vrais font quelques Ko).

## Tests
- `test_requirement_keys_present_reads_are_bounded` : un paquet placé au-delà de la borne n'est pas lu.
- Suite #482 verte ; ruff check + format OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)