### PR TITLE
feat(planner): committer SPEC.md dans le repo cible (A3)

### DIFF
--- a/collegue/planner/github_sync.py
+++ b/collegue/planner/github_sync.py
@@ -29,12 +29,14 @@ Module **isolé** : non câblé au runtime tant que le pilote (Phase 3) ne l'enc
 
 from __future__ import annotations
 
+import logging
 from collections import deque
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from collegue.planner.plan_review import require_approved
 from collegue.tools.github_commands import (
+    FileCommands,
     IssueCommands,
     LabelCommands,
     MilestoneCommands,
@@ -42,6 +44,9 @@ from collegue.tools.github_commands import (
 )
 
 DEFAULT_LABELS = ["autonome"]
+DEFAULT_SPEC_FILENAME = "SPEC.md"
+
+logger = logging.getLogger(__name__)
 
 
 class SyncError(Exception):
@@ -79,12 +84,17 @@ def _topo_sort_tasks(tasks: List[Any]) -> List[Any]:
 
 @dataclass
 class SyncClients:
-    """Clients GitHub injectables (mockés en test)."""
+    """Clients GitHub injectables (mockés en test).
+
+    ``files`` (A3) est **optionnel** (défaut ``None``) : sans lui, le commit du
+    fichier ``SPEC.md`` est un no-op (rétro-compat des appelants à 4 clients).
+    """
 
     issues: Any
     labels: Any
     milestones: Any
     projects: Any
+    files: Any = None
 
 
 @dataclass
@@ -93,6 +103,8 @@ class SyncResult:
     issues: List[Dict[str, Any]]
     milestone: Optional[str] = None
     board: Optional[str] = None
+    # A3 : chemin du SPEC committé dans le repo cible (None si non committé).
+    spec_committed: Optional[str] = None
 
 
 def _default_clients(token: Optional[str]) -> SyncClients:
@@ -101,7 +113,38 @@ def _default_clients(token: Optional[str]) -> SyncClients:
         labels=LabelCommands(token=token),
         milestones=MilestoneCommands(token=token),
         projects=ProjectCommands(token=token),
+        files=FileCommands(token=token),
     )
+
+
+def _commit_spec(clients: SyncClients, manager: Any, project_id: int, owner: str, repo: str, spec_filename: str):
+    """Committe le SPEC (``Project.spec``) comme fichier versionné du repo cible (§4.2).
+
+    Le SPEC vit en DB ; le brief en exige une matérialisation **committée** = le
+    contrat du projet, lisible et versionné dans le repo. **Best-effort** : un échec
+    (droits, repo absent) n'échoue PAS la synchro des issues (on journalise un
+    avertissement et on renvoie ``None``). ``FileCommands.update_file`` joint le SHA
+    courant (anti-conflit) ; un contenu identique ne crée pas de commit vide côté
+    GitHub (arbre inchangé), donc re-synchroniser est sûr. No-op si pas de client
+    ``files`` ou pas de spec.
+    """
+    files = getattr(clients, "files", None)
+    project = manager.get_project(project_id)
+    spec = getattr(project, "spec", None) if project is not None else None
+    if files is None or not spec:
+        return None
+    try:
+        files.update_file(
+            owner,
+            repo,
+            spec_filename,
+            message=f"docs: SPEC du projet (planification, project_id={project_id})",
+            content=spec,
+        )
+        return spec_filename
+    except Exception as exc:  # noqa: BLE001 - commit best-effort, ne bloque pas la synchro
+        logger.warning("Commit de %s échoué (synchro des issues poursuivie) : %s", spec_filename, exc)
+        return None
 
 
 def _issue_body(task: Any, dep_numbers: List[int]) -> str:
