### PR TITLE
feat(gate): §4.7 tests d acceptation exécutables, auteur indépendant (Phase B)

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -126,6 +126,11 @@ class Settings(BaseSettings):
     # « livraison fantôme » (feature fermée par +1 ligne de requirements) ne
     # passe plus. Opt-in : un appel LLM par PR candidate.
     GATE_ADEQUACY: bool = False
+    # §4.7 (Phase B) : tests d'acceptation EXÉCUTABLES dérivés des critères du SPEC,
+    # écrits par un rôle INDÉPENDANT du coder (REVIEWER) et lancés en sandbox →
+    # vérification OBJECTIVE (exit code pytest), non circulaire. Opt-in (un appel LLM
+    # + une exécution pytest par PR candidate) ; activable une fois validé en réel.
+    GATE_ACCEPTANCE_TESTS: bool = False
     # Exiger qu'un diff touche au moins un fichier de test (sinon : simple
     # signal ⚠️ dans le rapport de gate / corps de PR).
     GATE_REQUIRE_TEST_CHANGES: bool = False

--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -929,6 +929,14 @@ class QualityReport:
     # rejet (sinon, en mode signal, elle masquerait le vrai motif d'échec). Run v6 :
     # `server.log` bloquait le gate mais le feedback montrait du bruit pip trompeur.
     forbidden_files_blocking: bool = False
+    # §4.7 (Phase B) : tests d'acceptation EXÉCUTABLES dérivés des critères du SPEC,
+    # écrits par un rôle INDÉPENDANT du coder et lancés en sandbox → verdict OBJECTIF
+    # (exit code pytest), pas un avis LLM (anti-vérification circulaire). None = non
+    # évalué (checker absent / pas de critères) ; False ⇒ gate rouge. Une erreur de
+    # GÉNÉRATION (best-effort) renseigne ``acceptance_error`` sans bloquer.
+    acceptance_passed: Optional[bool] = None
+    acceptance_output: str = ""
+    acceptance_error: Optional[str] = None
 
     def to_markdown(self) -> str:
         """Rapport Markdown pour le corps de PR (texte de revue fencé, anti-injection)."""
@@ -1014,6 +1022,18 @@ class QualityReport:
                 "",
                 "> ⚠️ **aucun fichier de test touché** par ce diff (#437) — la feature livrée "
                 "n'est couverte par aucun test nouveau ou modifié.",
+            ]
+        if self.acceptance_passed is False:
+            lines += [
+                "",
+                "> ⛔ **tests d'acceptation dérivés du SPEC en ÉCHEC (§4.7)** — des tests exécutables "
+                "écrits indépendamment du coder (depuis les critères d'acceptation) ne passent pas sur "
+                "le code livré. Vérification objective et non circulaire de la conformité au contrat.",
+            ]
+        elif self.acceptance_error:
+            lines += [
+                "",
+                f"> ⚠️ contrôle d'acceptation (§4.7) indisponible : {_fence_safe_line(self.acceptance_error)}",
             ]
         lines += ["", f"**Verdict** : {'✅ PASSÉ' if self.passed else '❌ NON PASSÉ'}"]
         return "\n".join(lines)
@@ -1512,6 +1532,125 @@ def _default_adequacy_sample_fn():  # pragma: no cover - chemin réel (integrati
     return sample
 
 
