### PR TITLE
feat(improve): #549 — auto-fix lint déterministe avant mesure (débloque le coder LLM)

### DIFF
--- a/collegue/improve/loop.py
+++ b/collegue/improve/loop.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
 from collegue.improve.gate import DEFAULT_MIN_GAIN, evaluate
-from collegue.improve.metrics import DEFAULT_WEIGHTS, CompositeWeights, measure, persist
+from collegue.improve.metrics import DEFAULT_WEIGHTS, CompositeWeights, autofix_lint, measure, persist
 from collegue.improve.proposer import AttemptRecord, build_improvement_task, next_dimension
 
 # Raisons d'arrêt.
@@ -164,7 +164,7 @@ async def run_improvement(
     # est aussi lazy car importer le sous-module déclenche ``pilot/__init__`` (→ driver
     # → exécuteur) — on ne veut pas tirer tout ça au simple import du package improve.
     from collegue.executor.agent import IssueSpec
-    from collegue.executor.runner import run_issue
+    from collegue.executor.runner import capture_diff, run_issue
     from collegue.executor.workspace import prepare_workspace
     from collegue.pilot.budget import ACTION_PAUSED_BUDGET, BudgetTimeController
 
@@ -229,8 +229,16 @@ async def run_improvement(
                 break
             continue
 
+        # Auto-fix lint déterministe (#549) : nettoie le lint auto-corrigible des
+        # fichiers touchés AVANT la mesure (le gate est tolérance-0 sur le lint, donc
+        # le code de test/refactor du coder ne doit pas être recalé pour un import
+        # inutilisé ou un espacement). On re-capture le diff : mesure, PR et compounding
+        # utilisent la version corrigée. Un fix cassant un test ⇒ rejeté par le gate.
+        autofix_lint(workspace.path, execution.files_changed)
+        final_diff, final_files = capture_diff(workspace)
+
         after = await measure_fn(
-            workspace.path, ctx, sandbox=sandbox, reviewer=reviewer, diff=execution.diff, weights=weights
+            workspace.path, ctx, sandbox=sandbox, reviewer=reviewer, diff=final_diff, weights=weights
         )
         result.final_score = after.composite
         gate = evaluate(before, after, min_gain=min_gain)
@@ -246,7 +254,7 @@ async def run_improvement(
                 improvement,
                 owner,
                 repo,
-                files_changed=execution.files_changed,
+                files_changed=final_files,
                 base=base,
                 clients=clients,
                 dry_run=dry_run,
@@ -257,9 +265,9 @@ async def run_improvement(
             )
             if not dry_run:
                 persist(manager, project_id, after)
-            # Compounding (#545) : mémorise le diff promu pour le réappliquer aux
-            # rounds suivants (baseline cumulative) — y compris en dry_run.
-            promoted_diffs.append(execution.diff)
+            # Compounding (#545) : mémorise le diff promu (corrigé) pour le réappliquer
+            # aux rounds suivants (baseline cumulative) — y compris en dry_run.
+            promoted_diffs.append(final_diff)
             result.promoted.append(PromotedImprovement(dimension.value, gate.delta, pr.number))
             plateau = 0
         else:

--- a/collegue/improve/metrics.py
+++ b/collegue/improve/metrics.py
@@ -273,6 +273,40 @@ def _scan_quality(workspace: str, *, scan_fn=None) -> Tuple[int, int, bool]:
         return 0, 0, False
 
 
+def autofix_lint(workspace: str, files, *, lint_select=DEFAULT_LINT_SELECT) -> int:
+    """Auto-corrige le lint des fichiers Python touchés (ruff --fix + format), in-place (#549).
+
+    Appelé par la boucle APRÈS le diff du coder et AVANT la mesure : le coder se
+    concentre sur le fond, le lint auto-corrigible (imports inutilisés, espaces, mise
+    en forme) est nettoyé → une amélioration de couverture/refactor n'est pas bloquée
+    par du lint résiduel (le gate étant tolérance-0 sur le lint).
+
+    Déterministe et générique : ``--isolated`` (ignore la config du projet généré) ;
+    scopé aux ``.py`` réellement présents parmi ``files`` ; ruff absent ou projet
+    non-Python ⇒ **no-op** (renvoie 0). Best-effort (toute panne ruff ignorée). Sûr :
+    un fix qui casserait un test est rattrapé par la mesure ``after`` (tests rouges ⇒
+    le gate rejette) — on ne promeut jamais un fix cassant. Renvoie le nb de fichiers
+    Python traités.
+    """
+    ruff = _find_ruff()
+    if not ruff:
+        return 0
+    py = [os.path.join(workspace, f) for f in files if f.endswith(".py") and os.path.isfile(os.path.join(workspace, f))]
+    if not py:
+        return 0
+    try:
+        subprocess.run(
+            [ruff, "check", *py, "--isolated", "--select", ",".join(lint_select), "--fix", "--no-cache"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        subprocess.run([ruff, "format", *py, "--isolated"], capture_output=True, text=True, timeout=120)
+    except Exception:  # noqa: BLE001 — auto-fix best-effort, jamais bloquant
+        pass
+    return len(py)
+
+
 async def measure(
     workspace: str,
     ctx,

--- a/tests/test_improve_loop.py
+++ b/tests/test_improve_loop.py
@@ -301,6 +301,49 @@ async def test_compounding_reapplies_promoted_diff_on_next_round(git_repo, manag
     assert baseline_has_feature[1] is True  # round 2 : diff promu réappliqué (cumulatif)
 
 
+async def test_autofix_lint_cleans_promoted_diff_end_to_end(git_repo, manager):
+    # Le coder écrit un .py avec un import inutilisé ; l'auto-fix (#549) le retire AVANT
+    # la mesure → le diff promu (passé à la mesure « after ») est propre. Couvre aussi
+    # le chemin « diff vidé » (round 2 : l'auto-fix ramène le diff au HEAD cumulé →
+    # gain nul → rejet « gain insuffisant », sans promotion ni crash).
+    from collegue.improve.metrics import _find_ruff
+
+    if _find_ruff() is None:
+        pytest.skip("ruff indisponible dans cet environnement")
+
+    after_diffs = []
+
+    class _Probe:
+        def __init__(self):
+            self.i = 0
+
+        async def __call__(self, workspace, ctx, *, sandbox=None, reviewer=None, diff="", weights=None):
+            if diff:  # mesure « after »
+                after_diffs.append(diff)
+            m = _metrics([0.5, 0.7][min(self.i, 1)])
+            self.i += 1
+            return m
+
+    result = await run_improvement(
+        manager.create_project(name="autofix"),
+        git_repo,
+        ctx=None,
+        agent=FakeCodeAgent(files={"feat.py": "import os\nVALUE = 1\n"}),
+        owner="o",
+        repo="r",
+        manager=manager,
+        budget=_Budget(),
+        clients=_clients(),
+        dry_run=True,
+        plateau_rounds=1,
+        measure_fn=_Probe(),
+    )
+    assert len(result.promoted) == 1
+    assert after_diffs  # une mesure « after » a bien eu lieu
+    assert "import os" not in after_diffs[0]  # F401 retiré par l'auto-fix avant mesure
+    assert "feat.py" in after_diffs[0]  # le diff promu reste celui du round
+
+
 async def test_unreliable_baseline_skips_agent_round(git_repo, manager):
     # Baseline non fiable (composite non fini, ex. scan sécu KO → inf) → round à vide
     # SANS appel agent ; fail-closed : aucune promotion, pas de score fantôme inf (#541).

--- a/tests/test_improve_metrics.py
+++ b/tests/test_improve_metrics.py
@@ -242,6 +242,30 @@ def test_default_security_scan_detects_planted_secret(tmp_path):
     assert total1 >= 1 and weighted1 > 0.0
 
 
+def test_autofix_lint_cleans_fixable_violations(tmp_path):
+    # ruff --fix + format nettoie le lint auto-corrigible des fichiers Python touchés.
+    from collegue.improve.metrics import _find_ruff, autofix_lint
+
+    if _find_ruff() is None:
+        pytest.skip("ruff indisponible dans cet environnement")
+
+    f = tmp_path / "dirty.py"
+    f.write_text("import os\nimport sys\nx=1\n")  # os/sys inutilisés (F401) + espacement (E225)
+    n = autofix_lint(str(tmp_path), ["dirty.py"])
+    assert n == 1
+    cleaned = f.read_text()
+    assert "import os" not in cleaned and "import sys" not in cleaned  # F401 retirés (--fix)
+    assert "x = 1" in cleaned  # espacement corrigé (format)
+
+
+def test_autofix_lint_noop_without_python(tmp_path):
+    from collegue.improve.metrics import autofix_lint
+
+    (tmp_path / "data.txt").write_text("import os\n")
+    assert autofix_lint(str(tmp_path), ["data.txt"]) == 0  # aucun .py → no-op
+    assert autofix_lint(str(tmp_path), ["missing.py"]) == 0  # fichier absent → no-op
+
+
 def test_default_security_scan_excludes_generated_and_tests(tmp_path):
     # Le scan sécu de la boucle (#547) ignore lockfiles + emplacements de test : un
     # secret qui y est planté n'est PAS compté ; le même dans du code produit l'est.


### PR DESCRIPTION
Closes #549. Suite de la re-validation post-débruitage (#548).

## Problème

Échelle assainie (#548), le proposeur passe à `coverage` — mais le gate multi-signal (lint **slack 0**) recale la passe car le code de test ajouté par le coder introduit ~16 violations lint (`84 > 68`). Exiger qu'une sortie LLM soit parfaite sur **tous** les signaux à la fois fait plafonner la boucle.

## Correctif — auto-fix déterministe

- **`metrics.py`** : `autofix_lint(workspace, files)` lance `ruff check --fix` + `ruff format` sur les **`.py` touchés** (`--isolated`, scopé à `execution.files_changed`, best-effort, no-op si ruff absent / projet non-Python).
- **`loop.py`** : après `run_issue` et **avant** la mesure `after`, on auto-fixe puis on **re-capture le diff** (`capture_diff`) ; mesure / PR / compounding utilisent désormais `final_diff` / `final_files` (le diff promu inclut les corrections).

Le coder se concentre sur le fond (couverture/refactor) ; le lint auto-corrigible (imports inutilisés, espacement, mise en forme) est nettoyé → plus de faux blocage. La complexité (C901, non auto-corrigible) reste gatée — le coder doit la traiter.

### Pourquoi c'est sûr
- **Auto-protégé** : la mesure `after` relance les tests ; un auto-fix cassant (ex. F401 d'un import à effet de bord) → `tests_passed=False` → le gate rejette. On ne promeut jamais un fix cassant.
- **Re-capture correcte** : `capture_diff` diffe vs HEAD, et HEAD a déjà absorbé le compounding (diffs promus commités par `_seed_promoted_diffs`) → `final_diff` ne contient que (coder + auto-fix), pas de double-comptage.
- **« Diff vidé »** : si l'auto-fix ramène le diff au HEAD cumulé → `final_files` vide → `after ≈ before` → gate « gain insuffisant » → pas de promotion (pas de `''` dans le compounding).
- **Déterministe et générique** : `--isolated`, aucune hypothèse produit.

## Tests

- `autofix_lint` : nettoyage F401 + format ; no-op sans `.py` / fichier absent.
- **Intégration end-to-end** : le coder écrit un `.py` avec import inutilisé → le diff promu (passé à la mesure) est propre ; couvre aussi le chemin « diff vidé ».
- **67 tests `improve` verts** ; `ruff check` + `ruff format --check` verts ; suite complète verte.

Revue adversariale indépendante : 0 finding bloquant (re-capture vs compounding, filet tests-rouges, diff vidé, scope auto-fix — tous vérifiés empiriquement) ; NITs de couverture de test intégrés.

## Suivi

Re-valider v9 (la boucle doit maintenant promouvoir des gains de couverture). Étape 3 (maintainability informatif, dep_vulns derrière flag) reste optionnelle.