### PR TITLE
Landing pre-main → main : documentation (Phase 4, .env.example, config README)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,9 @@ LLM_API_KEY="votre_clé_api_gemini"
 # LLM_MODEL_QA="<modèle économique pour QA/triage>"
 # LLM_PROVIDER_QA="lmstudio"
 # LLM_MODEL_PLANNER="<modèle pour la planification>"
+# LLM_PROVIDER_PLANNER="gemini"
 # LLM_MODEL_REVIEWER="<modèle pour la revue>"
+# LLM_PROVIDER_REVIEWER="gemini"
 
 # --- LM Studio (serveur local compatible OpenAI) ---
 # Pour utiliser un modèle local via LM Studio :
@@ -86,6 +88,7 @@ LLM_API_KEY="votre_clé_api_gemini"
 # SENTRY_AUTH_TOKEN=sntrys_xxxxxxxxxxxx
 # SENTRY_ORG=my-organization
 # SENTRY_DSN=https://xxx@xxx.ingest.sentry.io/xxx
+# SENTRY_ENVIRONMENT=production       # tag d'environnement Sentry (défaut: production)
 
 # Watchdog Autonome (Self-Healing)
 # --------------------------------
@@ -100,6 +103,10 @@ LLM_API_KEY="votre_clé_api_gemini"
 # ENGINE_INIT_TIMEOUT=10.0
 # ENGINE_WAIT_TIMEOUT=30.0
 # MAX_TOKENS=8192
+#
+# Cache des réponses d'outils (middleware). Activé par défaut.
+# CACHE_ENABLED=true
+# CACHE_TTL=3600                      # durée de vie du cache, en secondes
 
 # LLM Rate Limiting (par identité client)
 # ---------------------------------------
@@ -140,6 +147,20 @@ LLM_API_KEY="votre_clé_api_gemini"
 # BUDGET_EXHAUSTED_ACTION=pause       # pause (défaut) | warn
 # COLLEGUE_RUN_DEADLINE_SECONDS=0     # durée mur max d'un run (0 = pas de deadline)
 # LLM_CALL_TIMEOUT=0                  # timeout par appel LLM, s (0 = off)
+
+# --- Persistance & sandbox du pilote ---
+# COLLEGUE_HOME : racine de persistance (budget cumulé, métriques, checkpoints).
+# DOIT être un chemin ABSOLU et STABLE pour qu'un budget dur survive aux
+# redémarrages (sinon deux runs lancés depuis des dossiers différents lisent deux
+# cumuls distincts). Défaut : .collegue (relatif).
+# COLLEGUE_HOME=/chemin/absolu/.collegue
+# Cache pip persistant du sandbox (chemin HÔTE) : évite de retélécharger PyPI à
+# chaque passe réseau du gate. Vide (défaut) = aucun cache.
+# SANDBOX_PIP_CACHE_DIR=/chemin/hote/.pip_cache
+# Creds d'abonnement OpenHands (coder via abonnement, sans coût API) : chemin HÔTE
+# (ex. ~/.openhands) monté en lecture-écriture dans le sandbox du worker. Vide
+# (défaut) = aucun montage (mode clé API inchangé).
+# SANDBOX_SUBSCRIPTION_AUTH_DIR=/home/vous/.openhands
 
 # --- Auto-merge progressif (opt-in, OFF par défaut) ---
 # §6 reste le défaut : approbation humaine avant chaque merge. L'auto-merge ne

--- a/README.en.md
+++ b/README.en.md
@@ -137,19 +137,25 @@ Each expert uses an LLM, iterates through an **agentic loop**, and can **delegat
 
 ### Environment variables (.env)
 
