### PR TITLE
feat(improve): #554 — PR d'amélioration stackées en mode --execute

### DIFF
--- a/collegue/improve/loop.py
+++ b/collegue/improve/loop.py
@@ -161,6 +161,11 @@ async def run_improvement(
     exécute l'agent (diff) → mesure après → gate (G2). Si accepté : PR (E4) + métrique
     persistée. Sinon : diff jeté. Stop quand ``plateau_rounds`` rounds consécutifs
     n'apportent pas de gain (≥ ``min_gain``), ou au budget/deadline.
+
+    En mode réel (``dry_run=False``), les PR d'amélioration sont **stackées** (#554) :
+    chaque PR a pour base la branche de la promotion précédente (la 1ʳᵉ sur ``base``),
+    pour des diffs incrémentaux mergeables dans l'ordre sans conflit (le compounding
+    rendrait sinon les PR cumulatives).
     """
     # Imports paresseux : garder l'import de ``collegue.improve`` léger. ``pilot.budget``
     # est aussi lazy car importer le sous-module déclenche ``pilot/__init__`` (→ driver
@@ -175,6 +180,12 @@ async def run_improvement(
     # Compounding (#545) : diffs déjà promus, réappliqués sur le clone neuf de chaque
     # round pour une baseline cumulative (le score monte ; le proposeur avance).
     promoted_diffs: List[str] = []
+    # Stacking des PR (#554) : en mode --execute, chaque PR d'amélioration prend pour
+    # base la branche de la promotion PRÉCÉDENTE (au lieu de `base`/main), pour que son
+    # diff ne contienne QUE les changements de son round (sinon le compounding rend les
+    # PR cumulatives → conflits une fois les premières mergées, vécu au run V10). En
+    # dry_run, reste None → base inchangée (aucune PR créée de toute façon).
+    last_promoted_branch: Optional[str] = None
     result = ImprovementResult(stop_reason=STOP_PLATEAU, rounds=0)
     plateau = 0
     round_num = 0
@@ -257,7 +268,9 @@ async def run_improvement(
                 owner,
                 repo,
                 files_changed=final_files,
-                base=base,
+                # Stacking (#554) : base = branche de la promotion précédente si elle
+                # existe (mode --execute), sinon la base d'origine. → diff de PR propre.
+                base=(last_promoted_branch or base),
                 clients=clients,
                 dry_run=dry_run,
                 manager=manager,
@@ -267,6 +280,10 @@ async def run_improvement(
             )
             if not dry_run:
                 persist(manager, project_id, after)
+                # Stacking (#554) : la PROCHAINE PR se basera sur celle-ci (chaîne de PR
+                # mergeables dans l'ordre). Uniquement en réel (en dry_run aucune branche
+                # n'existe → on garde la base d'origine).
+                last_promoted_branch = pr.head
             # Compounding (#545) : mémorise le diff promu (corrigé) pour le réappliquer
             # aux rounds suivants (baseline cumulative) — y compris en dry_run.
             promoted_diffs.append(final_diff)

--- a/tests/test_improve_loop.py
+++ b/tests/test_improve_loop.py
@@ -344,6 +344,55 @@ async def test_autofix_lint_cleans_promoted_diff_end_to_end(git_repo, manager):
     assert "feat.py" in after_diffs[0]  # le diff promu reste celui du round
 
 
+async def test_execute_mode_stacks_prs_on_previous_branch(git_repo, manager):
+    # En --execute (#554), la PR du round N se base sur la branche de la promotion N-1
+    # (la 1ʳᵉ sur `main`) → diffs incrémentaux, mergeables dans l'ordre, pas de conflit.
+    from collegue.executor import PrClients
+    from collegue.executor.agent import AgentResult
+
+    class _CounterAgent:
+        def __init__(self):
+            self.n = 0
+
+        def implement_issue(self, workspace, issue):
+            self.n += 1
+            rel = f"feat_{self.n}.py"
+            with open(os.path.join(workspace, rel), "w") as fh:
+                fh.write(f"VALUE_{self.n} = {self.n}\n")  # fichier unique → diff à chaque round
+            return AgentResult(success=True, files_changed=(rel,), summary="feat", logs="ok")
+
+    created = []
+
+    class _PRsRec:
+        def find_pr_by_head(self, owner, repo, head, base=None, state="open"):
+            return None
+
+        def create_pr(self, owner, repo, title, head, base, body):
+            created.append({"head": head, "base": base})
+            return SimpleNamespace(number=100 + len(created), html_url="https://gh", head_branch=head)
+
+    clients = PrClients(branches=_Branches(), files=_Files(), prs=_PRsRec())
+    seq = [_metrics(0.5), _metrics(0.7), _metrics(0.7), _metrics(0.9), _metrics(0.9), _metrics(0.9)]
+    result = await run_improvement(
+        manager.create_project(name="stack"),
+        git_repo,
+        ctx=None,
+        agent=_CounterAgent(),
+        owner="o",
+        repo="r",
+        manager=manager,
+        budget=_Budget(),
+        clients=clients,
+        dry_run=False,
+        plateau_rounds=1,
+        measure_fn=_ScriptedMeasure(seq),
+    )
+    assert len(result.promoted) >= 2
+    assert len(created) >= 2
+    assert created[0]["base"] == "main"  # 1ʳᵉ PR : base = main
+    assert created[1]["base"] == created[0]["head"]  # 2ᵉ PR : stackée sur la 1ʳᵉ
+
+
 async def test_unreliable_baseline_skips_agent_round(git_repo, manager):
     # Baseline non fiable (composite non fini, ex. scan sécu KO → inf) → round à vide
     # SANS appel agent ; fail-closed : aucune promotion, pas de score fantôme inf (#541).


### PR DESCRIPTION
Closes #554.

## Problème (confirmé au run V10)

En `--execute`, la boucle d'amélioration ouvrait une PR par promotion, **toutes basées sur `main`**. Avec le compounding (#545, réapplication des diffs promus non-mergés), chaque PR tardive **re-contenait** les changements antérieurs → **conflits** une fois les premières mergées. Vécu : #256/#257 mergées → #258/#259 `dirty` (conflit `app/main.py`/`requirements.txt`), #258 supprimait même un test sécu (artefact pré-merge). Résolution manuelle nécessaire.

## Correctif — PR stackées

Chaque PR prend pour **base la branche de la promotion précédente** (la 1ʳᵉ garde `base`/main) :
- `loop.py` : `last_promoted_branch` ; `base=(last_promoted_branch or base)` ; mis à jour `last_promoted_branch = pr.head` **uniquement en réel** (`if not dry_run`).
- `open_pr` crée déjà `head` **depuis `base`** puis pousse les fichiers du round → le **diff de chaque PR ne contient que les changements de son round** (incrémental, propre, mergeable dans l'ordre #1→#N sans conflit).

Le **compounding reste** (état workspace cumulé pour mesure + coder) ; seul change le **`base` de PR** — orthogonaux. **Merge humain préservé** (§6), **granularité par dimension conservée**. En `dry_run`, `last_promoted_branch` reste `None` → base inchangée (aucune PR créée de toute façon).

## Tests

- `test_execute_mode_stacks_prs_on_previous_branch` : 2 promotions successives en `--execute` (agent à compteur = diff unique/round) → **PR-1.base == `main`**, **PR-2.base == PR-1.head**.
- **76 tests `improve` verts** ; `ruff check` + `ruff format --check` verts ; suite complète verte.

Revue adversariale indépendante : 0 finding bloquant (`pr.head` = `workspace.branch` confirmé ; garde dry_run correcte ; cas `skipped` géré ; pas de course `ensure_branch`) ; docstring mise à jour.

## Note (comportement GitHub, hors-code)

Stacker impose un **merge ordonné** (#1 puis #2…). Cas nominal OK : à chaque merge GitHub re-cible automatiquement la PR enfant. Risque résiduel uniquement si merge dans le désordre / suppression d'une branche de base avant le merge de son enfant.