### PR TITLE
fix(improve): #547 — débruiter le signal sécu (exclure lockfiles + tests du scan de la boucle)

### DIFF
--- a/collegue/improve/metrics.py
+++ b/collegue/improve/metrics.py
@@ -40,6 +40,51 @@ DEFAULT_COVERAGE_COMMAND = "pytest -q --cov --cov-report=term-missing"
 # le plus ; le composite et le gate (tolérance 0) raisonnent sur ce total pondéré.
 SECURITY_SEVERITY_WEIGHTS = {"critical": 10.0, "high": 5.0, "medium": 2.0, "low": 1.0}
 
+# Fichiers/dossiers EXCLUS du scan sécu de la BOUCLE (#547). Les lockfiles générés et
+# les emplacements de test/fixtures/exemples contiennent légitimement des chaînes qui
+# ressemblent à des secrets (URLs de registre npm, faux tokens, sqlite:/// de fixtures)
+# qu'on ne « corrige » jamais — sans exclusion ils noient le signal (sur un MVP réel,
+# ~99 % du poids sécu venait de package-lock.json). Conventions GÉNÉRIQUES, multi-
+# langage, sans hypothèse produit. Lockfiles alignés sur ``_GENERATED_DIFF_FILES``
+# (#526). C'est propre à la **fonction objectif de la boucle** (pas un audit de
+# sécurité exhaustif) : un secret en fixture/test n'atteint pas le runtime produit.
+# Extensions de test explicites (pas ``*.test.*`` / ``*.spec.*``) pour ne pas exclure
+# un contrat produit type ``openapi.spec.yaml`` / ``manifest.test.json``.
+SECURITY_SCAN_EXCLUDES = (
+    # lockfiles générés
+    "package-lock.json",
+    "npm-shrinkwrap.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "poetry.lock",
+    "Pipfile.lock",
+    "composer.lock",
+    "Cargo.lock",
+    "go.sum",
+    # dossiers de test / fixtures (conventions multi-langage)
+    "tests",
+    "test",
+    "__tests__",
+    "fixtures",
+    # fichiers de test (conventions par langage, extensions explicites)
+    "test_*.py",
+    "*_test.py",
+    "*_test.go",
+    "conftest.py",
+    "*.test.ts",
+    "*.test.tsx",
+    "*.test.js",
+    "*.test.jsx",
+    "*.spec.ts",
+    "*.spec.tsx",
+    "*.spec.js",
+    "*.spec.jsx",
+    # gabarits/exemples de config (placeholders, jamais des secrets réels)
+    "*.example",
+    "*.sample",
+    "*.template",
+)
+
 # Règles ruff comptées comme « violations de lint » (erreurs pyflakes/pycodestyle).
 DEFAULT_LINT_SELECT = ("E", "F", "W")
 # Seuil de complexité cyclomatique (mccabe / ruff C901) : au-delà = « bloc complexe ».
@@ -138,7 +183,9 @@ def _default_security_scan(workspace: str) -> Tuple[int, float]:
     tool = SecretScanTool()
     tool.rate_limit_enabled = False
     tool.quota_enabled = False
