### PR TITLE
feat(improve): #551 — maintenabilité informative (doc_coverage) + dep_vulns (flag) [Étape 3]

### DIFF
--- a/collegue/improve/gate.py
+++ b/collegue/improve/gate.py
@@ -65,7 +65,9 @@ def evaluate(
          dure ; un scan sécu en échec ⇒ composite non fini ⇒ rejet à la règle 2) ;
        - lint : ``after.lint_violations <= before.lint_violations + lint_slack`` ;
        - complexité : ``after.complexity_bad_blocks <= before.complexity_bad_blocks
-         + complexity_slack``.
+         + complexity_slack`` ;
+       - vulns deps : ``after.dep_vulns <= before.dep_vulns`` (tolérance 0 dure ;
+         signal opt-in #551 — ``dep_vulns`` vaut 0 quand le flag est off ⇒ no-op).
     5. **Gain réel** : ``after.composite >= before.composite + min_gain``.
 
     ``min_gain`` négatif inverserait la garde « pas de régression » → borné à 0 ; les
@@ -96,6 +98,8 @@ def evaluate(
             f"régression complexité : {after.complexity_bad_blocks} > "
             f"{before.complexity_bad_blocks} (slack {complexity_slack})"
         )
+    if after.dep_vulns > before.dep_vulns:
+        return reject(f"régression vulns deps : {after.dep_vulns} > {before.dep_vulns} (tolérance 0)")
     if delta < min_gain:
         return reject(f"gain insuffisant : Δ={delta:.4f} < min_gain={min_gain:.4f}")
 

--- a/collegue/improve/loop.py
+++ b/collegue/improve/loop.py
@@ -73,7 +73,9 @@ def _improvement_quality_report(dimension, before, after, delta):
         f"Couverture {before.coverage_pct:.0f}% → {after.coverage_pct:.0f}% ; "
         f"sécu pondérée {before.security_weighted:.1f} → {after.security_weighted:.1f} ; "
         f"lint {before.lint_violations} → {after.lint_violations} ; "
-        f"complexité {before.complexity_bad_blocks} → {after.complexity_bad_blocks}."
+        f"complexité {before.complexity_bad_blocks} → {after.complexity_bad_blocks} ; "
+        f"vulns deps {before.dep_vulns} → {after.dep_vulns} ; "
+        f"docstrings {before.doc_coverage:.0%} → {after.doc_coverage:.0%}."
     )
     return QualityReport(
         tests_passed=after.tests_passed,

--- a/collegue/improve/metrics.py
+++ b/collegue/improve/metrics.py
@@ -23,6 +23,7 @@ Module **isolé** : non câblé au runtime (la boucle G4 l'orchestre).
 
 from __future__ import annotations
 
+import ast
 import json
 import math
 import os
@@ -107,6 +108,7 @@ class CompositeWeights:
     security: float = 0.1  # pénalité par unité de score sécu pondéré
     lint: float = 0.02  # pénalité par violation de lint
     complexity: float = 0.05  # pénalité par bloc trop complexe
+    dep_vulns: float = 0.5  # pénalité par vuln. de dépendance (signal opt-in, #551)
 
 
 DEFAULT_WEIGHTS = CompositeWeights()
@@ -135,6 +137,12 @@ class ProjectQualityMetrics:
     # False si ruff n'a pas pu tourner (absent / panne). Le gate rejette une bascule
     # avant≠après (sinon un échec de scan après gonflerait le composite — #543).
     quality_measured: bool = True
+    # INFORMATIF (hors-gate, #551) : couverture de docstrings des symboles publics
+    # [0–1], proxy de maintenabilité/documentation. N'entre PAS dans le composite.
+    doc_coverage: float = 1.0
+    # Vulnérabilités de dépendances (pip-audit). Signal OPT-IN : 0 par défaut (flag
+    # off) → terme composite nul + règle gate no-op. Gaté (tolérance 0) quand activé.
+    dep_vulns: int = 0
 
 
 def parse_coverage(output: str) -> Optional[float]:
@@ -155,19 +163,22 @@ def composite_score(
     *,
     lint_violations: int = 0,
     complexity_bad_blocks: int = 0,
+    dep_vulns: int = 0,
     weights: CompositeWeights = DEFAULT_WEIGHTS,
 ) -> float:
     """Score composite pondéré (déterministe).
 
-    Monotone : ↑couverture → ↑ ; ↑sécu pondérée / ↑lint / ↑complexité → ↓. La
-    couverture (0–100) est normalisée en 0–1 ; sécu/lint/complexité sont des
-    pénalités. La revue LLM n'y figure pas (informative, hors-gate).
+    Monotone : ↑couverture → ↑ ; ↑sécu pondérée / ↑lint / ↑complexité / ↑vulns deps
+    → ↓. La couverture (0–100) est normalisée en 0–1 ; les autres sont des pénalités.
+    ``dep_vulns`` vaut 0 quand le flag est off (terme nul). La revue LLM et la
+    couverture de docstrings n'y figurent pas (informatives, hors-gate).
     """
     return (
         weights.coverage * (coverage_pct / 100.0)
         - weights.security * security_weighted
         - weights.lint * lint_violations
         - weights.complexity * complexity_bad_blocks
+        - weights.dep_vulns * dep_vulns
     )
 
 
@@ -307,6 +318,98 @@ def autofix_lint(workspace: str, files, *, lint_select=DEFAULT_LINT_SELECT) -> i
     return len(py)
 
 
+# Dossiers élagués du calcul de couverture de docstrings (générés / tests).
+_DOC_SKIP_DIRS = frozenset(
+    {
+        ".git",
+        "node_modules",
+        "__pycache__",
+        ".venv",
+        "venv",
+        "env",
+        "dist",
+        "build",
+        "tests",
+        "test",
+        "__tests__",
+        "fixtures",
+    }
+)
+
+
+def _is_doc_test_file(filename: str) -> bool:
+    """Vrai pour un fichier de test (exclu de la couverture de docstrings)."""
+    return filename == "conftest.py" or filename.startswith("test_") or filename.endswith("_test.py")
+
+
+def _default_doc_coverage(workspace: str) -> float:
+    """Fraction de symboles publics munis d'une docstring [0–1] (ast, stdlib).
+
+    Proxy de **maintenabilité/documentation** déterministe : compte la docstring de
+    module + celles des classes/fonctions publiques (nom ne commençant pas par ``_``)
+    sur les ``.py`` du workspace, hors emplacements de test. ``1.0`` si aucun symbole
+    public (vacuité). **Informatif** (hors-gate) ; générique Python, sans dépendance.
+    """
+    documented = total = 0
+    for root, dirs, fnames in os.walk(workspace):
+        dirs[:] = [d for d in dirs if d not in _DOC_SKIP_DIRS]
+        for fname in fnames:
+            if not fname.endswith(".py") or _is_doc_test_file(fname):
+                continue
+            try:
+                with open(os.path.join(root, fname), encoding="utf-8") as handle:
+                    tree = ast.parse(handle.read())
+            except (OSError, SyntaxError, ValueError):
+                continue
+            total += 1  # le module lui-même
+            if ast.get_docstring(tree):
+                documented += 1
+            for node in ast.walk(tree):
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)) and not node.name.startswith(
+                    "_"
+                ):
+                    total += 1
+                    if ast.get_docstring(node):
+                        documented += 1
+    return 1.0 if total == 0 else documented / total
+
+
+def _find_pip_audit() -> Optional[str]:
+    """Localise pip-audit : PATH puis à côté de l'interpréteur (venv). ``None`` si absent."""
+    found = shutil.which("pip-audit")
+    if found:
+        return found
+    candidate = os.path.join(os.path.dirname(sys.executable), "pip-audit")
+    return candidate if os.path.exists(candidate) else None
+
+
+def _default_dep_audit(workspace: str) -> int:
+    """Compte les vulnérabilités connues des dépendances via pip-audit (#551).
+
+    Opt-in (appelé seulement si ``dep_vulns_enabled``). Audite ``requirements.txt`` du
+    workspace (réseau, base OSV). pip-audit absent / pas de requirements / panne ⇒
+    **0** (no-op, comme ``_find_ruff``) — pip-audit n'est PAS imposé en dépendance.
+    """
+    audit = _find_pip_audit()
+    if not audit:
+        return 0
+    req = os.path.join(workspace, "requirements.txt")
+    if not os.path.isfile(req):
+        return 0
+    try:
+        proc = subprocess.run(
+            [audit, "-r", req, "-f", "json", "--progress-spinner", "off"],
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        data = json.loads(proc.stdout or "{}")
+        deps = data.get("dependencies", []) if isinstance(data, dict) else (data or [])
+        return sum(len(d.get("vulns", [])) for d in deps if isinstance(d, dict))
+    except Exception:  # noqa: BLE001 — audit best-effort, jamais bloquant
+        return 0
+
+
 async def measure(
     workspace: str,
     ctx,
@@ -319,14 +422,19 @@ async def measure(
     weights: CompositeWeights = DEFAULT_WEIGHTS,
     security_scan_fn=None,
     quality_scan_fn=None,
+    doc_coverage_fn=None,
+    dep_vulns_enabled: bool = False,
+    dep_vulns_fn=None,
 ) -> ProjectQualityMetrics:
     """Mesure couverture + sécu + lint/complexité (déterministes) → composite.
 
     ``sandbox`` est injectable (mocké en CI) ; la couverture vient du parsing de la
     sortie pytest-cov et ``tests_passed`` = exit 0. Sécu (``security_scan_fn``) et
     lint/complexité (``quality_scan_fn``) viennent de scans **statiques déterministes**
-    du **workspace** (injectables en tests). La revue LLM (``reviewer``/``diff``) est
-    **optionnelle et informative** (corps de PR) : elle n'entre pas dans le composite.
+    du **workspace** (injectables en tests). La couverture de docstrings
+    (``doc_coverage_fn``) est **informative** (hors composite). Les vulns de dépendances
+    (``dep_vulns_fn``) ne sont mesurées que si ``dep_vulns_enabled`` (opt-in, gaté).
+    La revue LLM (``reviewer``/``diff``) est **optionnelle et informative**.
     """
     test_res = sandbox.run_tests(workspace, coverage_command)
     tests_passed = bool(test_res.ok)
@@ -336,6 +444,21 @@ async def measure(
 
     security_findings, security_weighted = _scan_security(workspace, scan_fn=security_scan_fn)
     lint_violations, complexity_bad_blocks, quality_measured = _scan_quality(workspace, scan_fn=quality_scan_fn)
+
+    # Maintenabilité informative (hors-gate) : couverture de docstrings, jamais bloquante.
+    try:
+        doc_coverage = float((doc_coverage_fn or _default_doc_coverage)(workspace))
+    except Exception:  # noqa: BLE001 — informatif, jamais bloquant
+        doc_coverage = 1.0
+
+    # Vulns de dépendances : OPT-IN (flag). Off ⇒ 0 (terme composite nul, gate no-op).
+    # Symétrique à doc_coverage : une fn injectée qui lève ne fait pas planter la mesure.
+    dep_vulns = 0
+    if dep_vulns_enabled:
+        try:
+            dep_vulns = int((dep_vulns_fn or _default_dep_audit)(workspace))
+        except Exception:  # noqa: BLE001 — audit best-effort, jamais bloquant
+            dep_vulns = 0
 
     # Revue LLM : INFORMATIVE uniquement (hors composite). Calculée seulement s'il y
     # a un reviewer ET un diff à examiner ; toute panne reste sans effet sur le gate.
@@ -357,6 +480,7 @@ async def measure(
             security_weighted,
             lint_violations=lint_violations,
             complexity_bad_blocks=complexity_bad_blocks,
+            dep_vulns=dep_vulns,
             weights=weights,
         ),
         coverage_measured=coverage_measured,
@@ -364,6 +488,8 @@ async def measure(
         lint_violations=lint_violations,
         complexity_bad_blocks=complexity_bad_blocks,
         quality_measured=quality_measured,
+        doc_coverage=doc_coverage,
+        dep_vulns=dep_vulns,
     )
 
 
@@ -378,4 +504,6 @@ def persist(manager, project_id: int, metrics: ProjectQualityMetrics) -> None:
     manager.add_metric(project_id, "lint_violations", float(metrics.lint_violations))
     manager.add_metric(project_id, "complexity_bad_blocks", float(metrics.complexity_bad_blocks))
     manager.add_metric(project_id, "quality_measured", 1.0 if metrics.quality_measured else 0.0)
+    manager.add_metric(project_id, "doc_coverage", metrics.doc_coverage)
+    manager.add_metric(project_id, "dep_vulns", float(metrics.dep_vulns))
     manager.add_metric(project_id, "composite", metrics.composite)

--- a/tests/test_improve_gate.py
+++ b/tests/test_improve_gate.py
@@ -12,6 +12,7 @@ def _m(
     security=0,
     lint=0,
     complexity=0,
+    dep_vulns=0,
     tests=True,
     measured=True,
     quality_measured=True,
@@ -21,11 +22,14 @@ def _m(
         security_findings=security,
         security_weighted=security_weighted,
         tests_passed=tests,
-        composite=composite_score(coverage, security_weighted, lint_violations=lint, complexity_bad_blocks=complexity),
+        composite=composite_score(
+            coverage, security_weighted, lint_violations=lint, complexity_bad_blocks=complexity, dep_vulns=dep_vulns
+        ),
         coverage_measured=measured,
         lint_violations=lint,
         complexity_bad_blocks=complexity,
         quality_measured=quality_measured,
+        dep_vulns=dep_vulns,
     )
 
 
@@ -85,6 +89,21 @@ def test_reject_on_complexity_regression():
     d = evaluate(_m(coverage=70.0, complexity=1), _m(coverage=90.0, complexity=3))
     assert d.accepted is False
     assert "complexité" in d.reason
+
+
+def test_reject_on_dep_vulns_regression():
+    # Signal opt-in (#551) : plus de vulns de dépendances = rejet dur (tolérance 0),
+    # même avec un gain de couverture.
+    d = evaluate(_m(coverage=70.0, dep_vulns=1), _m(coverage=90.0, dep_vulns=3))
+    assert d.accepted is False
+    assert "vulns deps" in d.reason
+
+
+def test_dep_vulns_no_op_when_disabled():
+    # Par défaut dep_vulns=0 des deux côtés → la règle ne bloque pas (boucle validée
+    # préservée à l'identique).
+    d = evaluate(_m(coverage=70.0), _m(coverage=90.0))
+    assert d.accepted is True
 
 
 def test_lint_slack_allows_tolerated_regression():

--- a/tests/test_improve_metrics.py
+++ b/tests/test_improve_metrics.py
@@ -107,6 +107,13 @@ def test_composite_weights_tunable():
     assert composite_score(100.0, 5.0, lint_violations=9, complexity_bad_blocks=9, weights=w) == pytest.approx(2.0)
 
 
+def test_composite_dep_vulns_penalty():
+    # dep_vulns pénalise le composite ; 0 (défaut, flag off) = aucun effet.
+    base = composite_score(80.0, 0.0)
+    assert composite_score(80.0, 0.0, dep_vulns=0) == base  # off → inchangé
+    assert composite_score(80.0, 0.0, dep_vulns=2) < base  # 2 vulns → ↓
+
+
 # --- measure --------------------------------------------------------------------
 
 
@@ -166,6 +173,60 @@ async def test_measure_without_reviewer_is_deterministic():
     )
     assert m.review_score == 0.0
     assert m.composite == pytest.approx(0.9)
+
+
+async def test_measure_doc_coverage_informative(tmp_path):
+    # doc_coverage est calculée (informative) mais N'ENTRE PAS dans le composite.
+    base = await measure(
+        "/ws", ctx=None, sandbox=_Sandbox(), security_scan_fn=_scan(0, 0.0), quality_scan_fn=_quality(0, 0)
+    )
+    m = await measure(
+        "/ws",
+        ctx=None,
+        sandbox=_Sandbox(),
+        security_scan_fn=_scan(0, 0.0),
+        quality_scan_fn=_quality(0, 0),
+        doc_coverage_fn=lambda ws: 0.42,
+    )
+    assert m.doc_coverage == 0.42
+    assert m.composite == base.composite  # doc_coverage hors-composite
+
+
+async def test_measure_dep_vulns_opt_in():
+    # OFF par défaut → dep_vulns=0, composite inchangé. ON (fn injectée) → compté + gaté.
+    off = await measure(
+        "/ws", ctx=None, sandbox=_Sandbox(), security_scan_fn=_scan(0, 0.0), quality_scan_fn=_quality(0, 0)
+    )
+    assert off.dep_vulns == 0
+    on = await measure(
+        "/ws",
+        ctx=None,
+        sandbox=_Sandbox(),
+        security_scan_fn=_scan(0, 0.0),
+        quality_scan_fn=_quality(0, 0),
+        dep_vulns_enabled=True,
+        dep_vulns_fn=lambda ws: 3,
+    )
+    assert on.dep_vulns == 3
+    assert on.composite < off.composite  # 3 vulns pénalisent le composite
+
+
+def test_default_doc_coverage_ast(tmp_path):
+    # ast réel : 1 module + 1 fonction publique sur 2 documentés → 0.5 ; tests exclus.
+    (tmp_path / "mod.py").write_text('"""Module documenté."""\n\n\ndef public():\n    return 1\n')
+    (tmp_path / "test_mod.py").write_text("def helper():\n    return 1\n")  # exclu
+    from collegue.improve.metrics import _default_doc_coverage
+
+    cov = _default_doc_coverage(str(tmp_path))
+    # symboles comptés : module (doc=oui) + public() (doc=non) → 1/2 = 0.5
+    assert cov == pytest.approx(0.5)
+
+
+def test_default_dep_audit_noop_without_pip_audit(tmp_path):
+    # pip-audit absent (ou pas de requirements) → 0 (no-op), jamais d'exception.
+    from collegue.improve.metrics import _default_dep_audit
+
+    assert _default_dep_audit(str(tmp_path)) == 0  # pas de requirements.txt
 
 
 async def test_measure_tests_red_and_no_coverage():
@@ -325,6 +386,8 @@ def test_persist_writes_metrics(tmp_path):
         lint_violations=3,
         complexity_bad_blocks=2,
         quality_measured=True,
+        doc_coverage=0.75,
+        dep_vulns=1,
     )
     persist(manager, pid, m)
     names = {metric.name for metric in manager.get_metrics(pid)}
@@ -338,6 +401,8 @@ def test_persist_writes_metrics(tmp_path):
         "lint_violations",
         "complexity_bad_blocks",
         "quality_measured",
+        "doc_coverage",
+        "dep_vulns",
         "composite",
     }
     assert manager.get_metrics(pid, "composite")[0].value == pytest.approx(0.4)


### PR DESCRIPTION
Closes #551. **Dernière étape** (optionnelle) du redesign Phase 4, après la campagne validée (#542/#544/#546/#548/#550).

Ajoute deux signaux **sans changer le comportement de la boucle par défaut**.

## 1. `doc_coverage` — maintenabilité informative (hors-gate)

Fraction de symboles publics (module + classes/fonctions non `_`) munis d'une docstring [0–1], via **`ast`/stdlib** (`_default_doc_coverage`), emplacements de test exclus. **Déterministe, générique, sans nouvelle dépendance**, projet-level. N'entre **ni** dans le composite **ni** dans le gate (comme `review_score`) → affiché dans le corps de PR.

> La conception initiale évoquait `code_review` sans ctx, mais c'est snippet-level (mal défini à l'échelle projet) ; la couverture de docstrings est un proxy mieux adapté, sans dépendance.

