### PR TITLE
ci(sandbox): image OpenHands #404 constructible par le produit + build nightly (Phase D)

### DIFF
--- a/.github/workflows/integration-nightly.yml
+++ b/.github/workflows/integration-nightly.yml
@@ -151,3 +151,21 @@ jobs:
                 body,
               });
             }
+
+  build-sandbox-openhands:
+    name: Build image sandbox OpenHands (#404)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+      # Construit l'image #404 depuis les SOURCES COMMITTÉES SEULES (le harnais
+      # gitignoré scripts/facnor_run/ n'est pas présent en CI) — prouve que le
+      # blocage « image non constructible » est levé. Build-only : aucun run réel
+      # (LLM/GitHub) ici ; le smoke e2e réel (plan→execute→PR sur fixture) reste
+      # un suivi secret-gated.
+      - name: Build OpenHands sandbox image (committed sources only)
+        run: docker build -f docker/sandbox/Dockerfile.openhands -t collegue-sandbox-openhands:ci .
+      - name: Vérifier l'entrypoint produit (openhands.core.main) importable
+        run: |
+          docker run --rm collegue-sandbox-openhands:ci \
+            python -c "import openhands.core.main; print('openhands.core.main OK')"

--- a/.gitignore
+++ b/.gitignore
@@ -275,6 +275,8 @@ tests/evals/reports/
 # Échafaudage du run de test autonome FacNor (drivers + état + venv) — hors repo.
 # Les correctifs moteur qu'il a révélés sont portés proprement via les issues #409-#414.
 scripts/facnor_run/
-docker/sandbox/Dockerfile.openhands
 .facnor_run/
 .venv-facnor/
+# NB : docker/sandbox/Dockerfile.openhands est désormais COMMITTÉ (#404) — image
+# produit constructible depuis les sources committées (n'embarque oh_runner.py du
+# harnais que s'il est présent dans le contexte de build).

--- a/docker/sandbox/Dockerfile.openhands
+++ b/docker/sandbox/Dockerfile.openhands
@@ -1,0 +1,95 @@
+# Image sandbox AVEC OpenHands embarqué (exécuteur autonome réel — issue #404).
+# Étend la base sandbox durcie (python:3.12-slim + Node) avec l'agent codeur
+# OpenHands, pour que collegue/executor/openhands_agent.py puisse le lancer en
+# headless via DockerSandbox. Utilise le runtime PROCESS (pas de Docker imbriqué).
+#
+# Résolution via uv : le resolver pip échoue sur le closure d'openhands-ai 1.7.0
+# (lmnr épingle opentelemetry-semantic-conventions==0.60b1 → backtracking pip
+# explosif), là où uv (PubGrub) converge.
+
+FROM python:3.12-slim
+
+# git : indispensable à l'agent (diffs, commits locaux) et au runtime process.
+# nodejs/npm : stack frontend JS/TS des projets générés (§8).
+# build-essential : deps Python natives d'OpenHands.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        curl \
+        ca-certificates \
+        nodejs \
+        npm \
+        build-essential \
+        tmux \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv : resolver/install rapide et capable du closure otel d'OpenHands.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Agent codeur OpenHands (headless), version pinnée, installé dans le python système.
+# lmnr épinglé (faux départ v5) : la 0.7.53 a retiré observe(rollout_entrypoint=…)
+# attendu par openhands 1.7.0 → TypeError à l'import, agent mort-né.
+RUN uv pip install --system "openhands-ai==1.7.0" "lmnr==0.7.52"
+
+# Runner de tests du gate qualité (pytest) — couche distincte (cache openhands préservé).
+# PIN pytest<9 : pytest 9.0 a retiré `FixtureDef` du namespace top-level, ce qui
+# casse `from pytest import FixtureDef` de pytest-asyncio<0.24 (que les projets
+# générés pinnent couramment, ex. 0.23.6) → ImportError à la collecte → TOUTE
+# tâche avec tests échoue au gate (run v6 bloqué dès la tâche 1). On épingle le
+# runner système sur 8.x + le pytest-asyncio aligné sur l'écosystème projet.
+RUN uv pip install --system "pytest>=8.1,<9" "pytest-asyncio==0.23.6"
+
+# Stack web Python courant pré-installé : le conteneur de test (gate) est ÉPHÉMÈRE et
+# SÉPARÉ de celui de l'agent → sans ça, le code généré (FastAPI + JWT auth, etc.)
+# casse à l'import (ex. `No module named 'jose'`). fastapi/uvicorn/sqlalchemy/pydantic
+# arrivent déjà via openhands ; on ajoute l'auth/validation/migrations.
+RUN uv pip install --system \
+    "python-jose[cryptography]" \
+    "passlib[bcrypt]" \
+    "bcrypt<4.1" \
+    python-multipart \
+    email-validator \
+    pydantic-settings \
+    alembic \
+    "psycopg2-binary" \
+    aiosqlite \
+    httpx
+
+# Navigateur headless pour le GATE E2E (#503 suivi). Playwright (Python) est DÉJÀ
+# fourni par openhands-ai (1.60) → on ajoute SEULEMENT le binaire chromium + ses
+# libs système (libnss3, libatk… que le download seul ne pose pas), en ROOT via
+# --with-deps. PLAYWRIGHT_BROWSERS_PATH PARTAGÉ + lisible pour que l'utilisateur
+# `sandbox` (non-root) trouve le navigateur au run. Le gate drive l'UI via le
+# playwright python (cohérent avec la sonde smoke) ; distinct du browsing
+# d'OpenHands (toujours désactivé).
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
+RUN python -m playwright install --with-deps chromium \
+    && chmod -R a+rX /opt/ms-playwright
+
+# Runtime PROCESS : aucun Docker imbriqué ; l'agent agit dans le workspace monté.
+# Navigateur d'OpenHands désactivé (le gate E2E utilise Playwright directement).
+ENV RUNTIME=process \
+    INSTALL_DOCKER=0 \
+    OPENHANDS_DISABLE_BROWSER=1 \
+    OPENHANDS_SUPPRESS_BANNER=1
+
+# Runner SDK du HARNAIS (scripts/facnor_run/oh_runner.py, gitignoré) baké SI présent
+# dans le contexte de build — utilisé par l'OHSdkAgent du harnais. Le PRODUIT
+# (collegue/executor/openhands_agent.py → openhands.core.main) n'en a PAS besoin :
+# l'image se construit donc depuis les **sources committées seules** (CI / #404).
+# `scripts/` est committé (le COPY ne casse jamais) ; oh_runner.py n'y apparaît que
+# dans l'arbre du harnais (pas de .dockerignore → inclus au contexte quand présent).
+COPY scripts/ /tmp/_collegue_scripts/
+RUN if [ -f /tmp/_collegue_scripts/facnor_run/oh_runner.py ]; then \
+        cp /tmp/_collegue_scripts/facnor_run/oh_runner.py /opt/oh_runner.py; \
+    fi; \
+    rm -rf /tmp/_collegue_scripts
+
+# Utilisateur non-root (le `docker run` surcharge --user pour matcher l'UID hôte).
+RUN useradd --create-home --uid 1000 sandbox
+
+WORKDIR /workspace
+USER sandbox
+
+# Pas d'ENTRYPOINT applicatif : l'exécuteur fournit la commande à chaque run.
+CMD ["python", "--version"]


### PR DESCRIPTION
## Phase D — image sandbox OpenHands constructible par le produit (#404)

### Pourquoi (le blocage du run réel)
`docker/sandbox/Dockerfile.openhands` était **gitignoré** (artefact du harnais) ET faisait `COPY scripts/facnor_run/oh_runner.py` (fichier lui aussi gitignoré). Donc l'image #404 — nécessaire au **run réel de bout en bout** — n'existait **pas dans le repo** et n'était **pas constructible** depuis les sources committées. Or le produit (`collegue/executor/openhands_agent.py`) lance `openhands.core.main`, pas `oh_runner.py` (ça, c'est l'`OHSdkAgent` du harnais).

### Quoi
- **D1** — Dockerfile committé + **COPY conditionnel** : `COPY scripts/` (committé) puis `cp oh_runner.py` **uniquement s'il est présent** dans le contexte. Build OK depuis les **sources committées seules** (produit, branche « ABSENT ») ET depuis l'arbre du harnais (oh_runner baké). `.gitignore` mis à jour (dé-ignore + note).
  - **Validé empiriquement** : sur un contexte `git archive HEAD` (committé seul), l'ancien `COPY scripts/facnor_run/oh_runner.py` échoue (`not found`) ; le nouveau build réussit (branche « oh_runner ABSENT »).
- **D2** — job nightly `build-sandbox-openhands` : construit l'image depuis les sources committées + vérifie que `openhands.core.main` (entrypoint produit) y est **importable**. Prouve en CI que l'image #404 est constructible.

Le smoke e2e **réel** (plan→execute→PR sur dépôt fixture, avec LLM + GitHub) reste un suivi **secret-gated** (au-delà du build).

YAML du workflow validé ; aucun `.py`/test applicatif touché. Cible : `pre-main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
