### PR TITLE
feat(pilot): ctx de sampling offline multi-provider (A1 — end-to-end par le produit)

### DIFF
--- a/collegue/app.py
+++ b/collegue/app.py
@@ -351,19 +351,14 @@ async def core_lifespan(server):
 sampling_handler = None
 if settings.LLM_API_KEY or settings.is_local_provider:
     try:
-        from collegue.core.llm.sampling_handler import build_sampling_handler
+        from collegue.core.llm.sampling_handler import build_sampling_handler, resolve_openai_endpoint
 
         provider = settings.LLM_PROVIDER.lower()
-        # Gemini par défaut ; sinon l'endpoint OpenAI-compatible du provider.
-        if provider in ("gemini", ""):
-            base_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
-        else:
-            base_url = settings.llm_base_url  # None pour OpenAI cloud → défaut SDK
-        # Clé factice pour les locaux qui l'ignorent (le SDK OpenAI en exige une).
-        api_key = settings.LLM_API_KEY or ("local" if settings.is_local_provider else None)
+        # Résolution provider→endpoint partagée avec le ctx offline (source unique).
+        default_model, api_key, base_url = resolve_openai_endpoint(settings)
 
         sampling_handler = build_sampling_handler(
-            default_model=settings.LLM_MODEL,
+            default_model=default_model,
             api_key=api_key,
             base_url=base_url,
         )