## 2. `dep_vulns` — vulnérabilités de dépendances (flag, OFF par défaut)

`measure(dep_vulns_enabled=False)`. Quand activé : `_default_dep_audit` audite `requirements.txt` via **pip-audit si disponible** — sinon **no-op** (0), comme `_find_ruff`. **pip-audit n'est PAS imposé en dépendance.** Quand activé : signal **gaté** (terme composite `− w_dep·dep_vulns` + anti-régression tolérance 0, comme la sécu).

## Préservation de la boucle validée (prouvée)

Par défaut (`dep_vulns_enabled=False`) → `dep_vulns = 0` partout → **terme composite nul** + règle gate `0 > 0` **no-op** → **composite et gate strictement inchangés**. Aucun chemin par défaut n'appelle pip-audit (réseau). `doc_coverage` est hors-gate. La boucle validée en réel est préservée à l'identique.

## Robustesse

Mesure des deux signaux **best-effort** (try/except → valeur neutre, jamais bloquante). `_default_dep_audit` : pip-audit absent / pas de requirements / panne JSON → 0. `_default_doc_coverage` : SyntaxError/OSError ignorés, total=0 → 1.0.

## Tests

- composite (pénalité dep_vulns), doc_coverage **hors-composite**, dep_vulns **opt-in** (off=0 / on compté), `_default_doc_coverage` (ast réel → 0.5), `_default_dep_audit` no-op sans pip-audit, **régression gate** dep_vulns + no-op par défaut.
- **75 tests `improve` verts** ; `ruff check` + `ruff format --check` verts ; suite complète verte.

Revue adversariale indépendante : 0 finding bloquant (préservation par défaut prouvée) ; MINEUR intégré (try/except autour de `dep_vulns_fn` injectée).

## Suivi (hors-périmètre)

`dep_vulns` activé par défaut (réseau non déterministe), couverture deps pour projets poetry/pyproject, précision des patterns `secret_scan`, lockfiles dans `DEFAULT_EXCLUDES` global — fixes séparés.

---

🏁 Avec cette PR, la **campagne Phase 4 est complète** : objectif déterministe (#542) → lint/complexité + gate multi-signal (#544) → compounding (#546) → débruitage sécu (#548) → auto-fix lint (#550) → maintenabilité + dep_vulns (#551).