-    resp = tool.execute({"target": workspace, "scan_type": "directory"})
+    resp = tool.execute(
+        {"target": workspace, "scan_type": "directory", "exclude_patterns": list(SECURITY_SCAN_EXCLUDES)}
+    )
     weighted = (
         SECURITY_SEVERITY_WEIGHTS["critical"] * resp.critical
         + SECURITY_SEVERITY_WEIGHTS["high"] * resp.high

--- a/tests/test_improve_metrics.py
+++ b/tests/test_improve_metrics.py
@@ -242,6 +242,24 @@ def test_default_security_scan_detects_planted_secret(tmp_path):
     assert total1 >= 1 and weighted1 > 0.0
 
 
+def test_default_security_scan_excludes_generated_and_tests(tmp_path):
+    # Le scan sécu de la boucle (#547) ignore lockfiles + emplacements de test : un
+    # secret qui y est planté n'est PAS compté ; le même dans du code produit l'est.
+    from collegue.improve.metrics import _default_security_scan
+
+    rsa = '"-----BEGIN RSA PRIVATE KEY-----"'
+    (tmp_path / "package-lock.json").write_text("{" + f'"k": {rsa}' + "}\n")
+    (tmp_path / "test_thing.py").write_text(f"KEY = {rsa}\n")
+    (tmp_path / "fixtures").mkdir()
+    (tmp_path / "fixtures" / "data.py").write_text(f"KEY = {rsa}\n")
+    total0, weighted0 = _default_security_scan(str(tmp_path))
+    assert total0 == 0 and weighted0 == 0.0  # tout est dans des emplacements exclus
+
+    (tmp_path / "app.py").write_text(f"KEY = {rsa}\n")  # code produit → compté
+    total1, weighted1 = _default_security_scan(str(tmp_path))
+    assert total1 >= 1 and weighted1 > 0.0
+
+
 def test_default_quality_scan_counts_lint_and_complexity(tmp_path):
     # Valide le CÂBLAGE réel de ruff (pas un stub) : fichier propre → (0, 0) ;
     # imports inutilisés + fonction très imbriquée → lint > 0 ET complexité > 0.


### PR DESCRIPTION
Closes #547. Suite de la validation full-stack (#546).

## Diagnostic (mesuré, principe anti-inertie)

`secret_scan` sur le MVP FacNor v8 : **173 findings, `security_weighted ≈ 548`**. Décomposition réelle :
- **171/173 = `package-lock.json`** — la regex « mot de passe dans URL » matche les URLs de registre npm (`https://registry.npmjs.org/@babel/...`). Pur faux positif sur un lockfile généré (que `DEFAULT_EXCLUDES` rate : il couvre `*.lock` mais pas `package-lock.json`).
- Reste = faux tokens / `sqlite:///` dans des **fichiers de test**.

→ Toute modif du coder (surtout l'ajout de tests pour la couverture) faisait monter `security_weighted` → gate tolérance-0 → plateau.

## Correctif (générique, scopé à la boucle)

`_default_security_scan` exclut désormais (`SECURITY_SCAN_EXCLUDES`) :
- **lockfiles générés** — alignés sur `_GENERATED_DIFF_FILES` (#526) ;
- **emplacements de test/fixtures/exemples** — `tests`/`test`/`__tests__`/`fixtures`, `test_*.py`/`*_test.py`/`*_test.go`/`conftest.py`, extensions de test **explicites** (`*.test.ts|tsx|js|jsx`, `*.spec.ts|tsx|js|jsx` — pas `*.test.*`/`*.spec.*`, pour ne pas exclure un contrat produit type `openapi.spec.yaml`), `*.example`/`*.sample`/`*.template`.

Conventions **génériques** multi-langage, sans hypothèse produit. Propre à la **fonction objectif de la boucle** (pas un audit exhaustif) : un secret en fixture/test n'atteint pas le runtime produit.

## Effet mesuré

`_default_security_scan` sur FacNor : **173 → 2 findings** (`weighted` 548 → 10). Les 2 restants sont dans `app/main.py` (code produit, stables, probables faux positifs `password_in_url` sur `http://localhost:5173`) — stables, donc inoffensifs pour un gate delta-based.

## Tests

- Nouveau test : secret planté dans lockfile / `test_*.py` / `fixtures/` → **non compté** ; le même dans du code produit → compté.
- Tests `improve` verts ; `ruff check` + `ruff format --check` verts ; suite complète verte.

Revue adversariale ciblée : 0 finding bloquant ; 2 NITs intégrés (commentaire corrigé ; extensions de test explicites).

## Suivi

Re-valider v9. Précision des patterns `secret_scan` + ajout des lockfiles à `DEFAULT_EXCLUDES` global : fixes séparés.