+# ── §4.7 (Phase B) : tests d'acceptation exécutables, auteur indépendant ─────────
+
+
+@dataclass(frozen=True)
+class AcceptanceOutcome:
+    """Verdict des tests d'acceptation §4.7 — exécution OBJECTIVE (exit code pytest)."""
+
+    passed: Optional[bool] = None  # None = non évalué (pas de critères / checker absent)
+    output: str = ""
+    error: Optional[str] = None  # erreur de GÉNÉRATION (best-effort, ne bloque pas)
+    skipped: bool = False
+
+
+@runtime_checkable
+class AcceptanceChecker(Protocol):
+    """Génère des tests d'acceptation depuis les critères du SPEC puis les LANCE (§4.7)."""
+
+    async def check(self, workspace: str, diff: str, issue: IssueSpec, ctx, *, sandbox) -> AcceptanceOutcome: ...
+
+
+_ACCEPTANCE_SYSTEM = (
+    "Tu es un ingénieur QA INDÉPENDANT (tu n'as PAS écrit le code). À partir des critères "
+    "d'acceptation d'une issue et du code livré (diff), écris des tests pytest EXÉCUTABLES qui "
+    "VÉRIFIENT chaque critère contre le code réel (imports, fixtures, démarrage d'app si nécessaire). "
+    "Les tests doivent ÉCHOUER si un critère n'est pas respecté. Réponds UNIQUEMENT avec un module "
+    "Python exécutable (aucune prose), en commençant par les imports."
+)
+
+_ACCEPTANCE_TEST_PATH = "tests/acceptance/test_acceptance_generated.py"
+
+
+def _strip_code_fences(text: str) -> str:
+    """Retire un éventuel fence Markdown (```python … ```) autour du code généré."""
+    stripped = (text or "").strip()
+    if stripped.startswith("```"):
+        stripped = stripped.split("\n", 1)[1] if "\n" in stripped else ""
+        if stripped.rstrip().endswith("```"):
+            stripped = stripped.rstrip()[:-3]
+    stripped = stripped.strip()
+    return (stripped + "\n") if stripped else ""
+
+
+def _write_acceptance_file(workspace: str, code: str) -> None:
+    """Écrit le module de tests d'acceptation généré dans le workspace (chemin fixe)."""
+    path = os.path.join(workspace, _ACCEPTANCE_TEST_PATH)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(code)
+
+
+class LLMAcceptanceChecker:
+    """:class:`AcceptanceChecker` — un LLM (rôle REVIEWER, ≠ coder) écrit les tests, la SANDBOX les lance.
+
+    Anti-circularité (§4.7) : le verdict est l'**exit code** de pytest (objectif), pas
+    un avis du modèle, et l'auteur des tests est **distinct du coder**. ``sample_fn``
+    injectable (mocké en CI). La GÉNÉRATION est best-effort (une erreur ⇒ ``error``
+    renseigné, gate non bloqué sur ce volet) ; mais des tests qui ÉCHOUENT ⇒
+    ``passed=False`` (bloquant). Les tests générés sont écrits dans le workspace pour
+    la durée du gate (hors diff de la PR, déjà capturé) et lancés avec les deps du projet.
+    """
+
+    def __init__(self, sample_fn=None, *, max_diff_chars: int = 60000):
+        self._sample_fn = sample_fn or _default_acceptance_sample_fn()
+        self._max_diff_chars = max_diff_chars
+
+    async def check(self, workspace: str, diff: str, issue: IssueSpec, ctx, *, sandbox) -> AcceptanceOutcome:
+        if issue is None or not issue.acceptance_criteria:
+            return AcceptanceOutcome(skipped=True)
+        bounded = strip_generated_from_diff(diff or "")[: self._max_diff_chars]
+        prompt = (
+            f"## Issue\n{issue.to_prompt()}\n\n"
+            f"## Code livré (diff)\n```diff\n{bounded or '(diff vide)'}\n```\n\n"
+            "Écris le module de tests pytest d'acceptation."
+        )
+        try:
+            code = _strip_code_fences(await self._sample_fn(prompt, _ACCEPTANCE_SYSTEM))
+        except Exception as exc:  # noqa: BLE001 - génération best-effort (BaseException budget remonte)
+            return AcceptanceOutcome(error=str(exc) or repr(exc))
+        if not code.strip():
+            return AcceptanceOutcome(error="génération de tests d'acceptation vide")
+        try:
+            _write_acceptance_file(workspace, code)
+        except OSError as exc:
+            return AcceptanceOutcome(error=f"écriture des tests d'acceptation impossible : {exc}")
+        prelude = deps_install_prelude(workspace)
+        pytest_cmd = f"{_PYTEST_WIDE_COLUMNS} python -m pytest {shlex.quote(_ACCEPTANCE_TEST_PATH)} -q"
+        command = f"({prelude}) && {pytest_cmd}" if prelude else pytest_cmd
+        res = sandbox.run_tests(workspace, command)
+        output = "\n".join(part for part in (res.stdout, res.stderr) if part).strip()
+        # pytest exit 5 = AUCUN test collecté → génération inexploitable (0 fonction
+        # test_*). Best-effort : on NE bloque PAS (passed=None + error), sinon une
+        # génération dégénérée serait un faux-rouge dur, à l'inverse de la sémantique.
+        if getattr(res, "exit_code", None) == 5:
+            return AcceptanceOutcome(
+                error="aucun test d'acceptation collecté (génération inexploitable)", output=output
+            )
+        return AcceptanceOutcome(passed=bool(res.ok), output=output)
+
+
+def _default_acceptance_sample_fn():  # pragma: no cover - chemin réel (integration)
+    from collegue.config import settings
+    from collegue.core.llm.roles import LLMRole, resolve_role
+    from collegue.resources.llm.providers import LLMConfig, generate_text
+
+    _provider, model = resolve_role(LLMRole.REVIEWER, settings)  # auteur INDÉPENDANT du coder
+    config = LLMConfig(
+        model_name=model or settings.llm_model,
+        api_key=settings.llm_api_key,
+        max_tokens=settings.MAX_TOKENS,
+        temperature=0.2,
+    )
+
+    async def sample(prompt: str, system_prompt: str) -> str:
+        response = await generate_text(config, prompt, system_prompt)
+        return response.text
+
+    return sample
+
+
 class FakeAdequacyChecker:
     """:class:`AdequacyChecker` déterministe pour la CI (aucun LLM)."""
 
