### PR TITLE
feat(improve): #545 — compounding par réapplication des diffs promus (Étape 2)

### DIFF
--- a/collegue/improve/loop.py
+++ b/collegue/improve/loop.py
@@ -86,6 +86,51 @@ def _improvement_quality_report(dimension, before, after, delta):
     )
 
 
+def _seed_promoted_diffs(workspace, diffs, *, git_bin: str = "git") -> int:
+    """Réapplique ET COMMITE les diffs déjà promus sur le clone neuf (#545, Étape 2).
+
+    Levier 2 du redesign : ``apply_seed_diff`` (git apply -3) réapplique chaque diff
+    promu ; ici on le **commite** pour que ``HEAD`` reflète l'état cumulé. Sans commit,
+    le diff capturé du round courant (``git diff`` vs HEAD, cf. ``capture_diff``)
+    ré-embarquerait les changements déjà promus → double-comptage au round suivant.
+    Après commit, la mesure baseline porte sur le projet **cumulé amélioré** : le score
+    monte round après round et le proposeur (métrique-driven) passe à la dimension
+    suivante car la métrique d'une dimension réglée redevient bonne sur l'état cumulé.
+    ``execution.diff`` ne contient alors que les nouveaux changements du round.
+
+    Best-effort : un diff inapplicable (conflit, base déplacée) est **sauté** —
+    ``apply_seed_diff`` restaure alors un arbre propre — plutôt que d'échouer le run.
+    Renvoie le nombre de diffs effectivement intégrés (commités).
+    """
+    from collegue.executor.command import LocalCommandRunner
+    from collegue.executor.workspace import apply_seed_diff
+
+    runner = LocalCommandRunner()
+    applied = 0
+    for index, diff in enumerate(diffs):
+        if not apply_seed_diff(workspace, diff, git_bin=git_bin):
+            continue
+        if not runner.run_command([git_bin, "add", "-A"], workspace.path).ok:
+            continue
+        commit = runner.run_command(
+            [
+                git_bin,
+                "-c",
+                "user.email=improve@collegue.local",
+                "-c",
+                "user.name=collegue-improve",
+                "commit",
+                "-q",
+                "-m",
+                f"compounding: amélioration promue #{index + 1}",
+            ],
+            workspace.path,
+        )
+        if commit.ok:
+            applied += 1
+    return applied
+
+
 async def run_improvement(
     project_id: int,
     repo_source: str,
@@ -125,6 +170,9 @@ async def run_improvement(
 
     budget = budget or BudgetTimeController()
     history: List[AttemptRecord] = []
+    # Compounding (#545) : diffs déjà promus, réappliqués sur le clone neuf de chaque
+    # round pour une baseline cumulative (le score monte ; le proposeur avance).
+    promoted_diffs: List[str] = []
     result = ImprovementResult(stop_reason=STOP_PLATEAU, rounds=0)
     plateau = 0
     round_num = 0
@@ -141,6 +189,12 @@ async def run_improvement(
         round_num += 1
         task = IssueSpec(number=round_num, title=f"Amélioration continue (round {round_num})")
         workspace = prepare_workspace(repo_source, task)
+
+        # Compounding (#545) : réapplique les diffs promus sur le clone neuf AVANT la
+        # mesure baseline → l'objectif porte sur l'état cumulé (le score monte ; une
+        # dimension réglée n'est plus proposée car sa métrique redevient bonne).
+        if promoted_diffs:
+            _seed_promoted_diffs(workspace, promoted_diffs)
 
         # Levier 1 (#541) : la mesure baseline porte sur le WORKSPACE sur disque, pas
         # sur un diff (il n'y en a pas encore) — objectif symétrique avant/après.
@@ -203,6 +257,9 @@ async def run_improvement(
             )
             if not dry_run:
                 persist(manager, project_id, after)
+            # Compounding (#545) : mémorise le diff promu pour le réappliquer aux
+            # rounds suivants (baseline cumulative) — y compris en dry_run.
+            promoted_diffs.append(execution.diff)
             result.promoted.append(PromotedImprovement(dimension.value, gate.delta, pr.number))
             plateau = 0
         else:

--- a/tests/test_improve_loop.py
+++ b/tests/test_improve_loop.py
@@ -1,6 +1,7 @@
 """Tests G4 (#386) : boucle d'amélioration continue (mesures scriptées, fixture git)."""
 
 import math
+import os
 import subprocess
 from types import SimpleNamespace
 
@@ -198,6 +199,106 @@ async def test_no_diff_round_counts_as_no_gain(git_repo, manager):
     assert result.promoted == []
     assert result.rejected[0][1] == "aucun diff produit"
     assert result.stop_reason == "plateau"
+
+
+# --- compounding (#545) ---------------------------------------------------------
+
+
+def test_seed_promoted_diffs_reapplies_and_commits(git_repo):
+    # Un diff promu réappliqué sur un clone neuf → fichier présent ET committé.
+    from collegue.executor.agent import IssueSpec
+    from collegue.executor.runner import capture_diff
+    from collegue.executor.workspace import prepare_workspace
+    from collegue.improve.loop import _seed_promoted_diffs
+
+    ws = prepare_workspace(git_repo, IssueSpec(number=1, title="t"))
+    with open(os.path.join(ws.path, "feature.py"), "w") as fh:
+        fh.write("VALUE = 1\n")
+    diff, _ = capture_diff(ws)
+    # remet le clone à l'état vierge (simule le clone neuf d'un round)
+    _git(ws.path, "reset", "--hard")
+    _git(ws.path, "clean", "-fdq")
+    assert not os.path.exists(os.path.join(ws.path, "feature.py"))
+
+    applied = _seed_promoted_diffs(ws, [diff])
+    assert applied == 1
+    assert os.path.exists(os.path.join(ws.path, "feature.py"))
+    status = subprocess.run(["git", "status", "--porcelain"], cwd=ws.path, capture_output=True, text=True)
+    assert status.stdout.strip() == ""  # tout est committé (HEAD = état cumulé)
+
+
+def test_seed_promoted_diffs_applies_two_in_cascade(git_repo):
+    # Deux diffs promus successifs (diff2 capturé SUR base+diff1) réappliqués en
+    # cascade sur un clone neuf → les deux fichiers présents (3-way en série).
+    from collegue.executor.agent import IssueSpec
+    from collegue.executor.runner import capture_diff
+    from collegue.executor.workspace import prepare_workspace
+    from collegue.improve.loop import _seed_promoted_diffs
+
+    ws = prepare_workspace(git_repo, IssueSpec(number=3, title="t"))
+    with open(os.path.join(ws.path, "a.py"), "w") as fh:
+        fh.write("A = 1\n")
+    diff1, _ = capture_diff(ws)
+    _git(ws.path, "-c", "user.email=t@e.x", "-c", "user.name=t", "commit", "-q", "-m", "a")
+    with open(os.path.join(ws.path, "b.py"), "w") as fh:
+        fh.write("B = 2\n")
+    diff2, _ = capture_diff(ws)  # capturé contre base+diff1 (b.py seul)
+    # remet à l'état vierge (clone neuf) : ni a.py ni b.py
+    _git(ws.path, "reset", "--hard", "HEAD~1")
+    _git(ws.path, "clean", "-fdq")
+    assert not os.path.exists(os.path.join(ws.path, "a.py"))
+    assert not os.path.exists(os.path.join(ws.path, "b.py"))
+
+    applied = _seed_promoted_diffs(ws, [diff1, diff2])
+    assert applied == 2
+    assert os.path.exists(os.path.join(ws.path, "a.py"))
+    assert os.path.exists(os.path.join(ws.path, "b.py"))
+
+
+def test_seed_promoted_diffs_skips_inapplicable(git_repo):
+    # Un diff corrompu/inapplicable est sauté (best-effort), sans casser le run.
+    from collegue.executor.agent import IssueSpec
+    from collegue.executor.workspace import prepare_workspace
+    from collegue.improve.loop import _seed_promoted_diffs
+
+    ws = prepare_workspace(git_repo, IssueSpec(number=2, title="t"))
+    assert _seed_promoted_diffs(ws, ["pas un diff valide\n"]) == 0
+
+
+async def test_compounding_reapplies_promoted_diff_on_next_round(git_repo, manager):
+    # Round 1 promeut (feature.py) ; round 2 doit RÉAPPLIQUER ce diff sur le clone neuf
+    # → feature.py présent à la mesure baseline du round 2 (score cumulatif).
+    baseline_has_feature = []
+
+    class _ProbeMeasure:
+        def __init__(self):
+            self.i = 0
+
+        async def __call__(self, workspace, ctx, *, sandbox=None, reviewer=None, diff="", weights=None):
+            if not diff:  # mesure baseline (« avant »)
+                baseline_has_feature.append(os.path.exists(os.path.join(workspace, "feature.py")))
+            scores = [0.5, 0.7, 0.7, 0.7]  # r1.before, r1.after (promu), r2.before, …
+            m = _metrics(scores[min(self.i, len(scores) - 1)])
+            self.i += 1
+            return m
+
+    result = await run_improvement(
+        manager.create_project(name="compound"),
+        git_repo,
+        ctx=None,
+        agent=FakeCodeAgent(files={"feature.py": "VALUE = 1\n"}),
+        owner="o",
+        repo="r",
+        manager=manager,
+        budget=_Budget(),
+        clients=_clients(),
+        dry_run=True,
+        plateau_rounds=1,
+        measure_fn=_ProbeMeasure(),
+    )
+    assert len(result.promoted) == 1
+    assert baseline_has_feature[0] is False  # round 1 : clone neuf, pas de feature.py
+    assert baseline_has_feature[1] is True  # round 2 : diff promu réappliqué (cumulatif)
 
 
 async def test_unreliable_baseline_skips_agent_round(git_repo, manager):


### PR DESCRIPTION
Closes #545. Suite de #541 (Étape 0) et #543 (Étape 1).

## Pourquoi

La re-validation v9 du moteur corrigé a confirmé que la boucle **promeut désormais** (5 promus / 0 rejeté) — mais les promotions étaient **non cumulatives** : chaque round repartait du **même clone neuf**, donc le proposeur restait bloqué sur la dimension `security` et le score n'augmentait pas durablement (−85 → −50, puis re-−85 au round suivant).

## Quoi (Levier 2 du redesign)

- `promoted_diffs: list[str]` accumule les diffs promus.
- Nouveau helper `_seed_promoted_diffs(workspace, diffs)` : pour chaque diff promu, `apply_seed_diff` (git apply -3) **puis `git add -A` + `git commit`** (identité inline) sur le clone neuf, **avant** la mesure baseline.
- **Le commit est crucial** : `capture_diff` fait `git diff --staged` vs HEAD. Si les diffs promus restaient en working-tree (non committés), `execution.diff` du round courant les ré-embarquerait → **double-comptage** au round suivant. Après commit, `HEAD` = état cumulé → la baseline porte sur le projet **cumulé amélioré** et `execution.diff` ne contient que les **nouveaux** changements.

### Effet

Le score monte round après round ; une fois une dimension réglée (et **maintenue** par réapplication), sa métrique redevient bonne sur l'état cumulé → le proposeur (métrique-driven, #543) **passe à la dimension suivante** (sécu → couverture → lint/complexité). Le plateau devient sémantiquement valide.

### Robustesse

Best-effort : un diff inapplicable (conflit, base déplacée) est **sauté** — `apply_seed_diff` restaure un arbre propre — plutôt que d'échouer le run. `_seed_promoted_diffs` ne lève jamais. Court-circuité quand rien n'est promu (comportement inchangé).

## Tests

- `_seed_promoted_diffs` : réapplication + commit (arbre propre), **cascade ≥2 diffs** (3-way en série), diff inapplicable sauté.
- Intégration : round N+1 voit le diff promu **réappliqué** à la mesure baseline (clone neuf round 1 sans le fichier, round 2 avec).
- **12 tests `loop` verts** ; `ruff check` + `ruff format --check` verts ; suite complète verte.

Revue adversariale indépendante : 0 finding bloquant (double-comptage écarté, 3-way en cascade validé, `open_pr`/persistance non impactés car la PR pousse les fichiers par contenu et non le diff git, et `base_commit` n'est lu nulle part) ; 2 NITs intégrés.

## Suivi

Re-valider v9 avec le compounding (confirmer un score qui monte cumulativement et le proposeur qui change de dimension). Étape 3 : maintainability informatif, `dep_vulns` (pip-audit) derrière flag. Sémantique des PR en mode `execute` à affiner si on active les vraies PR.