### PR TITLE
feat(improve): #543 — signaux qualité déterministes lint + complexité (Étape 1)

### DIFF
--- a/collegue/improve/gate.py
+++ b/collegue/improve/gate.py
@@ -22,6 +22,11 @@ from collegue.improve.metrics import ProjectQualityMetrics
 # Gain composite minimal pour promouvoir (évite de promouvoir du bruit / surplace).
 DEFAULT_MIN_GAIN = 0.01
 
+# Tolérances de régression PAR SIGNAL qualité (#543). 0 = aucune régression tolérée.
+# (La sécu n'a pas de slack : tolérance 0 dure, non configurable.)
+DEFAULT_LINT_SLACK = 0
+DEFAULT_COMPLEXITY_SLACK = 0
+
 
 @dataclass(frozen=True)
 class GateDecision:
@@ -39,6 +44,8 @@ def evaluate(
     after: ProjectQualityMetrics,
     *,
     min_gain: float = DEFAULT_MIN_GAIN,
+    lint_slack: int = DEFAULT_LINT_SLACK,
+    complexity_slack: int = DEFAULT_COMPLEXITY_SLACK,
 ) -> GateDecision:
     """Décide si l'amélioration (``before`` → ``after``) est promue. Fail-closed.
 
@@ -49,17 +56,24 @@ def evaluate(
        (mesure corrompue) passerait sinon la garde de gain (``NaN < x`` est ``False``)
        et ferait échouer le fail-closed ⇒ rejet.
     3. **Mesurabilité stable** : ``before.coverage_measured == after.coverage_measured``
-       — un changement qui casse/active la mesure de couverture rend le delta de
-       couverture non fiable (cf. G1) ⇒ rejet.
-    4. **Pas de régression sécu** : ``after.security_weighted <= before.security_weighted``
-       (tolérance 0 — toute aggravation sécu pondérée est un rejet dur). Un échec de
-       scan sécu produit un ``security_weighted`` non fini ⇒ composite non fini ⇒
-       rejet à la règle 2 (fail-closed).
+       ET ``before.quality_measured == after.quality_measured`` — une bascule de
+       mesurabilité (couverture OU lint/complexité) rend le delta non fiable et, pour
+       la qualité, gonflerait le composite (échec de scan après ⇒ pénalité retirée) ⇒
+       rejet (cf. G1, #543).
+    4. **Anti-régression multi-signal** (par signal, avec tolérance — #543) :
+       - sécu : ``after.security_weighted <= before.security_weighted`` (tolérance 0
+         dure ; un scan sécu en échec ⇒ composite non fini ⇒ rejet à la règle 2) ;
+       - lint : ``after.lint_violations <= before.lint_violations + lint_slack`` ;
+       - complexité : ``after.complexity_bad_blocks <= before.complexity_bad_blocks
+         + complexity_slack``.
     5. **Gain réel** : ``after.composite >= before.composite + min_gain``.
 
-    ``min_gain`` négatif inverserait la garde « pas de régression » → borné à 0.
+    ``min_gain`` négatif inverserait la garde « pas de régression » → borné à 0 ; les
+    slacks négatifs sont bornés à 0 (un slack < 0 rejetterait une amélioration).
     """
     min_gain = max(0.0, min_gain)
+    lint_slack = max(0, lint_slack)
+    complexity_slack = max(0, complexity_slack)
     delta = after.composite - before.composite
 
     def reject(reason: str) -> GateDecision:
