### PR TITLE
feat(pilot): sous-commande plan — Phase 1 par le produit (A2)

### DIFF
--- a/collegue/pilot/__init__.py
+++ b/collegue/pilot/__init__.py
@@ -59,7 +59,13 @@ from collegue.pilot.mcp_tool import (
     run_pilot_tool,
 )
 from collegue.pilot.resume import load_run_start, persist_run_start
-from collegue.pilot.runtime import format_run_report, run_project_from_settings
+from collegue.pilot.runtime import (
+    PlanResult,
+    format_plan_report,
+    format_run_report,
+    plan_project_from_settings,
+    run_project_from_settings,
+)
 from collegue.pilot.scheduler import (
     SchedulerError,
     is_blocked,
@@ -92,6 +98,10 @@ __all__ = [
     # F4 — câblage runtime
     "run_project_from_settings",
     "format_run_report",
+    # A2 — planification par le produit (sous-commande plan)
+    "plan_project_from_settings",
+    "PlanResult",
+    "format_plan_report",
     # H4 (Phase 5) — observabilité du run autonome
     "RunAuditLog",
     "NullAuditLog",

--- a/collegue/pilot/__main__.py
+++ b/collegue/pilot/__main__.py
@@ -51,6 +51,21 @@ def build_parser() -> argparse.ArgumentParser:
     rs.add_argument("task_id", type=int, help="Id de la tâche à réinitialiser.")
     rs.add_argument("--status", default="todo", help="Statut cible (défaut: todo).")
     rs.add_argument("--message", required=True, help="Motif du reset (tracé dans decisions).")
+    # Phase 1 (A2) : planification — problème → SPEC → DAG → issues GitHub. dry-run par défaut.
+    plan_p = sub.add_parser("plan", help="Planifie un projet (SPEC → graphe de tâches → issues GitHub).")
+    plan_p.add_argument("--name", default="projet", help="Nom du projet (état durable).")
+    plan_p.add_argument("--problem", required=True, help="Problématique en langage naturel (1+ phrases).")
+    plan_p.add_argument("--owner", required=True, help="Owner GitHub cible des issues.")
+    plan_p.add_argument("--repo", required=True, help="Repo GitHub cible des issues.")
+    plan_p.add_argument("--deadline-hours", type=float, default=None, help="Deadline du run, en heures (optionnel).")
+    plan_p.add_argument(
+        "--approve", action="store_true", help="Approuve le plan (gate humain P5) — requis pour --execute-sync."
+    )
+    plan_p.add_argument(
+        "--execute-sync", action="store_true", help="Crée RÉELLEMENT les issues GitHub (sinon dry-run/aperçu)."
+    )
+    plan_p.add_argument("--labels", default=None, help="Labels d'issue (CSV ; défaut: autonome).")
+    plan_p.add_argument("--milestone", default=None, help="Titre du milestone (défaut: '<name> MVP').")
     # --- args du RUN par défaut (required=False : validés dans main si pas de sous-commande) ---
     parser.add_argument("--project-id", type=int, default=None, help="Id du projet (état durable).")
     parser.add_argument("--repo-source", default=None, help="Dépôt git source (repo-agnostique).")
@@ -86,6 +101,30 @@ async def _run(args: argparse.Namespace) -> int:
     return 0 if result.stop_reason in _OK_STOPS else 1
 
 
+async def _plan(args: argparse.Namespace) -> int:
+    from datetime import datetime, timedelta, timezone
+
+    from collegue.pilot.runtime import format_plan_report, plan_project_from_settings
+
+    deadline = None
+    if args.deadline_hours:
+        deadline = datetime.now(timezone.utc) + timedelta(hours=args.deadline_hours)
+    labels = [s.strip() for s in args.labels.split(",") if s.strip()] if args.labels else None
+    result = await plan_project_from_settings(
+        args.name,
+        args.problem,
+        owner=args.owner,
+        repo=args.repo,
+        deadline=deadline,
+        approve=args.approve,
+        execute_sync=args.execute_sync,
+        labels=labels,
+        milestone_title=args.milestone,
+    )
+    print(format_plan_report(result))
+    return 0
+
+
 def _run_task_command(args: argparse.Namespace) -> int:
     """Glue CLI des interventions opérateur (#506) : manager réel + audit persistant.
 
@@ -117,6 +156,8 @@ def main(argv: Optional[List[str]] = None) -> int:
     args = parser.parse_args(argv)
     if args.command == "task":
         return _run_task_command(args)
+    if args.command == "plan":
+        return asyncio.run(_plan(args))
     # Run par défaut : valider les args requis ici (argparse ne peut pas les
     # conditionner sur l'absence de sous-commande). parser.error lève SystemExit.
     missing = [name for name in _RUN_REQUIRED if getattr(args, name) is None]

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -11,18 +11,22 @@ l'entrypoint ``python -m collegue.pilot`` (voir ``__main__``). ``dry_run`` est l
 défaut. L'exécution réelle de bout en bout (Docker + OpenHands + LLM + écriture
 GitHub) est derrière le marqueur ``integration`` ; en CI on injecte des doubles.
 
-Note ``ctx`` : le reviewer expert (``code_review``) a besoin d'un contexte de
-sampling LLM. En usage réel hors serveur MCP, fournir un ``ctx`` adéquat (ou un
-shim) — différé à l'intégration. Un outil MCP exposant le pilote est volontairement
-**reporté à la Phase 5** (durcissement/auth) : l'auto-découverte des outils
-l'activerait au démarrage, et le serveur tourne ``OAUTH_ENABLED=false`` par défaut.
+Note ``ctx`` : le reviewer expert (``code_review``) et le planner ont besoin d'un
+contexte de sampling LLM. Hors serveur MCP, ``run_project_from_settings`` et
+``plan_project_from_settings`` en assemblent un automatiquement (``_build_ctx`` →
+``LocalSamplingContext`` offline, OpenAI-compatible) quand aucun n'est fourni.
+L'outil MCP exposant le pilote est volontairement **reporté à la Phase 5**
+(durcissement/auth) : l'auto-découverte des outils l'activerait au démarrage, et
+le serveur tourne ``OAUTH_ENABLED=false`` par défaut.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
-from typing import List, Optional
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
 
 from collegue.pilot.audit import RunAuditLog, default_process_cost_source
 from collegue.pilot.budget import BudgetTimeController
@@ -358,6 +362,131 @@ async def run_project_from_settings(
                     logger.warning("Fermeture du ctx de sampling échouée: %s", exc)
 
 
+# ── planification (Phase 1) assemblée ──────────────────────────────────────────
+
+
+@dataclass
+class PlanResult:
+    """Bilan d'une planification (Phase 1) assemblée depuis la config."""
+
+    project_id: int
+    spec_title: str
+    objectives: int
+    acceptance_criteria: int
+    task_count: int
+    preview_markdown: str
+    dry_run: bool
+    issues: List[dict] = field(default_factory=list)
+
+
+async def plan_project_from_settings(
+    name: str,
+    problem: str,
+    *,
+    owner: str,
+    repo: str,
+    ctx=None,
+    settings_obj: Optional[object] = None,
+    github_token: Optional[str] = None,
+    manager=None,
+    deadline: Any = None,
+    context: Optional[str] = None,
+    approve: bool = False,
+    execute_sync: bool = False,
+    labels: Optional[List[str]] = None,
+    milestone_title: Optional[str] = None,
+    board_title: Optional[str] = None,
+    decompose_max_tokens: int = 16384,
+    decompose_attempts: int = 3,
+    retry_sleep_seconds: float = 3.0,
+) -> PlanResult:
+    """Phase 1 **par le produit** : problème → SPEC → DAG → (gate humain) → issues GitHub.
+
+    Assemble les dépendances depuis la config (ctx de sampling offline via ``_build_ctx``,
+    état durable) et enchaîne ``generate_spec`` → ``persist_spec`` → ``decompose`` →
+    ``build_plan_preview`` → (``approve_plan`` si ``approve``/``execute_sync``) →
+    ``sync_plan``. **dry-run par défaut** (``execute_sync=False`` : aucune écriture GitHub).
+    ``approve`` satisfait le gate humain P5 (anti-TOCTOU). Le commit du fichier ``SPEC.md``
+    dans le repo cible est porté par ``sync_plan`` (A3).
+
+    ``decompose`` est re-tenté sur ``ValueError`` (décomposition vide — aléa d'un modèle
+    « thinking » coupé trop tôt, d'où ``max_tokens`` élargi).
+    """
+    settings_obj = settings_obj or _settings()
+    manager = manager or _build_manager(settings_obj)
+    owns_ctx = ctx is None
+    if ctx is None:
+        ctx = _build_ctx(settings_obj)
+
+    try:
+        from collegue.planner.decomposer import decompose
+        from collegue.planner.github_sync import sync_plan
+        from collegue.planner.plan_review import approve_plan, build_plan_preview
+        from collegue.planner.spec_generator import generate_spec, persist_spec
+
+        spec = await generate_spec(problem, ctx, context=context, settings_obj=settings_obj)
+        project_id = persist_spec(manager, name, spec, deadline=deadline)
+
+        last_err: Optional[Exception] = None
+        tasks: list = []
+        attempts = max(1, decompose_attempts)
+        for attempt in range(1, attempts + 1):
+            try:
+                tasks = await decompose(
+                    spec,
+                    ctx,
+                    manager=manager,
+                    project_id=project_id,
+                    settings_obj=settings_obj,
+                    max_tokens=decompose_max_tokens,
+                )
+                break
+            except ValueError as exc:  # décomposition vide → aléa du modèle, on retente
+                last_err = exc
+                logger.warning("decompose tentative %d/%d : %s", attempt, attempts, exc)
+                if attempt < attempts and retry_sleep_seconds > 0:
+                    await asyncio.sleep(retry_sleep_seconds)
+        else:
+            raise last_err if last_err is not None else ValueError("Décomposition impossible.")
+
+        preview = build_plan_preview(manager, project_id)
+        preview_md = preview.to_markdown() if preview is not None else ""
+
+        if approve or execute_sync:
+            approve_plan(manager, project_id, actor="operator:collegue-cli")
+
+        token = github_token if github_token is not None else os.environ.get(GITHUB_TOKEN_ENV)
+        sync = sync_plan(
+            manager,
+            project_id,
+            owner,
+            repo,
+            dry_run=not execute_sync,
+            token=token,
+            labels=labels if labels is not None else ["autonome"],
+            milestone_title=milestone_title if milestone_title is not None else f"{name} MVP",
+            board_title=board_title,
+        )
+        return PlanResult(
+            project_id=project_id,
+            spec_title=getattr(spec, "title", ""),
+            objectives=len(getattr(spec, "objectives", []) or []),
+            acceptance_criteria=len(getattr(spec, "acceptance_criteria", []) or []),
+            task_count=len(tasks),
+            preview_markdown=preview_md,
+            dry_run=not execute_sync,
+            issues=list(getattr(sync, "issues", []) or []),
+        )
+    finally:
+        if owns_ctx:
+            aclose = getattr(ctx, "aclose", None)
+            if aclose is not None:
+                try:
+                    await aclose()
+                except Exception as exc:  # noqa: BLE001 - fermeture best-effort
+                    logger.warning("Fermeture du ctx de sampling échouée: %s", exc)
+
+
 # ── reporting lisible ──────────────────────────────────────────────────────────
 
 
@@ -387,4 +516,26 @@ def format_run_report(result: ProjectRunResult, *, project_id: Optional[int] = N
         lines.append(f"⚠ Reviews en attente de merge (drain requis) : tâches {pending}")
     lines.append(f"Statut projet : {result.project_status or '(inchangé)'}")
     lines.append(f"Budget-temps restant : {_remaining_label(budget)}")
+    return "\n".join(lines)
+
+
+def format_plan_report(result: PlanResult) -> str:
+    """Rendu lisible d'une planification (Phase 1) pour le CLI.
+
+    Affiche l'**aperçu complet du plan** (SPEC + tâches/dépendances) : c'est ce que
+    l'opérateur doit voir avant d'approuver/exécuter (gate humain P5).
+    """
+    mode = "dry-run (aperçu, aucune écriture)" if result.dry_run else "EXECUTE (issues créées)"
+    lines = [
+        f"Plan projet #{result.project_id} — « {result.spec_title} »",
+        f"  SPEC : {result.objectives} objectif(s), {result.acceptance_criteria} critère(s) d'acceptation",
+        f"  Tâches : {result.task_count}",
+        f"  Sync GitHub : {mode}",
+    ]
+    for it in result.issues:
+        num = it.get("issue_number")
+        tag = "skip" if it.get("skipped") else (f"#{num}" if num else "(dry-run)")
+        lines.append(f"    [{tag}] task {it.get('task_id')}: {it.get('title', '')}")
+    if result.preview_markdown:
+        lines += ["", "── Aperçu du plan ──", result.preview_markdown]
     return "\n".join(lines)

--- a/tests/test_pilot_plan.py
+++ b/tests/test_pilot_plan.py
@@ -1,0 +1,247 @@
+"""Tests A2 — planification par le produit : runtime.plan_project_from_settings + CLI `plan`."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from collegue.pilot import PlanResult, format_plan_report, plan_project_from_settings
+
+# --- doubles du planner (monkeypatchés là où plan_project_from_settings les importe) ---
+
+
+def _spec(title="T", objectives=("o1",), criteria=("c1", "c2")):
+    return SimpleNamespace(title=title, objectives=list(objectives), acceptance_criteria=list(criteria))
+
+
+def _patch_planner(monkeypatch, *, tasks=None, decompose_fn=None, sync_issues=None, calls=None):
+    calls = calls if calls is not None else {}
+
+    async def _generate_spec(problem, ctx, **kw):
+        calls["generate"] = (problem, kw)
+        return _spec()
+
+    def _persist_spec(manager, name, spec, **kw):
+        calls["persist"] = (name, kw)
+        return 42
+
+    async def _decompose(spec, ctx, **kw):
+        calls["decompose"] = kw
+        return list(tasks if tasks is not None else [object(), object()])
+
+    def _build_preview(manager, project_id):
+        return SimpleNamespace(to_markdown=lambda: "PREVIEW")
+
+    def _approve(manager, project_id, **kw):
+        calls["approve"] = (project_id, kw)
+        return True
+
+    def _sync(manager, project_id, owner, repo, **kw):
+        calls["sync"] = {"owner": owner, "repo": repo, **kw}
+        issues = sync_issues if sync_issues is not None else [{"task_id": 1, "title": "T1", "issue_number": None}]
+        return SimpleNamespace(issues=issues)
+
+    monkeypatch.setattr("collegue.planner.spec_generator.generate_spec", _generate_spec)
+    monkeypatch.setattr("collegue.planner.spec_generator.persist_spec", _persist_spec)
+    monkeypatch.setattr("collegue.planner.decomposer.decompose", decompose_fn or _decompose)
+    monkeypatch.setattr("collegue.planner.plan_review.build_plan_preview", _build_preview)
+    monkeypatch.setattr("collegue.planner.plan_review.approve_plan", _approve)
+    monkeypatch.setattr("collegue.planner.github_sync.sync_plan", _sync)
+    return calls
+
+
+async def _plan(monkeypatch, **kwargs):
+    closed = {"v": False}
+
+    class _Ctx:
+        async def aclose(self):
+            closed["v"] = True
+
+    defaults = dict(
+        name="proj",
+        problem="construire X",
+        owner="o",
+        repo="r",
+        ctx=_Ctx(),
+        settings_obj=SimpleNamespace(),
+        manager=object(),
+    )
+    defaults.update(kwargs)
+    result = await plan_project_from_settings(**defaults)
+    return result, closed
+
+
+# --- orchestration --------------------------------------------------------------
+
+
+async def test_dry_run_does_not_approve_and_syncs_in_dry_run(monkeypatch):
+    calls = _patch_planner(monkeypatch)
+    result, _ = await _plan(monkeypatch)
+    assert isinstance(result, PlanResult)
+    assert result.project_id == 42
+    assert result.spec_title == "T"
+    assert result.acceptance_criteria == 2
+    assert result.task_count == 2
+    assert result.dry_run is True
+    assert result.preview_markdown == "PREVIEW"
+    assert "approve" not in calls  # ni approve ni execute → pas d'approbation
+    assert calls["sync"]["dry_run"] is True
+    assert calls["sync"]["labels"] == ["autonome"]  # défaut
+    assert calls["sync"]["milestone_title"] == "proj MVP"  # défaut
+
+
+async def test_execute_sync_approves_and_creates(monkeypatch):
+    calls = _patch_planner(monkeypatch, sync_issues=[{"task_id": 1, "title": "T1", "issue_number": 101}])
+    result, _ = await _plan(monkeypatch, execute_sync=True, labels=["x"], milestone_title="M")
+    assert result.dry_run is False
+    assert calls["approve"][0] == 42  # gate P5 satisfait
+    assert calls["sync"]["dry_run"] is False
+    assert calls["sync"]["labels"] == ["x"]
+    assert calls["sync"]["milestone_title"] == "M"
+    assert result.issues[0]["issue_number"] == 101
+
+
+async def test_approve_flag_alone_approves_without_execute(monkeypatch):
+    calls = _patch_planner(monkeypatch)
+    result, _ = await _plan(monkeypatch, approve=True)
+    assert "approve" in calls
+    assert calls["sync"]["dry_run"] is True  # approuvé mais pas exécuté → dry-run
+
+
+async def test_decompose_max_tokens_widened(monkeypatch):
+    calls = _patch_planner(monkeypatch)
+    await _plan(monkeypatch, decompose_max_tokens=16384)
+    assert calls["decompose"]["max_tokens"] == 16384
+
+
+async def test_decompose_retries_on_empty_then_succeeds(monkeypatch):
+    attempts = {"n": 0}
+
+    async def _flaky(spec, ctx, **kw):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise ValueError("Décomposition vide")
+        return [object()]
+
+    _patch_planner(monkeypatch, decompose_fn=_flaky)
+    result, _ = await _plan(monkeypatch, retry_sleep_seconds=0)
+    assert attempts["n"] == 2  # 1 échec + 1 succès
+    assert result.task_count == 1
+
+
+async def test_decompose_raises_after_all_attempts(monkeypatch):
+    async def _always_empty(spec, ctx, **kw):
+        raise ValueError("Décomposition vide")
+
+    _patch_planner(monkeypatch, decompose_fn=_always_empty)
+    with pytest.raises(ValueError):
+        await _plan(monkeypatch, decompose_attempts=2, retry_sleep_seconds=0)
+
+
+async def test_owned_ctx_is_closed(monkeypatch):
+    _patch_planner(monkeypatch)
+    closed = {"v": False}
+
+    class _Ctx:
+        async def aclose(self):
+            closed["v"] = True
+
+    monkeypatch.setattr("collegue.pilot.runtime._build_ctx", lambda _s: _Ctx())
+    # ctx non fourni → assemblé puis fermé
+    await plan_project_from_settings(
+        name="p", problem="x", owner="o", repo="r", settings_obj=SimpleNamespace(), manager=object()
+    )
+    assert closed["v"] is True
+
+
+async def test_injected_ctx_not_closed(monkeypatch):
+    _patch_planner(monkeypatch)
+    result, closed = await _plan(monkeypatch)  # _plan injecte un ctx
+    assert closed["v"] is False
+
+
+# --- reporting -----------------------------------------------------------------
+
+
+def test_format_plan_report_dry_run_and_issues():
+    result = PlanResult(
+        project_id=7,
+        spec_title="Facturation",
+        objectives=3,
+        acceptance_criteria=5,
+        task_count=2,
+        preview_markdown="# Plan détaillé\n- tâche A",
+        dry_run=True,
+        issues=[{"task_id": 1, "title": "Schéma", "issue_number": None}],
+    )
+    report = format_plan_report(result)
+    assert "Plan projet #7" in report
+    assert "Facturation" in report
+    assert "dry-run" in report
+    assert "task 1: Schéma" in report
+    assert "Aperçu du plan" in report  # l'opérateur voit le plan avant d'approuver
+    assert "# Plan détaillé" in report
+
+
+def test_format_plan_report_execute_shows_issue_numbers():
+    result = PlanResult(
+        project_id=8,
+        spec_title="X",
+        objectives=1,
+        acceptance_criteria=1,
+        task_count=1,
+        preview_markdown="",
+        dry_run=False,
+        issues=[{"task_id": 9, "title": "Auth", "issue_number": 123}],
+    )
+    report = format_plan_report(result)
+    assert "EXECUTE" in report
+    assert "[#123] task 9: Auth" in report
+
+
+# --- CLI -----------------------------------------------------------------------
+
+
+def test_cli_parses_plan_subcommand():
+    from collegue.pilot.__main__ import build_parser
+
+    args = build_parser().parse_args(["plan", "--problem", "P", "--owner", "o", "--repo", "r"])
+    assert args.command == "plan"
+    assert args.problem == "P" and args.owner == "o" and args.repo == "r"
+    assert args.execute_sync is False  # dry-run par défaut
+
+
+def test_cli_plan_dispatches_and_parses_args(monkeypatch, capsys):
+    import collegue.pilot.__main__ as cli
+
+    captured = {}
+
+    async def _fake_plan(name, problem, **kw):
+        captured["name"] = name
+        captured["problem"] = problem
+        captured.update(kw)
+        return PlanResult(
+            project_id=1,
+            spec_title="X",
+            objectives=0,
+            acceptance_criteria=0,
+            task_count=0,
+            preview_markdown="",
+            dry_run=False,
+            issues=[],
+        )
+
+    monkeypatch.setattr("collegue.pilot.runtime.plan_project_from_settings", _fake_plan)
+    monkeypatch.setattr("collegue.pilot.runtime.format_plan_report", lambda r: "REPORT")
+
+    rc = cli.main(
+        ["plan", "--name", "X", "--problem", "P", "--owner", "o", "--repo", "r", "--execute-sync", "--labels", "a, b"]
+    )
+    assert rc == 0
+    assert captured["name"] == "X" and captured["problem"] == "P"
+    assert captured["owner"] == "o" and captured["repo"] == "r"
+    assert captured["execute_sync"] is True
+    assert captured["labels"] == ["a", "b"]  # CSV nettoyé
+    assert captured["deadline"] is None  # pas de --deadline-hours
+    assert "REPORT" in capsys.readouterr().out


### PR DESCRIPTION
## Phase A2 — sous-commande `plan` (Phase 1 par le produit)

### Pourquoi
La planification (problème → SPEC → graphe de tâches → issues GitHub) n'existait que dans le **harnais gitignoré** `scripts/facnor_run/plan.py`. Le produit (`python -m collegue.pilot`) ne savait que `run`/`task`. 2ᵉ brique du plan end-to-end-par-le-produit (après A1).

### Quoi
- **`collegue/pilot/runtime.py`** — `plan_project_from_settings(name, problem, *, owner, repo, …)` : enchaîne `generate_spec` → `persist_spec` → `decompose` (retry sur décomposition vide, `max_tokens` élargi pour modèle « thinking ») → `build_plan_preview` → `approve_plan` (si `--approve`/`--execute-sync`, **gate humain P5**) → `sync_plan` (**dry-run par défaut**). Assemble un ctx offline (A1) quand `ctx=None`, fermé en `finally` sans masquer l'exception. + `PlanResult` + `format_plan_report` (affiche l'aperçu du plan que l'opérateur approuve).
- **`collegue/pilot/__main__.py`** — `python -m collegue.pilot plan --problem … --owner … --repo … [--name --deadline-hours --approve --execute-sync --labels --milestone]`.
- **`collegue/pilot/__init__.py`** — exports.

### Tests / qualité
- 12 cas (`tests/test_pilot_plan.py`) : orchestration dry-run/approve/execute, retry decompose (succès/échec total/non-ValueError), ctx créé+fermé vs injecté, parsing CLI + dispatch, reporting.
- **Suite non-integration complète verte** ; `ruff check` + `ruff format --check` propres.
- **Revue adversariale** (contexte frais) : 0 bloquant ; signatures du planner vérifiées contre le code, gate P5 vs `execute_sync` correct, boucle `for/else` correcte ; NIT-1 (aperçu dans le rapport) appliqué.

Combiné à A1, `python -m collegue.pilot plan …` est désormais exécutable **sans le harnais**. Cible : `pre-main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