@@ -1586,6 +1725,7 @@ async def run_quality_gate(
     require_deps_install: bool = False,
     check_installability: bool = False,
     adequacy_checker: Optional[AdequacyChecker] = None,
+    acceptance_checker: Optional[AcceptanceChecker] = None,
     require_test_changes: bool = False,
     smoke_run: bool = False,
     smoke_command: Optional[str] = None,
@@ -1801,15 +1941,33 @@ async def run_quality_gate(
         except Exception as exc:  # noqa: BLE001 - fail-closed ; BaseException (budget) remonte
             adequacy_error = str(exc) or repr(exc)
 
+    # §4.7 (Phase B) : tests d'acceptation EXÉCUTABLES (auteur indépendant du coder)
+    # lancés en sandbox — verdict OBJECTIF. Seulement si le reste est vert ET qu'il y a
+    # des critères (borne le coût). Une erreur de GÉNÉRATION ne bloque pas (best-effort) ;
+    # des tests qui ÉCHOUENT (``acceptance_passed is False``) bloquent.
+    acceptance_passed: Optional[bool] = None
+    acceptance_output = ""
+    acceptance_error: Optional[str] = None
+    if acceptance_checker is not None and issue is not None and issue.acceptance_criteria and would_pass:
+        try:
+            acc = await acceptance_checker.check(workspace, diff, issue, ctx, sandbox=sandbox)
+            acceptance_passed = acc.passed
+            acceptance_output = acc.output
+            acceptance_error = acc.error
+        except Exception as exc:  # noqa: BLE001 - fail-soft sur génération ; BaseException (budget) remonte
+            acceptance_error = str(exc) or repr(exc)
+
     touched = tests_touched(diff)
     # #499 : `is not False` — None (non évalué) et True passent ; seul False
     # bloque (rétrocompat #437 : un checker qui n'évalue pas la couverture ne
-    # rend jamais le gate rouge sur ce volet).
+    # rend jamais le gate rouge sur ce volet). Idem §4.7 : seul un ÉCHEC de tests
+    # d'acceptation (False) bloque ; une génération indisponible (error, passed=None) non.
     passed = (
         would_pass
         and adequacy_implemented is not False
         and adequacy_tests_assert is not False
         and adequacy_error is None
+        and acceptance_passed is not False
     )
     if require_test_changes and not touched:
         passed = False
@@ -1840,6 +1998,9 @@ async def run_quality_gate(
         adequacy_tests_justification=adequacy_tests_justification,
         forbidden_files=forbidden_files,
         forbidden_files_blocking=forbidden_blocked,
+        acceptance_passed=acceptance_passed,
+        acceptance_output=acceptance_output,
+        acceptance_error=acceptance_error,
     )
 
 

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -186,6 +186,10 @@ def _gate_options(settings_obj) -> dict:
         options["test_command"] = str(test_command)
     if bool(getattr(settings_obj, "GATE_ADEQUACY", False)):
         options["adequacy_checker"] = _build_adequacy_checker(settings_obj)
+    # §4.7 (Phase B, opt-in) : tests d'acceptation EXÉCUTABLES dérivés du SPEC, écrits
+    # par un rôle indépendant du coder et lancés en sandbox (verdict objectif).
+    if bool(getattr(settings_obj, "GATE_ACCEPTANCE_TESTS", False)):
+        options["acceptance_checker"] = _build_acceptance_checker(settings_obj)
     # Smoke run (#458, opt-in) : démarrer l'app livrée et vérifier qu'elle répond.
     if bool(getattr(settings_obj, "GATE_SMOKE_RUN", False)):
         options["smoke_run"] = True
@@ -213,6 +217,12 @@ def _build_adequacy_checker(settings_obj):  # pragma: no cover - infra réelle (
     from collegue.executor.quality_gate import LLMAdequacyChecker
 
     return LLMAdequacyChecker()
+
+
+def _build_acceptance_checker(settings_obj):  # pragma: no cover - infra réelle (integration)
+    from collegue.executor.quality_gate import LLMAcceptanceChecker
+
+    return LLMAcceptanceChecker()
 
 
 # ── point d'entrée assemblé ────────────────────────────────────────────────────

--- a/tests/test_acceptance_gate.py
+++ b/tests/test_acceptance_gate.py
@@ -1,0 +1,205 @@
+"""Tests §4.7 (Phase B) : tests d'acceptation exécutables, auteur indépendant du coder.
+
+Vérifie le mécanisme (LLMAcceptanceChecker : génère via sample_fn mocké → écrit en
+workspace → lance via sandbox mockée → verdict = exit code) et son intégration au
+gate (un ÉCHEC bloque ; une erreur de génération non ; skip sans critères ; pas
+lancé si le gate est déjà rouge). Aucun LLM ni Docker réel.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from collegue.executor import FakeReviewer, IssueSpec, run_quality_gate
+from collegue.executor.quality_gate import (
+    AcceptanceOutcome,
+    LLMAcceptanceChecker,
+    _strip_code_fences,
+)
+from collegue.sandbox import SandboxResult
+
+ISSUE_AC = IssueSpec(number=5, title="T", acceptance_criteria=("La TVA est calculée à 0.01 près",))
+ISSUE_NO_AC = IssueSpec(number=6, title="T")
+DIFF = "diff --git a/x.py b/x.py\n+print('x')\n"
+
+
+class _Sandbox:
+    def __init__(self, result):
+        self._result = result
+        self.commands = []
+
+    def run_tests(self, workspace, command="pytest -q"):
+        self.commands.append(command)
+        return self._result
+
+
+def _green():
+    return _Sandbox(SandboxResult(exit_code=0, stdout="2 passed", stderr=""))
+
+
+def _red():
+    return _Sandbox(SandboxResult(exit_code=1, stdout="", stderr="1 failed"))
+
+
+# --- _strip_code_fences --------------------------------------------------------
+
+
+def test_strip_code_fences_removes_python_block():
+    assert _strip_code_fences("```python\nx = 1\n```") == "x = 1\n"
+
+
+def test_strip_code_fences_passthrough_and_empty():
+    assert _strip_code_fences("x = 1") == "x = 1\n"
+    assert _strip_code_fences("   ") == ""
+
+
+# --- LLMAcceptanceChecker ------------------------------------------------------
+
+
+async def test_skipped_without_criteria():
+    async def _gen(prompt, system):
+        raise AssertionError("ne doit pas générer sans critères")
+
+    out = await LLMAcceptanceChecker(sample_fn=_gen).check("/ws", DIFF, ISSUE_NO_AC, None, sandbox=_green())
+    assert out.skipped is True and out.passed is None
+
+
+async def test_writes_file_and_passes_on_green(tmp_path):
+    async def _gen(prompt, system):
+        # le diff et les critères sont bien dans le prompt
+        assert "TVA" in prompt
+        return "```python\ndef test_ok():\n    assert True\n```"
+
+    sb = _green()
+    out = await LLMAcceptanceChecker(sample_fn=_gen).check(str(tmp_path), DIFF, ISSUE_AC, None, sandbox=sb)
+    assert out.passed is True
+    written = (tmp_path / "tests" / "acceptance" / "test_acceptance_generated.py").read_text()
+    assert "def test_ok" in written  # fences retirées, code écrit
+    assert any("tests/acceptance/test_acceptance_generated.py" in c for c in sb.commands)  # lancé
+
+
+async def test_fails_on_red(tmp_path):
+    async def _gen(prompt, system):
+        return "def test_no():\n    assert False\n"
+
+    out = await LLMAcceptanceChecker(sample_fn=_gen).check(str(tmp_path), DIFF, ISSUE_AC, None, sandbox=_red())
+    assert out.passed is False  # verdict OBJECTIF = exit code pytest
+
+
+async def test_exit5_no_tests_collected_is_soft(tmp_path):
+    # Génération sans aucune fonction test_* → pytest exit 5 → ne bloque PAS (best-effort).
+    async def _gen(prompt, system):
+        return "# rien de testable\nx = 1\n"
+
+    sb = _Sandbox(SandboxResult(exit_code=5, stdout="no tests ran", stderr=""))
+    out = await LLMAcceptanceChecker(sample_fn=_gen).check(str(tmp_path), DIFF, ISSUE_AC, None, sandbox=sb)
+    assert out.passed is None  # ni bloquant ni « réussi »
+    assert out.error and "collecté" in out.error
+
+
+async def test_generation_error_is_soft(tmp_path):
+    async def _boom(prompt, system):
+        raise RuntimeError("LLM indisponible")
+
+    out = await LLMAcceptanceChecker(sample_fn=_boom).check(str(tmp_path), DIFF, ISSUE_AC, None, sandbox=_green())
+    assert out.passed is None and "LLM indisponible" in (out.error or "")
+
+
+async def test_empty_generation_is_error(tmp_path):
+    async def _empty(prompt, system):
+        return "   "
+
+    out = await LLMAcceptanceChecker(sample_fn=_empty).check(str(tmp_path), DIFF, ISSUE_AC, None, sandbox=_green())
+    assert out.passed is None and out.error
+
+
+# --- intégration au gate (run_quality_gate) ------------------------------------
+
+
+class _FakeAcceptance:
+    def __init__(self, *, passed=None, error=None):
+        self._outcome = AcceptanceOutcome(passed=passed, error=error)
+        self.called = False
+
+    async def check(self, workspace, diff, issue, ctx, *, sandbox):
+        self.called = True
+        return self._outcome
+
+
+async def test_gate_blocks_when_acceptance_fails():
+    chk = _FakeAcceptance(passed=False)
+    report = await run_quality_gate(
+        "/ws", DIFF, ctx=None, sandbox=_green(), reviewer=FakeReviewer(), issue=ISSUE_AC, acceptance_checker=chk
+    )
+    assert chk.called is True
+    assert report.acceptance_passed is False
+    assert report.passed is False  # un critère du SPEC non vérifié → gate rouge
+
+
+async def test_gate_passes_when_acceptance_passes():
+    chk = _FakeAcceptance(passed=True)
+    report = await run_quality_gate(
+        "/ws", DIFF, ctx=None, sandbox=_green(), reviewer=FakeReviewer(), issue=ISSUE_AC, acceptance_checker=chk
+    )
+    assert report.acceptance_passed is True and report.passed is True
+
+
+async def test_gate_generation_error_does_not_block():
+    chk = _FakeAcceptance(passed=None, error="génération KO")
+    report = await run_quality_gate(
+        "/ws", DIFF, ctx=None, sandbox=_green(), reviewer=FakeReviewer(), issue=ISSUE_AC, acceptance_checker=chk
+    )
+    assert report.acceptance_error == "génération KO"
+    assert report.passed is True  # best-effort : une génération indisponible ne bloque pas
+
+
+async def test_gate_skips_acceptance_without_criteria():
+    chk = _FakeAcceptance(passed=False)  # bloquerait SI appelé
+    report = await run_quality_gate(
+        "/ws", DIFF, ctx=None, sandbox=_green(), reviewer=FakeReviewer(), issue=ISSUE_NO_AC, acceptance_checker=chk
+    )
+    assert chk.called is False  # pas de critères → pas lancé
+    assert report.passed is True
+
+
+async def test_gate_skips_acceptance_when_already_failing():
+    chk = _FakeAcceptance(passed=False)
+    report = await run_quality_gate(
+        "/ws", DIFF, ctx=None, sandbox=_red(), reviewer=FakeReviewer(), issue=ISSUE_AC, acceptance_checker=chk
+    )
+    assert chk.called is False  # tests rouges → would_pass False → acceptance non lancé (borne le coût)
+    assert report.passed is False
+
+
+def test_acceptance_failure_rendered_in_report():
+    from collegue.executor import QualityReport
+
+    md = QualityReport(
+        tests_passed=True,
+        test_exit_code=0,
+        test_output="",
+        review_summary="",
+        review_findings=(),
+        review_blocking=False,
+        passed=False,
+        acceptance_passed=False,
+    ).to_markdown()
+    assert "tests d'acceptation dérivés du SPEC en ÉCHEC" in md
+
+
+# --- câblage runtime (opt-in) --------------------------------------------------
+
+
+def test_gate_options_includes_acceptance_when_enabled(monkeypatch):
+    from collegue.pilot import runtime
+
+    monkeypatch.setattr(runtime, "_build_acceptance_checker", lambda s: "CHECKER")
+    opts = runtime._gate_options(SimpleNamespace(GATE_ACCEPTANCE_TESTS=True))
+    assert opts.get("acceptance_checker") == "CHECKER"
+
+
+def test_gate_options_excludes_acceptance_by_default():
+    from collegue.pilot import runtime
+
+    opts = runtime._gate_options(SimpleNamespace())
+    assert "acceptance_checker" not in opts


### PR DESCRIPTION
## Phase B — §4.7 : tests d'acceptation exécutables, auteur indépendant du coder

### Pourquoi (anti-vérification circulaire)
Avant, la conformité d'un diff aux critères d'acceptation était **jugée par un LLM** qui relit le diff (`AdequacyChecker`) — un modèle frère du coder grade le travail du coder → **circulaire** (§4.7/§6 violés). Cette PR ajoute une **vérification objective** : un rôle **indépendant** (REVIEWER, ≠ coder) génère des tests pytest depuis `issue.acceptance_criteria`, écrits en sandbox et **lancés** → le verdict est l'**exit code**, pas un avis du modèle.

*Décision : « auteur indépendant à l'exécution » (choix utilisateur).*

### Quoi
- **`quality_gate.py`** : `AcceptanceOutcome` + `AcceptanceChecker` (Protocol) + `LLMAcceptanceChecker` :
  - `sample_fn` rôle **REVIEWER** (injectable, mocké en CI) ; écrit `tests/acceptance/test_acceptance_generated.py`, lance via la sandbox avec les **deps réinstallées** (conteneur éphémère) ;
  - `exit 5` (aucun test collecté) = **soft no-op** (ne bloque pas) ; génération KO = best-effort (`error`, ne bloque pas) ; tests qui **échouent** ⇒ `passed=False` (**bloquant**).
  - Passe câblée dans `run_quality_gate` **après** tests/adéquation, **seulement si** le gate est vert et qu'il y a des critères (borne le coût). `QualityReport` + rapport markdown étendus.
- **`runtime.py`** : `_build_acceptance_checker` + clé `gate_options` gated `GATE_ACCEPTANCE_TESTS`.
- **`config.py`** : `GATE_ACCEPTANCE_TESTS` — **opt-in, défaut OFF** (activable une fois validé en réel, comme l'e2e gate v7→v8).

### Tests / qualité
- 16 cas : génère/écrit/lance/verdict, `exit 5` soft, erreur soft, skip sans critères / gate déjà rouge, intégration verdict (échec bloque, erreur non), rendu rapport, câblage runtime opt-in.
- **Suite non-integration complète verte** ; `ruff check` + `ruff format --check` propres.
- **Revue adversariale** (contexte frais) : 0 bloquant ; sémantique du verdict, non-pollution de la PR (fichier généré hors `files_changed`), deps en conteneur éphémère **validés** ; MINEUR `exit 5` corrigé.

Le grader n'est plus le diff relu par un LLM frère : **auteur ≠ coder + verdict = test**. Cible : `pre-main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
