### PR TITLE
docs(.env.example): synchroniser avec les variables réellement lues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,9 @@ LLM_API_KEY="votre_clé_api_gemini"
 # LLM_MODEL_QA="<modèle économique pour QA/triage>"
 # LLM_PROVIDER_QA="lmstudio"
 # LLM_MODEL_PLANNER="<modèle pour la planification>"
+# LLM_PROVIDER_PLANNER="gemini"
 # LLM_MODEL_REVIEWER="<modèle pour la revue>"
+# LLM_PROVIDER_REVIEWER="gemini"
 
 # --- LM Studio (serveur local compatible OpenAI) ---
 # Pour utiliser un modèle local via LM Studio :
@@ -86,6 +88,7 @@ LLM_API_KEY="votre_clé_api_gemini"
 # SENTRY_AUTH_TOKEN=sntrys_xxxxxxxxxxxx
 # SENTRY_ORG=my-organization
 # SENTRY_DSN=https://xxx@xxx.ingest.sentry.io/xxx
+# SENTRY_ENVIRONMENT=production       # tag d'environnement Sentry (défaut: production)
 
 # Watchdog Autonome (Self-Healing)
 # --------------------------------
@@ -100,6 +103,10 @@ LLM_API_KEY="votre_clé_api_gemini"
 # ENGINE_INIT_TIMEOUT=10.0
 # ENGINE_WAIT_TIMEOUT=30.0
 # MAX_TOKENS=8192
+#
+# Cache des réponses d'outils (middleware). Activé par défaut.
+# CACHE_ENABLED=true
+# CACHE_TTL=3600                      # durée de vie du cache, en secondes
 
 # LLM Rate Limiting (par identité client)
 # ---------------------------------------
@@ -140,6 +147,20 @@ LLM_API_KEY="votre_clé_api_gemini"
 # BUDGET_EXHAUSTED_ACTION=pause       # pause (défaut) | warn
 # COLLEGUE_RUN_DEADLINE_SECONDS=0     # durée mur max d'un run (0 = pas de deadline)
 # LLM_CALL_TIMEOUT=0                  # timeout par appel LLM, s (0 = off)
+
+# --- Persistance & sandbox du pilote ---
+# COLLEGUE_HOME : racine de persistance (budget cumulé, métriques, checkpoints).
+# DOIT être un chemin ABSOLU et STABLE pour qu'un budget dur survive aux
+# redémarrages (sinon deux runs lancés depuis des dossiers différents lisent deux
+# cumuls distincts). Défaut : .collegue (relatif).
+# COLLEGUE_HOME=/chemin/absolu/.collegue
+# Cache pip persistant du sandbox (chemin HÔTE) : évite de retélécharger PyPI à
+# chaque passe réseau du gate. Vide (défaut) = aucun cache.
+# SANDBOX_PIP_CACHE_DIR=/chemin/hote/.pip_cache
+# Creds d'abonnement OpenHands (coder via abonnement, sans coût API) : chemin HÔTE
+# (ex. ~/.openhands) monté en lecture-écriture dans le sandbox du worker. Vide
+# (défaut) = aucun montage (mode clé API inchangé).
+# SANDBOX_SUBSCRIPTION_AUTH_DIR=/home/vous/.openhands
 
 # --- Auto-merge progressif (opt-in, OFF par défaut) ---
 # §6 reste le défaut : approbation humaine avant chaque merge. L'auto-merge ne


### PR DESCRIPTION
## Pourquoi

`.env.example` avait dérivé : plusieurs variables réellement lues par le produit (et présentes dans le `.env` local) n'y étaient pas documentées. Synchronisation **noms uniquement**, valeurs = placeholders (aucun secret).

## Ajouts (placeholders, commentés)

- **LLM_PROVIDER_PLANNER / LLM_PROVIDER_REVIEWER** — providers par rôle manquants (les modèles l'étaient déjà).
- **SENTRY_ENVIRONMENT** — tag d'environnement Sentry (défaut `production`).
- **CACHE_ENABLED / CACHE_TTL** — cache des réponses d'outils (middleware).
- **COLLEGUE_HOME** — racine de persistance (budget/métriques/checkpoints), chemin absolu stable.
- **SANDBOX_PIP_CACHE_DIR** — cache pip persistant du sandbox.
- **SANDBOX_SUBSCRIPTION_AUTH_DIR** — creds d'abonnement OpenHands (coder via abo, sans coût API).

## Volontairement non ajoutées

`CODER_SUBSCRIPTION` / `_FALLBACK` / `_MODEL` / `_JUDGE_MODEL` : présentes dans `.env` mais **lues par aucun fichier** du produit ni du harnais gitignoré → restes manuels/legacy ; les documenter dans l'exemple serait trompeur.

## Sûreté

Aucun `.py` touché (CI triviale). Garde-fou anti-fuite : aucun token réel dans le diff (seuls placeholders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
