### PR TITLE
docs(readme): table de config par thème alignée sur le .env (FR+EN)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -137,19 +137,25 @@ Each expert uses an LLM, iterates through an **agentic loop**, and can **delegat
 
 ### Environment variables (.env)
 
-| Variable | Description | Required |
-|----------|-------------|----------|
-| `LLM_API_KEY` | Google Gemini API key | ✓ |
-| `POSTGRES_URL` | PostgreSQL URI | |
-| `GITHUB_TOKEN` | GitHub token (repo, read:org) | |
-| `SENTRY_AUTH_TOKEN` | Sentry auth token | |
-| `SENTRY_ORG` | Sentry organization slug | |
-| `KUBECONFIG` | Path to kubeconfig | |
-| `STATE_DATABASE_URL` | Autonomous engine durable state (Postgres/SQLite) | |
-| `MAX_COST_USD` / `MAX_TOKENS_BUDGET` | Hard budget (auto-pause) | |
-| `AUTO_MERGE_ENABLED` / `PILOT_TOOL_ENABLED` | Autonomous capabilities (opt-in, **off** by default) | |
+Overview **by theme** (full list and default values in
+**[.env.example](.env.example)**):
 
-> Full autonomous-engine settings (budget, auto-merge/revert, pilot MCP tool):
+| Variable(s) | Description | Required |
+|-------------|-------------|----------|
+| `LLM_API_KEY` | LLM provider API key (Gemini by default) | ✓ |
+| `LLM_PROVIDER` / `LLM_MODEL` | Default LLM provider and model | |
+| `LLM_MODEL_*` / `LLM_PROVIDER_*` | Per-**role** model/provider (CODER, QA, PLANNER, REVIEWER) | |
+| `LLM_RATE_LIMIT_*` | Per-client LLM call limits (per minute / day) | |
+| `CACHE_ENABLED` / `CACHE_TTL` | Tool response cache | |
+| `OAUTH_ENABLED` (+ `OAUTH_*`, Keycloak) | OAuth authentication (**off** by default) | |
+| `GITHUB_TOKEN` / `GITHUB_OWNER` / `GITHUB_REPO` | GitHub integration (watchdog, PRs) | |
+| `SENTRY_DSN` / `SENTRY_ENVIRONMENT` | Sentry observability | |
+| `STATE_DATABASE_URL` | Autonomous engine durable state (Postgres/SQLite) | |
+| `MAX_COST_USD` / `MAX_TOKENS_BUDGET` / `COLLEGUE_RUN_DEADLINE_SECONDS` | Hard run budget (auto-pause) | |
+| `COLLEGUE_HOME` | Persistence root (budget, metrics, checkpoints) | |
+| `AUTO_MERGE_ENABLED` / `AUTO_REVERT_ENABLED` / `PILOT_TOOL_ENABLED` | Autonomous capabilities (opt-in, **off** by default) | |
+
+> Detailed autonomous-engine settings (budget, auto-merge/revert, pilot MCP tool):
 > [docs/moteur_autonome.md](docs/moteur_autonome.md#réglages-env) (FR).
 
 ---

--- a/README.md
+++ b/README.md
@@ -137,19 +137,25 @@ Chaque expert utilise un LLM, itère via une **boucle agentique**, et peut **dé
 
 ### Variables d'environnement (.env)
 
-| Variable | Description | Requis |
-|----------|-------------|--------|
-| `LLM_API_KEY` | Clé API Google Gemini | ✓ |
-| `POSTGRES_URL` | URI PostgreSQL | |
-| `GITHUB_TOKEN` | Token GitHub (repo, read:org) | |
-| `SENTRY_AUTH_TOKEN` | Token Sentry | |
-| `SENTRY_ORG` | Organisation Sentry | |
-| `KUBECONFIG` | Chemin kubeconfig | |
-| `STATE_DATABASE_URL` | État durable du moteur autonome (Postgres/SQLite) | |
-| `MAX_COST_USD` / `MAX_TOKENS_BUDGET` | Budget dur (auto-pause) | |
-| `AUTO_MERGE_ENABLED` / `PILOT_TOOL_ENABLED` | Capacités autonomes (opt-in, **off** par défaut) | |
+Aperçu **par thème** (liste exhaustive et valeurs par défaut dans
+**[.env.example](.env.example)**) :
 
-> Réglages complets du moteur autonome (budget, auto-merge/revert, outil MCP du pilote) :
+| Variable(s) | Description | Requis |
+|-------------|-------------|--------|
+| `LLM_API_KEY` | Clé API du provider LLM (Gemini par défaut) | ✓ |
+| `LLM_PROVIDER` / `LLM_MODEL` | Provider et modèle LLM par défaut | |
+| `LLM_MODEL_*` / `LLM_PROVIDER_*` | Modèle/provider par **rôle** (CODER, QA, PLANNER, REVIEWER) | |
+| `LLM_RATE_LIMIT_*` | Limites d'appels LLM par client (minute / jour) | |
+| `CACHE_ENABLED` / `CACHE_TTL` | Cache des réponses d'outils | |
+| `OAUTH_ENABLED` (+ `OAUTH_*`, Keycloak) | Authentification OAuth (**off** par défaut) | |
+| `GITHUB_TOKEN` / `GITHUB_OWNER` / `GITHUB_REPO` | Intégration GitHub (watchdog, PR) | |
+| `SENTRY_DSN` / `SENTRY_ENVIRONMENT` | Observabilité Sentry | |
+| `STATE_DATABASE_URL` | État durable du moteur autonome (Postgres/SQLite) | |
+| `MAX_COST_USD` / `MAX_TOKENS_BUDGET` / `COLLEGUE_RUN_DEADLINE_SECONDS` | Budget dur du run (auto-pause) | |
+| `COLLEGUE_HOME` | Racine de persistance (budget, métriques, checkpoints) | |
+| `AUTO_MERGE_ENABLED` / `AUTO_REVERT_ENABLED` / `PILOT_TOOL_ENABLED` | Capacités autonomes (opt-in, **off** par défaut) | |
+
+> Réglages détaillés du moteur autonome (budget, auto-merge/revert, outil MCP du pilote) :
 > [docs/moteur_autonome.md](docs/moteur_autonome.md#réglages-env).
 
 ---


### PR DESCRIPTION
## Pourquoi

La table « Configuration → Variables d'environnement (.env) » du README listait des variables au cas par cas, dont certaines absentes du `.env` réel (`POSTGRES_URL`, `KUBECONFIG`) et sans plusieurs variables désormais utilisées. Mise à jour **générale**, groupée par thème, fidèle au `.env`, avec renvoi vers `.env.example` pour l'exhaustif.

## Changements (README.md + README.en.md, parité FR/EN)

Table regroupée par thème :
- LLM : `LLM_API_KEY`, `LLM_PROVIDER`/`LLM_MODEL`, modèles/providers **par rôle** (`LLM_MODEL_*`/`LLM_PROVIDER_*`), `LLM_RATE_LIMIT_*`.
- Serveur : `CACHE_ENABLED`/`CACHE_TTL`, `OAUTH_ENABLED` (+ Keycloak).
- Intégrations : `GITHUB_TOKEN`/`GITHUB_OWNER`/`GITHUB_REPO`, `SENTRY_DSN`/`SENTRY_ENVIRONMENT`.
- Moteur autonome : `STATE_DATABASE_URL`, budget (`MAX_COST_USD`/`MAX_TOKENS_BUDGET`/`COLLEGUE_RUN_DEADLINE_SECONDS`), `COLLEGUE_HOME`, capacités opt-in (`AUTO_MERGE_ENABLED`/`AUTO_REVERT_ENABLED`/`PILOT_TOOL_ENABLED`).

Renvoi ajouté vers **`.env.example`** (liste complète + défauts) ; le lien détaillé vers `docs/moteur_autonome.md` est conservé.

## Sûreté

Doc-only, aucun `.py` touché (CI triviale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
