### PR TITLE
fix(improve): #541 — objectif d'amélioration déterministe projet-scopé (Étape 0)

### DIFF
--- a/collegue/improve/gate.py
+++ b/collegue/improve/gate.py
@@ -51,7 +51,10 @@ def evaluate(
     3. **Mesurabilité stable** : ``before.coverage_measured == after.coverage_measured``
        — un changement qui casse/active la mesure de couverture rend le delta de
        couverture non fiable (cf. G1) ⇒ rejet.
-    4. **Pas de régression sécu** : ``after.security_findings <= before.security_findings``.
+    4. **Pas de régression sécu** : ``after.security_weighted <= before.security_weighted``
+       (tolérance 0 — toute aggravation sécu pondérée est un rejet dur). Un échec de
+       scan sécu produit un ``security_weighted`` non fini ⇒ composite non fini ⇒
+       rejet à la règle 2 (fail-closed).
     5. **Gain réel** : ``after.composite >= before.composite + min_gain``.
 
     ``min_gain`` négatif inverserait la garde « pas de régression » → borné à 0.
@@ -68,8 +71,8 @@ def evaluate(
         return reject("score composite non fini (NaN/inf) — mesure non fiable")
     if before.coverage_measured != after.coverage_measured:
         return reject("mesurabilité de la couverture instable (avant≠après) — delta non fiable")
-    if after.security_findings > before.security_findings:
-        return reject(f"régression sécu : {after.security_findings} > {before.security_findings} findings")
+    if after.security_weighted > before.security_weighted:
+        return reject(f"régression sécu : {after.security_weighted:.1f} > {before.security_weighted:.1f} (pondéré)")
     if delta < min_gain:
         return reject(f"gain insuffisant : Δ={delta:.4f} < min_gain={min_gain:.4f}")
 

--- a/collegue/improve/loop.py
+++ b/collegue/improve/loop.py
@@ -19,6 +19,7 @@ Module **isolé** : non câblé au runtime.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
@@ -70,7 +71,7 @@ def _improvement_quality_report(dimension, before, after, delta):
         f"Amélioration « {dimension} » : score composite {before.composite:.3f} → "
         f"{after.composite:.3f} (Δ{delta:+.3f}). "
         f"Couverture {before.coverage_pct:.0f}% → {after.coverage_pct:.0f}% ; "
-        f"findings sécu {before.security_findings} → {after.security_findings}."
+        f"sécu pondérée {before.security_weighted:.1f} → {after.security_weighted:.1f}."
     )
     return QualityReport(
         tests_passed=after.tests_passed,
@@ -139,7 +140,21 @@ async def run_improvement(
         task = IssueSpec(number=round_num, title=f"Amélioration continue (round {round_num})")
         workspace = prepare_workspace(repo_source, task)
 
-        before = await measure_fn(workspace.path, ctx, sandbox=sandbox, reviewer=reviewer, diff="", weights=weights)
+        # Levier 1 (#541) : la mesure baseline porte sur le WORKSPACE sur disque, pas
+        # sur un diff (il n'y en a pas encore) — objectif symétrique avant/après.
+        before = await measure_fn(workspace.path, ctx, sandbox=sandbox, reviewer=reviewer, weights=weights)
+
+        # Baseline non fiable (composite non fini, ex. scan sécu en échec → inf) :
+        # round à vide. On NE lance PAS l'agent (coûteux) pour rien et on n'enregistre
+        # pas de score fantôme (inf) ; fail-closed — rien ne sera promu (#541).
+        if not math.isfinite(before.composite):
+            result.rejected.append(("baseline", "mesure baseline non fiable (composite non fini)"))
+            plateau += 1
+            if plateau >= plateau_rounds:
+                result.stop_reason = STOP_PLATEAU
+                break
+            continue
+
         if result.initial_score is None:
             result.initial_score = before.composite
         result.final_score = before.composite

--- a/collegue/improve/metrics.py
+++ b/collegue/improve/metrics.py
@@ -1,25 +1,39 @@
 """Mesure des métriques de qualité du projet généré (G1, epic #382, Phase 4).
 
-Mesure **déterministe en sandbox** de la qualité du projet, agrégée en un **score
-composite** pluggable : couverture de tests ↑ + score de revue (``code_review``) ↑
-− findings sécu ↓, avec ``tests_passed`` comme garde dure (utilisée par le gate G2).
+Mesure **déterministe et projet-scopée** de la qualité du projet généré, agrégée
+en un **score composite** pluggable. L'objectif est mesuré sur le **workspace sur
+disque** (et non sur le diff d'une itération) pour rester **symétrique** avant/après
+— c'est ce qui permet à la boucle G4 de promouvoir un vrai gain sans faux-rejet
+(cf. #541) :
 
-Le « score du dashboard » du serveur (latence/coût de SES experts) ne convient
-PAS ici : on mesure la qualité du **projet généré**, pas celle de Collègue.
+* **couverture de tests ↑** (parsée de la sortie pytest-cov) ;
+* **sécurité ↓** : compte de secrets **pondéré par sévérité**, issu d'un scan
+  **statique** (``secret_scan``, moteur regex, zéro LLM) sur le répertoire du
+  projet — déterministe par construction ;
+* ``tests_passed`` comme **garde dure** (utilisée par le gate G2).
 
-Module **isolé** : non câblé au runtime (la boucle G4 l'orchestrera).
+La **revue LLM** (``review_score``) est conservée à titre **informatif** (corps de
+PR, relecteur humain) mais **n'entre pas** dans le composite gaté : un signal LLM
+diff-scopé est non déterministe et asymétrique avant/après (la cause racine du
+faux-rejet v9). Le « score du dashboard » du serveur (latence/coût de SES experts)
+ne convient pas non plus : on mesure la qualité du **projet généré**.
+
+Module **isolé** : non câblé au runtime (la boucle G4 l'orchestre).
 """
 
 from __future__ import annotations
 
+import math
 import re
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Tuple
 
-# Catégorie de findings considérée « sécurité » dans la revue experte.
-SECURITY_CATEGORY = "security"
 # Commande de couverture par défaut (parsée depuis la sortie pytest-cov).
 DEFAULT_COVERAGE_COMMAND = "pytest -q --cov --cov-report=term-missing"
+
+# Pondération par sévérité des findings de sécurité (secret_scan). Le critique pèse
+# le plus ; le composite et le gate (tolérance 0) raisonnent sur ce total pondéré.
+SECURITY_SEVERITY_WEIGHTS = {"critical": 10.0, "high": 5.0, "medium": 2.0, "low": 1.0}
 
 # Regex de la ligne récapitulative TOTAL de pytest-cov : « TOTAL  120  6  95% ».
 # On exige un espace juste après TOTAL (rejette un fichier nommé « TOTAL.py »).
@@ -31,8 +45,7 @@ class CompositeWeights:
     """Pondérations du score composite (extensibles)."""
 
     coverage: float = 1.0  # par point de couverture normalisé (0–1)
-    review: float = 1.0  # par point de score de revue (0–1)
-    security: float = 0.1  # pénalité par finding de sécurité
+    security: float = 0.1  # pénalité par unité de score sécu pondéré
 
 
 DEFAULT_WEIGHTS = CompositeWeights()
@@ -43,14 +56,17 @@ class ProjectQualityMetrics:
     """Instantané des métriques de qualité d'un projet (à un instant/itération)."""
 
     coverage_pct: float  # 0–100 (0.0 si non mesurée — voir coverage_measured)
-    review_score: float  # 0–1
-    security_findings: int
+    security_findings: int  # compte BRUT de secrets (proposeur + corps de PR)
+    security_weighted: float  # score sécu pondéré par sévérité (composite + gate)
     tests_passed: bool
     composite: float
     # False si la couverture n'a PAS pu être mesurée (pas de ligne TOTAL). Le gate
     # (G2) doit alors traiter le delta de couverture comme inconnu (fail-closed),
     # plutôt que de confondre « non mesuré » avec « 0 % réel ».
     coverage_measured: bool = True
+    # INFORMATIF (hors-gate) : score de revue LLM pour le corps de PR. N'entre PAS
+    # dans ``composite`` (un signal LLM diff-scopé est non déterministe — #541).
+    review_score: float = 0.0
 
 
 def parse_coverage(output: str) -> Optional[float]:
@@ -67,24 +83,53 @@ def parse_coverage(output: str) -> Optional[float]:
 
 def composite_score(
     coverage_pct: float,
-    review_score: float,
-    security_findings: int,
+    security_weighted: float,
     *,
     weights: CompositeWeights = DEFAULT_WEIGHTS,
 ) -> float:
-    """Score composite pondéré (monotone : ↑couverture/revue → ↑ ; ↑sécu → ↓).
+    """Score composite pondéré (monotone : ↑couverture → ↑ ; ↑sécu pondérée → ↓).
 
-    La couverture (0–100) est normalisée en 0–1 ; le score de revue est déjà 0–1 ;
-    chaque finding de sécurité retire ``weights.security``.
+    La couverture (0–100) est normalisée en 0–1 ; le score sécu pondéré est retiré
+    proportionnellement à ``weights.security``. La revue LLM n'y figure pas
+    (informative, hors-gate).
     """
-    return (
-        weights.coverage * (coverage_pct / 100.0) + weights.review * review_score - weights.security * security_findings
+    return weights.coverage * (coverage_pct / 100.0) - weights.security * security_weighted
+
+
+def _default_security_scan(workspace: str) -> Tuple[int, float]:
+    """Scan statique de secrets sur le RÉPERTOIRE du projet (déterministe, sans LLM).
+
+    Mesure interne au moteur (pas une requête MCP) : on désarme rate-limit/quotas
+    (état global non déterministe) ; le scan reste 100 % statique (moteur regex).
+    Retourne ``(compte_total, score_pondéré_par_sévérité)``.
+    """
+    from collegue.tools.secret_scan.tool import SecretScanTool
+
+    tool = SecretScanTool()
+    tool.rate_limit_enabled = False
+    tool.quota_enabled = False
+    resp = tool.execute({"target": workspace, "scan_type": "directory"})
+    weighted = (
+        SECURITY_SEVERITY_WEIGHTS["critical"] * resp.critical
+        + SECURITY_SEVERITY_WEIGHTS["high"] * resp.high
+        + SECURITY_SEVERITY_WEIGHTS["medium"] * resp.medium
+        + SECURITY_SEVERITY_WEIGHTS["low"] * resp.low
     )
+    return int(resp.total_findings), float(weighted)
 
 
-def _count_security_findings(outcome) -> int:
-    """Compte les findings de catégorie sécurité d'un :class:`ReviewOutcome` (E3)."""
-    return sum(1 for finding in getattr(outcome, "findings", ()) if finding.category == SECURITY_CATEGORY)
+def _scan_security(workspace: str, *, scan_fn=None) -> Tuple[int, float]:
+    """Mesure sécu déterministe (injectable). Échec ⇒ ``(-1, inf)`` (fail-closed).
+
+    Un score pondéré ``inf`` rend le composite non fini → le gate (G2) rejette le
+    round : on ne promeut jamais un changement dont on n'a pas pu mesurer la sécu.
+    """
+    fn = scan_fn or _default_security_scan
+    try:
+        total, weighted = fn(workspace)
+        return int(total), float(weighted)
+    except Exception:  # noqa: BLE001 — toute panne de scan ⇒ fail-closed
+        return -1, math.inf
 
 
 async def measure(
@@ -92,17 +137,20 @@ async def measure(
     ctx,
     *,
     sandbox,
-    reviewer,
+    reviewer=None,
     diff: str = "",
     issue=None,
     coverage_command: str = DEFAULT_COVERAGE_COMMAND,
     weights: CompositeWeights = DEFAULT_WEIGHTS,
+    security_scan_fn=None,
 ) -> ProjectQualityMetrics:
-    """Mesure couverture (sandbox) + revue + findings sécu → métriques composites.
+    """Mesure couverture (sandbox) + sécu (scan statique) → métriques composites.
 
-    ``sandbox``/``reviewer`` sont injectables (mockés en CI). La couverture vient
-    du parsing de la sortie pytest-cov ; ``tests_passed`` = exit 0. Le score de
-    revue et le compte sécu viennent de l'``ExpertReviewer`` (E3) sur le diff.
+    ``sandbox`` est injectable (mocké en CI) ; la couverture vient du parsing de la
+    sortie pytest-cov et ``tests_passed`` = exit 0. La sécu vient d'un scan statique
+    déterministe du **workspace** (``security_scan_fn`` injectable). La revue LLM
+    (``reviewer``/``diff``) est **optionnelle et informative** (corps de PR) : elle
+    n'entre pas dans le composite.
     """
     test_res = sandbox.run_tests(workspace, coverage_command)
     tests_passed = bool(test_res.ok)
@@ -110,25 +158,35 @@ async def measure(
     coverage_measured = raw_coverage is not None
     coverage_pct = raw_coverage if coverage_measured else 0.0  # composite conservateur
 
-    outcome = await reviewer.review(diff, ctx, issue=issue)
-    review_score = float(getattr(outcome, "quality_score", 0.0))
-    security_findings = _count_security_findings(outcome)
+    security_findings, security_weighted = _scan_security(workspace, scan_fn=security_scan_fn)
+
+    # Revue LLM : INFORMATIVE uniquement (hors composite). Calculée seulement s'il y
+    # a un reviewer ET un diff à examiner ; toute panne reste sans effet sur le gate.
+    review_score = 0.0
+    if reviewer is not None and diff:
+        try:
+            outcome = await reviewer.review(diff, ctx, issue=issue)
+            review_score = float(getattr(outcome, "quality_score", 0.0))
+        except Exception:  # noqa: BLE001 — la revue est informative, jamais bloquante
+            review_score = 0.0
 
     return ProjectQualityMetrics(
         coverage_pct=coverage_pct,
-        review_score=review_score,
         security_findings=security_findings,
+        security_weighted=security_weighted,
         tests_passed=tests_passed,
-        composite=composite_score(coverage_pct, review_score, security_findings, weights=weights),
+        composite=composite_score(coverage_pct, security_weighted, weights=weights),
         coverage_measured=coverage_measured,
+        review_score=review_score,
     )
 
 
 def persist(manager, project_id: int, metrics: ProjectQualityMetrics) -> None:
     """Enregistre les métriques (modèle ``Metric``, C6) pour suivi/itérations."""
     manager.add_metric(project_id, "coverage_pct", metrics.coverage_pct)
-    manager.add_metric(project_id, "review_score", metrics.review_score)
     manager.add_metric(project_id, "security_findings", float(metrics.security_findings))
+    manager.add_metric(project_id, "security_weighted", metrics.security_weighted)
     manager.add_metric(project_id, "tests_passed", 1.0 if metrics.tests_passed else 0.0)
     manager.add_metric(project_id, "coverage_measured", 1.0 if metrics.coverage_measured else 0.0)
+    manager.add_metric(project_id, "review_score", metrics.review_score)
     manager.add_metric(project_id, "composite", metrics.composite)

--- a/tests/test_improve_gate.py
+++ b/tests/test_improve_gate.py
@@ -1,17 +1,17 @@
-"""Tests G2 (#384) : gate par métrique avant PR (gain sans régression, fail-closed)."""
+"""Tests G2 (#384, #541) : gate par métrique avant PR (gain sans régression, fail-closed)."""
 
 import math
 
 from collegue.improve import ProjectQualityMetrics, composite_score, evaluate
 
 
-def _m(*, coverage=80.0, review=0.7, security=0, tests=True, measured=True):
+def _m(*, coverage=80.0, security_weighted=0.0, security=0, tests=True, measured=True):
     return ProjectQualityMetrics(
         coverage_pct=coverage,
-        review_score=review,
         security_findings=security,
+        security_weighted=security_weighted,
         tests_passed=tests,
-        composite=composite_score(coverage, review, security),
+        composite=composite_score(coverage, security_weighted),
         coverage_measured=measured,
     )
 
@@ -27,10 +27,10 @@ def test_accept_on_real_gain_without_regression():
     assert d.delta > 0
 
 
-def test_accept_gain_from_review_when_coverage_unmeasurable_both_sides():
-    # Projet sans couverture mesurable (both False) : le gain vient de la revue.
-    before = _m(coverage=0.0, review=0.5, measured=False)
-    after = _m(coverage=0.0, review=0.8, measured=False)
+def test_accept_gain_from_security_when_coverage_unmeasurable_both_sides():
+    # Projet sans couverture mesurable (both False) : le gain vient de la baisse sécu.
+    before = _m(coverage=0.0, security_weighted=5.0, measured=False)
+    after = _m(coverage=0.0, security_weighted=2.0, measured=False)
     d = evaluate(before, after)
     assert d.accepted is True
 
@@ -45,7 +45,8 @@ def test_reject_when_tests_red():
 
 
 def test_reject_on_security_regression():
-    d = evaluate(_m(security=1, coverage=70.0), _m(security=2, coverage=90.0))
+    # Même avec un gain de couverture, une sécu pondérée qui empire = rejet dur.
+    d = evaluate(_m(security_weighted=1.0, coverage=70.0), _m(security_weighted=2.0, coverage=90.0))
     assert d.accepted is False
     assert "sécu" in d.reason
 
@@ -79,13 +80,14 @@ def test_min_gain_threshold_filters_noise():
 
 
 def test_reject_non_finite_composite():
-    # Score NaN/inf : la garde de gain (NaN < x = False) laisserait passer → fail-closed.
+    # Score NaN/inf (ex. scan sécu en échec → inf) : la garde de gain (NaN < x =
+    # False) laisserait passer → fail-closed.
     before = _m(coverage=70.0)
     for bad in (math.nan, math.inf):
         after = ProjectQualityMetrics(
             coverage_pct=90.0,
-            review_score=0.8,
             security_findings=0,
+            security_weighted=0.0,
             tests_passed=True,
             composite=bad,
             coverage_measured=True,

--- a/tests/test_improve_loop.py
+++ b/tests/test_improve_loop.py
@@ -1,5 +1,6 @@
 """Tests G4 (#386) : boucle d'amélioration continue (mesures scriptées, fixture git)."""
 
+import math
 import subprocess
 from types import SimpleNamespace
 
@@ -15,14 +16,15 @@ CONT = ContinueDecision(action=ACTION_CONTINUE, reason="ok")
 PAUSE = ContinueDecision(action=ACTION_PAUSED_BUDGET, reason="budget")
 
 
-def _metrics(composite, *, tests=True, security=0, measured=True, coverage=80.0, review=0.7):
+def _metrics(composite, *, tests=True, security=0, security_weighted=0.0, measured=True, coverage=80.0, review=0.7):
     return ProjectQualityMetrics(
         coverage_pct=coverage,
-        review_score=review,
         security_findings=security,
+        security_weighted=security_weighted,
         tests_passed=tests,
         composite=composite,
         coverage_measured=measured,
+        review_score=review,
     )
 
 
@@ -196,6 +198,16 @@ async def test_no_diff_round_counts_as_no_gain(git_repo, manager):
     assert result.promoted == []
     assert result.rejected[0][1] == "aucun diff produit"
     assert result.stop_reason == "plateau"
+
+
+async def test_unreliable_baseline_skips_agent_round(git_repo, manager):
+    # Baseline non fiable (composite non fini, ex. scan sécu KO → inf) → round à vide
+    # SANS appel agent ; fail-closed : aucune promotion, pas de score fantôme inf (#541).
+    result = await _run(git_repo, manager, measure_seq=[_metrics(math.inf)], plateau_rounds=1)
+    assert result.promoted == []
+    assert result.stop_reason == "plateau"
+    assert result.rejected[0] == ("baseline", "mesure baseline non fiable (composite non fini)")
+    assert result.initial_score is None  # pas de score fantôme inf enregistré
 
 
 # --- arrêts ---------------------------------------------------------------------

--- a/tests/test_improve_metrics.py
+++ b/tests/test_improve_metrics.py
@@ -1,9 +1,14 @@
-"""Tests G1 (#383) : mesure des métriques de qualité projet (sandbox/reviewer mockés)."""
+"""Tests G1 (#383, #541) : mesure des métriques de qualité projet.
+
+Sécu = scan statique déterministe (injectable) ; couverture = sandbox mocké ;
+revue LLM = informative (hors composite).
+"""
+
+import math
 
 import pytest
 
 from collegue.executor import FakeReviewer
-from collegue.executor.quality_gate import ReviewFindingLite
 from collegue.improve import (
     CompositeWeights,
     ProjectQualityMetrics,
@@ -30,6 +35,15 @@ class _Sandbox:
 
     def run_tests(self, workspace, command="pytest -q"):
         return SandboxResult(exit_code=0 if self._ok else 1, stdout=self._stdout, stderr="")
+
+
+def _scan(total, weighted):
+    """Stub de scan sécu déterministe (compte brut, score pondéré)."""
+
+    def fn(workspace):
+        return total, weighted
+
+    return fn
 
 
 # --- parse_coverage -------------------------------------------------------------
@@ -64,42 +78,62 @@ def test_parse_coverage_ignores_file_named_total():
 
 
 def test_composite_monotonic():
-    base = composite_score(50.0, 0.5, 1)
-    assert composite_score(60.0, 0.5, 1) > base  # ↑ couverture → ↑
-    assert composite_score(50.0, 0.7, 1) > base  # ↑ revue → ↑
-    assert composite_score(50.0, 0.5, 3) < base  # ↑ sécu → ↓
+    base = composite_score(50.0, 1.0)  # couverture 50, sécu pondérée 1.0
+    assert composite_score(60.0, 1.0) > base  # ↑ couverture → ↑
+    assert composite_score(50.0, 0.0) > base  # ↓ sécu → ↑
+    assert composite_score(50.0, 3.0) < base  # ↑ sécu → ↓
+
+
+def test_composite_excludes_review():
+    # La revue n'est PAS un paramètre du composite (informative, hors-gate).
+    assert composite_score(80.0, 0.0) == pytest.approx(0.8)
 
 
 def test_composite_weights_tunable():
-    w = CompositeWeights(coverage=2.0, review=0.0, security=0.0)
-    # review/security ignorés ; couverture 100 % → 2.0
-    assert composite_score(100.0, 0.9, 5, weights=w) == pytest.approx(2.0)
+    w = CompositeWeights(coverage=2.0, security=0.0)
+    # sécu ignorée ; couverture 100 % → 2.0
+    assert composite_score(100.0, 5.0, weights=w) == pytest.approx(2.0)
 
 
 # --- measure --------------------------------------------------------------------
 
 
 async def test_measure_aggregates_all_dimensions():
-    reviewer = FakeReviewer(
-        quality_score=0.8,
-        findings=[
-            ReviewFindingLite("security", "critical", "RCE"),
-            ReviewFindingLite("naming", "warning", "x"),  # non-sécu : ignoré
-        ],
-    )
-    m = await measure("/ws", ctx=None, sandbox=_Sandbox(), reviewer=reviewer, diff="d")
+    reviewer = FakeReviewer(quality_score=0.8, findings=[])  # informatif
+    m = await measure("/ws", ctx=None, sandbox=_Sandbox(), reviewer=reviewer, diff="d", security_scan_fn=_scan(2, 5.0))
     assert isinstance(m, ProjectQualityMetrics)
     assert m.coverage_pct == 90.0
-    assert m.review_score == 0.8
-    assert m.security_findings == 1  # seul le finding sécu compte
+    assert m.review_score == 0.8  # informatif (reviewer + diff fournis)
+    assert m.security_findings == 2
+    assert m.security_weighted == 5.0
     assert m.tests_passed is True
     assert m.coverage_measured is True
-    assert m.composite == pytest.approx(1.0 * 0.9 + 1.0 * 0.8 - 0.1 * 1)
+    # composite = w_cov*0.9 − w_sec*5.0 (la revue n'y entre PAS)
+    assert m.composite == pytest.approx(1.0 * 0.9 - 0.1 * 5.0)
+
+
+async def test_measure_review_excluded_from_composite():
+    # Deux revues opposées, même couverture/sécu → même composite (revue hors-gate).
+    sb, scan = _Sandbox(), _scan(0, 0.0)
+    m_hi = await measure(
+        "/ws", ctx=None, sandbox=sb, reviewer=FakeReviewer(quality_score=0.9), diff="d", security_scan_fn=scan
+    )
+    m_lo = await measure(
+        "/ws", ctx=None, sandbox=sb, reviewer=FakeReviewer(quality_score=0.1), diff="d", security_scan_fn=scan
+    )
+    assert m_hi.review_score == 0.9 and m_lo.review_score == 0.1
+    assert m_hi.composite == m_lo.composite
+
+
+async def test_measure_without_reviewer_is_deterministic():
+    # Pas de reviewer → review_score neutre (0.0), composite purement déterministe.
+    m = await measure("/ws", ctx=None, sandbox=_Sandbox(), security_scan_fn=_scan(0, 0.0))
+    assert m.review_score == 0.0
+    assert m.composite == pytest.approx(0.9)
 
 
 async def test_measure_tests_red_and_no_coverage():
-    reviewer = FakeReviewer(quality_score=0.5, findings=[])
-    m = await measure("/ws", ctx=None, sandbox=_Sandbox(stdout="boom", ok=False), reviewer=reviewer)
+    m = await measure("/ws", ctx=None, sandbox=_Sandbox(stdout="boom", ok=False), security_scan_fn=_scan(0, 0.0))
     assert m.tests_passed is False
     assert m.coverage_pct == 0.0  # pas de ligne TOTAL → 0
     assert m.coverage_measured is False  # « non mesuré » distingué d'un vrai 0 %
@@ -108,10 +142,36 @@ async def test_measure_tests_red_and_no_coverage():
 
 async def test_measure_genuine_zero_coverage_is_measured():
     # 0 % RÉEL (ligne TOTAL présente) doit être marqué mesuré (distinct de None).
-    reviewer = FakeReviewer(quality_score=0.5, findings=[])
-    m = await measure("/ws", ctx=None, sandbox=_Sandbox(stdout="TOTAL  5  5  0%\n"), reviewer=reviewer)
+    m = await measure("/ws", ctx=None, sandbox=_Sandbox(stdout="TOTAL  5  5  0%\n"), security_scan_fn=_scan(0, 0.0))
     assert m.coverage_pct == 0.0
     assert m.coverage_measured is True
+
+
+async def test_measure_security_scan_failure_is_fail_closed():
+    # Toute panne du scan sécu ⇒ (-1, inf) ⇒ composite non fini ⇒ le gate rejettera.
+    def boom(workspace):
+        raise RuntimeError("scan KO")
+
+    m = await measure("/ws", ctx=None, sandbox=_Sandbox(), security_scan_fn=boom)
+    assert m.security_findings == -1
+    assert math.isinf(m.security_weighted)
+    assert not math.isfinite(m.composite)
+
+
+def test_default_security_scan_detects_planted_secret(tmp_path):
+    # Valide le CÂBLAGE réel de secret_scan (pas un stub) : répertoire propre → 0 ;
+    # secret planté (clé privée RSA, critique) → détecté et pondéré (> 0).
+    from collegue.improve.metrics import _default_security_scan
+
+    (tmp_path / "clean.py").write_text("x = 1\n")
+    total0, weighted0 = _default_security_scan(str(tmp_path))
+    assert total0 == 0 and weighted0 == 0.0
+
+    (tmp_path / "leak.py").write_text(
+        'KEY = """-----BEGIN RSA PRIVATE KEY-----\nMIIBmQ\n-----END RSA PRIVATE KEY-----"""\n'
+    )
+    total1, weighted1 = _default_security_scan(str(tmp_path))
+    assert total1 >= 1 and weighted1 > 0.0
 
 
 # --- persist --------------------------------------------------------------------
@@ -121,17 +181,24 @@ def test_persist_writes_metrics(tmp_path):
     manager = ProjectStateManager.from_url(f"sqlite:///{tmp_path / 'state.db'}", create=True)
     pid = manager.create_project(name="demo")
     m = ProjectQualityMetrics(
-        coverage_pct=90.0, review_score=0.8, security_findings=1, tests_passed=True, composite=1.6
+        coverage_pct=90.0,
+        security_findings=1,
+        security_weighted=5.0,
+        tests_passed=True,
+        composite=0.4,
+        review_score=0.8,
     )
     persist(manager, pid, m)
     names = {metric.name for metric in manager.get_metrics(pid)}
     assert names == {
         "coverage_pct",
-        "review_score",
         "security_findings",
+        "security_weighted",
         "tests_passed",
         "coverage_measured",
+        "review_score",
         "composite",
     }
-    assert manager.get_metrics(pid, "composite")[0].value == pytest.approx(1.6)
+    assert manager.get_metrics(pid, "composite")[0].value == pytest.approx(0.4)
+    assert manager.get_metrics(pid, "security_weighted")[0].value == pytest.approx(5.0)
     assert manager.get_metrics(pid, "tests_passed")[0].value == 1.0

--- a/tests/test_improve_proposer.py
+++ b/tests/test_improve_proposer.py
@@ -14,11 +14,12 @@ from collegue.improve import (
 def _m(*, coverage=95.0, security=0, measured=True):
     return ProjectQualityMetrics(
         coverage_pct=coverage,
-        review_score=0.7,
         security_findings=security,
+        security_weighted=0.0,
         tests_passed=True,
         composite=0.0,
         coverage_measured=measured,
+        review_score=0.7,
     )
 
 


### PR DESCRIPTION
Closes #541.

## Problème (validation v9)

La 1ʳᵉ exécution réelle de `run_improvement` a montré une boucle **non fonctionnelle** : 100 % de rejets, plateau en 2 rounds, score 1,88 → 1,50. **Cause racine** : la fonction objectif `measure()` était *scopée sur le diff* avec une baseline à diff vide → la revue LLM voyait `0` finding sécu **avant** et `N` findings **après** → toute amélioration réelle paraissait être une régression sécu (`1 > 0`). Le signal sécu **et** le `review_score` étaient diff-scopés et asymétriques par construction.

## Correctif (Étape 0 du redesign — socle déterministe projet-scopé)

L'objectif est désormais **déterministe** et mesuré sur le **workspace sur disque** (symétrique avant/après) :

| Fichier | Changement |
|---|---|
| `metrics.py` | Sécu = scan statique **`secret_scan`** (`scan_type="directory"`, moteur regex, **zéro LLM**) sur le répertoire du projet, **pondéré par sévérité** (`security_weighted`). Revue LLM (`review_score`) rendue **INFORMATIVE** (hors composite). `composite = w_cov·(cov/100) − w_sec·security_weighted`. Scan **injectable** (`security_scan_fn`) ; tout échec ⇒ `(-1, inf)` → fail-closed. |
| `gate.py` | Anti-régression sur **`security_weighted`** (tolérance 0 — toute aggravation est un rejet dur). Reste du fail-closed inchangé (tests rouges, composite non fini, mesurabilité couverture, gain ≥ min_gain). |
| `loop.py` | **Levier 1** : la mesure baseline ne dépend plus du diff. Garde **« baseline non fiable »** : un composite non fini (scan KO) ⇒ round à vide, pas d'appel agent (coûteux) ni score fantôme `inf`. |

## Pourquoi ça corrige le bug *par construction*

La sécurité provient du **même scan déterministe** du **même workspace** avant et après ; la revue LLM (non déterministe, diff-scopée) ne pèse plus dans la décision. Il n'y a plus de signal asymétrique → plus de faux-rejet.

## Tests

- `tests/test_improve_metrics.py` / `gate.py` / `loop.py` / `proposer.py` mis à jour.
- Câblage **réel** de `secret_scan` validé (secret planté détecté, répertoire propre → 0).
- Fail-closed couvert (échec scan, baseline non fiable, régression sécu malgré gain couverture).
- **47 tests `improve` verts** ; `ruff check` + `ruff format --check` verts ; suite complète verte.

Revue adversariale indépendante : aucun finding bloquant ; le garde-fou baseline (M1) a été intégré suite à la revue.

## Hors-périmètre (suivi)

Étape 1 (lint ruff + complexité radon + tolérances par signal, paramétrage du module-cible pour projets générés), Étape 2 (compounding via `apply_seed_diff`), Étape 3 (maintainability informatif, `dep_vulns` derrière flag).