--- a/collegue/core/llm/sampling_ctx.py
+++ b/collegue/core/llm/sampling_ctx.py
@@ -1,0 +1,272 @@
+"""Contexte de sampling **offline** (hors serveur MCP) pour piloter le moteur en CLI.
+
+Le planner (``generate_spec``/``decompose``), le reviewer (``code_review`` via
+``BaseTool``) et la boucle agentique attendent un objet ``ctx`` exposant une
+coroutine ``sample(...)`` (sampling FastMCP). En CLI il n'y a **pas** de serveur
+MCP, donc pas de ``ctx`` : ``run_project_from_settings`` recevait ``ctx=None`` et
+les chemins LLM réels échouaient.
+
+Ce module fournit un ``ctx`` qui appelle le LLM via un client **OpenAI-compatible**
+(``AsyncOpenAI`` + ``base_url`` par provider), en réutilisant la MÊME résolution
+provider→endpoint que le handler serveur (``resolve_openai_endpoint``) → **multi-
+provider** (Gemini OpenAI-compat / OpenAI / lmstudio / ollama / unsloth), pas de
+lock-in (brief §8). Au même chokepoint que le handler serveur, on applique la
+**garde budget dur** (``enforce_budget``, C4) et la **capture d'usage**
+(``record_usage``) — tous les ``ctx.sample()`` offline transitent ici.
+
+Contrat reproduit fidèlement (lu dans le code) :
+- ``sample(messages, *, system_prompt, result_type, temperature, max_tokens,
+  model_preferences, **ignored)`` renvoie un objet avec ``.text`` (texte brut) et
+  ``.result`` (instance ``result_type`` si parsable, sinon le texte) — exactement
+  ce que lisent ``tools/base.py`` (``result.result if result_type else result.text``)
+  et le planner ;
+- ``model_preferences=[modèle]`` route vers ce modèle (rôle → modèle, C1/C2) ;
+- stubs ``info/debug/warning/error/report_progress`` no-op attendus par les outils ;
+- ``max_output_tokens`` généreux par défaut (quirk gemma : trop bas ⇒ contenu vide).
+
+Le client ``AsyncOpenAI`` est construit **paresseusement** (au 1er ``sample``) : la
+seule construction du ctx n'ouvre aucune connexion ni n'exige de clé (les tests qui
+n'échantillonnent pas restent inertes).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+DEFAULT_MAX_TOKENS = 8192
+
+
+@dataclass
+class SampleResult:
+    """Réponse de sampling : ``.text`` brut + ``.result`` structuré optionnel."""
+
+    text: str = ""
+    result: Any = None
+
+
+class PerModelRateLimiter:
+    """Cap glissant par modèle : ``per_minute`` req/60 s et ``per_day`` req/24 h.
+
+    ``acquire`` bloque (``asyncio.sleep``) jusqu'à ce qu'un créneau se libère. Le
+    décompte est par **nom de modèle**. Thread-safe (lock court) ; attentes hors-lock.
+    Sert à respecter un quota partagé (ex. Gemini free-tier) pour les appels de CE ctx.
+    """
+
+    def __init__(self, per_minute: int = 0, per_day: int = 0):
+        self.per_minute = max(0, int(per_minute or 0))
+        self.per_day = max(0, int(per_day or 0))
+        self._minute: Dict[str, deque] = {}
+        self._day: Dict[str, deque] = {}
+        self._lock = threading.Lock()
+
+    def _wait_needed(self, model: str, now: float) -> float:
+        mdq = self._minute.setdefault(model, deque())
+        ddq = self._day.setdefault(model, deque())
+        while mdq and now - mdq[0] >= 60:
+            mdq.popleft()
+        while ddq and now - ddq[0] >= 86400:
+            ddq.popleft()
+        wait = 0.0
+        if self.per_minute and len(mdq) >= self.per_minute:
+            wait = max(wait, 60.0 - (now - mdq[0]))
+        if self.per_day and len(ddq) >= self.per_day:
+            wait = max(wait, 86400.0 - (now - ddq[0]))
+        return wait
+
+    async def acquire(self, model: str) -> None:
+        while True:
+            now = time.time()
+            with self._lock:
+                wait = self._wait_needed(model, now)
+                if wait <= 0:
+                    self._minute[model].append(now)
+                    self._day[model].append(now)
+                    return
+            await asyncio.sleep(min(wait, 5.0) + 0.05)
+
+
+def _pick_model(model_preferences: Any, default_model: str) -> str:
+    """Choisit le modèle effectif depuis ``model_preferences`` (rôle → modèle)."""
+    if isinstance(model_preferences, (list, tuple)) and model_preferences:
+        first = str(model_preferences[0]).strip()
+        if first:
+            return first
+    return default_model
+
+
+def to_openai_messages(messages: Any, system_prompt: Optional[str]) -> List[Dict[str, str]]:
+    """Normalise ``messages`` (str ou liste ``{role,content}``) en messages OpenAI.
+
+    ``BaseTool.sample_llm`` envoie soit une chaîne (+ ``system_prompt`` séparé), soit
+    ``[{"role":"system","content":...},{"role":"user","content":...}]``. L'endpoint
+    OpenAI-compatible gère nativement le rôle ``system`` (pas de pliage gemma requis).
+    Garantit au moins un tour ``user`` (l'API refuse une conversation sans user).
+    """
+    out: List[Dict[str, str]] = []
+    if system_prompt:
+        out.append({"role": "system", "content": str(system_prompt)})
+    if isinstance(messages, str):
+        if messages:
+            out.append({"role": "user", "content": messages})
+    elif isinstance(messages, (list, tuple)):
+        for m in messages:
+            if isinstance(m, dict):
+                role = str(m.get("role", "user"))
+                content = m.get("content", m.get("text", ""))
+                if content is None:
+                    content = ""
+                elif isinstance(content, (list, tuple)):
+                    content = " ".join(p.get("text", "") if isinstance(p, dict) else str(p) for p in content)
+                out.append({"role": role, "content": str(content)})
+            else:
+                out.append({"role": "user", "content": str(m)})
+    elif messages:
+        out.append({"role": "user", "content": str(messages)})
+    if not any(m["role"] == "user" for m in out):
+        out.append({"role": "user", "content": "(vide)"})
+    return out
+
+
+def _coerce(text: str, result_type: Any) -> Any:
+    """Parse ``text`` (JSON, fences tolérées) en ``result_type`` ; sinon rend le texte."""
+    try:
+        from collegue.planner._parsing import json_from_text
+    except Exception:  # noqa: BLE001 - parsing best-effort
+        json_from_text = None
+    data = json_from_text(text) if json_from_text else None
+    if isinstance(data, dict) and hasattr(result_type, "model_validate"):
+        try:
+            return result_type.model_validate(data)
+        except Exception:  # noqa: BLE001 - retombe sur le texte brut
+            return text
+    return text
+
+
+class LocalSamplingContext:
+    """``ctx`` de sampling offline routé vers un endpoint OpenAI-compatible.
+
+    Construire le ctx n'ouvre aucune connexion : le client ``AsyncOpenAI`` est créé
+    au premier ``sample`` (ou injecté en test via ``client=``).
+    """
+
+    def __init__(
+        self,
+        *,
+        default_model: str,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        rate_limiter: Optional[PerModelRateLimiter] = None,
+        default_max_tokens: int = DEFAULT_MAX_TOKENS,
+        max_retries: int = 4,
+        client: Any = None,
+    ):
+        self._default_model = default_model or ""
+        self._api_key = api_key
+        self._base_url = base_url
+        self._limiter = rate_limiter
+        self._default_max_tokens = int(default_max_tokens)
+        self._max_retries = int(max_retries)
+        self._client = client
+        # Stubs ctx attendus par les outils (no-op async).
+        self.info = self._noop
+        self.debug = self._noop
+        self.warning = self._noop
+        self.error = self._noop
+        self.report_progress = self._noop
+
+    @classmethod
+    def from_settings(cls, settings_obj: Any) -> "LocalSamplingContext":
+        """Construit le ctx depuis la config (provider→endpoint).
+
+        **Pas de rate-limiter par défaut** : les réglages ``LLM_RATE_LIMIT_*`` bornent
+        le middleware **serveur par-client** (autre couche) ; les y réutiliser
+        throttlerait le moteur (15/min, 500/jour) bien en-dessous d'un run réel. Les
+        429 sont gérés par le retry du SDK (``max_retries``) et le coût est borné par
+        ``enforce_budget`` (C4). Un ``PerModelRateLimiter`` reste **injectable** au
+        constructeur pour qui veut cadencer un quota free-tier.
+        """
+        from collegue.core.llm.sampling_handler import resolve_openai_endpoint
+
+        default_model, api_key, base_url = resolve_openai_endpoint(settings_obj)
+        return cls(default_model=default_model, api_key=api_key, base_url=base_url)
+
+    async def _noop(self, *args: Any, **kwargs: Any) -> None:  # ctx.info/debug/...
+        return None
+
+    def _client_obj(self) -> Any:
+        if self._client is None:
+            from openai import AsyncOpenAI
+
+            self._client = AsyncOpenAI(api_key=self._api_key, base_url=self._base_url, max_retries=self._max_retries)
+        return self._client
+
+    async def sample(
+        self,
+        messages: Any = "",
+        *,
+        system_prompt: Optional[str] = None,
+        result_type: Any = None,
+        temperature: float = 0.7,
+        max_tokens: Optional[int] = None,
+        model_preferences: Any = None,
+        **_ignored: Any,
+    ) -> SampleResult:
+        model = _pick_model(model_preferences, self._default_model)
+        oai_messages = to_openai_messages(messages, system_prompt)
+        # On RESPECTE le ``max_tokens`` explicite de l'appelant (parité avec le handler
+        # serveur — sinon on inflerait ×4 les caps voulus, ex. 2000) ; seul un appel SANS
+        # cap retombe sur ``_default_max_tokens`` (généreux : un modèle « raisonnant »
+        # type gemma coupé trop tôt rend un contenu vide).
+        eff_max = int(max_tokens) if max_tokens else self._default_max_tokens
+        if self._limiter is not None:
+            await self._limiter.acquire(model)
+        text = await self._create(model, oai_messages, temperature, eff_max)
+        res = SampleResult(text=text)
+        if result_type is not None:
+            res.result = _coerce(text, result_type)
+        return res
+
+    async def _create(self, model: str, messages: List[Dict[str, str]], temperature: float, max_tokens: int) -> str:
+        # Garde budget dur (C4) + capture d'usage AU MÊME chokepoint que le handler
+        # serveur : tous les ctx.sample() offline passent ici. ``enforce_budget`` lève
+        # ``BudgetExceeded`` (BaseException) si le plafond cumulé est atteint — on NE la
+        # capture pas (auto-pause volontaire). No-op si plafonds désactivés.
+        from collegue.monitoring.metrics import enforce_budget
+        from collegue.monitoring.sampling_usage import record_usage
+
+        enforce_budget()
+        resp = await self._client_obj().chat.completions.create(
+            model=model, messages=messages, temperature=temperature, max_tokens=max_tokens
+        )
+        usage = getattr(resp, "usage", None)
+        if usage is not None:
+            record_usage(
+                getattr(usage, "prompt_tokens", 0) or 0,
+                getattr(usage, "completion_tokens", 0) or 0,
+                getattr(resp, "model", model) or model,
+            )
+        return _extract_text(resp)
+
+    async def aclose(self) -> None:
+        if self._client is not None:
+            close = getattr(self._client, "close", None) or getattr(self._client, "aclose", None)
+            if close is not None:
+                maybe = close()
+                if asyncio.iscoroutine(maybe):
+                    await maybe
+            self._client = None
+
+
+def _extract_text(resp: Any) -> str:
+    """Texte du 1er choix d'une réponse chat.completions (OpenAI-compatible)."""
+    choices = getattr(resp, "choices", None) or []
+    if not choices:
+        return ""
+    message = getattr(choices[0], "message", None)
+    content = getattr(message, "content", "") if message is not None else ""
+    return content or ""

--- a/collegue/core/llm/sampling_handler.py
+++ b/collegue/core/llm/sampling_handler.py
@@ -65,6 +65,27 @@ def _make_handler_class():
     return UsageTrackingSamplingHandler
 
 
+def resolve_openai_endpoint(settings_obj: Any) -> tuple[str, Optional[str], Optional[str]]:
+    """``(default_model, api_key, base_url)`` pour un client OpenAI-compatible, depuis la config.
+
+    Source unique de vérité du routage provider→endpoint (utilisée par ``app.py`` pour
+    le handler serveur ET par le ``ctx`` offline ``LocalSamplingContext``) :
+
+    - ``gemini`` (défaut) → endpoint **OpenAI-compatible** de Google ;
+    - provider **local** (lmstudio/ollama/unsloth) → ``settings.llm_base_url`` + clé factice ;
+    - ``openai`` cloud → ``base_url=None`` (défaut du SDK).
+    """
+    provider = (getattr(settings_obj, "LLM_PROVIDER", "gemini") or "gemini").lower()
+    if provider in ("gemini", ""):
+        base_url: Optional[str] = "https://generativelanguage.googleapis.com/v1beta/openai/"
+    else:
+        base_url = getattr(settings_obj, "llm_base_url", None)
+    is_local = bool(getattr(settings_obj, "is_local_provider", False))
+    api_key = getattr(settings_obj, "LLM_API_KEY", None) or ("local" if is_local else None)
+    default_model = getattr(settings_obj, "LLM_MODEL", "") or ""
+    return default_model, api_key, base_url
+
+
 def build_sampling_handler(default_model: str, api_key: Optional[str], base_url: Optional[str]) -> Optional[Any]:
     """Instancie le handler de sampling, ou ``None`` si les dépendances manquent."""
     try:

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -143,6 +143,13 @@ def _build_clients(github_token):  # pragma: no cover - infra réelle (integrati
     return _default_clients(token=github_token)
 
 
+def _build_ctx(settings_obj):  # pragma: no cover - infra réelle (integration)
+    """ctx de sampling offline (OpenAI-compatible, multi-provider) pour le CLI/hors-MCP."""
+    from collegue.core.llm.sampling_ctx import LocalSamplingContext
+
+    return LocalSamplingContext.from_settings(settings_obj)
+
+
 def _gate_options(settings_obj) -> dict:
     """Options du gate qualité depuis la config (#437/#438/#439) — vers ``execute_issue``.
 
@@ -270,66 +277,85 @@ async def run_project_from_settings(
         started_at = load_run_start(manager, project_id)
         budget = BudgetTimeController(settings_obj=settings_obj, started_at=started_at)
 
-    result = await run_project(
-        project_id,
-        repo_source,
-        ctx,
-        agent=agent,
-        owner=owner,
-        repo=repo,
-        manager=manager,
-        base=base,
-        budget=budget,
-        sandbox=sandbox,
-        reviewer=reviewer,
-        clients=clients,
-        dry_run=dry_run,
-        max_iterations=max_iterations,
-        improve=improve,
-        run_improvement_fn=run_improvement_fn,
-        # Retry au niveau tâche (#420) : le chemin assemblé est résilient par défaut
-        # (TASK_MAX_ATTEMPTS=3 en config) ; le module driver isolé reste, lui, à 1.
-        max_task_attempts=getattr(settings_obj, "TASK_MAX_ATTEMPTS", 3),
-        retry_backoff_seconds=getattr(settings_obj, "TASK_RETRY_BACKOFF_SECONDS", 15.0),
-        # Cohérence inter-tâches (#411) : opt-in pour exiger le merge des deps.
-        require_merged_deps=bool(getattr(settings_obj, "DEPS_REQUIRE_MERGED", False)),
-        # Intégration sérielle en mode strict (#434) : 1 PR en vol par défaut.
-        max_inflight_reviews=getattr(settings_obj, "STRICT_MAX_INFLIGHT_PRS", 1),
-        # Gate configurable par projet (#438) : commande de tests + passe frontend.
-        gate_options=_gate_options(settings_obj),
-        # Gouvernance de coût (#441) : ledger + source process branchés en réel.
-        audit=audit,
-        cost_source=cost_source,
-        # #502 : refus opt-in de démarrer si le prix coder n'est pas résolvable.
-        require_cost_pricing=bool(getattr(settings_obj, "REQUIRE_COST_PRICING", False)),
-    )
+    # ctx de sampling : hors serveur MCP (CLI), aucun ``ctx`` n'est fourni → le
+    # reviewer/planner/boucle agentique échoueraient. On en assemble un offline
+    # (OpenAI-compatible, multi-provider) et on le ferme en fin de run si on l'a créé.
+    owns_ctx = ctx is None
+    if ctx is None:
+        ctx = _build_ctx(settings_obj)
 
-    # Reporting (journal de décisions) — réel uniquement (dry_run n'écrit rien).
-    if not dry_run:
-        prs = ", ".join(str(n) for n in result.opened_prs) or "aucune"
-        # #440 : un arrêt deadline laisse du travail VALIDÉ en attente de merge —
-        # le signaler dans le journal pour que le drain ne dépende pas d'un
-        # post-mortem (la PR FacNor #72 est restée ouverte, mergée à la main).
-        drain = ""
-        if result.pending_reviews:
-            drain = f" ; {len(result.pending_reviews)} tâche(s) in_review À DRAINER (merge requis)"
-        # #441 : bilan de coût du run dans le journal (ledger enfin vivant).
-        cost_note = ""
-        if audit is not None:
-            ledger = audit.cost_summary()
-            cost_note = f" ; coût≈{ledger.get('usd', 0.0)}$ / {ledger.get('tokens', 0)} tokens"
-            # #502 : un coût à 0 sans prix coder configuré est suspect — le dire.
-            from collegue.executor.openhands_agent import coder_pricing_resolvable
-
-            if not coder_pricing_resolvable(settings_obj):
-                cost_note += " [PRIX CODER NON CONFIGURÉS — coût $ possiblement INCONNU]"
-        manager.record_decision(
+    try:
+        result = await run_project(
             project_id,
-            f"Run pilote: {result.stop_reason} — {result.iterations} tâche(s), PR {prs}{drain}{cost_note}",
-            rationale=f"statut projet={result.project_status or 'inchangé'}",
+            repo_source,
+            ctx,
+            agent=agent,
+            owner=owner,
+            repo=repo,
+            manager=manager,
+            base=base,
+            budget=budget,
+            sandbox=sandbox,
+            reviewer=reviewer,
+            clients=clients,
+            dry_run=dry_run,
+            max_iterations=max_iterations,
+            improve=improve,
+            run_improvement_fn=run_improvement_fn,
+            # Retry au niveau tâche (#420) : le chemin assemblé est résilient par défaut
+            # (TASK_MAX_ATTEMPTS=3 en config) ; le module driver isolé reste, lui, à 1.
+            max_task_attempts=getattr(settings_obj, "TASK_MAX_ATTEMPTS", 3),
+            retry_backoff_seconds=getattr(settings_obj, "TASK_RETRY_BACKOFF_SECONDS", 15.0),
+            # Cohérence inter-tâches (#411) : opt-in pour exiger le merge des deps.
+            require_merged_deps=bool(getattr(settings_obj, "DEPS_REQUIRE_MERGED", False)),
+            # Intégration sérielle en mode strict (#434) : 1 PR en vol par défaut.
+            max_inflight_reviews=getattr(settings_obj, "STRICT_MAX_INFLIGHT_PRS", 1),
+            # Gate configurable par projet (#438) : commande de tests + passe frontend.
+            gate_options=_gate_options(settings_obj),
+            # Gouvernance de coût (#441) : ledger + source process branchés en réel.
+            audit=audit,
+            cost_source=cost_source,
+            # #502 : refus opt-in de démarrer si le prix coder n'est pas résolvable.
+            require_cost_pricing=bool(getattr(settings_obj, "REQUIRE_COST_PRICING", False)),
         )
 
-    return result
+        # Reporting (journal de décisions) — réel uniquement (dry_run n'écrit rien).
+        if not dry_run:
+            prs = ", ".join(str(n) for n in result.opened_prs) or "aucune"
+            # #440 : un arrêt deadline laisse du travail VALIDÉ en attente de merge —
+            # le signaler dans le journal pour que le drain ne dépende pas d'un
+            # post-mortem (la PR FacNor #72 est restée ouverte, mergée à la main).
+            drain = ""
+            if result.pending_reviews:
+                drain = f" ; {len(result.pending_reviews)} tâche(s) in_review À DRAINER (merge requis)"
+            # #441 : bilan de coût du run dans le journal (ledger enfin vivant).
+            cost_note = ""
+            if audit is not None:
+                ledger = audit.cost_summary()
+                cost_note = f" ; coût≈{ledger.get('usd', 0.0)}$ / {ledger.get('tokens', 0)} tokens"
+                # #502 : un coût à 0 sans prix coder configuré est suspect — le dire.
+                from collegue.executor.openhands_agent import coder_pricing_resolvable
+
+                if not coder_pricing_resolvable(settings_obj):
+                    cost_note += " [PRIX CODER NON CONFIGURÉS — coût $ possiblement INCONNU]"
+            manager.record_decision(
+                project_id,
+                f"Run pilote: {result.stop_reason} — {result.iterations} tâche(s), PR {prs}{drain}{cost_note}",
+                rationale=f"statut projet={result.project_status or 'inchangé'}",
+            )
+
+        return result
+    finally:
+        # Ne fermer que le ctx qu'on a créé (un ctx injecté appartient à l'appelant).
+        # Une erreur de fermeture ne doit JAMAIS masquer l'exception en cours (ex.
+        # ``BudgetExceeded`` de ``run_project`` = auto-pause volontaire) : on l'avale.
+        if owns_ctx:
+            aclose = getattr(ctx, "aclose", None)
+            if aclose is not None:
+                try:
+                    await aclose()
+                except Exception as exc:  # noqa: BLE001 - fermeture best-effort
+                    logger.warning("Fermeture du ctx de sampling échouée: %s", exc)
 
 
 # ── reporting lisible ──────────────────────────────────────────────────────────

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -160,6 +160,79 @@ async def test_real_run_wires_cost_governance_by_default(git_repo, manager):
     assert any("coût≈" in d.summary for d in manager.get_decisions(pid))
 
 
+# --- ctx de sampling offline (A1) ----------------------------------------------
+
+
+async def test_builds_offline_ctx_when_none_and_closes(monkeypatch, manager, git_repo):
+    """Hors serveur MCP, ``ctx=None`` → un ctx offline est assemblé puis fermé."""
+    import collegue.pilot.runtime as runtime
+
+    closed = {"v": False}
+    captured = {}
+
+    class _Ctx:
+        async def aclose(self):
+            closed["v"] = True
+
+    async def _fake_run_project(pid, src, ctx, **kw):
+        captured["ctx"] = ctx
+        return ProjectRunResult(stop_reason="completed", iterations=0, processed=[])
+
+    monkeypatch.setattr(runtime, "_build_ctx", lambda _s: _Ctx())
+    monkeypatch.setattr(runtime, "run_project", _fake_run_project)
+
+    pid = _linear(manager, 1)
+    await run_project_from_settings(
+        pid,
+        git_repo,
+        owner="o",
+        repo="r",
+        dry_run=True,
+        manager=manager,
+        sandbox=_Sandbox(),
+        agent=FakeCodeAgent(),
+        reviewer=FakeReviewer(),
+        clients=_clients(),
+        budget=_Budget(),
+    )
+    assert isinstance(captured["ctx"], _Ctx)  # ctx assemblé et transmis
+    assert closed["v"] is True  # fermé en fin de run (on l'a créé)
+
+
+async def test_injected_ctx_is_not_closed(monkeypatch, manager, git_repo):
+    """Un ctx fourni par l'appelant lui appartient : ``run_project_from_settings`` ne le ferme pas."""
+    import collegue.pilot.runtime as runtime
+
+    closed = {"v": False}
+
+    class _Ctx:
+        async def aclose(self):
+            closed["v"] = True
+
+    async def _fake_run_project(pid, src, ctx, **kw):
+        return ProjectRunResult(stop_reason="completed", iterations=0, processed=[])
+
+    monkeypatch.setattr(runtime, "run_project", _fake_run_project)
+
+    pid = _linear(manager, 1)
+    mine = _Ctx()
+    await run_project_from_settings(
+        pid,
+        git_repo,
+        owner="o",
+        repo="r",
+        ctx=mine,
+        dry_run=True,
+        manager=manager,
+        sandbox=_Sandbox(),
+        agent=FakeCodeAgent(),
+        reviewer=FakeReviewer(),
+        clients=_clients(),
+        budget=_Budget(),
+    )
+    assert closed["v"] is False  # ctx injecté → non fermé par le runtime
+
+
 # --- reporting ------------------------------------------------------------------
 
 

--- a/tests/test_sampling_ctx.py
+++ b/tests/test_sampling_ctx.py
@@ -1,0 +1,209 @@
+"""Tests du ctx de sampling offline (A1) — collegue/core/llm/sampling_ctx.py."""
+
+from __future__ import annotations
+
+from collections import deque
+from types import SimpleNamespace
+
+import pytest
+
+from collegue.core.llm.sampling_ctx import (
+    DEFAULT_MAX_TOKENS,
+    LocalSamplingContext,
+    PerModelRateLimiter,
+    SampleResult,
+    _coerce,
+    _pick_model,
+    to_openai_messages,
+)
+
+# --- faux client OpenAI-compatible ---------------------------------------------
+
+
+def _resp(content, *, model="m", usage=None):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+        model=model,
+        usage=usage,
+    )
+
+
+class _FakeClient:
+    def __init__(self, resp):
+        self._resp = resp
+        self.calls = []
+        self.closed = False
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
+
+    async def _create(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._resp
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _neutralize_budget_usage(monkeypatch):
+    """Défaut : budget no-op + usage avalé (les tests qui veulent l'inverse re-patchent)."""
+    monkeypatch.setattr("collegue.monitoring.metrics.enforce_budget", lambda: None)
+    monkeypatch.setattr("collegue.monitoring.sampling_usage.record_usage", lambda *a, **k: None)
+
+
+# --- normalisation des messages ------------------------------------------------
+
+
+def test_to_openai_messages_string_plus_system():
+    msgs = to_openai_messages("salut", "tu es X")
+    assert msgs == [{"role": "system", "content": "tu es X"}, {"role": "user", "content": "salut"}]
+
+
+def test_to_openai_messages_list_roles_and_list_content():
+    msgs = to_openai_messages(
+        [{"role": "system", "content": "S"}, {"role": "user", "content": [{"text": "a"}, "b"]}],
+        None,
+    )
+    assert msgs == [{"role": "system", "content": "S"}, {"role": "user", "content": "a b"}]
+
+
+def test_to_openai_messages_guarantees_user_turn():
+    msgs = to_openai_messages("", "S")  # system seul → un tour user est garanti
+    assert msgs[0]["role"] == "system"
+    assert any(m["role"] == "user" for m in msgs)
+
+
+def test_to_openai_messages_none_content_becomes_empty_string():
+    # content=None explicite → "" (jamais le littéral "None" envoyé au modèle).
+    msgs = to_openai_messages([{"role": "user", "content": None}], None)
+    assert msgs == [{"role": "user", "content": ""}]
+
+
+# --- choix du modèle + coercition ---------------------------------------------
+
+
+def test_pick_model_prefers_first_preference():
+    assert _pick_model(["gpt-x"], "default") == "gpt-x"
+    assert _pick_model([], "default") == "default"
+    assert _pick_model(None, "default") == "default"
+
+
+class _Spec:
+    def __init__(self, title):
+        self.title = title
+
+    @classmethod
+    def model_validate(cls, data):
+        return cls(data["title"])
+
+
+def test_coerce_parses_json_into_result_type():
+    out = _coerce('{"title": "T"}', _Spec)
+    assert isinstance(out, _Spec) and out.title == "T"
+
+
+def test_coerce_falls_back_to_text_on_unparsable():
+    assert _coerce("pas du json", _Spec) == "pas du json"
+
+
+# --- sample() ------------------------------------------------------------------
+
+
+async def test_sample_returns_text_and_records_usage(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        "collegue.monitoring.sampling_usage.record_usage",
+        lambda p, c, m: seen.update(p=p, c=c, m=m),
+    )
+    usage = SimpleNamespace(prompt_tokens=12, completion_tokens=3)
+    client = _FakeClient(_resp("bonjour", model="gemma-x", usage=usage))
+    ctx = LocalSamplingContext(default_model="d", client=client)
+
+    res = await ctx.sample("hi", model_preferences=["gemma-x"], max_tokens=2000)
+
+    assert isinstance(res, SampleResult)
+    assert res.text == "bonjour"
+    assert res.result is None  # pas de result_type
+    assert client.calls[0]["model"] == "gemma-x"
+    assert client.calls[0]["max_tokens"] == 2000  # cap explicite de l'appelant RESPECTÉ
+    assert seen == {"p": 12, "c": 3, "m": "gemma-x"}
+
+
+async def test_sample_defaults_max_tokens_when_absent():
+    client = _FakeClient(_resp("ok"))
+    ctx = LocalSamplingContext(default_model="d", client=client)
+    await ctx.sample("hi")  # aucun max_tokens → défaut généreux
+    assert client.calls[0]["max_tokens"] == DEFAULT_MAX_TOKENS
+
+
+async def test_sample_coerces_result_type():
+    client = _FakeClient(_resp('{"title": "T"}'))
+    ctx = LocalSamplingContext(default_model="d", client=client)
+    res = await ctx.sample("x", result_type=_Spec)
+    assert isinstance(res.result, _Spec) and res.result.title == "T"
+
+
+async def test_sample_enforces_budget_before_call(monkeypatch):
+    class _Stop(BaseException):
+        pass
+
+    def _boom():
+        raise _Stop()
+
+    monkeypatch.setattr("collegue.monitoring.metrics.enforce_budget", _boom)
+    client = _FakeClient(_resp("never"))
+    ctx = LocalSamplingContext(default_model="d", client=client)
+    with pytest.raises(_Stop):
+        await ctx.sample("hi")
+    assert client.calls == []  # le budget coupe AVANT l'appel LLM
+
+
+async def test_noop_stubs_are_awaitable():
+    ctx = LocalSamplingContext(default_model="d", client=_FakeClient(_resp("x")))
+    assert await ctx.info("m") is None
+    assert await ctx.debug("m") is None
+    assert await ctx.warning("m") is None
+    assert await ctx.error("m") is None
+    assert await ctx.report_progress(1, 2) is None
+
+
+async def test_aclose_closes_client():
+    client = _FakeClient(_resp("x"))
+    ctx = LocalSamplingContext(default_model="d", client=client)
+    await ctx.aclose()
+    assert client.closed is True
+
+
+# --- from_settings -------------------------------------------------------------
+
+
+def test_from_settings_resolves_endpoint_without_limiter(monkeypatch):
+    # Les LLM_RATE_LIMIT_* (middleware serveur par-client) NE doivent PAS throttler
+    # le ctx du moteur : aucun limiter assemblé depuis la config, même si définis.
+    monkeypatch.setattr(
+        "collegue.core.llm.sampling_handler.resolve_openai_endpoint",
+        lambda s: ("modX", "k", "http://bu/"),
+    )
+    settings = SimpleNamespace(LLM_RATE_LIMIT_PER_MINUTE=5, LLM_RATE_LIMIT_PER_DAY=500)
+    ctx = LocalSamplingContext.from_settings(settings)
+    assert ctx._default_model == "modX"
+    assert ctx._api_key == "k"
+    assert ctx._base_url == "http://bu/"
+    assert ctx._limiter is None  # pas de throttle moteur par défaut
+
+
+def test_rate_limiter_injectable_via_constructor():
+    rl = PerModelRateLimiter(per_minute=15, per_day=1500)
+    ctx = LocalSamplingContext(default_model="m", rate_limiter=rl)
+    assert ctx._limiter is rl  # cadençage opt-in pour qui le veut
+
+
+# --- rate limiter (maths, sans dormir) -----------------------------------------
+
+
+def test_rate_limiter_wait_needed_when_minute_full():
+    rl = PerModelRateLimiter(per_minute=1, per_day=0)
+    now = 1000.0
+    rl._minute["m"] = deque([now])
+    rl._day["m"] = deque([now])
+    assert rl._wait_needed("m", now + 1) > 0  # créneau pris → attente
+    assert rl._wait_needed("m", now + 61) == 0  # après 60 s → libre


### PR DESCRIPTION
## Phase A1 — ctx de sampling offline (plan end-to-end par le produit)

### Pourquoi
`python -m collegue.pilot` n'était pas réellement utilisable **hors serveur MCP** : le reviewer (`code_review`), le planner et la boucle agentique attendent un `ctx.sample()`, mais en CLI il n'y en a pas — `run_project_from_settings(ctx=None)` passait `ctx=None` → les chemins LLM réels échouaient. Seuls les **scripts harnais gitignorés** (`scripts/facnor_run/gemini_ctx.py`) fournissaient un ctx. C'est la 1ʳᵉ brique pour exécuter le cycle complet **par le produit** (cf. plan, Phase A).

### Quoi
- **`collegue/core/llm/sampling_ctx.py`** (nouveau) — `LocalSamplingContext` :
  - `.sample(...)` via client **OpenAI-compatible** (`AsyncOpenAI` + `base_url` par provider) → **multi-provider** (Gemini OpenAI-compat / OpenAI / lmstudio / ollama / unsloth), pas de lock-in (§8) ;
  - client **paresseux** (aucune connexion ni clé à la simple construction) ;
  - garde **budget dur** (`enforce_budget`, C4) + **capture d'usage** (`record_usage`) au MÊME chokepoint que le handler serveur ;
  - contrat fidèle : `.text` + `.result` (coercition `result_type`), stubs no-op `info/debug/...`, signature tolérante ;
  - `PerModelRateLimiter` **injectable** mais **off par défaut** (les `LLM_RATE_LIMIT_*` bornent le middleware serveur par-client — les réutiliser throttlerait le moteur à 15/min·500/j ; les 429 sont gérés par le retry SDK).
- **`collegue/core/llm/sampling_handler.py`** — `resolve_openai_endpoint()` : source unique du routage provider→endpoint ; **`app.py` refactoré** pour la réutiliser (DRY, comportement équivalent).
- **`collegue/pilot/runtime.py`** — `_build_ctx()` + `run_project_from_settings` assemble un ctx offline quand `ctx=None`, fermé en `finally` (ctx **injecté** = non fermé ; une erreur de fermeture n'avale jamais l'exception en cours, ex. `BudgetExceeded`).

### Tests / qualité
- 48 cas (`tests/test_sampling_ctx.py` + câblage dans `tests/test_pilot_runtime.py`) : contrat `sample`, budget coupe avant l'appel, usage, no-op, coercition, normalisation messages, ctx créé/fermé vs injecté.
- **Suite non-integration complète verte** ; `ruff check` + `ruff format --check` propres.
- **Revue adversariale** (contexte frais) : 0 bloquant ; F1 (masquage d'exception au `finally`), F2 (cap `max_tokens` explicite respecté au lieu d'un plancher ×4), F3 (`content=None`) corrigés.

Aucun comportement serveur modifié (refactor `app.py` équivalent). Cible : `pre-main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