-| Variable | Description | Required |
-|----------|-------------|----------|
-| `LLM_API_KEY` | Google Gemini API key | ✓ |
-| `POSTGRES_URL` | PostgreSQL URI | |
-| `GITHUB_TOKEN` | GitHub token (repo, read:org) | |
-| `SENTRY_AUTH_TOKEN` | Sentry auth token | |
-| `SENTRY_ORG` | Sentry organization slug | |
-| `KUBECONFIG` | Path to kubeconfig | |
-| `STATE_DATABASE_URL` | Autonomous engine durable state (Postgres/SQLite) | |
-| `MAX_COST_USD` / `MAX_TOKENS_BUDGET` | Hard budget (auto-pause) | |
-| `AUTO_MERGE_ENABLED` / `PILOT_TOOL_ENABLED` | Autonomous capabilities (opt-in, **off** by default) | |
+Overview **by theme** (full list and default values in
+**[.env.example](.env.example)**):
 
-> Full autonomous-engine settings (budget, auto-merge/revert, pilot MCP tool):
+| Variable(s) | Description | Required |
+|-------------|-------------|----------|
+| `LLM_API_KEY` | LLM provider API key (Gemini by default) | ✓ |
+| `LLM_PROVIDER` / `LLM_MODEL` | Default LLM provider and model | |
+| `LLM_MODEL_*` / `LLM_PROVIDER_*` | Per-**role** model/provider (CODER, QA, PLANNER, REVIEWER) | |
+| `LLM_RATE_LIMIT_*` | Per-client LLM call limits (per minute / day) | |
+| `CACHE_ENABLED` / `CACHE_TTL` | Tool response cache | |
+| `OAUTH_ENABLED` (+ `OAUTH_*`, Keycloak) | OAuth authentication (**off** by default) | |
+| `GITHUB_TOKEN` / `GITHUB_OWNER` / `GITHUB_REPO` | GitHub integration (watchdog, PRs) | |
+| `SENTRY_DSN` / `SENTRY_ENVIRONMENT` | Sentry observability | |
+| `STATE_DATABASE_URL` | Autonomous engine durable state (Postgres/SQLite) | |
+| `MAX_COST_USD` / `MAX_TOKENS_BUDGET` / `COLLEGUE_RUN_DEADLINE_SECONDS` | Hard run budget (auto-pause) | |
+| `COLLEGUE_HOME` | Persistence root (budget, metrics, checkpoints) | |
+| `AUTO_MERGE_ENABLED` / `AUTO_REVERT_ENABLED` / `PILOT_TOOL_ENABLED` | Autonomous capabilities (opt-in, **off** by default) | |
+
+> Detailed autonomous-engine settings (budget, auto-merge/revert, pilot MCP tool):
 > [docs/moteur_autonome.md](docs/moteur_autonome.md#réglages-env) (FR).
 
 ---

--- a/README.en.md
+++ b/README.en.md
@@ -172,8 +172,13 @@ python -m collegue.pilot ... --execute            # real writes (PRs + state)
 python -m collegue.pilot ... --execute --improve  # + improvement cycle
 ```
 
-Architecture, guardrails, observability/audit, crash resume and settings:
-**[docs/moteur_autonome.md](docs/moteur_autonome.md)** (FR).
+Once the MVP is built, `--improve` chains the **continuous-improvement loop** (Phase 4):
+a **deterministic quality objective** (coverage − security − lint − complexity, no LLM
+judgment) opens PRs only when a diff **improves without regression** (fail-closed gate);
+PRs are **stacked** and stop at a plateau.
+
+Architecture, improvement loop, guardrails, observability/audit, crash resume and
+settings: **[docs/moteur_autonome.md](docs/moteur_autonome.md)** (FR).
 
 ---
 
@@ -197,7 +202,7 @@ See [docs/watchdog_deployment.md](docs/watchdog_deployment.md) for deployment.
 | [Integration Guide](docs/guide_integration.md) | Claude Desktop, Cursor, Windsurf, CI/CD integration |
 | [Expert Reference](docs/reference_experts.md) | Parameters, outputs and use cases for each expert |
 | [Multi-Agent System](docs/multi_agent_expert_system.md) | Technical architecture, delegation, memory |
-| [Autonomous Development Engine](docs/moteur_autonome.md) | Autonomous pilot: architecture, guardrails, audit, resume, settings (FR) |
+| [Autonomous Development Engine](docs/moteur_autonome.md) | Autonomous pilot: architecture, **continuous improvement (Phase 4)**, guardrails, audit, resume, settings (FR) |
 | [LLM Evaluations](docs/llm_evals.md) | Output quality benchmarks |
 | [Rate Limiting](docs/rate_limiting_and_quotas.md) | Quotas and limits |
 

--- a/README.md
+++ b/README.md
@@ -137,19 +137,25 @@ Chaque expert utilise un LLM, itère via une **boucle agentique**, et peut **dé
 
 ### Variables d'environnement (.env)
 
-| Variable | Description | Requis |
-|----------|-------------|--------|
-| `LLM_API_KEY` | Clé API Google Gemini | ✓ |
-| `POSTGRES_URL` | URI PostgreSQL | |
-| `GITHUB_TOKEN` | Token GitHub (repo, read:org) | |
-| `SENTRY_AUTH_TOKEN` | Token Sentry | |
-| `SENTRY_ORG` | Organisation Sentry | |
-| `KUBECONFIG` | Chemin kubeconfig | |
-| `STATE_DATABASE_URL` | État durable du moteur autonome (Postgres/SQLite) | |
-| `MAX_COST_USD` / `MAX_TOKENS_BUDGET` | Budget dur (auto-pause) | |
-| `AUTO_MERGE_ENABLED` / `PILOT_TOOL_ENABLED` | Capacités autonomes (opt-in, **off** par défaut) | |
+Aperçu **par thème** (liste exhaustive et valeurs par défaut dans
+**[.env.example](.env.example)**) :
 
-> Réglages complets du moteur autonome (budget, auto-merge/revert, outil MCP du pilote) :
+| Variable(s) | Description | Requis |
+|-------------|-------------|--------|
+| `LLM_API_KEY` | Clé API du provider LLM (Gemini par défaut) | ✓ |
+| `LLM_PROVIDER` / `LLM_MODEL` | Provider et modèle LLM par défaut | |
+| `LLM_MODEL_*` / `LLM_PROVIDER_*` | Modèle/provider par **rôle** (CODER, QA, PLANNER, REVIEWER) | |
+| `LLM_RATE_LIMIT_*` | Limites d'appels LLM par client (minute / jour) | |
+| `CACHE_ENABLED` / `CACHE_TTL` | Cache des réponses d'outils | |
+| `OAUTH_ENABLED` (+ `OAUTH_*`, Keycloak) | Authentification OAuth (**off** par défaut) | |
+| `GITHUB_TOKEN` / `GITHUB_OWNER` / `GITHUB_REPO` | Intégration GitHub (watchdog, PR) | |
+| `SENTRY_DSN` / `SENTRY_ENVIRONMENT` | Observabilité Sentry | |
+| `STATE_DATABASE_URL` | État durable du moteur autonome (Postgres/SQLite) | |
+| `MAX_COST_USD` / `MAX_TOKENS_BUDGET` / `COLLEGUE_RUN_DEADLINE_SECONDS` | Budget dur du run (auto-pause) | |
+| `COLLEGUE_HOME` | Racine de persistance (budget, métriques, checkpoints) | |
+| `AUTO_MERGE_ENABLED` / `AUTO_REVERT_ENABLED` / `PILOT_TOOL_ENABLED` | Capacités autonomes (opt-in, **off** par défaut) | |
+
+> Réglages détaillés du moteur autonome (budget, auto-merge/revert, outil MCP du pilote) :
 > [docs/moteur_autonome.md](docs/moteur_autonome.md#réglages-env).
 
 ---

--- a/README.md
+++ b/README.md
@@ -172,8 +172,13 @@ python -m collegue.pilot ... --execute            # écritures réelles (PR + é
 python -m collegue.pilot ... --execute --improve  # + cycle d'amélioration
 ```
 
-Architecture, garde-fous, observabilité/audit, reprise après crash et réglages :
-**[docs/moteur_autonome.md](docs/moteur_autonome.md)**.
+`--improve` enchaîne, une fois le MVP construit, la **boucle d'amélioration continue**
+(Phase 4) : un **objectif de qualité déterministe** (couverture − sécu − lint −
+complexité, sans avis de LLM) ouvre des PR seulement quand le diff **progresse sans
+régression** (gate fail-closed) ; les PR sont **stackées** et s'arrêtent au plateau.
+
+Architecture, boucle d'amélioration, garde-fous, observabilité/audit, reprise après
+crash et réglages : **[docs/moteur_autonome.md](docs/moteur_autonome.md)**.
 
 ---
 
@@ -197,7 +202,7 @@ Voir [docs/watchdog_deployment.md](docs/watchdog_deployment.md) pour le déploie
 | [Guide d'Intégration](docs/guide_integration.md) | Intégration Claude Desktop, Cursor, Windsurf, CI/CD |
 | [Référence des Experts](docs/reference_experts.md) | Paramètres, sorties et cas d'usage de chaque expert |
 | [Système Multi-Agents](docs/multi_agent_expert_system.md) | Architecture technique, délégation, mémoire |
-| [Moteur de développement autonome](docs/moteur_autonome.md) | Pilote autonome : architecture, garde-fous, audit, reprise, réglages |
+| [Moteur de développement autonome](docs/moteur_autonome.md) | Pilote autonome : architecture, **amélioration continue (Phase 4)**, garde-fous, audit, reprise, réglages |
 | [Évaluations LLM](docs/llm_evals.md) | Benchmarks qualité des sorties LLM |
 | [Rate Limiting](docs/rate_limiting_and_quotas.md) | Quotas et limites |
 

--- a/docs/guide_utilisateur.md
+++ b/docs/guide_utilisateur.md
@@ -25,6 +25,14 @@ Collègue MCP est un **collectif d'experts IA spécialisés** qui fonctionne com
 
 Chaque expert utilise un LLM en backend et peut **déléguer automatiquement** à d'autres experts quand il détecte des problèmes hors de son domaine.
 
+> **Deux modes d'usage.** Ce guide couvre le mode **réactif** : les experts appelés
+> depuis votre IDE. Collègue embarque aussi un mode **autonome** de bout en bout
+> (planifier → coder → tester → ouvrir des PR sous budget, puis **amélioration
+> continue** gatée par un objectif de qualité déterministe). Ce mode s'invoque
+> explicitement (`python -m collegue.pilot … --execute --improve`), n'est **jamais**
+> auto-démarré par le serveur MCP, et garde le merge humain par défaut. Voir
+> **[Moteur de développement autonome](moteur_autonome.md)**.
+
 ---
 
 ## Installation

--- a/docs/moteur_autonome.md
+++ b/docs/moteur_autonome.md
@@ -42,7 +42,7 @@ problématique + budget
 | **Planner** | `collegue/planner/` | Problématique → `SPEC.md` → graphe de tâches (DAG) → labels/milestones/board GitHub. Gate de **validation humaine** du plan (anti-TOCTOU par empreinte SHA-256). |
 | **Pilote** | `collegue/pilot/` | Ordonnance les tâches prêtes (DFS anti-cycle) sous un **contrôleur budget-temps**, chaîne l'exécuteur, checkpoint, et bascule en mode amélioration quand le MVP est construit. |
 | **Executor** | `collegue/executor/` | Exécute **une** issue de bout en bout : workspace git → agent codeur (OpenHands, en sandbox) → tests + revue experte (gate fail-closed) → ouverture de PR. |
-| **Improve** | `collegue/improve/` | Après le MVP, fait cycler les experts pour élever un **score de qualité** ; ne promeut un changement que s'il progresse **sans régression** (gating par métrique), s'arrête sur rendements décroissants. |
+| **Improve** | `collegue/improve/` | Après le MVP, fait cycler les experts pour élever un **objectif de qualité déterministe** (couverture − sécu − lint − complexité) ; ne promeut un diff que s'il progresse **sans régression** (gate fail-closed), s'arrête sur rendements décroissants. Détail : [Amélioration continue (Phase 4)](#amélioration-continue-phase-4). |
 
 Socle commun :
 
@@ -70,6 +70,96 @@ ou on refuse) :
 | **Auto-merge opt-in** | `AUTO_MERGE_ENABLED=false` par défaut. Activé, il ne fusionne **que** du faible risque (allowlist de chemins **non exécutables**, plafond de LOC, **toutes** les vérifs CI vertes). Tout code/exécutable/secret/CI est bloqué par une garde dure insensible à la casse. |
 | **Auto-revert** | Filet de l'auto-merge : après un auto-merge, si `main` devient rouge (tests en sandbox), un revert est préparé. Fail-closed : santé non concluante = traitée comme rouge. Un revert qui échoue **escalade** vers un humain (ne passe jamais pour un succès). |
 | **Outil MCP du pilote** | Exposé en MCP **uniquement** si `PILOT_TOOL_ENABLED=true` **et** `OAUTH_ENABLED=true` (sinon **refus de démarrer**). Allowlist d'appelants (sujets OAuth vérifiés, jamais un en-tête client). Jamais auto-découvert. `dry_run` par défaut. |
+
+---
+
+## Amélioration continue (Phase 4)
+
+Une fois le MVP construit (`--improve`), le moteur ne s'arrête pas : il **fait
+progresser la qualité du projet généré** en ouvrant des PR d'amélioration, sous le
+budget restant. Le cœur est une **fonction objectif déterministe** — pas un avis de
+LLM — pour qu'une promotion soit reproductible et **sans faux-rejet** :
+
+```
+composite = w_cov·(couverture/100)
+          − w_séc·sécu_pondérée
+          − w_lint·violations_lint
+          − w_cx·blocs_complexes
+          − w_dep·vulns_deps
+```
+
+| Poids | Valeur | Note |
+|-------|--------|------|
+| `w_cov` (couverture) | `1.0` | Domine : la couverture (0–100) normalisée en 0–1. |
+| `w_séc` (sécurité) | `0.1` | Pénalité par unité de score sécu **pondéré par sévérité**. |
+| `w_lint` | `0.02` | Pénalité faible par violation (un gain de couverture ne doit pas sauter sur un lint marginal). |
+| `w_cx` (complexité) | `0.05` | Pénalité par bloc trop complexe (mccabe). |
+| `w_dep` (vulns deps) | `0.5` | **Signal opt-in**, off par défaut (terme nul) ; voir plus bas. |
+
+**Mesuré sur le workspace sur disque** (pas sur le diff d'un round) : l'objectif est
+donc **symétrique avant/après**, ce qui permet de promouvoir un vrai gain sans le
+faux-rejet d'un signal diff-scopé non déterministe (cause racine corrigée en Phase 4).
+
+### Ce qui entre dans l'objectif (déterministe)
+
+| Signal | Source | Détail |
+|--------|--------|--------|
+| **Couverture de tests** | `pytest --cov` (ligne `TOTAL`) | `tests_passed` (exit 0) sert de **garde dure** au gate. |
+| **Sécurité (pondérée)** | `secret_scan` statique (regex, **zéro LLM**) | Sévérités pondérées (critical 10 / high 5 / medium 2 / low 1). Lockfiles générés + dossiers/fichiers de test/fixtures exclus du scan (sinon ~99 % du poids vient de `package-lock.json`). |
+| **Lint** | `ruff` (`E,F,W`) | `--isolated --no-cache` : reproductible, indépendant de la config du projet généré. |
+| **Complexité** | `ruff` mccabe (`C901`, seuil 10) | Compte de blocs au-delà du seuil. |
+
+Signaux **informatifs** (corps de PR / relecteur humain, **hors composite gaté**) :
+la **revue LLM** (`review_score`) et la **couverture de docstrings** (`doc_coverage`,
+proxy de maintenabilité). Un signal LLM diff-scopé est non déterministe → jamais dans
+la décision de promotion.
+
+Signal **opt-in** : les **vulnérabilités de dépendances** (`pip-audit` sur
+`requirements.txt`). Off par défaut (terme composite nul, règle de gate no-op) ;
+activé, il est **gaté en tolérance 0**. `pip-audit` n'est pas imposé en dépendance —
+absent ⇒ no-op.
+
+### Le gate (fail-closed) — `collegue/improve/gate.py`
+
+Avant **chaque** PR, deux instantanés (avant/après le diff) sont comparés. Toutes ces
+règles doivent passer, sinon le diff est **jeté** (rollback avant promotion — aucune
+régression n'atteint la branche de base) :
+
+1. **Tests verts** après le diff (garde dure).
+2. **Scores composites finis** (un `NaN`/`inf` = mesure corrompue ⇒ rejet).
+3. **Mesurabilité stable** : couverture ET lint/complexité mesurés des deux côtés
+   (une bascule « mesuré → non mesuré » gonflerait le composite ⇒ rejet).
+4. **Anti-régression par signal** : sécu (tolérance 0), lint (slack 0), complexité
+   (slack 0), vulns deps (tolérance 0).
+5. **Gain réel** : `Δcomposite ≥ min_gain` (défaut `0.01`) — pas de promotion de bruit.
+
+### La boucle — `collegue/improve/loop.py`
+
+Chaque round, sur un **clone neuf** :
+
+1. **Compounding** — réapplique **et commite** les diffs déjà promus, pour que `HEAD`
+   reflète l'état cumulé amélioré. Le diff capturé du round ne contient alors que ses
+   **nouveaux** changements (pas de double-comptage), et la baseline monte round après round.
+2. **Mesure baseline** → **propose une dimension** (piloté par la métrique) parmi
+   `coverage`, `security`, `refactoring`, `documentation`, `consistency` (les trois
+   dernières en round-robin de polissage).
+3. L'**agent code un diff** pour cette dimension.
+4. **Auto-fix lint** — `ruff --fix` + `ruff format` sur les `.py` touchés, **avant** la
+   mesure : le coder se concentre sur le fond, le lint auto-corrigible est nettoyé (le
+   gate étant tolérance 0 sur le lint). Best-effort ; un fix qui casserait un test est
+   rattrapé par la mesure `after` (tests rouges ⇒ rejet).
+5. **Mesure après** → **gate**. Accepté ⇒ **PR** + métrique persistée. Rejeté ⇒ diff jeté.
+
+**PR stackées** (mode `--execute`) : chaque PR d'amélioration est basée sur la branche
+de la **promotion précédente** → des diffs incrémentaux **mergeables dans l'ordre**,
+sans conflit cumulatif. Le merge des PR d'amélioration reste **humain** (§6).
+
+**Arrêt** : `plateau` (deux rounds consécutifs sans promotion — rendements décroissants),
+`paused_budget` / `deadline_reached` (budget-temps), ou `safety_cap` (garde-fou
+anti-boucle, 50 itérations).
+
+> En `dry_run` (défaut), la boucle va jusqu'aux **aperçus** de PR sans aucune écriture
+> (utile pour valider l'objectif et les promotions avant de lancer en réel).
 
 ---
 


### PR DESCRIPTION
## Landing `pre-main` → `main`

Reporte sur `main` les 3 PR documentation mergées dans `pre-main` cette session (doc-only, aucun code applicatif touché) :

- **#557** — `docs/moteur_autonome.md` : nouvelle section « Amélioration continue (Phase 4) » (objectif déterministe, gate fail-closed, compounding, PR stackées, auto-fix) + README FR/EN + guide utilisateur.
- **#558** — `.env.example` synchronisé avec les variables réellement lues (placeholders, aucun secret).
- **#559** — README FR+EN : table de configuration `.env` regroupée par thème, alignée sur le `.env`, renvoi vers `.env.example`.

### Périmètre

```
.env.example              | +21
README.en.md / README.md  | tables config + section moteur autonome
docs/guide_utilisateur.md | note « deux modes d'usage »
docs/moteur_autonome.md   | +92 (section Phase 4)
```

Aucun `.py` modifié → CI triviale attendue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