@@ -151,12 +194,14 @@ def sync_plan(
     board_title: Optional[str] = None,
     token: Optional[str] = None,
     clients: Optional[SyncClients] = None,
+    spec_filename: str = DEFAULT_SPEC_FILENAME,
 ) -> SyncResult:
     """Synchronise le plan d'un projet vers GitHub (issues + labels + milestone + board).
 
     ``dry_run=True`` (défaut) ne touche pas GitHub. ``dry_run=False`` exige un plan
-    **approuvé** (lève :class:`~collegue.planner.plan_review.PlanNotApproved` sinon)
-    et crée les issues liées de façon idempotente.
+    **approuvé** (lève :class:`~collegue.planner.plan_review.PlanNotApproved` sinon),
+    **committe ``SPEC.md``** (le contrat, §4.2) dans le repo cible, puis crée les
+    issues liées de façon idempotente.
     """
     labels = labels or DEFAULT_LABELS
     if dry_run:
@@ -168,6 +213,11 @@ def sync_plan(
     require_approved(manager, project_id)
 
     clients = clients or _default_clients(token)
+
+    # §4.2 : matérialiser le SPEC (DB) en fichier committé du repo cible. AVANT les
+    # issues pour que le contrat atterrisse en premier ; best-effort (n'échoue pas la synchro).
+    spec_committed = _commit_spec(clients, manager, project_id, owner, repo, spec_filename)
+
     tasks = manager.get_tasks(project_id)
     order = _topo_sort_tasks(tasks)  # dépendances d'abord ; raise sur cycle/dep pendante
 
@@ -177,7 +227,9 @@ def sync_plan(
     # Rien de neuf à créer → ne pas brûler d'appels API (ensure_*). Idempotent.
     if all(t.id in task_to_issue for t in tasks):
         return SyncResult(
-            dry_run=False, issues=[{"task_id": t.id, "issue_number": t.issue_number, "skipped": True} for t in order]
+            dry_run=False,
+            issues=[{"task_id": t.id, "issue_number": t.issue_number, "skipped": True} for t in order],
+            spec_committed=spec_committed,
         )
 
     # Pré-garantir labels / milestone / board (idempotent).
@@ -217,11 +269,15 @@ def sync_plan(
     manager.record_decision(
         project_id,
         summary=f"Plan synchronisé sur GitHub : {len(created)} issue(s)",
-        rationale=f"repo={owner}/{repo}; milestone={milestone_title}; board={board_title}",
+        rationale=(
+            f"repo={owner}/{repo}; milestone={milestone_title}; board={board_title}; "
+            f"spec={spec_committed or 'non committé'}"
+        ),
     )
     return SyncResult(
         dry_run=False,
         issues=created,
         milestone=(milestone.title if milestone else None),
         board=(board.title if board else None),
+        spec_committed=spec_committed,
     )

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -65,8 +65,24 @@ class _FakeProjects:
         return "ITEM"
 
 
+class _FakeFiles:
+    def __init__(self, fail=False):
+        self.calls = []
+        self._fail = fail
+
+    def update_file(self, owner, repo, path, message, content, branch=None):
+        if self._fail:
+            raise RuntimeError("commit refusé")
+        self.calls.append({"owner": owner, "repo": repo, "path": path, "message": message, "content": content})
+        return {"commit": {"sha": "abc"}}
+
+
 def _clients():
     return SyncClients(_FakeIssues(), _FakeLabels(), _FakeMilestones(), _FakeProjects())
+
+
+def _clients_with_files(files=None):
+    return SyncClients(_FakeIssues(), _FakeLabels(), _FakeMilestones(), _FakeProjects(), files=files or _FakeFiles())
 
 
 def _planned(manager, *, approve=False):
@@ -244,3 +260,57 @@ def test_partial_failure_then_retry_no_duplicate(manager):
 def test_default_clients_smoke():
     clients = _default_clients(token="x")
     assert clients.issues and clients.labels and clients.milestones and clients.projects
+
+
+# --- A3 : commit du SPEC.md dans le repo cible ----------------------------------
+
+
+def test_real_sync_commits_spec_md(manager):
+    pid = _planned(manager, approve=True)
+    files = _FakeFiles()
+    result = sync_plan(manager, pid, "o", "r", dry_run=False, clients=_clients_with_files(files))
+    assert result.spec_committed == "SPEC.md"
+    assert len(files.calls) == 1
+    call = files.calls[0]
+    assert call["path"] == "SPEC.md" and call["owner"] == "o" and call["repo"] == "r"
+    assert "Demo" in call["content"]  # le SPEC markdown persisté en DB est committé
+
+
+def test_spec_filename_configurable(manager):
+    pid = _planned(manager, approve=True)
+    files = _FakeFiles()
+    result = sync_plan(
+        manager, pid, "o", "r", dry_run=False, clients=_clients_with_files(files), spec_filename="docs/SPEC.md"
+    )
+    assert result.spec_committed == "docs/SPEC.md"
+    assert files.calls[0]["path"] == "docs/SPEC.md"
+
+
+def test_spec_commit_is_best_effort(manager):
+    # Un échec de commit du SPEC ne casse PAS la synchro des issues (best-effort).
+    pid = _planned(manager, approve=True)
+    result = sync_plan(manager, pid, "o", "r", dry_run=False, clients=_clients_with_files(_FakeFiles(fail=True)))
+    assert result.spec_committed is None  # échec signalé
+    assert all(t.issue_number for t in manager.get_tasks(pid))  # issues créées quand même
+
+
+def test_no_files_client_skips_spec_commit(manager):
+    # SyncClients 4-clients (rétro-compat) → pas de client files → no-op, pas d'erreur.
+    pid = _planned(manager, approve=True)
+    result = sync_plan(manager, pid, "o", "r", dry_run=False, clients=_clients())
+    assert result.spec_committed is None
+    assert all(t.issue_number for t in manager.get_tasks(pid))
+
+
+def test_dry_run_does_not_commit_spec(manager):
+    pid = _planned(manager)  # non approuvé, dry-run
+    files = _FakeFiles()
+    result = sync_plan(manager, pid, "o", "r", dry_run=True, clients=_clients_with_files(files))
+    assert result.spec_committed is None
+    assert files.calls == []  # aucune écriture en dry-run
+
+
+def test_default_clients_includes_files():
+    from collegue.tools.github_commands import FileCommands
+
+    assert isinstance(_default_clients(token=None).files, FileCommands)


### PR DESCRIPTION
## Phase A3 — committer `SPEC.md` dans le repo cible

### Pourquoi
Le SPEC d'un projet vit en DB (`Project.spec`, markdown) mais le brief §4.2 exige un fichier **`SPEC.md` committé** dans le repo cible (le contrat, lisible et versionné). `sync_plan` créait les issues mais pas ce fichier. 3ᵉ brique du plan end-to-end-par-le-produit.

### Quoi (`collegue/planner/github_sync.py`)
- `SyncClients` gagne `files` (FileCommands) — **optionnel** (`= None`) → rétro-compat des appelants à 4 clients ; `_default_clients` le peuple.
- `_commit_spec(...)` : committe `Project.spec` en `SPEC.md` via `FileCommands.update_file`, **AVANT** les issues, **APRÈS** `require_approved` (jamais committé sans approbation P5), **best-effort** (un échec — droits, repo absent — n'échoue pas la synchro : `logger.warning` + `spec_committed=None`).
- `sync_plan` gagne `spec_filename` (défaut `SPEC.md`) ; `SyncResult` gagne `spec_committed` ; l'état du SPEC est tracé dans le **journal de décisions** (observabilité).
- Aucun commit en `dry_run` (la branche dry-run retourne avant).

### Tests / qualité
- 6 cas A3 (commit nominal, filename configurable, best-effort sur échec, no-op sans `files`/sans spec, aucun commit en dry-run, `_default_clients` inclut `files`) + les tests P4 existants intacts.
- **Suite non-integration complète verte** ; `ruff check` + `ruff format --check` propres.
- **Revue adversariale** (contexte frais) : 0 bloquant ; signature `update_file` vérifiée contre le code, `get_project`/`.spec` corrects, best-effort bien scopé, rétro-compat préservée ; NIT docstring (idempotence : joint le SHA, pas de commit vide côté GitHub) + observabilité (état SPEC au journal) appliqués.

Avec A1+A2+A3, `python -m collegue.pilot plan … --execute-sync` crée **SPEC.md + issues** dans le repo, sans le harnais. Cible : `pre-main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