@@ -71,8 +85,17 @@ def evaluate(
         return reject("score composite non fini (NaN/inf) — mesure non fiable")
     if before.coverage_measured != after.coverage_measured:
         return reject("mesurabilité de la couverture instable (avant≠après) — delta non fiable")
+    if before.quality_measured != after.quality_measured:
+        return reject("mesurabilité qualité instable (avant≠après) — lint/complexité non fiables")
     if after.security_weighted > before.security_weighted:
         return reject(f"régression sécu : {after.security_weighted:.1f} > {before.security_weighted:.1f} (pondéré)")
+    if after.lint_violations > before.lint_violations + lint_slack:
+        return reject(f"régression lint : {after.lint_violations} > {before.lint_violations} (slack {lint_slack})")
+    if after.complexity_bad_blocks > before.complexity_bad_blocks + complexity_slack:
+        return reject(
+            f"régression complexité : {after.complexity_bad_blocks} > "
+            f"{before.complexity_bad_blocks} (slack {complexity_slack})"
+        )
     if delta < min_gain:
         return reject(f"gain insuffisant : Δ={delta:.4f} < min_gain={min_gain:.4f}")
 

--- a/collegue/improve/loop.py
+++ b/collegue/improve/loop.py
@@ -71,7 +71,9 @@ def _improvement_quality_report(dimension, before, after, delta):
         f"Amélioration « {dimension} » : score composite {before.composite:.3f} → "
         f"{after.composite:.3f} (Δ{delta:+.3f}). "
         f"Couverture {before.coverage_pct:.0f}% → {after.coverage_pct:.0f}% ; "
-        f"sécu pondérée {before.security_weighted:.1f} → {after.security_weighted:.1f}."
+        f"sécu pondérée {before.security_weighted:.1f} → {after.security_weighted:.1f} ; "
+        f"lint {before.lint_violations} → {after.lint_violations} ; "
+        f"complexité {before.complexity_bad_blocks} → {after.complexity_bad_blocks}."
     )
     return QualityReport(
         tests_passed=after.tests_passed,

--- a/collegue/improve/metrics.py
+++ b/collegue/improve/metrics.py
@@ -23,8 +23,13 @@ Module **isolé** : non câblé au runtime (la boucle G4 l'orchestre).
 
 from __future__ import annotations
 
+import json
 import math
+import os
 import re
+import shutil
+import subprocess
+import sys
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
@@ -35,6 +40,11 @@ DEFAULT_COVERAGE_COMMAND = "pytest -q --cov --cov-report=term-missing"
 # le plus ; le composite et le gate (tolérance 0) raisonnent sur ce total pondéré.
 SECURITY_SEVERITY_WEIGHTS = {"critical": 10.0, "high": 5.0, "medium": 2.0, "low": 1.0}
 
+# Règles ruff comptées comme « violations de lint » (erreurs pyflakes/pycodestyle).
+DEFAULT_LINT_SELECT = ("E", "F", "W")
+# Seuil de complexité cyclomatique (mccabe / ruff C901) : au-delà = « bloc complexe ».
+DEFAULT_COMPLEXITY_MAX = 10
+
 # Regex de la ligne récapitulative TOTAL de pytest-cov : « TOTAL  120  6  95% ».
 # On exige un espace juste après TOTAL (rejette un fichier nommé « TOTAL.py »).
 _TOTAL_RE = re.compile(r"^\s*TOTAL\s+.*?(\d+(?:\.\d+)?)%", re.MULTILINE)
@@ -42,10 +52,16 @@ _TOTAL_RE = re.compile(r"^\s*TOTAL\s+.*?(\d+(?:\.\d+)?)%", re.MULTILINE)
 
 @dataclass(frozen=True)
 class CompositeWeights:
-    """Pondérations du score composite (extensibles)."""
+    """Pondérations du score composite (extensibles).
+
+    La couverture domine ; lint/complexité sont des pénalités faibles (un gain de
+    couverture ne doit pas être annulé par une violation de lint marginale).
+    """
 
     coverage: float = 1.0  # par point de couverture normalisé (0–1)
     security: float = 0.1  # pénalité par unité de score sécu pondéré
+    lint: float = 0.02  # pénalité par violation de lint
+    complexity: float = 0.05  # pénalité par bloc trop complexe
 
 
 DEFAULT_WEIGHTS = CompositeWeights()
@@ -67,6 +83,13 @@ class ProjectQualityMetrics:
     # INFORMATIF (hors-gate) : score de revue LLM pour le corps de PR. N'entre PAS
     # dans ``composite`` (un signal LLM diff-scopé est non déterministe — #541).
     review_score: float = 0.0
+    # Signaux qualité déterministes (ruff/mccabe, #543). 0 = neutre (projet non-Python
+    # où ruff tourne sans erreur) ; un signal qualité non mesurable ne bloque pas (≠ sécu).
+    lint_violations: int = 0
+    complexity_bad_blocks: int = 0
+    # False si ruff n'a pas pu tourner (absent / panne). Le gate rejette une bascule
+    # avant≠après (sinon un échec de scan après gonflerait le composite — #543).
+    quality_measured: bool = True
 
 
 def parse_coverage(output: str) -> Optional[float]:
@@ -85,15 +108,22 @@ def composite_score(
     coverage_pct: float,
     security_weighted: float,
     *,
+    lint_violations: int = 0,
+    complexity_bad_blocks: int = 0,
     weights: CompositeWeights = DEFAULT_WEIGHTS,
 ) -> float:
-    """Score composite pondéré (monotone : ↑couverture → ↑ ; ↑sécu pondérée → ↓).
+    """Score composite pondéré (déterministe).
 
-    La couverture (0–100) est normalisée en 0–1 ; le score sécu pondéré est retiré
-    proportionnellement à ``weights.security``. La revue LLM n'y figure pas
-    (informative, hors-gate).
+    Monotone : ↑couverture → ↑ ; ↑sécu pondérée / ↑lint / ↑complexité → ↓. La
+    couverture (0–100) est normalisée en 0–1 ; sécu/lint/complexité sont des
+    pénalités. La revue LLM n'y figure pas (informative, hors-gate).
     """
-    return weights.coverage * (coverage_pct / 100.0) - weights.security * security_weighted
+    return (
+        weights.coverage * (coverage_pct / 100.0)
+        - weights.security * security_weighted
+        - weights.lint * lint_violations
+        - weights.complexity * complexity_bad_blocks
+    )
 
 
 def _default_security_scan(workspace: str) -> Tuple[int, float]:
@@ -132,6 +162,70 @@ def _scan_security(workspace: str, *, scan_fn=None) -> Tuple[int, float]:
         return -1, math.inf
 
 
+def _find_ruff() -> Optional[str]:
+    """Localise l'exécutable ruff : PATH, puis à côté de l'interpréteur (venv)."""
+    found = shutil.which("ruff")
+    if found:
+        return found
+    candidate = os.path.join(os.path.dirname(sys.executable), "ruff")
+    return candidate if os.path.exists(candidate) else None
+
+
+def _ruff_count(ruff: str, workspace: str, select_args) -> int:
+    """Compte les diagnostics ruff (JSON) pour une sélection de règles, sur le workspace.
+
+    ``--isolated`` ignore la config ruff du PROJET GÉNÉRÉ → mesure reproductible et
+    indépendante du projet ; ``--no-cache`` évite toute pollution inter-runs ;
+    ``timeout`` borne le temps. Toute panne (timeout, JSON illisible) **se propage**
+    → traitée comme « non mesuré » par :func:`_scan_quality` (et non comme un faux 0).
+    """
+    proc = subprocess.run(
+        [ruff, "check", workspace, "--isolated", *select_args, "--output-format=json", "--no-cache"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    return len(json.loads(proc.stdout or "[]"))
+
+
+def _default_quality_scan(
+    workspace: str,
+    *,
+    lint_select=DEFAULT_LINT_SELECT,
+    complexity_max: int = DEFAULT_COMPLEXITY_MAX,
+) -> Tuple[int, int, bool]:
+    """Lint + complexité déterministes via ruff (mccabe), sur le workspace.
+
+    Retourne ``(lint_violations, complexity_bad_blocks, measured)``. ruff absent ⇒
+    ``(0, 0, False)`` (non mesuré). Un projet non-Python où ruff tourne sans erreur
+    ⇒ ``(0, 0, True)`` (mesuré, neutre). Une panne de scan se propage (→ non mesuré).
+    """
+    ruff = _find_ruff()
+    if not ruff:
+        return 0, 0, False
+    lint = _ruff_count(ruff, workspace, ["--select", ",".join(lint_select)])
+    complexity = _ruff_count(
+        ruff, workspace, ["--select", "C901", "--config", f"lint.mccabe.max-complexity={complexity_max}"]
+    )
+    return lint, complexity, True
+
+
+def _scan_quality(workspace: str, *, scan_fn=None) -> Tuple[int, int, bool]:
+    """Mesure lint/complexité déterministe (injectable). Échec ⇒ ``(0, 0, False)``.
+
+    ``measured`` distingue « ruff a tourné » de « non mesuré » (ruff absent / panne) :
+    le gate (G2) rejette une **bascule de mesurabilité** (avant≠après) — sinon un échec
+    de scan APRÈS (lint→0) gonflerait le composite et promouvrait à tort (#543). Hors
+    bascule, un signal qualité non mesurable reste neutre (≠ sécu, fail-closed dur).
+    """
+    fn = scan_fn or _default_quality_scan
+    try:
+        lint, complexity, measured = fn(workspace)
+        return int(lint), int(complexity), bool(measured)
+    except Exception:  # noqa: BLE001 — panne de scan ⇒ non mesuré (le gate gère la bascule)
+        return 0, 0, False
+
+
 async def measure(
     workspace: str,
     ctx,
@@ -143,14 +237,15 @@ async def measure(
     coverage_command: str = DEFAULT_COVERAGE_COMMAND,
     weights: CompositeWeights = DEFAULT_WEIGHTS,
     security_scan_fn=None,
+    quality_scan_fn=None,
 ) -> ProjectQualityMetrics:
-    """Mesure couverture (sandbox) + sécu (scan statique) → métriques composites.
+    """Mesure couverture + sécu + lint/complexité (déterministes) → composite.
 
     ``sandbox`` est injectable (mocké en CI) ; la couverture vient du parsing de la
-    sortie pytest-cov et ``tests_passed`` = exit 0. La sécu vient d'un scan statique
-    déterministe du **workspace** (``security_scan_fn`` injectable). La revue LLM
-    (``reviewer``/``diff``) est **optionnelle et informative** (corps de PR) : elle
-    n'entre pas dans le composite.
+    sortie pytest-cov et ``tests_passed`` = exit 0. Sécu (``security_scan_fn``) et
+    lint/complexité (``quality_scan_fn``) viennent de scans **statiques déterministes**
+    du **workspace** (injectables en tests). La revue LLM (``reviewer``/``diff``) est
+    **optionnelle et informative** (corps de PR) : elle n'entre pas dans le composite.
     """
     test_res = sandbox.run_tests(workspace, coverage_command)
     tests_passed = bool(test_res.ok)
@@ -159,6 +254,7 @@ async def measure(
     coverage_pct = raw_coverage if coverage_measured else 0.0  # composite conservateur
 
     security_findings, security_weighted = _scan_security(workspace, scan_fn=security_scan_fn)
+    lint_violations, complexity_bad_blocks, quality_measured = _scan_quality(workspace, scan_fn=quality_scan_fn)
 
     # Revue LLM : INFORMATIVE uniquement (hors composite). Calculée seulement s'il y
     # a un reviewer ET un diff à examiner ; toute panne reste sans effet sur le gate.
@@ -175,9 +271,18 @@ async def measure(
         security_findings=security_findings,
         security_weighted=security_weighted,
         tests_passed=tests_passed,
-        composite=composite_score(coverage_pct, security_weighted, weights=weights),
+        composite=composite_score(
+            coverage_pct,
+            security_weighted,
+            lint_violations=lint_violations,
+            complexity_bad_blocks=complexity_bad_blocks,
+            weights=weights,
+        ),
         coverage_measured=coverage_measured,
         review_score=review_score,
+        lint_violations=lint_violations,
+        complexity_bad_blocks=complexity_bad_blocks,
+        quality_measured=quality_measured,
     )
 
 
@@ -189,4 +294,7 @@ def persist(manager, project_id: int, metrics: ProjectQualityMetrics) -> None:
     manager.add_metric(project_id, "tests_passed", 1.0 if metrics.tests_passed else 0.0)
     manager.add_metric(project_id, "coverage_measured", 1.0 if metrics.coverage_measured else 0.0)
     manager.add_metric(project_id, "review_score", metrics.review_score)
+    manager.add_metric(project_id, "lint_violations", float(metrics.lint_violations))
+    manager.add_metric(project_id, "complexity_bad_blocks", float(metrics.complexity_bad_blocks))
+    manager.add_metric(project_id, "quality_measured", 1.0 if metrics.quality_measured else 0.0)
     manager.add_metric(project_id, "composite", metrics.composite)

--- a/collegue/improve/proposer.py
+++ b/collegue/improve/proposer.py
@@ -99,6 +99,12 @@ def next_dimension(metrics: ProjectQualityMetrics, *, history: Sequence[AttemptR
     # (NaN < cible est False) — on ne cible alors pas la couverture (fail-silent évité).
     if metrics.coverage_measured and math.isfinite(metrics.coverage_pct) and metrics.coverage_pct < COVERAGE_TARGET:
         candidates.append(Dimension.COVERAGE)
+    # Dimensions qualité MÉTRIQUE-DRIVEN (#543) : priorité quand leur signal
+    # déterministe est non nul (avant le round-robin de polissage).
+    if metrics.complexity_bad_blocks > 0:
+        candidates.append(Dimension.REFACTORING)
+    if metrics.lint_violations > 0:
+        candidates.append(Dimension.CONSISTENCY)
     candidates.extend(_rotate_quality(history))
 
     for dimension in candidates:
@@ -121,9 +127,10 @@ _TEMPLATES = {
         ("Le nombre de findings de sécurité diminue", "Aucun nouveau finding", "Tous les tests passent"),
     ),
     Dimension.REFACTORING: (
-        "Refactoring pour la qualité",
-        "Améliorer lisibilité et structure sans changer le comportement observable.",
-        ("Le score de revue augmente", "Tous les tests passent", "Aucun changement de comportement"),
+        "Refactoring pour réduire la complexité",
+        "Réduire la complexité cyclomatique : {complexity} bloc(s) dépassent le seuil. "
+        "Simplifier (extraire des fonctions, aplatir les branches) sans changer le comportement observable.",
+        ("Le nombre de blocs trop complexes diminue", "Tous les tests passent", "Aucun changement de comportement"),
     ),
     Dimension.DOCUMENTATION: (
         "Améliorer la documentation",
@@ -131,9 +138,10 @@ _TEMPLATES = {
         ("La documentation des éléments publics s'améliore", "Tous les tests passent"),
     ),
     Dimension.CONSISTENCY: (
-        "Améliorer la cohérence du code",
-        "Uniformiser nommage, conventions et patterns pour réduire la charge cognitive.",
-        ("Le score de revue augmente", "Tous les tests passent"),
+        "Corriger les violations de lint",
+        "Corriger les {lint} violation(s) de lint (ruff) et uniformiser nommage/conventions "
+        "pour réduire la charge cognitive.",
+        ("Le nombre de violations de lint diminue", "Tous les tests passent"),
     ),
 }
 
@@ -151,6 +159,8 @@ def build_improvement_task(dimension: Dimension, metrics: ProjectQualityMetrics,
     body = body_template.format(
         coverage=max(0.0, metrics.coverage_pct) if math.isfinite(metrics.coverage_pct) else 0.0,
         security=max(0, metrics.security_findings),
+        lint=max(0, metrics.lint_violations),
+        complexity=max(0, metrics.complexity_bad_blocks),
     )
     return IssueSpec(
         number=int(number),

--- a/tests/test_improve_gate.py
+++ b/tests/test_improve_gate.py
@@ -5,14 +5,27 @@ import math
 from collegue.improve import ProjectQualityMetrics, composite_score, evaluate
 
 
-def _m(*, coverage=80.0, security_weighted=0.0, security=0, tests=True, measured=True):
+def _m(
+    *,
+    coverage=80.0,
+    security_weighted=0.0,
+    security=0,
+    lint=0,
+    complexity=0,
+    tests=True,
+    measured=True,
+    quality_measured=True,
+):
     return ProjectQualityMetrics(
         coverage_pct=coverage,
         security_findings=security,
         security_weighted=security_weighted,
         tests_passed=tests,
-        composite=composite_score(coverage, security_weighted),
+        composite=composite_score(coverage, security_weighted, lint_violations=lint, complexity_bad_blocks=complexity),
         coverage_measured=measured,
+        lint_violations=lint,
+        complexity_bad_blocks=complexity,
+        quality_measured=quality_measured,
     )
 
 
@@ -49,6 +62,52 @@ def test_reject_on_security_regression():
     d = evaluate(_m(security_weighted=1.0, coverage=70.0), _m(security_weighted=2.0, coverage=90.0))
     assert d.accepted is False
     assert "sécu" in d.reason
+
+
+def test_reject_on_quality_measurability_flip():
+    # Scan qualité mesuré avant mais en échec après (lint→0 artificiel) → faux gain
+    # composite ⇒ rejet (sinon promotion à tort, #543).
+    before = _m(coverage=70.0, lint=5, quality_measured=True)
+    after = _m(coverage=90.0, lint=0, quality_measured=False)
+    d = evaluate(before, after)
+    assert d.accepted is False
+    assert "mesurabilité qualité" in d.reason
+
+
+def test_reject_on_lint_regression():
+    # Même avec un gain de couverture, plus de violations de lint = rejet (slack 0).
+    d = evaluate(_m(coverage=70.0, lint=2), _m(coverage=90.0, lint=5))
+    assert d.accepted is False
+    assert "lint" in d.reason
+
+
+def test_reject_on_complexity_regression():
+    d = evaluate(_m(coverage=70.0, complexity=1), _m(coverage=90.0, complexity=3))
+    assert d.accepted is False
+    assert "complexité" in d.reason
+
+
+def test_lint_slack_allows_tolerated_regression():
+    before = _m(coverage=70.0, lint=2)
+    after = _m(coverage=90.0, lint=3)  # +1 lint, mais gros gain couverture
+    assert evaluate(before, after, lint_slack=0).accepted is False  # 3 > 2
+    assert evaluate(before, after, lint_slack=1).accepted is True  # 3 <= 2+1
+
+
+def test_accept_when_lint_and_complexity_reduced():
+    # Réduire lint + complexité à couverture constante → composite ↑ → accepté.
+    before = _m(coverage=80.0, lint=8, complexity=4)
+    after = _m(coverage=80.0, lint=2, complexity=1)
+    d = evaluate(before, after)
+    assert d.accepted is True
+    assert d.delta > 0
+
+
+def test_negative_lint_slack_is_clamped():
+    # slack négatif rejetterait une amélioration → borné à 0 (pas de régression = OK).
+    before = _m(coverage=80.0, lint=2)
+    after = _m(coverage=90.0, lint=2)  # lint stable, gain couverture
+    assert evaluate(before, after, lint_slack=-5).accepted is True
 
 
 def test_reject_on_insufficient_gain():

--- a/tests/test_improve_metrics.py
+++ b/tests/test_improve_metrics.py
@@ -46,6 +46,15 @@ def _scan(total, weighted):
     return fn
 
 
+def _quality(lint=0, complexity=0, measured=True):
+    """Stub de scan qualité déterministe (lint, complexité, measured)."""
+
+    def fn(workspace):
+        return lint, complexity, measured
+
+    return fn
+
+
 # --- parse_coverage -------------------------------------------------------------
 
 
@@ -78,10 +87,13 @@ def test_parse_coverage_ignores_file_named_total():
 
 
 def test_composite_monotonic():
-    base = composite_score(50.0, 1.0)  # couverture 50, sécu pondérée 1.0
-    assert composite_score(60.0, 1.0) > base  # ↑ couverture → ↑
-    assert composite_score(50.0, 0.0) > base  # ↓ sécu → ↑
-    assert composite_score(50.0, 3.0) < base  # ↑ sécu → ↓
+    base = composite_score(50.0, 1.0, lint_violations=2, complexity_bad_blocks=1)
+    assert composite_score(60.0, 1.0, lint_violations=2, complexity_bad_blocks=1) > base  # ↑ couverture → ↑
+    assert composite_score(50.0, 0.0, lint_violations=2, complexity_bad_blocks=1) > base  # ↓ sécu → ↑
+    assert composite_score(50.0, 1.0, lint_violations=0, complexity_bad_blocks=1) > base  # ↓ lint → ↑
+    assert composite_score(50.0, 1.0, lint_violations=2, complexity_bad_blocks=0) > base  # ↓ complexité → ↑
+    assert composite_score(50.0, 3.0, lint_violations=2, complexity_bad_blocks=1) < base  # ↑ sécu → ↓
+    assert composite_score(50.0, 1.0, lint_violations=9, complexity_bad_blocks=1) < base  # ↑ lint → ↓
 
 
 def test_composite_excludes_review():
@@ -90,9 +102,9 @@ def test_composite_excludes_review():
 
 
 def test_composite_weights_tunable():
-    w = CompositeWeights(coverage=2.0, security=0.0)
-    # sécu ignorée ; couverture 100 % → 2.0
-    assert composite_score(100.0, 5.0, weights=w) == pytest.approx(2.0)
+    w = CompositeWeights(coverage=2.0, security=0.0, lint=0.0, complexity=0.0)
+    # sécu/lint/complexité ignorés ; couverture 100 % → 2.0
+    assert composite_score(100.0, 5.0, lint_violations=9, complexity_bad_blocks=9, weights=w) == pytest.approx(2.0)
 
 
 # --- measure --------------------------------------------------------------------
@@ -100,26 +112,48 @@ def test_composite_weights_tunable():
 
 async def test_measure_aggregates_all_dimensions():
     reviewer = FakeReviewer(quality_score=0.8, findings=[])  # informatif
-    m = await measure("/ws", ctx=None, sandbox=_Sandbox(), reviewer=reviewer, diff="d", security_scan_fn=_scan(2, 5.0))
+    m = await measure(
+        "/ws",
+        ctx=None,
+        sandbox=_Sandbox(),
+        reviewer=reviewer,
+        diff="d",
+        security_scan_fn=_scan(2, 5.0),
+        quality_scan_fn=_quality(3, 1),
+    )
     assert isinstance(m, ProjectQualityMetrics)
     assert m.coverage_pct == 90.0
     assert m.review_score == 0.8  # informatif (reviewer + diff fournis)
     assert m.security_findings == 2
     assert m.security_weighted == 5.0
+    assert m.lint_violations == 3
+    assert m.complexity_bad_blocks == 1
     assert m.tests_passed is True
     assert m.coverage_measured is True
-    # composite = w_cov*0.9 − w_sec*5.0 (la revue n'y entre PAS)
-    assert m.composite == pytest.approx(1.0 * 0.9 - 0.1 * 5.0)
+    # composite = w_cov*0.9 − w_sec*5.0 − w_lint*3 − w_cx*1 (la revue n'y entre PAS)
+    assert m.composite == pytest.approx(1.0 * 0.9 - 0.1 * 5.0 - 0.02 * 3 - 0.05 * 1)
 
 
 async def test_measure_review_excluded_from_composite():
-    # Deux revues opposées, même couverture/sécu → même composite (revue hors-gate).
-    sb, scan = _Sandbox(), _scan(0, 0.0)
+    # Deux revues opposées, même couverture/sécu/qualité → même composite (revue hors-gate).
+    sb, scan, qual = _Sandbox(), _scan(0, 0.0), _quality(0, 0)
     m_hi = await measure(
-        "/ws", ctx=None, sandbox=sb, reviewer=FakeReviewer(quality_score=0.9), diff="d", security_scan_fn=scan
+        "/ws",
+        ctx=None,
+        sandbox=sb,
+        reviewer=FakeReviewer(quality_score=0.9),
+        diff="d",
+        security_scan_fn=scan,
+        quality_scan_fn=qual,
     )
     m_lo = await measure(
-        "/ws", ctx=None, sandbox=sb, reviewer=FakeReviewer(quality_score=0.1), diff="d", security_scan_fn=scan
+        "/ws",
+        ctx=None,
+        sandbox=sb,
+        reviewer=FakeReviewer(quality_score=0.1),
+        diff="d",
+        security_scan_fn=scan,
+        quality_scan_fn=qual,
     )
     assert m_hi.review_score == 0.9 and m_lo.review_score == 0.1
     assert m_hi.composite == m_lo.composite
@@ -127,13 +161,21 @@ async def test_measure_review_excluded_from_composite():
 
 async def test_measure_without_reviewer_is_deterministic():
     # Pas de reviewer → review_score neutre (0.0), composite purement déterministe.
-    m = await measure("/ws", ctx=None, sandbox=_Sandbox(), security_scan_fn=_scan(0, 0.0))
+    m = await measure(
+        "/ws", ctx=None, sandbox=_Sandbox(), security_scan_fn=_scan(0, 0.0), quality_scan_fn=_quality(0, 0)
+    )
     assert m.review_score == 0.0
     assert m.composite == pytest.approx(0.9)
 
 
 async def test_measure_tests_red_and_no_coverage():
-    m = await measure("/ws", ctx=None, sandbox=_Sandbox(stdout="boom", ok=False), security_scan_fn=_scan(0, 0.0))
+    m = await measure(
+        "/ws",
+        ctx=None,
+        sandbox=_Sandbox(stdout="boom", ok=False),
+        security_scan_fn=_scan(0, 0.0),
+        quality_scan_fn=_quality(0, 0),
+    )
     assert m.tests_passed is False
     assert m.coverage_pct == 0.0  # pas de ligne TOTAL → 0
     assert m.coverage_measured is False  # « non mesuré » distingué d'un vrai 0 %
@@ -142,7 +184,13 @@ async def test_measure_tests_red_and_no_coverage():
 
 async def test_measure_genuine_zero_coverage_is_measured():
     # 0 % RÉEL (ligne TOTAL présente) doit être marqué mesuré (distinct de None).
-    m = await measure("/ws", ctx=None, sandbox=_Sandbox(stdout="TOTAL  5  5  0%\n"), security_scan_fn=_scan(0, 0.0))
+    m = await measure(
+        "/ws",
+        ctx=None,
+        sandbox=_Sandbox(stdout="TOTAL  5  5  0%\n"),
+        security_scan_fn=_scan(0, 0.0),
+        quality_scan_fn=_quality(0, 0),
+    )
     assert m.coverage_pct == 0.0
     assert m.coverage_measured is True
 
@@ -152,10 +200,30 @@ async def test_measure_security_scan_failure_is_fail_closed():
     def boom(workspace):
         raise RuntimeError("scan KO")
 
-    m = await measure("/ws", ctx=None, sandbox=_Sandbox(), security_scan_fn=boom)
+    m = await measure("/ws", ctx=None, sandbox=_Sandbox(), security_scan_fn=boom, quality_scan_fn=_quality(0, 0))
     assert m.security_findings == -1
     assert math.isinf(m.security_weighted)
     assert not math.isfinite(m.composite)
+
+
+async def test_measure_quality_scan_failure_is_not_measured():
+    # Panne du scan QUALITÉ ⇒ (0, 0, measured=False) : composite fini (neutre) MAIS
+    # marqué non mesuré → le gate rejettera une bascule avant≠après (≠ sécu fail-closed).
+    def boom(workspace):
+        raise RuntimeError("ruff KO")
+
+    m = await measure("/ws", ctx=None, sandbox=_Sandbox(), security_scan_fn=_scan(0, 0.0), quality_scan_fn=boom)
+    assert m.lint_violations == 0
+    assert m.complexity_bad_blocks == 0
+    assert m.quality_measured is False
+    assert m.composite == pytest.approx(0.9)  # fini, non bloquant seul
+
+
+async def test_measure_quality_measured_flag_true_when_scanned():
+    m = await measure(
+        "/ws", ctx=None, sandbox=_Sandbox(), security_scan_fn=_scan(0, 0.0), quality_scan_fn=_quality(0, 0, True)
+    )
+    assert m.quality_measured is True
 
 
 def test_default_security_scan_detects_planted_secret(tmp_path):
@@ -174,6 +242,31 @@ def test_default_security_scan_detects_planted_secret(tmp_path):
     assert total1 >= 1 and weighted1 > 0.0
 
 
+def test_default_quality_scan_counts_lint_and_complexity(tmp_path):
+    # Valide le CÂBLAGE réel de ruff (pas un stub) : fichier propre → (0, 0) ;
+    # imports inutilisés + fonction très imbriquée → lint > 0 ET complexité > 0.
+    from collegue.improve.metrics import _default_quality_scan, _find_ruff
+
+    if _find_ruff() is None:
+        pytest.skip("ruff indisponible dans cet environnement")
+
+    (tmp_path / "clean.py").write_text("def f():\n    return 1\n")
+    lint0, cx0, measured0 = _default_quality_scan(str(tmp_path), complexity_max=5)
+    assert lint0 == 0 and cx0 == 0 and measured0 is True
+
+    nested = "                                        return a\n"
+    (tmp_path / "bad.py").write_text(
+        "import os, sys\n"
+        "def g(a):\n"
+        "    if a > 0:\n        if a > 1:\n            if a > 2:\n                if a > 3:\n"
+        "                    if a > 4:\n                        if a > 5:\n" + nested + "    return 0\n"
+    )
+    lint1, cx1, measured1 = _default_quality_scan(str(tmp_path), complexity_max=5)
+    assert measured1 is True
+    assert lint1 >= 1  # E401 (imports multiples) / F401 (inutilisés)
+    assert cx1 >= 1  # C901 (complexité > seuil)
+
+
 # --- persist --------------------------------------------------------------------
 
 
@@ -187,6 +280,9 @@ def test_persist_writes_metrics(tmp_path):
         tests_passed=True,
         composite=0.4,
         review_score=0.8,
+        lint_violations=3,
+        complexity_bad_blocks=2,
+        quality_measured=True,
     )
     persist(manager, pid, m)
     names = {metric.name for metric in manager.get_metrics(pid)}
@@ -197,6 +293,9 @@ def test_persist_writes_metrics(tmp_path):
         "tests_passed",
         "coverage_measured",
         "review_score",
+        "lint_violations",
+        "complexity_bad_blocks",
+        "quality_measured",
         "composite",
     }
     assert manager.get_metrics(pid, "composite")[0].value == pytest.approx(0.4)

--- a/tests/test_improve_proposer.py
+++ b/tests/test_improve_proposer.py
@@ -11,7 +11,7 @@ from collegue.improve import (
 )
 
 
-def _m(*, coverage=95.0, security=0, measured=True):
+def _m(*, coverage=95.0, security=0, lint=0, complexity=0, measured=True):
     return ProjectQualityMetrics(
         coverage_pct=coverage,
         security_findings=security,
@@ -20,6 +20,8 @@ def _m(*, coverage=95.0, security=0, measured=True):
         composite=0.0,
         coverage_measured=measured,
         review_score=0.7,
+        lint_violations=lint,
+        complexity_bad_blocks=complexity,
     )
 
 
@@ -41,8 +43,24 @@ def test_coverage_skipped_when_unmeasured():
 
 
 def test_quality_cycle_when_metrics_healthy():
-    # Couverture haute + 0 sécu → polissage qualité (refactoring en tête).
+    # Couverture haute + 0 sécu + 0 lint/complexité → polissage qualité (refactoring en tête).
     assert next_dimension(_m(security=0, coverage=95.0)) is Dimension.REFACTORING
+
+
+def test_refactoring_prioritized_by_complexity_over_rotation():
+    # complexity_bad_blocks > 0 → REFACTORING (métrique-driven) même si la rotation
+    # qualité partirait sur DOCUMENTATION (dernière qualité essayée = REFACTORING).
+    metrics = _m(security=0, coverage=95.0, complexity=3)
+    history = [AttemptRecord(Dimension.REFACTORING, improved=True)]
+    assert next_dimension(metrics, history=history) is Dimension.REFACTORING
+
+
+def test_consistency_prioritized_by_lint_over_rotation():
+    # lint_violations > 0 (complexité 0) → CONSISTENCY (métrique-driven) même si la
+    # rotation partirait sur REFACTORING (dernière qualité essayée = CONSISTENCY).
+    metrics = _m(security=0, coverage=95.0, lint=5)
+    history = [AttemptRecord(Dimension.CONSISTENCY, improved=True)]
+    assert next_dimension(metrics, history=history) is Dimension.CONSISTENCY
 
 
 # --- rotation -------------------------------------------------------------------
@@ -112,6 +130,18 @@ def test_build_task_security_counts_findings():
     task = build_improvement_task(Dimension.SECURITY, _m(security=3), number=1)
     assert "sécurité" in task.title.lower()
     assert "3" in task.body
+
+
+def test_build_task_refactoring_counts_complexity():
+    task = build_improvement_task(Dimension.REFACTORING, _m(complexity=4), number=1)
+    assert "complexité" in task.title.lower()
+    assert "4" in task.body
+
+
+def test_build_task_consistency_counts_lint():
+    task = build_improvement_task(Dimension.CONSISTENCY, _m(lint=7), number=1)
+    assert "lint" in task.title.lower()
+    assert "7" in task.body
 
 
 def test_build_task_each_dimension_has_template():


### PR DESCRIPTION
Closes #543. Suite de #541 (Étape 0, PR #542).

## Quoi

Deux signaux qualité **déterministes** s'ajoutent à l'objectif, tous mesurés sur le **workspace** via **ruff** (aucune nouvelle dépendance — ruff est déjà au stack) :

| Signal | Mesure | Sens |
|---|---|---|
| `lint_violations` | `ruff check --isolated --select E,F,W --output-format=json` (len) | ↓ |
| `complexity_bad_blocks` | `ruff check --isolated --select C901 --config lint.mccabe.max-complexity=N` (len) | ↓ |

`composite = w_cov·(cov/100) − w_sec·security_weighted − w_lint·lint − w_cx·complexity` (couverture dominante ; poids lint/complexité faibles et paramétrables dans `CompositeWeights`).

## Pourquoi `--isolated` (générique par construction)

ruff ignore la config du **projet généré** → mesure **reproductible et indépendante du projet**, et auto-découvre les `.py` du workspace. Un projet non-Python → 0 (signal **neutre**). Cela résout par construction le risque « scope codé en dur » (cf. moteur générique, pas produit) : il n'y a plus de cible figée, c'est le workspace.

## Gate multi-signal (par signal, avec tolérance)

- sécu : tolérance **0 dure** (inchangé) ;
- lint / complexité : `lint_slack` / `complexity_slack` (défaut 0, bornés ≥0) ;
- **mesurabilité qualité** : `quality_measured` — une bascule avant≠après ⇒ rejet. Sans ce garde-fou, un échec de scan *après* (lint→0) gonflerait le composite et promouvrait à tort (asymétrie miroir du bug Étape 0). Dégradation gracieuse sinon : ruff absent / non-Python ⇒ neutre (≠ sécu, fail-closed).

## Proposeur métrique-driven

REFACTORING priorisé si `complexity_bad_blocks > 0`, CONSISTENCY si `lint_violations > 0` (au lieu du seul round-robin) ; gabarits de tâche mis à jour vers les critères déterministes.

## Tests

- metrics/gate/proposer mis à jour ; **câblage réel ruff validé** (imports inutilisés + fonction imbriquée → lint>0, C901>0 ; fichier propre → 0).
- Dégradation gracieuse + fail-closed + bascule de mesurabilité couverts.
- **60 tests `improve` verts** ; `ruff check` + `ruff format --check` verts ; suite complète verte.

Revue adversariale indépendante : 0 finding bloquant ; le garde-fou `quality_measured` (asymétrie de scan) intégré suite à la revue.

## Hors-périmètre (suivi)

Étape 2 (compounding via `apply_seed_diff`), Étape 3 (maintainability informatif, `dep_vulns` derrière flag). Le harness gitignored `improve_run.py` n'a pas besoin d'adaptation (utilise le vrai scan ruff automatiquement).