### PR TITLE
Landing pre-main → main : end-to-end par le produit + §4.7 + image #404 (A→D)

### DIFF
--- a/.github/workflows/integration-nightly.yml
+++ b/.github/workflows/integration-nightly.yml
@@ -151,3 +151,21 @@ jobs:
                 body,
               });
             }
+
+  build-sandbox-openhands:
+    name: Build image sandbox OpenHands (#404)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+      # Construit l'image #404 depuis les SOURCES COMMITTÉES SEULES (le harnais
+      # gitignoré scripts/facnor_run/ n'est pas présent en CI) — prouve que le
+      # blocage « image non constructible » est levé. Build-only : aucun run réel
+      # (LLM/GitHub) ici ; le smoke e2e réel (plan→execute→PR sur fixture) reste
+      # un suivi secret-gated.
+      - name: Build OpenHands sandbox image (committed sources only)
+        run: docker build -f docker/sandbox/Dockerfile.openhands -t collegue-sandbox-openhands:ci .
+      - name: Vérifier l'entrypoint produit (openhands.core.main) importable
+        run: |
+          docker run --rm collegue-sandbox-openhands:ci \
+            python -c "import openhands.core.main; print('openhands.core.main OK')"

--- a/.gitignore
+++ b/.gitignore
@@ -275,6 +275,8 @@ tests/evals/reports/
 # Échafaudage du run de test autonome FacNor (drivers + état + venv) — hors repo.
 # Les correctifs moteur qu'il a révélés sont portés proprement via les issues #409-#414.
 scripts/facnor_run/
-docker/sandbox/Dockerfile.openhands
 .facnor_run/
 .venv-facnor/
+# NB : docker/sandbox/Dockerfile.openhands est désormais COMMITTÉ (#404) — image
+# produit constructible depuis les sources committées (n'embarque oh_runner.py du
+# harnais que s'il est présent dans le contexte de build).

--- a/collegue/app.py
+++ b/collegue/app.py
@@ -351,19 +351,14 @@ async def core_lifespan(server):
 sampling_handler = None
 if settings.LLM_API_KEY or settings.is_local_provider:
     try:
-        from collegue.core.llm.sampling_handler import build_sampling_handler
+        from collegue.core.llm.sampling_handler import build_sampling_handler, resolve_openai_endpoint
 
         provider = settings.LLM_PROVIDER.lower()
-        # Gemini par défaut ; sinon l'endpoint OpenAI-compatible du provider.
-        if provider in ("gemini", ""):
-            base_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
-        else:
-            base_url = settings.llm_base_url  # None pour OpenAI cloud → défaut SDK
-        # Clé factice pour les locaux qui l'ignorent (le SDK OpenAI en exige une).
-        api_key = settings.LLM_API_KEY or ("local" if settings.is_local_provider else None)
+        # Résolution provider→endpoint partagée avec le ctx offline (source unique).
+        default_model, api_key, base_url = resolve_openai_endpoint(settings)
 
         sampling_handler = build_sampling_handler(
-            default_model=settings.LLM_MODEL,
+            default_model=default_model,
             api_key=api_key,
             base_url=base_url,
         )

--- a/collegue/config.py
+++ b/collegue/config.py
@@ -126,6 +126,11 @@ class Settings(BaseSettings):
     # « livraison fantôme » (feature fermée par +1 ligne de requirements) ne
     # passe plus. Opt-in : un appel LLM par PR candidate.
     GATE_ADEQUACY: bool = False
+    # §4.7 (Phase B) : tests d'acceptation EXÉCUTABLES dérivés des critères du SPEC,
+    # écrits par un rôle INDÉPENDANT du coder (REVIEWER) et lancés en sandbox →
+    # vérification OBJECTIVE (exit code pytest), non circulaire. Opt-in (un appel LLM
+    # + une exécution pytest par PR candidate) ; activable une fois validé en réel.
+    GATE_ACCEPTANCE_TESTS: bool = False
     # Exiger qu'un diff touche au moins un fichier de test (sinon : simple
     # signal ⚠️ dans le rapport de gate / corps de PR).
     GATE_REQUIRE_TEST_CHANGES: bool = False

--- a/collegue/core/llm/sampling_ctx.py
+++ b/collegue/core/llm/sampling_ctx.py
@@ -1,0 +1,272 @@
+"""Contexte de sampling **offline** (hors serveur MCP) pour piloter le moteur en CLI.
+
+Le planner (``generate_spec``/``decompose``), le reviewer (``code_review`` via
+``BaseTool``) et la boucle agentique attendent un objet ``ctx`` exposant une
+coroutine ``sample(...)`` (sampling FastMCP). En CLI il n'y a **pas** de serveur
+MCP, donc pas de ``ctx`` : ``run_project_from_settings`` recevait ``ctx=None`` et
+les chemins LLM réels échouaient.
+
+Ce module fournit un ``ctx`` qui appelle le LLM via un client **OpenAI-compatible**
+(``AsyncOpenAI`` + ``base_url`` par provider), en réutilisant la MÊME résolution
+provider→endpoint que le handler serveur (``resolve_openai_endpoint``) → **multi-
+provider** (Gemini OpenAI-compat / OpenAI / lmstudio / ollama / unsloth), pas de
+lock-in (brief §8). Au même chokepoint que le handler serveur, on applique la
+**garde budget dur** (``enforce_budget``, C4) et la **capture d'usage**
+(``record_usage``) — tous les ``ctx.sample()`` offline transitent ici.
+
+Contrat reproduit fidèlement (lu dans le code) :
+- ``sample(messages, *, system_prompt, result_type, temperature, max_tokens,
+  model_preferences, **ignored)`` renvoie un objet avec ``.text`` (texte brut) et
+  ``.result`` (instance ``result_type`` si parsable, sinon le texte) — exactement
+  ce que lisent ``tools/base.py`` (``result.result if result_type else result.text``)
+  et le planner ;
+- ``model_preferences=[modèle]`` route vers ce modèle (rôle → modèle, C1/C2) ;
+- stubs ``info/debug/warning/error/report_progress`` no-op attendus par les outils ;
+- ``max_output_tokens`` généreux par défaut (quirk gemma : trop bas ⇒ contenu vide).
+
+Le client ``AsyncOpenAI`` est construit **paresseusement** (au 1er ``sample``) : la
+seule construction du ctx n'ouvre aucune connexion ni n'exige de clé (les tests qui
+n'échantillonnent pas restent inertes).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+DEFAULT_MAX_TOKENS = 8192
+
+
+@dataclass
+class SampleResult:
+    """Réponse de sampling : ``.text`` brut + ``.result`` structuré optionnel."""
+
+    text: str = ""
+    result: Any = None
+
+
+class PerModelRateLimiter:
+    """Cap glissant par modèle : ``per_minute`` req/60 s et ``per_day`` req/24 h.
+
+    ``acquire`` bloque (``asyncio.sleep``) jusqu'à ce qu'un créneau se libère. Le
+    décompte est par **nom de modèle**. Thread-safe (lock court) ; attentes hors-lock.
+    Sert à respecter un quota partagé (ex. Gemini free-tier) pour les appels de CE ctx.
+    """
+
+    def __init__(self, per_minute: int = 0, per_day: int = 0):
+        self.per_minute = max(0, int(per_minute or 0))
+        self.per_day = max(0, int(per_day or 0))
+        self._minute: Dict[str, deque] = {}
+        self._day: Dict[str, deque] = {}
+        self._lock = threading.Lock()
+
+    def _wait_needed(self, model: str, now: float) -> float:
+        mdq = self._minute.setdefault(model, deque())
+        ddq = self._day.setdefault(model, deque())
+        while mdq and now - mdq[0] >= 60:
+            mdq.popleft()
+        while ddq and now - ddq[0] >= 86400:
+            ddq.popleft()
+        wait = 0.0
+        if self.per_minute and len(mdq) >= self.per_minute:
+            wait = max(wait, 60.0 - (now - mdq[0]))
+        if self.per_day and len(ddq) >= self.per_day:
+            wait = max(wait, 86400.0 - (now - ddq[0]))
+        return wait
+
+    async def acquire(self, model: str) -> None:
+        while True:
+            now = time.time()
+            with self._lock:
+                wait = self._wait_needed(model, now)
+                if wait <= 0:
+                    self._minute[model].append(now)
+                    self._day[model].append(now)
+                    return
+            await asyncio.sleep(min(wait, 5.0) + 0.05)
+
+
+def _pick_model(model_preferences: Any, default_model: str) -> str:
+    """Choisit le modèle effectif depuis ``model_preferences`` (rôle → modèle)."""
+    if isinstance(model_preferences, (list, tuple)) and model_preferences:
+        first = str(model_preferences[0]).strip()
+        if first:
+            return first
+    return default_model
+
+
+def to_openai_messages(messages: Any, system_prompt: Optional[str]) -> List[Dict[str, str]]:
+    """Normalise ``messages`` (str ou liste ``{role,content}``) en messages OpenAI.
+
+    ``BaseTool.sample_llm`` envoie soit une chaîne (+ ``system_prompt`` séparé), soit
+    ``[{"role":"system","content":...},{"role":"user","content":...}]``. L'endpoint
+    OpenAI-compatible gère nativement le rôle ``system`` (pas de pliage gemma requis).
+    Garantit au moins un tour ``user`` (l'API refuse une conversation sans user).
+    """
+    out: List[Dict[str, str]] = []
+    if system_prompt:
+        out.append({"role": "system", "content": str(system_prompt)})
+    if isinstance(messages, str):
+        if messages:
+            out.append({"role": "user", "content": messages})
+    elif isinstance(messages, (list, tuple)):
+        for m in messages:
+            if isinstance(m, dict):
+                role = str(m.get("role", "user"))
+                content = m.get("content", m.get("text", ""))
+                if content is None:
+                    content = ""
+                elif isinstance(content, (list, tuple)):
+                    content = " ".join(p.get("text", "") if isinstance(p, dict) else str(p) for p in content)
+                out.append({"role": role, "content": str(content)})
+            else:
+                out.append({"role": "user", "content": str(m)})
+    elif messages:
+        out.append({"role": "user", "content": str(messages)})
+    if not any(m["role"] == "user" for m in out):
+        out.append({"role": "user", "content": "(vide)"})
+    return out
+
+
+def _coerce(text: str, result_type: Any) -> Any:
+    """Parse ``text`` (JSON, fences tolérées) en ``result_type`` ; sinon rend le texte."""
+    try:
+        from collegue.planner._parsing import json_from_text
+    except Exception:  # noqa: BLE001 - parsing best-effort
+        json_from_text = None
+    data = json_from_text(text) if json_from_text else None
+    if isinstance(data, dict) and hasattr(result_type, "model_validate"):
+        try:
+            return result_type.model_validate(data)
+        except Exception:  # noqa: BLE001 - retombe sur le texte brut
+            return text
+    return text
+
+
+class LocalSamplingContext:
+    """``ctx`` de sampling offline routé vers un endpoint OpenAI-compatible.
+
+    Construire le ctx n'ouvre aucune connexion : le client ``AsyncOpenAI`` est créé
+    au premier ``sample`` (ou injecté en test via ``client=``).
+    """
+
+    def __init__(
+        self,
+        *,
+        default_model: str,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        rate_limiter: Optional[PerModelRateLimiter] = None,
+        default_max_tokens: int = DEFAULT_MAX_TOKENS,
+        max_retries: int = 4,
+        client: Any = None,
+    ):
+        self._default_model = default_model or ""
+        self._api_key = api_key
+        self._base_url = base_url
+        self._limiter = rate_limiter
+        self._default_max_tokens = int(default_max_tokens)
+        self._max_retries = int(max_retries)
+        self._client = client
+        # Stubs ctx attendus par les outils (no-op async).
+        self.info = self._noop
+        self.debug = self._noop
+        self.warning = self._noop
+        self.error = self._noop
+        self.report_progress = self._noop
+
+    @classmethod
+    def from_settings(cls, settings_obj: Any) -> "LocalSamplingContext":
+        """Construit le ctx depuis la config (provider→endpoint).
+
+        **Pas de rate-limiter par défaut** : les réglages ``LLM_RATE_LIMIT_*`` bornent
+        le middleware **serveur par-client** (autre couche) ; les y réutiliser
+        throttlerait le moteur (15/min, 500/jour) bien en-dessous d'un run réel. Les
+        429 sont gérés par le retry du SDK (``max_retries``) et le coût est borné par
+        ``enforce_budget`` (C4). Un ``PerModelRateLimiter`` reste **injectable** au
+        constructeur pour qui veut cadencer un quota free-tier.
+        """
+        from collegue.core.llm.sampling_handler import resolve_openai_endpoint
+
+        default_model, api_key, base_url = resolve_openai_endpoint(settings_obj)
+        return cls(default_model=default_model, api_key=api_key, base_url=base_url)
+
+    async def _noop(self, *args: Any, **kwargs: Any) -> None:  # ctx.info/debug/...
+        return None
+
+    def _client_obj(self) -> Any:
+        if self._client is None:
+            from openai import AsyncOpenAI
+
+            self._client = AsyncOpenAI(api_key=self._api_key, base_url=self._base_url, max_retries=self._max_retries)
+        return self._client
+
+    async def sample(
+        self,
+        messages: Any = "",
+        *,
+        system_prompt: Optional[str] = None,
+        result_type: Any = None,
+        temperature: float = 0.7,
+        max_tokens: Optional[int] = None,
+        model_preferences: Any = None,
+        **_ignored: Any,
+    ) -> SampleResult:
+        model = _pick_model(model_preferences, self._default_model)
+        oai_messages = to_openai_messages(messages, system_prompt)
+        # On RESPECTE le ``max_tokens`` explicite de l'appelant (parité avec le handler
+        # serveur — sinon on inflerait ×4 les caps voulus, ex. 2000) ; seul un appel SANS
+        # cap retombe sur ``_default_max_tokens`` (généreux : un modèle « raisonnant »
+        # type gemma coupé trop tôt rend un contenu vide).
+        eff_max = int(max_tokens) if max_tokens else self._default_max_tokens
+        if self._limiter is not None:
+            await self._limiter.acquire(model)
+        text = await self._create(model, oai_messages, temperature, eff_max)
+        res = SampleResult(text=text)
+        if result_type is not None:
+            res.result = _coerce(text, result_type)
+        return res
+
+    async def _create(self, model: str, messages: List[Dict[str, str]], temperature: float, max_tokens: int) -> str:
+        # Garde budget dur (C4) + capture d'usage AU MÊME chokepoint que le handler
+        # serveur : tous les ctx.sample() offline passent ici. ``enforce_budget`` lève
+        # ``BudgetExceeded`` (BaseException) si le plafond cumulé est atteint — on NE la
+        # capture pas (auto-pause volontaire). No-op si plafonds désactivés.
+        from collegue.monitoring.metrics import enforce_budget
+        from collegue.monitoring.sampling_usage import record_usage
+
+        enforce_budget()
+        resp = await self._client_obj().chat.completions.create(
+            model=model, messages=messages, temperature=temperature, max_tokens=max_tokens
+        )
+        usage = getattr(resp, "usage", None)
+        if usage is not None:
+            record_usage(
+                getattr(usage, "prompt_tokens", 0) or 0,
+                getattr(usage, "completion_tokens", 0) or 0,
+                getattr(resp, "model", model) or model,
+            )
+        return _extract_text(resp)
+
+    async def aclose(self) -> None:
+        if self._client is not None:
+            close = getattr(self._client, "close", None) or getattr(self._client, "aclose", None)
+            if close is not None:
+                maybe = close()
+                if asyncio.iscoroutine(maybe):
+                    await maybe
+            self._client = None
+
+
+def _extract_text(resp: Any) -> str:
+    """Texte du 1er choix d'une réponse chat.completions (OpenAI-compatible)."""
+    choices = getattr(resp, "choices", None) or []
+    if not choices:
+        return ""
+    message = getattr(choices[0], "message", None)
+    content = getattr(message, "content", "") if message is not None else ""
+    return content or ""

--- a/collegue/core/llm/sampling_handler.py
+++ b/collegue/core/llm/sampling_handler.py
@@ -65,6 +65,27 @@ def _make_handler_class():
     return UsageTrackingSamplingHandler
 
 
+def resolve_openai_endpoint(settings_obj: Any) -> tuple[str, Optional[str], Optional[str]]:
+    """``(default_model, api_key, base_url)`` pour un client OpenAI-compatible, depuis la config.
+
+    Source unique de vérité du routage provider→endpoint (utilisée par ``app.py`` pour
+    le handler serveur ET par le ``ctx`` offline ``LocalSamplingContext``) :
+
+    - ``gemini`` (défaut) → endpoint **OpenAI-compatible** de Google ;
+    - provider **local** (lmstudio/ollama/unsloth) → ``settings.llm_base_url`` + clé factice ;
+    - ``openai`` cloud → ``base_url=None`` (défaut du SDK).
+    """
+    provider = (getattr(settings_obj, "LLM_PROVIDER", "gemini") or "gemini").lower()
+    if provider in ("gemini", ""):
+        base_url: Optional[str] = "https://generativelanguage.googleapis.com/v1beta/openai/"
+    else:
+        base_url = getattr(settings_obj, "llm_base_url", None)
+    is_local = bool(getattr(settings_obj, "is_local_provider", False))
+    api_key = getattr(settings_obj, "LLM_API_KEY", None) or ("local" if is_local else None)
+    default_model = getattr(settings_obj, "LLM_MODEL", "") or ""
+    return default_model, api_key, base_url
+
+
 def build_sampling_handler(default_model: str, api_key: Optional[str], base_url: Optional[str]) -> Optional[Any]:
     """Instancie le handler de sampling, ou ``None`` si les dépendances manquent."""
     try:

--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -929,6 +929,14 @@ class QualityReport:
     # rejet (sinon, en mode signal, elle masquerait le vrai motif d'échec). Run v6 :
     # `server.log` bloquait le gate mais le feedback montrait du bruit pip trompeur.
     forbidden_files_blocking: bool = False
+    # §4.7 (Phase B) : tests d'acceptation EXÉCUTABLES dérivés des critères du SPEC,
+    # écrits par un rôle INDÉPENDANT du coder et lancés en sandbox → verdict OBJECTIF
+    # (exit code pytest), pas un avis LLM (anti-vérification circulaire). None = non
+    # évalué (checker absent / pas de critères) ; False ⇒ gate rouge. Une erreur de
+    # GÉNÉRATION (best-effort) renseigne ``acceptance_error`` sans bloquer.
+    acceptance_passed: Optional[bool] = None
+    acceptance_output: str = ""
+    acceptance_error: Optional[str] = None
 
     def to_markdown(self) -> str:
         """Rapport Markdown pour le corps de PR (texte de revue fencé, anti-injection)."""
@@ -1014,6 +1022,18 @@ class QualityReport:
                 "",
                 "> ⚠️ **aucun fichier de test touché** par ce diff (#437) — la feature livrée "
                 "n'est couverte par aucun test nouveau ou modifié.",
+            ]
+        if self.acceptance_passed is False:
+            lines += [
+                "",
+                "> ⛔ **tests d'acceptation dérivés du SPEC en ÉCHEC (§4.7)** — des tests exécutables "
+                "écrits indépendamment du coder (depuis les critères d'acceptation) ne passent pas sur "
+                "le code livré. Vérification objective et non circulaire de la conformité au contrat.",
+            ]
+        elif self.acceptance_error:
+            lines += [
+                "",
+                f"> ⚠️ contrôle d'acceptation (§4.7) indisponible : {_fence_safe_line(self.acceptance_error)}",
             ]
         lines += ["", f"**Verdict** : {'✅ PASSÉ' if self.passed else '❌ NON PASSÉ'}"]
         return "\n".join(lines)
@@ -1512,6 +1532,125 @@ def _default_adequacy_sample_fn():  # pragma: no cover - chemin réel (integrati
     return sample
 
 
+# ── §4.7 (Phase B) : tests d'acceptation exécutables, auteur indépendant ─────────
+
+
+@dataclass(frozen=True)
+class AcceptanceOutcome:
+    """Verdict des tests d'acceptation §4.7 — exécution OBJECTIVE (exit code pytest)."""
+
+    passed: Optional[bool] = None  # None = non évalué (pas de critères / checker absent)
+    output: str = ""
+    error: Optional[str] = None  # erreur de GÉNÉRATION (best-effort, ne bloque pas)
+    skipped: bool = False
+
+
+@runtime_checkable
+class AcceptanceChecker(Protocol):
+    """Génère des tests d'acceptation depuis les critères du SPEC puis les LANCE (§4.7)."""
+
+    async def check(self, workspace: str, diff: str, issue: IssueSpec, ctx, *, sandbox) -> AcceptanceOutcome: ...
+
+
+_ACCEPTANCE_SYSTEM = (
+    "Tu es un ingénieur QA INDÉPENDANT (tu n'as PAS écrit le code). À partir des critères "
+    "d'acceptation d'une issue et du code livré (diff), écris des tests pytest EXÉCUTABLES qui "
+    "VÉRIFIENT chaque critère contre le code réel (imports, fixtures, démarrage d'app si nécessaire). "
+    "Les tests doivent ÉCHOUER si un critère n'est pas respecté. Réponds UNIQUEMENT avec un module "
+    "Python exécutable (aucune prose), en commençant par les imports."
+)
+
+_ACCEPTANCE_TEST_PATH = "tests/acceptance/test_acceptance_generated.py"
+
+
+def _strip_code_fences(text: str) -> str:
+    """Retire un éventuel fence Markdown (```python … ```) autour du code généré."""
+    stripped = (text or "").strip()
+    if stripped.startswith("```"):
+        stripped = stripped.split("\n", 1)[1] if "\n" in stripped else ""
+        if stripped.rstrip().endswith("```"):
+            stripped = stripped.rstrip()[:-3]
+    stripped = stripped.strip()
+    return (stripped + "\n") if stripped else ""
+
+
+def _write_acceptance_file(workspace: str, code: str) -> None:
+    """Écrit le module de tests d'acceptation généré dans le workspace (chemin fixe)."""
+    path = os.path.join(workspace, _ACCEPTANCE_TEST_PATH)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(code)
+
+
+class LLMAcceptanceChecker:
+    """:class:`AcceptanceChecker` — un LLM (rôle REVIEWER, ≠ coder) écrit les tests, la SANDBOX les lance.
+
+    Anti-circularité (§4.7) : le verdict est l'**exit code** de pytest (objectif), pas
+    un avis du modèle, et l'auteur des tests est **distinct du coder**. ``sample_fn``
+    injectable (mocké en CI). La GÉNÉRATION est best-effort (une erreur ⇒ ``error``
+    renseigné, gate non bloqué sur ce volet) ; mais des tests qui ÉCHOUENT ⇒
+    ``passed=False`` (bloquant). Les tests générés sont écrits dans le workspace pour
+    la durée du gate (hors diff de la PR, déjà capturé) et lancés avec les deps du projet.
+    """
+
+    def __init__(self, sample_fn=None, *, max_diff_chars: int = 60000):
+        self._sample_fn = sample_fn or _default_acceptance_sample_fn()
+        self._max_diff_chars = max_diff_chars
+
+    async def check(self, workspace: str, diff: str, issue: IssueSpec, ctx, *, sandbox) -> AcceptanceOutcome:
+        if issue is None or not issue.acceptance_criteria:
+            return AcceptanceOutcome(skipped=True)
+        bounded = strip_generated_from_diff(diff or "")[: self._max_diff_chars]
+        prompt = (
+            f"## Issue\n{issue.to_prompt()}\n\n"
+            f"## Code livré (diff)\n```diff\n{bounded or '(diff vide)'}\n```\n\n"
+            "Écris le module de tests pytest d'acceptation."
+        )
+        try:
+            code = _strip_code_fences(await self._sample_fn(prompt, _ACCEPTANCE_SYSTEM))
+        except Exception as exc:  # noqa: BLE001 - génération best-effort (BaseException budget remonte)
+            return AcceptanceOutcome(error=str(exc) or repr(exc))
+        if not code.strip():
+            return AcceptanceOutcome(error="génération de tests d'acceptation vide")
+        try:
+            _write_acceptance_file(workspace, code)
+        except OSError as exc:
+            return AcceptanceOutcome(error=f"écriture des tests d'acceptation impossible : {exc}")
+        prelude = deps_install_prelude(workspace)
+        pytest_cmd = f"{_PYTEST_WIDE_COLUMNS} python -m pytest {shlex.quote(_ACCEPTANCE_TEST_PATH)} -q"
+        command = f"({prelude}) && {pytest_cmd}" if prelude else pytest_cmd
+        res = sandbox.run_tests(workspace, command)
+        output = "\n".join(part for part in (res.stdout, res.stderr) if part).strip()
+        # pytest exit 5 = AUCUN test collecté → génération inexploitable (0 fonction
+        # test_*). Best-effort : on NE bloque PAS (passed=None + error), sinon une
+        # génération dégénérée serait un faux-rouge dur, à l'inverse de la sémantique.
+        if getattr(res, "exit_code", None) == 5:
+            return AcceptanceOutcome(
+                error="aucun test d'acceptation collecté (génération inexploitable)", output=output
+            )
+        return AcceptanceOutcome(passed=bool(res.ok), output=output)
+
+
+def _default_acceptance_sample_fn():  # pragma: no cover - chemin réel (integration)
+    from collegue.config import settings
+    from collegue.core.llm.roles import LLMRole, resolve_role
+    from collegue.resources.llm.providers import LLMConfig, generate_text
+
+    _provider, model = resolve_role(LLMRole.REVIEWER, settings)  # auteur INDÉPENDANT du coder
+    config = LLMConfig(
+        model_name=model or settings.llm_model,
+        api_key=settings.llm_api_key,
+        max_tokens=settings.MAX_TOKENS,
+        temperature=0.2,
+    )
+
+    async def sample(prompt: str, system_prompt: str) -> str:
+        response = await generate_text(config, prompt, system_prompt)
+        return response.text
+
+    return sample
+
+
 class FakeAdequacyChecker:
     """:class:`AdequacyChecker` déterministe pour la CI (aucun LLM)."""
 
@@ -1586,6 +1725,7 @@ async def run_quality_gate(
     require_deps_install: bool = False,
     check_installability: bool = False,
     adequacy_checker: Optional[AdequacyChecker] = None,
+    acceptance_checker: Optional[AcceptanceChecker] = None,
     require_test_changes: bool = False,
     smoke_run: bool = False,
     smoke_command: Optional[str] = None,
@@ -1801,15 +1941,33 @@ async def run_quality_gate(
         except Exception as exc:  # noqa: BLE001 - fail-closed ; BaseException (budget) remonte
             adequacy_error = str(exc) or repr(exc)
 
+    # §4.7 (Phase B) : tests d'acceptation EXÉCUTABLES (auteur indépendant du coder)
+    # lancés en sandbox — verdict OBJECTIF. Seulement si le reste est vert ET qu'il y a
+    # des critères (borne le coût). Une erreur de GÉNÉRATION ne bloque pas (best-effort) ;
+    # des tests qui ÉCHOUENT (``acceptance_passed is False``) bloquent.
+    acceptance_passed: Optional[bool] = None
+    acceptance_output = ""
+    acceptance_error: Optional[str] = None
+    if acceptance_checker is not None and issue is not None and issue.acceptance_criteria and would_pass:
+        try:
+            acc = await acceptance_checker.check(workspace, diff, issue, ctx, sandbox=sandbox)
+            acceptance_passed = acc.passed
+            acceptance_output = acc.output
+            acceptance_error = acc.error
+        except Exception as exc:  # noqa: BLE001 - fail-soft sur génération ; BaseException (budget) remonte
+            acceptance_error = str(exc) or repr(exc)
+
     touched = tests_touched(diff)
     # #499 : `is not False` — None (non évalué) et True passent ; seul False
     # bloque (rétrocompat #437 : un checker qui n'évalue pas la couverture ne
-    # rend jamais le gate rouge sur ce volet).
+    # rend jamais le gate rouge sur ce volet). Idem §4.7 : seul un ÉCHEC de tests
+    # d'acceptation (False) bloque ; une génération indisponible (error, passed=None) non.
     passed = (
         would_pass
         and adequacy_implemented is not False
         and adequacy_tests_assert is not False
         and adequacy_error is None
+        and acceptance_passed is not False
     )
     if require_test_changes and not touched:
         passed = False
@@ -1840,6 +1998,9 @@ async def run_quality_gate(
         adequacy_tests_justification=adequacy_tests_justification,
         forbidden_files=forbidden_files,
         forbidden_files_blocking=forbidden_blocked,
+        acceptance_passed=acceptance_passed,
+        acceptance_output=acceptance_output,
+        acceptance_error=acceptance_error,
     )
 
 

--- a/collegue/pilot/__init__.py
+++ b/collegue/pilot/__init__.py
@@ -59,7 +59,13 @@ from collegue.pilot.mcp_tool import (
     run_pilot_tool,
 )
 from collegue.pilot.resume import load_run_start, persist_run_start
-from collegue.pilot.runtime import format_run_report, run_project_from_settings
+from collegue.pilot.runtime import (
+    PlanResult,
+    format_plan_report,
+    format_run_report,
+    plan_project_from_settings,
+    run_project_from_settings,
+)
 from collegue.pilot.scheduler import (
     SchedulerError,
     is_blocked,
@@ -92,6 +98,10 @@ __all__ = [
     # F4 — câblage runtime
     "run_project_from_settings",
     "format_run_report",
+    # A2 — planification par le produit (sous-commande plan)
+    "plan_project_from_settings",
+    "PlanResult",
+    "format_plan_report",
     # H4 (Phase 5) — observabilité du run autonome
     "RunAuditLog",
     "NullAuditLog",

--- a/collegue/pilot/__main__.py
+++ b/collegue/pilot/__main__.py
@@ -51,6 +51,21 @@ def build_parser() -> argparse.ArgumentParser:
     rs.add_argument("task_id", type=int, help="Id de la tâche à réinitialiser.")
     rs.add_argument("--status", default="todo", help="Statut cible (défaut: todo).")
     rs.add_argument("--message", required=True, help="Motif du reset (tracé dans decisions).")
+    # Phase 1 (A2) : planification — problème → SPEC → DAG → issues GitHub. dry-run par défaut.
+    plan_p = sub.add_parser("plan", help="Planifie un projet (SPEC → graphe de tâches → issues GitHub).")
+    plan_p.add_argument("--name", default="projet", help="Nom du projet (état durable).")
+    plan_p.add_argument("--problem", required=True, help="Problématique en langage naturel (1+ phrases).")
+    plan_p.add_argument("--owner", required=True, help="Owner GitHub cible des issues.")
+    plan_p.add_argument("--repo", required=True, help="Repo GitHub cible des issues.")
+    plan_p.add_argument("--deadline-hours", type=float, default=None, help="Deadline du run, en heures (optionnel).")
+    plan_p.add_argument(
+        "--approve", action="store_true", help="Approuve le plan (gate humain P5) — requis pour --execute-sync."
+    )
+    plan_p.add_argument(
+        "--execute-sync", action="store_true", help="Crée RÉELLEMENT les issues GitHub (sinon dry-run/aperçu)."
+    )
+    plan_p.add_argument("--labels", default=None, help="Labels d'issue (CSV ; défaut: autonome).")
+    plan_p.add_argument("--milestone", default=None, help="Titre du milestone (défaut: '<name> MVP').")
     # --- args du RUN par défaut (required=False : validés dans main si pas de sous-commande) ---
     parser.add_argument("--project-id", type=int, default=None, help="Id du projet (état durable).")
     parser.add_argument("--repo-source", default=None, help="Dépôt git source (repo-agnostique).")
@@ -86,6 +101,30 @@ async def _run(args: argparse.Namespace) -> int:
     return 0 if result.stop_reason in _OK_STOPS else 1
 
 
+async def _plan(args: argparse.Namespace) -> int:
+    from datetime import datetime, timedelta, timezone
+
+    from collegue.pilot.runtime import format_plan_report, plan_project_from_settings
+
+    deadline = None
+    if args.deadline_hours:
+        deadline = datetime.now(timezone.utc) + timedelta(hours=args.deadline_hours)
+    labels = [s.strip() for s in args.labels.split(",") if s.strip()] if args.labels else None
+    result = await plan_project_from_settings(
+        args.name,
+        args.problem,
+        owner=args.owner,
+        repo=args.repo,
+        deadline=deadline,
+        approve=args.approve,
+        execute_sync=args.execute_sync,
+        labels=labels,
+        milestone_title=args.milestone,
+    )
+    print(format_plan_report(result))
+    return 0
+
+
 def _run_task_command(args: argparse.Namespace) -> int:
     """Glue CLI des interventions opérateur (#506) : manager réel + audit persistant.
 
@@ -117,6 +156,8 @@ def main(argv: Optional[List[str]] = None) -> int:
     args = parser.parse_args(argv)
     if args.command == "task":
         return _run_task_command(args)
+    if args.command == "plan":
+        return asyncio.run(_plan(args))
     # Run par défaut : valider les args requis ici (argparse ne peut pas les
     # conditionner sur l'absence de sous-commande). parser.error lève SystemExit.
     missing = [name for name in _RUN_REQUIRED if getattr(args, name) is None]

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -11,18 +11,22 @@ l'entrypoint ``python -m collegue.pilot`` (voir ``__main__``). ``dry_run`` est l
 défaut. L'exécution réelle de bout en bout (Docker + OpenHands + LLM + écriture
 GitHub) est derrière le marqueur ``integration`` ; en CI on injecte des doubles.
 
-Note ``ctx`` : le reviewer expert (``code_review``) a besoin d'un contexte de
-sampling LLM. En usage réel hors serveur MCP, fournir un ``ctx`` adéquat (ou un
-shim) — différé à l'intégration. Un outil MCP exposant le pilote est volontairement
-**reporté à la Phase 5** (durcissement/auth) : l'auto-découverte des outils
-l'activerait au démarrage, et le serveur tourne ``OAUTH_ENABLED=false`` par défaut.
+Note ``ctx`` : le reviewer expert (``code_review``) et le planner ont besoin d'un
+contexte de sampling LLM. Hors serveur MCP, ``run_project_from_settings`` et
+``plan_project_from_settings`` en assemblent un automatiquement (``_build_ctx`` →
+``LocalSamplingContext`` offline, OpenAI-compatible) quand aucun n'est fourni.
+L'outil MCP exposant le pilote est volontairement **reporté à la Phase 5**
+(durcissement/auth) : l'auto-découverte des outils l'activerait au démarrage, et
+le serveur tourne ``OAUTH_ENABLED=false`` par défaut.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
-from typing import List, Optional
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
 
 from collegue.pilot.audit import RunAuditLog, default_process_cost_source
 from collegue.pilot.budget import BudgetTimeController
@@ -358,6 +362,131 @@ async def run_project_from_settings(
                     logger.warning("Fermeture du ctx de sampling échouée: %s", exc)
 
 
+# ── planification (Phase 1) assemblée ──────────────────────────────────────────
+
+
+@dataclass
+class PlanResult:
+    """Bilan d'une planification (Phase 1) assemblée depuis la config."""
+
+    project_id: int
+    spec_title: str
+    objectives: int
+    acceptance_criteria: int
+    task_count: int
+    preview_markdown: str
+    dry_run: bool
+    issues: List[dict] = field(default_factory=list)
+
+
+async def plan_project_from_settings(
+    name: str,
+    problem: str,
+    *,
+    owner: str,
+    repo: str,
+    ctx=None,
+    settings_obj: Optional[object] = None,
+    github_token: Optional[str] = None,
+    manager=None,
+    deadline: Any = None,
+    context: Optional[str] = None,
+    approve: bool = False,
+    execute_sync: bool = False,
+    labels: Optional[List[str]] = None,
+    milestone_title: Optional[str] = None,
+    board_title: Optional[str] = None,
+    decompose_max_tokens: int = 16384,
+    decompose_attempts: int = 3,
+    retry_sleep_seconds: float = 3.0,
+) -> PlanResult:
+    """Phase 1 **par le produit** : problème → SPEC → DAG → (gate humain) → issues GitHub.
+
+    Assemble les dépendances depuis la config (ctx de sampling offline via ``_build_ctx``,
+    état durable) et enchaîne ``generate_spec`` → ``persist_spec`` → ``decompose`` →
+    ``build_plan_preview`` → (``approve_plan`` si ``approve``/``execute_sync``) →
+    ``sync_plan``. **dry-run par défaut** (``execute_sync=False`` : aucune écriture GitHub).
+    ``approve`` satisfait le gate humain P5 (anti-TOCTOU). Le commit du fichier ``SPEC.md``
+    dans le repo cible est porté par ``sync_plan`` (A3).
+
+    ``decompose`` est re-tenté sur ``ValueError`` (décomposition vide — aléa d'un modèle
+    « thinking » coupé trop tôt, d'où ``max_tokens`` élargi).
+    """
+    settings_obj = settings_obj or _settings()
+    manager = manager or _build_manager(settings_obj)
+    owns_ctx = ctx is None
+    if ctx is None:
+        ctx = _build_ctx(settings_obj)
+
+    try:
+        from collegue.planner.decomposer import decompose
+        from collegue.planner.github_sync import sync_plan
+        from collegue.planner.plan_review import approve_plan, build_plan_preview
+        from collegue.planner.spec_generator import generate_spec, persist_spec
+
+        spec = await generate_spec(problem, ctx, context=context, settings_obj=settings_obj)
+        project_id = persist_spec(manager, name, spec, deadline=deadline)
+
+        last_err: Optional[Exception] = None
+        tasks: list = []
+        attempts = max(1, decompose_attempts)
+        for attempt in range(1, attempts + 1):
+            try:
+                tasks = await decompose(
+                    spec,
+                    ctx,
+                    manager=manager,
+                    project_id=project_id,
+                    settings_obj=settings_obj,
+                    max_tokens=decompose_max_tokens,
+                )
+                break
+            except ValueError as exc:  # décomposition vide → aléa du modèle, on retente
+                last_err = exc
+                logger.warning("decompose tentative %d/%d : %s", attempt, attempts, exc)
+                if attempt < attempts and retry_sleep_seconds > 0:
+                    await asyncio.sleep(retry_sleep_seconds)
+        else:
+            raise last_err if last_err is not None else ValueError("Décomposition impossible.")
+
+        preview = build_plan_preview(manager, project_id)
+        preview_md = preview.to_markdown() if preview is not None else ""
+
+        if approve or execute_sync:
+            approve_plan(manager, project_id, actor="operator:collegue-cli")
+
+        token = github_token if github_token is not None else os.environ.get(GITHUB_TOKEN_ENV)
+        sync = sync_plan(
+            manager,
+            project_id,
+            owner,
+            repo,
+            dry_run=not execute_sync,
+            token=token,
+            labels=labels if labels is not None else ["autonome"],
+            milestone_title=milestone_title if milestone_title is not None else f"{name} MVP",
+            board_title=board_title,
+        )
+        return PlanResult(
+            project_id=project_id,
+            spec_title=getattr(spec, "title", ""),
+            objectives=len(getattr(spec, "objectives", []) or []),
+            acceptance_criteria=len(getattr(spec, "acceptance_criteria", []) or []),
+            task_count=len(tasks),
+            preview_markdown=preview_md,
+            dry_run=not execute_sync,
+            issues=list(getattr(sync, "issues", []) or []),
+        )
+    finally:
+        if owns_ctx:
+            aclose = getattr(ctx, "aclose", None)
+            if aclose is not None:
+                try:
+                    await aclose()
+                except Exception as exc:  # noqa: BLE001 - fermeture best-effort
+                    logger.warning("Fermeture du ctx de sampling échouée: %s", exc)
+
+
 # ── reporting lisible ──────────────────────────────────────────────────────────
 
 
@@ -387,4 +516,26 @@ def format_run_report(result: ProjectRunResult, *, project_id: Optional[int] = N
         lines.append(f"⚠ Reviews en attente de merge (drain requis) : tâches {pending}")
     lines.append(f"Statut projet : {result.project_status or '(inchangé)'}")
     lines.append(f"Budget-temps restant : {_remaining_label(budget)}")
+    return "\n".join(lines)
+
+
+def format_plan_report(result: PlanResult) -> str:
+    """Rendu lisible d'une planification (Phase 1) pour le CLI.
+
+    Affiche l'**aperçu complet du plan** (SPEC + tâches/dépendances) : c'est ce que
+    l'opérateur doit voir avant d'approuver/exécuter (gate humain P5).
+    """
+    mode = "dry-run (aperçu, aucune écriture)" if result.dry_run else "EXECUTE (issues créées)"
+    lines = [
+        f"Plan projet #{result.project_id} — « {result.spec_title} »",
+        f"  SPEC : {result.objectives} objectif(s), {result.acceptance_criteria} critère(s) d'acceptation",
+        f"  Tâches : {result.task_count}",
+        f"  Sync GitHub : {mode}",
+    ]
+    for it in result.issues:
+        num = it.get("issue_number")
+        tag = "skip" if it.get("skipped") else (f"#{num}" if num else "(dry-run)")
+        lines.append(f"    [{tag}] task {it.get('task_id')}: {it.get('title', '')}")
+    if result.preview_markdown:
+        lines += ["", "── Aperçu du plan ──", result.preview_markdown]
     return "\n".join(lines)

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -143,6 +143,13 @@ def _build_clients(github_token):  # pragma: no cover - infra réelle (integrati
     return _default_clients(token=github_token)
 
 
+def _build_ctx(settings_obj):  # pragma: no cover - infra réelle (integration)
+    """ctx de sampling offline (OpenAI-compatible, multi-provider) pour le CLI/hors-MCP."""
+    from collegue.core.llm.sampling_ctx import LocalSamplingContext
+
+    return LocalSamplingContext.from_settings(settings_obj)
+
+
 def _gate_options(settings_obj) -> dict:
     """Options du gate qualité depuis la config (#437/#438/#439) — vers ``execute_issue``.
 
@@ -270,66 +277,85 @@ async def run_project_from_settings(
         started_at = load_run_start(manager, project_id)
         budget = BudgetTimeController(settings_obj=settings_obj, started_at=started_at)
 
-    result = await run_project(
-        project_id,
-        repo_source,
-        ctx,
-        agent=agent,
-        owner=owner,
-        repo=repo,
-        manager=manager,
-        base=base,
-        budget=budget,
-        sandbox=sandbox,
-        reviewer=reviewer,
-        clients=clients,
-        dry_run=dry_run,
-        max_iterations=max_iterations,
-        improve=improve,
-        run_improvement_fn=run_improvement_fn,
-        # Retry au niveau tâche (#420) : le chemin assemblé est résilient par défaut
-        # (TASK_MAX_ATTEMPTS=3 en config) ; le module driver isolé reste, lui, à 1.
-        max_task_attempts=getattr(settings_obj, "TASK_MAX_ATTEMPTS", 3),
-        retry_backoff_seconds=getattr(settings_obj, "TASK_RETRY_BACKOFF_SECONDS", 15.0),
-        # Cohérence inter-tâches (#411) : opt-in pour exiger le merge des deps.
-        require_merged_deps=bool(getattr(settings_obj, "DEPS_REQUIRE_MERGED", False)),
-        # Intégration sérielle en mode strict (#434) : 1 PR en vol par défaut.
-        max_inflight_reviews=getattr(settings_obj, "STRICT_MAX_INFLIGHT_PRS", 1),
-        # Gate configurable par projet (#438) : commande de tests + passe frontend.
-        gate_options=_gate_options(settings_obj),
-        # Gouvernance de coût (#441) : ledger + source process branchés en réel.
-        audit=audit,
-        cost_source=cost_source,
-        # #502 : refus opt-in de démarrer si le prix coder n'est pas résolvable.
-        require_cost_pricing=bool(getattr(settings_obj, "REQUIRE_COST_PRICING", False)),
-    )
+    # ctx de sampling : hors serveur MCP (CLI), aucun ``ctx`` n'est fourni → le
+    # reviewer/planner/boucle agentique échoueraient. On en assemble un offline
+    # (OpenAI-compatible, multi-provider) et on le ferme en fin de run si on l'a créé.
+    owns_ctx = ctx is None
+    if ctx is None:
+        ctx = _build_ctx(settings_obj)
 
-    # Reporting (journal de décisions) — réel uniquement (dry_run n'écrit rien).
-    if not dry_run:
-        prs = ", ".join(str(n) for n in result.opened_prs) or "aucune"
-        # #440 : un arrêt deadline laisse du travail VALIDÉ en attente de merge —
-        # le signaler dans le journal pour que le drain ne dépende pas d'un
-        # post-mortem (la PR FacNor #72 est restée ouverte, mergée à la main).
-        drain = ""
-        if result.pending_reviews:
-            drain = f" ; {len(result.pending_reviews)} tâche(s) in_review À DRAINER (merge requis)"
-        # #441 : bilan de coût du run dans le journal (ledger enfin vivant).
-        cost_note = ""
-        if audit is not None:
-            ledger = audit.cost_summary()
-            cost_note = f" ; coût≈{ledger.get('usd', 0.0)}$ / {ledger.get('tokens', 0)} tokens"
-            # #502 : un coût à 0 sans prix coder configuré est suspect — le dire.
-            from collegue.executor.openhands_agent import coder_pricing_resolvable
-
-            if not coder_pricing_resolvable(settings_obj):
-                cost_note += " [PRIX CODER NON CONFIGURÉS — coût $ possiblement INCONNU]"
-        manager.record_decision(
+    try:
+        result = await run_project(
             project_id,
-            f"Run pilote: {result.stop_reason} — {result.iterations} tâche(s), PR {prs}{drain}{cost_note}",
-            rationale=f"statut projet={result.project_status or 'inchangé'}",
+            repo_source,
+            ctx,
+            agent=agent,
+            owner=owner,
+            repo=repo,
+            manager=manager,
+            base=base,
+            budget=budget,
+            sandbox=sandbox,
+            reviewer=reviewer,
+            clients=clients,
+            dry_run=dry_run,
+            max_iterations=max_iterations,
+            improve=improve,
+            run_improvement_fn=run_improvement_fn,
+            # Retry au niveau tâche (#420) : le chemin assemblé est résilient par défaut
+            # (TASK_MAX_ATTEMPTS=3 en config) ; le module driver isolé reste, lui, à 1.
+            max_task_attempts=getattr(settings_obj, "TASK_MAX_ATTEMPTS", 3),
+            retry_backoff_seconds=getattr(settings_obj, "TASK_RETRY_BACKOFF_SECONDS", 15.0),
+            # Cohérence inter-tâches (#411) : opt-in pour exiger le merge des deps.
+            require_merged_deps=bool(getattr(settings_obj, "DEPS_REQUIRE_MERGED", False)),
+            # Intégration sérielle en mode strict (#434) : 1 PR en vol par défaut.
+            max_inflight_reviews=getattr(settings_obj, "STRICT_MAX_INFLIGHT_PRS", 1),
+            # Gate configurable par projet (#438) : commande de tests + passe frontend.
+            gate_options=_gate_options(settings_obj),
+            # Gouvernance de coût (#441) : ledger + source process branchés en réel.
+            audit=audit,
+            cost_source=cost_source,
+            # #502 : refus opt-in de démarrer si le prix coder n'est pas résolvable.
+            require_cost_pricing=bool(getattr(settings_obj, "REQUIRE_COST_PRICING", False)),
         )
 
-    return result
+        # Reporting (journal de décisions) — réel uniquement (dry_run n'écrit rien).
+        if not dry_run:
+            prs = ", ".join(str(n) for n in result.opened_prs) or "aucune"
+            # #440 : un arrêt deadline laisse du travail VALIDÉ en attente de merge —
+            # le signaler dans le journal pour que le drain ne dépende pas d'un
+            # post-mortem (la PR FacNor #72 est restée ouverte, mergée à la main).
+            drain = ""
+            if result.pending_reviews:
+                drain = f" ; {len(result.pending_reviews)} tâche(s) in_review À DRAINER (merge requis)"
+            # #441 : bilan de coût du run dans le journal (ledger enfin vivant).
+            cost_note = ""
+            if audit is not None:
+                ledger = audit.cost_summary()
+                cost_note = f" ; coût≈{ledger.get('usd', 0.0)}$ / {ledger.get('tokens', 0)} tokens"
+                # #502 : un coût à 0 sans prix coder configuré est suspect — le dire.
+                from collegue.executor.openhands_agent import coder_pricing_resolvable
+
+                if not coder_pricing_resolvable(settings_obj):
+                    cost_note += " [PRIX CODER NON CONFIGURÉS — coût $ possiblement INCONNU]"
+            manager.record_decision(
+                project_id,
+                f"Run pilote: {result.stop_reason} — {result.iterations} tâche(s), PR {prs}{drain}{cost_note}",
+                rationale=f"statut projet={result.project_status or 'inchangé'}",
+            )
+
+        return result
+    finally:
+        # Ne fermer que le ctx qu'on a créé (un ctx injecté appartient à l'appelant).
+        # Une erreur de fermeture ne doit JAMAIS masquer l'exception en cours (ex.
+        # ``BudgetExceeded`` de ``run_project`` = auto-pause volontaire) : on l'avale.
+        if owns_ctx:
+            aclose = getattr(ctx, "aclose", None)
+            if aclose is not None:
+                try:
+                    await aclose()
+                except Exception as exc:  # noqa: BLE001 - fermeture best-effort
+                    logger.warning("Fermeture du ctx de sampling échouée: %s", exc)
 
 
 # ── reporting lisible ──────────────────────────────────────────────────────────

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -186,6 +186,10 @@ def _gate_options(settings_obj) -> dict:
         options["test_command"] = str(test_command)
     if bool(getattr(settings_obj, "GATE_ADEQUACY", False)):
         options["adequacy_checker"] = _build_adequacy_checker(settings_obj)
+    # §4.7 (Phase B, opt-in) : tests d'acceptation EXÉCUTABLES dérivés du SPEC, écrits
+    # par un rôle indépendant du coder et lancés en sandbox (verdict objectif).
+    if bool(getattr(settings_obj, "GATE_ACCEPTANCE_TESTS", False)):
+        options["acceptance_checker"] = _build_acceptance_checker(settings_obj)
     # Smoke run (#458, opt-in) : démarrer l'app livrée et vérifier qu'elle répond.
     if bool(getattr(settings_obj, "GATE_SMOKE_RUN", False)):
         options["smoke_run"] = True
@@ -213,6 +217,12 @@ def _build_adequacy_checker(settings_obj):  # pragma: no cover - infra réelle (
     from collegue.executor.quality_gate import LLMAdequacyChecker
 
     return LLMAdequacyChecker()
+
+
+def _build_acceptance_checker(settings_obj):  # pragma: no cover - infra réelle (integration)
+    from collegue.executor.quality_gate import LLMAcceptanceChecker
+
+    return LLMAcceptanceChecker()
 
 
 # ── point d'entrée assemblé ────────────────────────────────────────────────────

--- a/collegue/planner/github_sync.py
+++ b/collegue/planner/github_sync.py
@@ -29,12 +29,14 @@ Module **isolé** : non câblé au runtime tant que le pilote (Phase 3) ne l'enc
 
 from __future__ import annotations
 
+import logging
 from collections import deque
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from collegue.planner.plan_review import require_approved
 from collegue.tools.github_commands import (
+    FileCommands,
     IssueCommands,
     LabelCommands,
     MilestoneCommands,
@@ -42,6 +44,9 @@ from collegue.tools.github_commands import (
 )
 
 DEFAULT_LABELS = ["autonome"]
+DEFAULT_SPEC_FILENAME = "SPEC.md"
+
+logger = logging.getLogger(__name__)
 
 
 class SyncError(Exception):
@@ -79,12 +84,17 @@ def _topo_sort_tasks(tasks: List[Any]) -> List[Any]:
 
 @dataclass
 class SyncClients:
-    """Clients GitHub injectables (mockés en test)."""
+    """Clients GitHub injectables (mockés en test).
+
+    ``files`` (A3) est **optionnel** (défaut ``None``) : sans lui, le commit du
+    fichier ``SPEC.md`` est un no-op (rétro-compat des appelants à 4 clients).
+    """
 
     issues: Any
     labels: Any
     milestones: Any
     projects: Any
+    files: Any = None
 
 
 @dataclass
@@ -93,6 +103,8 @@ class SyncResult:
     issues: List[Dict[str, Any]]
     milestone: Optional[str] = None
     board: Optional[str] = None
+    # A3 : chemin du SPEC committé dans le repo cible (None si non committé).
+    spec_committed: Optional[str] = None
 
 
 def _default_clients(token: Optional[str]) -> SyncClients:
@@ -101,7 +113,38 @@ def _default_clients(token: Optional[str]) -> SyncClients:
         labels=LabelCommands(token=token),
         milestones=MilestoneCommands(token=token),
         projects=ProjectCommands(token=token),
+        files=FileCommands(token=token),
     )
+
+
+def _commit_spec(clients: SyncClients, manager: Any, project_id: int, owner: str, repo: str, spec_filename: str):
+    """Committe le SPEC (``Project.spec``) comme fichier versionné du repo cible (§4.2).
+
+    Le SPEC vit en DB ; le brief en exige une matérialisation **committée** = le
+    contrat du projet, lisible et versionné dans le repo. **Best-effort** : un échec
+    (droits, repo absent) n'échoue PAS la synchro des issues (on journalise un
+    avertissement et on renvoie ``None``). ``FileCommands.update_file`` joint le SHA
+    courant (anti-conflit) ; un contenu identique ne crée pas de commit vide côté
+    GitHub (arbre inchangé), donc re-synchroniser est sûr. No-op si pas de client
+    ``files`` ou pas de spec.
+    """
+    files = getattr(clients, "files", None)
+    project = manager.get_project(project_id)
+    spec = getattr(project, "spec", None) if project is not None else None
+    if files is None or not spec:
+        return None
+    try:
+        files.update_file(
+            owner,
+            repo,
+            spec_filename,
+            message=f"docs: SPEC du projet (planification, project_id={project_id})",
+            content=spec,
+        )
+        return spec_filename
+    except Exception as exc:  # noqa: BLE001 - commit best-effort, ne bloque pas la synchro
+        logger.warning("Commit de %s échoué (synchro des issues poursuivie) : %s", spec_filename, exc)
+        return None
 
 
 def _issue_body(task: Any, dep_numbers: List[int]) -> str:
@@ -151,12 +194,14 @@ def sync_plan(
     board_title: Optional[str] = None,
     token: Optional[str] = None,
     clients: Optional[SyncClients] = None,
+    spec_filename: str = DEFAULT_SPEC_FILENAME,
 ) -> SyncResult:
     """Synchronise le plan d'un projet vers GitHub (issues + labels + milestone + board).
 
     ``dry_run=True`` (défaut) ne touche pas GitHub. ``dry_run=False`` exige un plan
-    **approuvé** (lève :class:`~collegue.planner.plan_review.PlanNotApproved` sinon)
-    et crée les issues liées de façon idempotente.
+    **approuvé** (lève :class:`~collegue.planner.plan_review.PlanNotApproved` sinon),
+    **committe ``SPEC.md``** (le contrat, §4.2) dans le repo cible, puis crée les
+    issues liées de façon idempotente.
     """
     labels = labels or DEFAULT_LABELS
     if dry_run:
@@ -168,6 +213,11 @@ def sync_plan(
     require_approved(manager, project_id)
 
     clients = clients or _default_clients(token)
+
+    # §4.2 : matérialiser le SPEC (DB) en fichier committé du repo cible. AVANT les
+    # issues pour que le contrat atterrisse en premier ; best-effort (n'échoue pas la synchro).
+    spec_committed = _commit_spec(clients, manager, project_id, owner, repo, spec_filename)
+
     tasks = manager.get_tasks(project_id)
     order = _topo_sort_tasks(tasks)  # dépendances d'abord ; raise sur cycle/dep pendante
 
@@ -177,7 +227,9 @@ def sync_plan(
     # Rien de neuf à créer → ne pas brûler d'appels API (ensure_*). Idempotent.
     if all(t.id in task_to_issue for t in tasks):
         return SyncResult(
-            dry_run=False, issues=[{"task_id": t.id, "issue_number": t.issue_number, "skipped": True} for t in order]
+            dry_run=False,
+            issues=[{"task_id": t.id, "issue_number": t.issue_number, "skipped": True} for t in order],
+            spec_committed=spec_committed,
         )
 
     # Pré-garantir labels / milestone / board (idempotent).
@@ -217,11 +269,15 @@ def sync_plan(
     manager.record_decision(
         project_id,
         summary=f"Plan synchronisé sur GitHub : {len(created)} issue(s)",
-        rationale=f"repo={owner}/{repo}; milestone={milestone_title}; board={board_title}",
+        rationale=(
+            f"repo={owner}/{repo}; milestone={milestone_title}; board={board_title}; "
+            f"spec={spec_committed or 'non committé'}"
+        ),
     )
     return SyncResult(
         dry_run=False,
         issues=created,
         milestone=(milestone.title if milestone else None),
         board=(board.title if board else None),
+        spec_committed=spec_committed,
     )

--- a/docker/sandbox/Dockerfile.openhands
+++ b/docker/sandbox/Dockerfile.openhands
@@ -1,0 +1,95 @@
+# Image sandbox AVEC OpenHands embarqué (exécuteur autonome réel — issue #404).
+# Étend la base sandbox durcie (python:3.12-slim + Node) avec l'agent codeur
+# OpenHands, pour que collegue/executor/openhands_agent.py puisse le lancer en
+# headless via DockerSandbox. Utilise le runtime PROCESS (pas de Docker imbriqué).
+#
+# Résolution via uv : le resolver pip échoue sur le closure d'openhands-ai 1.7.0
+# (lmnr épingle opentelemetry-semantic-conventions==0.60b1 → backtracking pip
+# explosif), là où uv (PubGrub) converge.
+
+FROM python:3.12-slim
+
+# git : indispensable à l'agent (diffs, commits locaux) et au runtime process.
+# nodejs/npm : stack frontend JS/TS des projets générés (§8).
+# build-essential : deps Python natives d'OpenHands.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        curl \
+        ca-certificates \
+        nodejs \
+        npm \
+        build-essential \
+        tmux \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv : resolver/install rapide et capable du closure otel d'OpenHands.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Agent codeur OpenHands (headless), version pinnée, installé dans le python système.
+# lmnr épinglé (faux départ v5) : la 0.7.53 a retiré observe(rollout_entrypoint=…)
+# attendu par openhands 1.7.0 → TypeError à l'import, agent mort-né.
+RUN uv pip install --system "openhands-ai==1.7.0" "lmnr==0.7.52"
+
+# Runner de tests du gate qualité (pytest) — couche distincte (cache openhands préservé).
+# PIN pytest<9 : pytest 9.0 a retiré `FixtureDef` du namespace top-level, ce qui
+# casse `from pytest import FixtureDef` de pytest-asyncio<0.24 (que les projets
+# générés pinnent couramment, ex. 0.23.6) → ImportError à la collecte → TOUTE
+# tâche avec tests échoue au gate (run v6 bloqué dès la tâche 1). On épingle le
+# runner système sur 8.x + le pytest-asyncio aligné sur l'écosystème projet.
+RUN uv pip install --system "pytest>=8.1,<9" "pytest-asyncio==0.23.6"
+
+# Stack web Python courant pré-installé : le conteneur de test (gate) est ÉPHÉMÈRE et
+# SÉPARÉ de celui de l'agent → sans ça, le code généré (FastAPI + JWT auth, etc.)
+# casse à l'import (ex. `No module named 'jose'`). fastapi/uvicorn/sqlalchemy/pydantic
+# arrivent déjà via openhands ; on ajoute l'auth/validation/migrations.
+RUN uv pip install --system \
+    "python-jose[cryptography]" \
+    "passlib[bcrypt]" \
+    "bcrypt<4.1" \
+    python-multipart \
+    email-validator \
+    pydantic-settings \
+    alembic \
+    "psycopg2-binary" \
+    aiosqlite \
+    httpx
+
+# Navigateur headless pour le GATE E2E (#503 suivi). Playwright (Python) est DÉJÀ
+# fourni par openhands-ai (1.60) → on ajoute SEULEMENT le binaire chromium + ses
+# libs système (libnss3, libatk… que le download seul ne pose pas), en ROOT via
+# --with-deps. PLAYWRIGHT_BROWSERS_PATH PARTAGÉ + lisible pour que l'utilisateur
+# `sandbox` (non-root) trouve le navigateur au run. Le gate drive l'UI via le
+# playwright python (cohérent avec la sonde smoke) ; distinct du browsing
+# d'OpenHands (toujours désactivé).
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
+RUN python -m playwright install --with-deps chromium \
+    && chmod -R a+rX /opt/ms-playwright
+
+# Runtime PROCESS : aucun Docker imbriqué ; l'agent agit dans le workspace monté.
+# Navigateur d'OpenHands désactivé (le gate E2E utilise Playwright directement).
+ENV RUNTIME=process \
+    INSTALL_DOCKER=0 \
+    OPENHANDS_DISABLE_BROWSER=1 \
+    OPENHANDS_SUPPRESS_BANNER=1
+
+# Runner SDK du HARNAIS (scripts/facnor_run/oh_runner.py, gitignoré) baké SI présent
+# dans le contexte de build — utilisé par l'OHSdkAgent du harnais. Le PRODUIT
+# (collegue/executor/openhands_agent.py → openhands.core.main) n'en a PAS besoin :
+# l'image se construit donc depuis les **sources committées seules** (CI / #404).
+# `scripts/` est committé (le COPY ne casse jamais) ; oh_runner.py n'y apparaît que
+# dans l'arbre du harnais (pas de .dockerignore → inclus au contexte quand présent).
+COPY scripts/ /tmp/_collegue_scripts/
+RUN if [ -f /tmp/_collegue_scripts/facnor_run/oh_runner.py ]; then \
+        cp /tmp/_collegue_scripts/facnor_run/oh_runner.py /opt/oh_runner.py; \
+    fi; \
+    rm -rf /tmp/_collegue_scripts
+
+# Utilisateur non-root (le `docker run` surcharge --user pour matcher l'UID hôte).
+RUN useradd --create-home --uid 1000 sandbox
+
+WORKDIR /workspace
+USER sandbox
+
+# Pas d'ENTRYPOINT applicatif : l'exécuteur fournit la commande à chaque run.
+CMD ["python", "--version"]

--- a/docs/moteur_autonome.md
+++ b/docs/moteur_autonome.md
@@ -67,8 +67,8 @@ ou on refuse) :
 | **`dry_run` par défaut** | Sans `--execute`, le pipeline va jusqu'aux **aperçus** de PR sans **aucune** écriture (ni GitHub ni état). |
 | **Budget dur** | `MAX_COST_USD` / `MAX_TOKENS_BUDGET` atteints → **auto-pause** (les appels LLM sont stoppés). `COLLEGUE_RUN_DEADLINE_SECONDS` borne la durée mur. |
 | **Gate qualité** | Un diff dont les tests sont rouges, ou qui n'améliore pas le score, **n'ouvre pas de PR** (il est jeté). |
-| **Auto-merge opt-in** | `AUTO_MERGE_ENABLED=false` par défaut. Activé, il ne fusionne **que** du faible risque (allowlist de chemins **non exécutables**, plafond de LOC, **toutes** les vérifs CI vertes). Tout code/exécutable/secret/CI est bloqué par une garde dure insensible à la casse. |
-| **Auto-revert** | Filet de l'auto-merge : après un auto-merge, si `main` devient rouge (tests en sandbox), un revert est préparé. Fail-closed : santé non concluante = traitée comme rouge. Un revert qui échoue **escalade** vers un humain (ne passe jamais pour un succès). |
+| **Auto-merge (politique, opt-in)** | Moteur de **politique** implémenté et testé (`AUTO_MERGE_ENABLED=false` par défaut ; activé, n'autoriserait **que** du faible risque : allowlist de chemins **non exécutables**, plafond de LOC, **toutes** les vérifs CI vertes ; garde dure code/exécutable/secret/CI insensible à la casse). ⚠️ **Pas encore câblé dans la boucle du pilote** — le **merge humain (§6) reste le mode opérant** ; le câblage exige une passe CI-aware (suivi). |
+| **Auto-revert (politique)** | Filet prévu de l'auto-merge : si `main` devenait rouge après un auto-merge (santé en sandbox), un revert serait préparé (fail-closed : santé non concluante = rouge ; un revert en échec **escalade**). Inactif tant que l'auto-merge n'est pas câblé. |
 | **Outil MCP du pilote** | Exposé en MCP **uniquement** si `PILOT_TOOL_ENABLED=true` **et** `OAUTH_ENABLED=true` (sinon **refus de démarrer**). Allowlist d'appelants (sujets OAuth vérifiés, jamais un en-tête client). Jamais auto-découvert. `dry_run` par défaut. |
 
 ---
@@ -245,7 +245,7 @@ lit :
 |----------|-------------|--------|
 | `STATE_DATABASE_URL` | État durable (Postgres ou SQLite). Requis pour un run réel. | — |
 | `LLM_MODEL_CODER` / `_QA` / `_PLANNER` / `_REVIEWER` | Modèle par **rôle** (codeur fort, QA économique, planificateur, revue). Retombe sur `LLM_MODEL` si absent. | `LLM_MODEL` |
-| `MAX_COST_USD` | Plafond dur de dépense cumulée (`0` = désactivé). NB : son enforcement lit le MetricsCollector serveur et ne voit PAS le canal coder (gap structurel) ; les prix `LLM_PRICE_*` ne corrigent que le ledger/reporting du run — sans eux, un modèle non mappé litellm laisse `run_cost_usd=0` (événement d'audit `cost_unknown`, #484). | `0` |
+| `MAX_COST_USD` | Plafond dur de dépense cumulée (`0` = désactivé) → auto-pause. Le canal **coder** est bien pris en compte dans l'enforcement (#495 : l'accumulateur coder-seul est sommé avant comparaison). Résidu : il faut des prix `LLM_PRICE_*` pour **valoriser** les tokens coder en `$` — sans eux, un modèle non mappé litellm laisse `cost_usd=0` (seul le plafond *tokens* mord ; événement d'audit `cost_unknown`, #484/#504). | `0` |
 | `LLM_PRICE_PROMPT_PER_1M` | Prix de secours du canal coder, $/1M tokens prompt — utilisé quand le runner émet `cost_usd=0` malgré des tokens (#484). | `0` |
 | `LLM_PRICE_COMPLETION_PER_1M` | Idem, $/1M tokens completion. `0` = désactivé. | `0` |
 | `MAX_TOKENS_BUDGET` | Plafond dur de tokens cumulés (`0` = désactivé). | `0` |

--- a/tests/test_acceptance_gate.py
+++ b/tests/test_acceptance_gate.py
@@ -1,0 +1,205 @@
+"""Tests §4.7 (Phase B) : tests d'acceptation exécutables, auteur indépendant du coder.
+
+Vérifie le mécanisme (LLMAcceptanceChecker : génère via sample_fn mocké → écrit en
+workspace → lance via sandbox mockée → verdict = exit code) et son intégration au
+gate (un ÉCHEC bloque ; une erreur de génération non ; skip sans critères ; pas
+lancé si le gate est déjà rouge). Aucun LLM ni Docker réel.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from collegue.executor import FakeReviewer, IssueSpec, run_quality_gate
+from collegue.executor.quality_gate import (
+    AcceptanceOutcome,
+    LLMAcceptanceChecker,
+    _strip_code_fences,
+)
+from collegue.sandbox import SandboxResult
+
+ISSUE_AC = IssueSpec(number=5, title="T", acceptance_criteria=("La TVA est calculée à 0.01 près",))
+ISSUE_NO_AC = IssueSpec(number=6, title="T")
+DIFF = "diff --git a/x.py b/x.py\n+print('x')\n"
+
+
+class _Sandbox:
+    def __init__(self, result):
+        self._result = result
+        self.commands = []
+
+    def run_tests(self, workspace, command="pytest -q"):
+        self.commands.append(command)
+        return self._result
+
+
+def _green():
+    return _Sandbox(SandboxResult(exit_code=0, stdout="2 passed", stderr=""))
+
+
+def _red():
+    return _Sandbox(SandboxResult(exit_code=1, stdout="", stderr="1 failed"))
+
+
+# --- _strip_code_fences --------------------------------------------------------
+
+
+def test_strip_code_fences_removes_python_block():
+    assert _strip_code_fences("```python\nx = 1\n```") == "x = 1\n"
+
+
+def test_strip_code_fences_passthrough_and_empty():
+    assert _strip_code_fences("x = 1") == "x = 1\n"
+    assert _strip_code_fences("   ") == ""
+
+
+# --- LLMAcceptanceChecker ------------------------------------------------------
+
+
+async def test_skipped_without_criteria():
+    async def _gen(prompt, system):
+        raise AssertionError("ne doit pas générer sans critères")
+
+    out = await LLMAcceptanceChecker(sample_fn=_gen).check("/ws", DIFF, ISSUE_NO_AC, None, sandbox=_green())
+    assert out.skipped is True and out.passed is None
+
+
+async def test_writes_file_and_passes_on_green(tmp_path):
+    async def _gen(prompt, system):
+        # le diff et les critères sont bien dans le prompt
+        assert "TVA" in prompt
+        return "```python\ndef test_ok():\n    assert True\n```"
+
+    sb = _green()
+    out = await LLMAcceptanceChecker(sample_fn=_gen).check(str(tmp_path), DIFF, ISSUE_AC, None, sandbox=sb)
+    assert out.passed is True
+    written = (tmp_path / "tests" / "acceptance" / "test_acceptance_generated.py").read_text()
+    assert "def test_ok" in written  # fences retirées, code écrit
+    assert any("tests/acceptance/test_acceptance_generated.py" in c for c in sb.commands)  # lancé
+
+
+async def test_fails_on_red(tmp_path):
+    async def _gen(prompt, system):
+        return "def test_no():\n    assert False\n"
+
+    out = await LLMAcceptanceChecker(sample_fn=_gen).check(str(tmp_path), DIFF, ISSUE_AC, None, sandbox=_red())
+    assert out.passed is False  # verdict OBJECTIF = exit code pytest
+
+
+async def test_exit5_no_tests_collected_is_soft(tmp_path):
+    # Génération sans aucune fonction test_* → pytest exit 5 → ne bloque PAS (best-effort).
+    async def _gen(prompt, system):
+        return "# rien de testable\nx = 1\n"
+
+    sb = _Sandbox(SandboxResult(exit_code=5, stdout="no tests ran", stderr=""))
+    out = await LLMAcceptanceChecker(sample_fn=_gen).check(str(tmp_path), DIFF, ISSUE_AC, None, sandbox=sb)
+    assert out.passed is None  # ni bloquant ni « réussi »
+    assert out.error and "collecté" in out.error
+
+
+async def test_generation_error_is_soft(tmp_path):
+    async def _boom(prompt, system):
+        raise RuntimeError("LLM indisponible")
+
+    out = await LLMAcceptanceChecker(sample_fn=_boom).check(str(tmp_path), DIFF, ISSUE_AC, None, sandbox=_green())
+    assert out.passed is None and "LLM indisponible" in (out.error or "")
+
+
+async def test_empty_generation_is_error(tmp_path):
+    async def _empty(prompt, system):
+        return "   "
+
+    out = await LLMAcceptanceChecker(sample_fn=_empty).check(str(tmp_path), DIFF, ISSUE_AC, None, sandbox=_green())
+    assert out.passed is None and out.error
+
+
+# --- intégration au gate (run_quality_gate) ------------------------------------
+
+
+class _FakeAcceptance:
+    def __init__(self, *, passed=None, error=None):
+        self._outcome = AcceptanceOutcome(passed=passed, error=error)
+        self.called = False
+
+    async def check(self, workspace, diff, issue, ctx, *, sandbox):
+        self.called = True
+        return self._outcome
+
+
+async def test_gate_blocks_when_acceptance_fails():
+    chk = _FakeAcceptance(passed=False)
+    report = await run_quality_gate(
+        "/ws", DIFF, ctx=None, sandbox=_green(), reviewer=FakeReviewer(), issue=ISSUE_AC, acceptance_checker=chk
+    )
+    assert chk.called is True
+    assert report.acceptance_passed is False
+    assert report.passed is False  # un critère du SPEC non vérifié → gate rouge
+
+
+async def test_gate_passes_when_acceptance_passes():
+    chk = _FakeAcceptance(passed=True)
+    report = await run_quality_gate(
+        "/ws", DIFF, ctx=None, sandbox=_green(), reviewer=FakeReviewer(), issue=ISSUE_AC, acceptance_checker=chk
+    )
+    assert report.acceptance_passed is True and report.passed is True
+
+
+async def test_gate_generation_error_does_not_block():
+    chk = _FakeAcceptance(passed=None, error="génération KO")
+    report = await run_quality_gate(
+        "/ws", DIFF, ctx=None, sandbox=_green(), reviewer=FakeReviewer(), issue=ISSUE_AC, acceptance_checker=chk
+    )
+    assert report.acceptance_error == "génération KO"
+    assert report.passed is True  # best-effort : une génération indisponible ne bloque pas
+
+
+async def test_gate_skips_acceptance_without_criteria():
+    chk = _FakeAcceptance(passed=False)  # bloquerait SI appelé
+    report = await run_quality_gate(
+        "/ws", DIFF, ctx=None, sandbox=_green(), reviewer=FakeReviewer(), issue=ISSUE_NO_AC, acceptance_checker=chk
+    )
+    assert chk.called is False  # pas de critères → pas lancé
+    assert report.passed is True
+
+
+async def test_gate_skips_acceptance_when_already_failing():
+    chk = _FakeAcceptance(passed=False)
+    report = await run_quality_gate(
+        "/ws", DIFF, ctx=None, sandbox=_red(), reviewer=FakeReviewer(), issue=ISSUE_AC, acceptance_checker=chk
+    )
+    assert chk.called is False  # tests rouges → would_pass False → acceptance non lancé (borne le coût)
+    assert report.passed is False
+
+
+def test_acceptance_failure_rendered_in_report():
+    from collegue.executor import QualityReport
+
+    md = QualityReport(
+        tests_passed=True,
+        test_exit_code=0,
+        test_output="",
+        review_summary="",
+        review_findings=(),
+        review_blocking=False,
+        passed=False,
+        acceptance_passed=False,
+    ).to_markdown()
+    assert "tests d'acceptation dérivés du SPEC en ÉCHEC" in md
+
+
+# --- câblage runtime (opt-in) --------------------------------------------------
+
+
+def test_gate_options_includes_acceptance_when_enabled(monkeypatch):
+    from collegue.pilot import runtime
+
+    monkeypatch.setattr(runtime, "_build_acceptance_checker", lambda s: "CHECKER")
+    opts = runtime._gate_options(SimpleNamespace(GATE_ACCEPTANCE_TESTS=True))
+    assert opts.get("acceptance_checker") == "CHECKER"
+
+
+def test_gate_options_excludes_acceptance_by_default():
+    from collegue.pilot import runtime
+
+    opts = runtime._gate_options(SimpleNamespace())
+    assert "acceptance_checker" not in opts

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -65,8 +65,24 @@ class _FakeProjects:
         return "ITEM"
 
 
+class _FakeFiles:
+    def __init__(self, fail=False):
+        self.calls = []
+        self._fail = fail
+
+    def update_file(self, owner, repo, path, message, content, branch=None):
+        if self._fail:
+            raise RuntimeError("commit refusé")
+        self.calls.append({"owner": owner, "repo": repo, "path": path, "message": message, "content": content})
+        return {"commit": {"sha": "abc"}}
+
+
 def _clients():
     return SyncClients(_FakeIssues(), _FakeLabels(), _FakeMilestones(), _FakeProjects())
+
+
+def _clients_with_files(files=None):
+    return SyncClients(_FakeIssues(), _FakeLabels(), _FakeMilestones(), _FakeProjects(), files=files or _FakeFiles())
 
 
 def _planned(manager, *, approve=False):
@@ -244,3 +260,57 @@ def test_partial_failure_then_retry_no_duplicate(manager):
 def test_default_clients_smoke():
     clients = _default_clients(token="x")
     assert clients.issues and clients.labels and clients.milestones and clients.projects
+
+
+# --- A3 : commit du SPEC.md dans le repo cible ----------------------------------
+
+
+def test_real_sync_commits_spec_md(manager):
+    pid = _planned(manager, approve=True)
+    files = _FakeFiles()
+    result = sync_plan(manager, pid, "o", "r", dry_run=False, clients=_clients_with_files(files))
+    assert result.spec_committed == "SPEC.md"
+    assert len(files.calls) == 1
+    call = files.calls[0]
+    assert call["path"] == "SPEC.md" and call["owner"] == "o" and call["repo"] == "r"
+    assert "Demo" in call["content"]  # le SPEC markdown persisté en DB est committé
+
+
+def test_spec_filename_configurable(manager):
+    pid = _planned(manager, approve=True)
+    files = _FakeFiles()
+    result = sync_plan(
+        manager, pid, "o", "r", dry_run=False, clients=_clients_with_files(files), spec_filename="docs/SPEC.md"
+    )
+    assert result.spec_committed == "docs/SPEC.md"
+    assert files.calls[0]["path"] == "docs/SPEC.md"
+
+
+def test_spec_commit_is_best_effort(manager):
+    # Un échec de commit du SPEC ne casse PAS la synchro des issues (best-effort).
+    pid = _planned(manager, approve=True)
+    result = sync_plan(manager, pid, "o", "r", dry_run=False, clients=_clients_with_files(_FakeFiles(fail=True)))
+    assert result.spec_committed is None  # échec signalé
+    assert all(t.issue_number for t in manager.get_tasks(pid))  # issues créées quand même
+
+
+def test_no_files_client_skips_spec_commit(manager):
+    # SyncClients 4-clients (rétro-compat) → pas de client files → no-op, pas d'erreur.
+    pid = _planned(manager, approve=True)
+    result = sync_plan(manager, pid, "o", "r", dry_run=False, clients=_clients())
+    assert result.spec_committed is None
+    assert all(t.issue_number for t in manager.get_tasks(pid))
+
+
+def test_dry_run_does_not_commit_spec(manager):
+    pid = _planned(manager)  # non approuvé, dry-run
+    files = _FakeFiles()
+    result = sync_plan(manager, pid, "o", "r", dry_run=True, clients=_clients_with_files(files))
+    assert result.spec_committed is None
+    assert files.calls == []  # aucune écriture en dry-run
+
+
+def test_default_clients_includes_files():
+    from collegue.tools.github_commands import FileCommands
+
+    assert isinstance(_default_clients(token=None).files, FileCommands)

--- a/tests/test_pilot_e2e.py
+++ b/tests/test_pilot_e2e.py
@@ -1,0 +1,167 @@
+"""A4 — validation end-to-end **par le produit** : handoff plan → run (sans harnais).
+
+Prouve que les entrypoints committés s'enchaînent via l'état durable partagé
+(``project_id``) : ``plan_project_from_settings`` crée projet + SPEC + tâches en DB,
+puis ``run_project_from_settings`` les reprend et les amène en ``in_review`` — le
+tout sans aucun script de ``scripts/facnor_run/``. Les appels LLM (planner) et
+l'infra (sandbox/agent/clients GitHub) sont des doubles ; le run RÉEL de bout en
+bout (Docker + OpenHands + LLM) est derrière le marqueur ``integration`` et dépend
+de l'image sandbox OpenHands (#404, Phase D).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from collegue.executor import FakeCodeAgent, FakeReviewer, PrClients
+from collegue.pilot import plan_project_from_settings, run_project_from_settings
+from collegue.planner.spec_generator import Spec
+from collegue.sandbox import SandboxResult
+from collegue.state import ProjectStateManager
+
+
+# --- doubles infra (alignés sur test_pilot_runtime) ----------------------------
+
+
+class _Sandbox:
+    def run_tests(self, workspace, command="pytest -q"):
+        return SandboxResult(exit_code=0, stdout="ok", stderr="")
+
+
+class _Branches:
+    def ensure_branch(self, owner, repo, branch, from_branch=None):
+        return SimpleNamespace(name=branch)
+
+
+class _Files:
+    def update_file(self, owner, repo, path, message, content, branch=None):
+        return {}
+
+    def delete_file(self, owner, repo, path, message, branch=None):
+        return {}
+
+
+class _PRs:
+    def find_pr_by_head(self, owner, repo, head, base=None, state="open"):
+        return None
+
+    def create_pr(self, owner, repo, title, head, base, body):
+        return SimpleNamespace(number=101, html_url="https://gh/pull/101", head_branch=head)
+
+
+def _clients():
+    return PrClients(branches=_Branches(), files=_Files(), prs=_PRs())
+
+
+class _Budget:
+    def should_continue(self):
+        return SimpleNamespace(action="continue", ok=True)
+
+    def time_remaining_seconds(self):
+        return None
+
+
+class _Ctx:
+    """ctx de sampling injecté (les doubles planner/reviewer ne l'appellent pas)."""
+
+    async def aclose(self):
+        return None
+
+
+def _git(cwd, *args):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    src = tmp_path / "source"
+    src.mkdir()
+    _git(src, "init", "-q")
+    _git(src, "config", "user.email", "t@example.com")
+    _git(src, "config", "user.name", "Test")
+    (src / "existing.txt").write_text("original\n")
+    _git(src, "add", "-A")
+    _git(src, "commit", "-q", "-m", "init")
+    return str(src)
+
+
+@pytest.fixture
+def manager(tmp_path):
+    return ProjectStateManager.from_url(f"sqlite:///{tmp_path / 'state.db'}", create=True)
+
+
+# --- doubles planner (le LLM est hors-scope ici ; la persistance DB est RÉELLE) ---
+
+
+def _patch_planner_llm(monkeypatch):
+    async def _generate(problem, ctx, **kw):
+        return Spec(title="E2E", summary=problem, acceptance_criteria=["AC1"])
+
+    async def _decompose(spec, ctx, *, manager, project_id, **kw):
+        # Écrit de VRAIES tâches en DB (comme le ferait le décomposeur) → testent le handoff.
+        a = manager.add_task(project_id, title="A", acceptance="critère A")
+        manager.add_task(project_id, title="B", acceptance="critère B", depends_on=[a])
+        return manager.get_tasks(project_id)
+
+    monkeypatch.setattr("collegue.planner.spec_generator.generate_spec", _generate)
+    monkeypatch.setattr("collegue.planner.decomposer.decompose", _decompose)
+
+
+# --- handoff plan → run --------------------------------------------------------
+
+
+async def test_plan_then_run_handoff_via_product(monkeypatch, manager, git_repo):
+    _patch_planner_llm(monkeypatch)
+
+    # 1) PLAN (sync en dry-run → pas de GitHub) : crée projet + SPEC + tâches en DB.
+    plan = await plan_project_from_settings(
+        "E2E",
+        "construire une app X",
+        owner="o",
+        repo="r",
+        settings_obj=SimpleNamespace(),
+        manager=manager,
+        ctx=_Ctx(),
+        approve=True,
+        execute_sync=False,
+    )
+    assert plan.task_count == 2
+    project = manager.get_project(plan.project_id)
+    assert project.spec and "E2E" in project.spec  # SPEC persisté (markdown)
+    assert all(t.status == "todo" for t in manager.get_tasks(plan.project_id))
+
+    # 2) RUN (doubles infra) sur le MÊME project_id : les tâches passent in_review.
+    result = await run_project_from_settings(
+        plan.project_id,
+        git_repo,
+        owner="o",
+        repo="r",
+        dry_run=False,
+        manager=manager,
+        sandbox=_Sandbox(),
+        agent=FakeCodeAgent(),
+        reviewer=FakeReviewer(),
+        clients=_clients(),
+        budget=_Budget(),
+        ctx=_Ctx(),
+    )
+    assert result.stop_reason == "completed"
+    assert result.iterations == 2
+    # Le handoff fonctionne : le run a repris les tâches planifiées et les a construites.
+    assert all(t.status == "in_review" for t in manager.get_tasks(plan.project_id))
+    assert any("Run pilote" in d.summary for d in manager.get_decisions(plan.project_id))
+
+
+async def test_plan_dry_run_sync_writes_nothing_to_github(monkeypatch, manager):
+    # En dry-run de sync, la planification persiste en DB mais ne touche pas GitHub.
+    _patch_planner_llm(monkeypatch)
+    plan = await plan_project_from_settings(
+        "E2E", "x", owner="o", repo="r", settings_obj=SimpleNamespace(), manager=manager, ctx=_Ctx()
+    )
+    assert plan.dry_run is True
+    assert plan.task_count == 2
+    # issues en aperçu (pas de numéro réel attribué).
+    assert all(i.get("issue_number") is None for i in plan.issues)

--- a/tests/test_pilot_e2e.py
+++ b/tests/test_pilot_e2e.py
@@ -22,7 +22,6 @@ from collegue.planner.spec_generator import Spec
 from collegue.sandbox import SandboxResult
 from collegue.state import ProjectStateManager
 
-
 # --- doubles infra (alignés sur test_pilot_runtime) ----------------------------
 
 

--- a/tests/test_pilot_plan.py
+++ b/tests/test_pilot_plan.py
@@ -1,0 +1,247 @@
+"""Tests A2 — planification par le produit : runtime.plan_project_from_settings + CLI `plan`."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from collegue.pilot import PlanResult, format_plan_report, plan_project_from_settings
+
+# --- doubles du planner (monkeypatchés là où plan_project_from_settings les importe) ---
+
+
+def _spec(title="T", objectives=("o1",), criteria=("c1", "c2")):
+    return SimpleNamespace(title=title, objectives=list(objectives), acceptance_criteria=list(criteria))
+
+
+def _patch_planner(monkeypatch, *, tasks=None, decompose_fn=None, sync_issues=None, calls=None):
+    calls = calls if calls is not None else {}
+
+    async def _generate_spec(problem, ctx, **kw):
+        calls["generate"] = (problem, kw)
+        return _spec()
+
+    def _persist_spec(manager, name, spec, **kw):
+        calls["persist"] = (name, kw)
+        return 42
+
+    async def _decompose(spec, ctx, **kw):
+        calls["decompose"] = kw
+        return list(tasks if tasks is not None else [object(), object()])
+
+    def _build_preview(manager, project_id):
+        return SimpleNamespace(to_markdown=lambda: "PREVIEW")
+
+    def _approve(manager, project_id, **kw):
+        calls["approve"] = (project_id, kw)
+        return True
+
+    def _sync(manager, project_id, owner, repo, **kw):
+        calls["sync"] = {"owner": owner, "repo": repo, **kw}
+        issues = sync_issues if sync_issues is not None else [{"task_id": 1, "title": "T1", "issue_number": None}]
+        return SimpleNamespace(issues=issues)
+
+    monkeypatch.setattr("collegue.planner.spec_generator.generate_spec", _generate_spec)
+    monkeypatch.setattr("collegue.planner.spec_generator.persist_spec", _persist_spec)
+    monkeypatch.setattr("collegue.planner.decomposer.decompose", decompose_fn or _decompose)
+    monkeypatch.setattr("collegue.planner.plan_review.build_plan_preview", _build_preview)
+    monkeypatch.setattr("collegue.planner.plan_review.approve_plan", _approve)
+    monkeypatch.setattr("collegue.planner.github_sync.sync_plan", _sync)
+    return calls
+
+
+async def _plan(monkeypatch, **kwargs):
+    closed = {"v": False}
+
+    class _Ctx:
+        async def aclose(self):
+            closed["v"] = True
+
+    defaults = dict(
+        name="proj",
+        problem="construire X",
+        owner="o",
+        repo="r",
+        ctx=_Ctx(),
+        settings_obj=SimpleNamespace(),
+        manager=object(),
+    )
+    defaults.update(kwargs)
+    result = await plan_project_from_settings(**defaults)
+    return result, closed
+
+
+# --- orchestration --------------------------------------------------------------
+
+
+async def test_dry_run_does_not_approve_and_syncs_in_dry_run(monkeypatch):
+    calls = _patch_planner(monkeypatch)
+    result, _ = await _plan(monkeypatch)
+    assert isinstance(result, PlanResult)
+    assert result.project_id == 42
+    assert result.spec_title == "T"
+    assert result.acceptance_criteria == 2
+    assert result.task_count == 2
+    assert result.dry_run is True
+    assert result.preview_markdown == "PREVIEW"
+    assert "approve" not in calls  # ni approve ni execute → pas d'approbation
+    assert calls["sync"]["dry_run"] is True
+    assert calls["sync"]["labels"] == ["autonome"]  # défaut
+    assert calls["sync"]["milestone_title"] == "proj MVP"  # défaut
+
+
+async def test_execute_sync_approves_and_creates(monkeypatch):
+    calls = _patch_planner(monkeypatch, sync_issues=[{"task_id": 1, "title": "T1", "issue_number": 101}])
+    result, _ = await _plan(monkeypatch, execute_sync=True, labels=["x"], milestone_title="M")
+    assert result.dry_run is False
+    assert calls["approve"][0] == 42  # gate P5 satisfait
+    assert calls["sync"]["dry_run"] is False
+    assert calls["sync"]["labels"] == ["x"]
+    assert calls["sync"]["milestone_title"] == "M"
+    assert result.issues[0]["issue_number"] == 101
+
+
+async def test_approve_flag_alone_approves_without_execute(monkeypatch):
+    calls = _patch_planner(monkeypatch)
+    result, _ = await _plan(monkeypatch, approve=True)
+    assert "approve" in calls
+    assert calls["sync"]["dry_run"] is True  # approuvé mais pas exécuté → dry-run
+
+
+async def test_decompose_max_tokens_widened(monkeypatch):
+    calls = _patch_planner(monkeypatch)
+    await _plan(monkeypatch, decompose_max_tokens=16384)
+    assert calls["decompose"]["max_tokens"] == 16384
+
+
+async def test_decompose_retries_on_empty_then_succeeds(monkeypatch):
+    attempts = {"n": 0}
+
+    async def _flaky(spec, ctx, **kw):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise ValueError("Décomposition vide")
+        return [object()]
+
+    _patch_planner(monkeypatch, decompose_fn=_flaky)
+    result, _ = await _plan(monkeypatch, retry_sleep_seconds=0)
+    assert attempts["n"] == 2  # 1 échec + 1 succès
+    assert result.task_count == 1
+
+
+async def test_decompose_raises_after_all_attempts(monkeypatch):
+    async def _always_empty(spec, ctx, **kw):
+        raise ValueError("Décomposition vide")
+
+    _patch_planner(monkeypatch, decompose_fn=_always_empty)
+    with pytest.raises(ValueError):
+        await _plan(monkeypatch, decompose_attempts=2, retry_sleep_seconds=0)
+
+
+async def test_owned_ctx_is_closed(monkeypatch):
+    _patch_planner(monkeypatch)
+    closed = {"v": False}
+
+    class _Ctx:
+        async def aclose(self):
+            closed["v"] = True
+
+    monkeypatch.setattr("collegue.pilot.runtime._build_ctx", lambda _s: _Ctx())
+    # ctx non fourni → assemblé puis fermé
+    await plan_project_from_settings(
+        name="p", problem="x", owner="o", repo="r", settings_obj=SimpleNamespace(), manager=object()
+    )
+    assert closed["v"] is True
+
+
+async def test_injected_ctx_not_closed(monkeypatch):
+    _patch_planner(monkeypatch)
+    result, closed = await _plan(monkeypatch)  # _plan injecte un ctx
+    assert closed["v"] is False
+
+
+# --- reporting -----------------------------------------------------------------
+
+
+def test_format_plan_report_dry_run_and_issues():
+    result = PlanResult(
+        project_id=7,
+        spec_title="Facturation",
+        objectives=3,
+        acceptance_criteria=5,
+        task_count=2,
+        preview_markdown="# Plan détaillé\n- tâche A",
+        dry_run=True,
+        issues=[{"task_id": 1, "title": "Schéma", "issue_number": None}],
+    )
+    report = format_plan_report(result)
+    assert "Plan projet #7" in report
+    assert "Facturation" in report
+    assert "dry-run" in report
+    assert "task 1: Schéma" in report
+    assert "Aperçu du plan" in report  # l'opérateur voit le plan avant d'approuver
+    assert "# Plan détaillé" in report
+
+
+def test_format_plan_report_execute_shows_issue_numbers():
+    result = PlanResult(
+        project_id=8,
+        spec_title="X",
+        objectives=1,
+        acceptance_criteria=1,
+        task_count=1,
+        preview_markdown="",
+        dry_run=False,
+        issues=[{"task_id": 9, "title": "Auth", "issue_number": 123}],
+    )
+    report = format_plan_report(result)
+    assert "EXECUTE" in report
+    assert "[#123] task 9: Auth" in report
+
+
+# --- CLI -----------------------------------------------------------------------
+
+
+def test_cli_parses_plan_subcommand():
+    from collegue.pilot.__main__ import build_parser
+
+    args = build_parser().parse_args(["plan", "--problem", "P", "--owner", "o", "--repo", "r"])
+    assert args.command == "plan"
+    assert args.problem == "P" and args.owner == "o" and args.repo == "r"
+    assert args.execute_sync is False  # dry-run par défaut
+
+
+def test_cli_plan_dispatches_and_parses_args(monkeypatch, capsys):
+    import collegue.pilot.__main__ as cli
+
+    captured = {}
+
+    async def _fake_plan(name, problem, **kw):
+        captured["name"] = name
+        captured["problem"] = problem
+        captured.update(kw)
+        return PlanResult(
+            project_id=1,
+            spec_title="X",
+            objectives=0,
+            acceptance_criteria=0,
+            task_count=0,
+            preview_markdown="",
+            dry_run=False,
+            issues=[],
+        )
+
+    monkeypatch.setattr("collegue.pilot.runtime.plan_project_from_settings", _fake_plan)
+    monkeypatch.setattr("collegue.pilot.runtime.format_plan_report", lambda r: "REPORT")
+
+    rc = cli.main(
+        ["plan", "--name", "X", "--problem", "P", "--owner", "o", "--repo", "r", "--execute-sync", "--labels", "a, b"]
+    )
+    assert rc == 0
+    assert captured["name"] == "X" and captured["problem"] == "P"
+    assert captured["owner"] == "o" and captured["repo"] == "r"
+    assert captured["execute_sync"] is True
+    assert captured["labels"] == ["a", "b"]  # CSV nettoyé
+    assert captured["deadline"] is None  # pas de --deadline-hours
+    assert "REPORT" in capsys.readouterr().out

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -160,6 +160,79 @@ async def test_real_run_wires_cost_governance_by_default(git_repo, manager):
     assert any("coût≈" in d.summary for d in manager.get_decisions(pid))
 
 
+# --- ctx de sampling offline (A1) ----------------------------------------------
+
+
+async def test_builds_offline_ctx_when_none_and_closes(monkeypatch, manager, git_repo):
+    """Hors serveur MCP, ``ctx=None`` → un ctx offline est assemblé puis fermé."""
+    import collegue.pilot.runtime as runtime
+
+    closed = {"v": False}
+    captured = {}
+
+    class _Ctx:
+        async def aclose(self):
+            closed["v"] = True
+
+    async def _fake_run_project(pid, src, ctx, **kw):
+        captured["ctx"] = ctx
+        return ProjectRunResult(stop_reason="completed", iterations=0, processed=[])
+
+    monkeypatch.setattr(runtime, "_build_ctx", lambda _s: _Ctx())
+    monkeypatch.setattr(runtime, "run_project", _fake_run_project)
+
+    pid = _linear(manager, 1)
+    await run_project_from_settings(
+        pid,
+        git_repo,
+        owner="o",
+        repo="r",
+        dry_run=True,
+        manager=manager,
+        sandbox=_Sandbox(),
+        agent=FakeCodeAgent(),
+        reviewer=FakeReviewer(),
+        clients=_clients(),
+        budget=_Budget(),
+    )
+    assert isinstance(captured["ctx"], _Ctx)  # ctx assemblé et transmis
+    assert closed["v"] is True  # fermé en fin de run (on l'a créé)
+
+
+async def test_injected_ctx_is_not_closed(monkeypatch, manager, git_repo):
+    """Un ctx fourni par l'appelant lui appartient : ``run_project_from_settings`` ne le ferme pas."""
+    import collegue.pilot.runtime as runtime
+
+    closed = {"v": False}
+
+    class _Ctx:
+        async def aclose(self):
+            closed["v"] = True
+
+    async def _fake_run_project(pid, src, ctx, **kw):
+        return ProjectRunResult(stop_reason="completed", iterations=0, processed=[])
+
+    monkeypatch.setattr(runtime, "run_project", _fake_run_project)
+
+    pid = _linear(manager, 1)
+    mine = _Ctx()
+    await run_project_from_settings(
+        pid,
+        git_repo,
+        owner="o",
+        repo="r",
+        ctx=mine,
+        dry_run=True,
+        manager=manager,
+        sandbox=_Sandbox(),
+        agent=FakeCodeAgent(),
+        reviewer=FakeReviewer(),
+        clients=_clients(),
+        budget=_Budget(),
+    )
+    assert closed["v"] is False  # ctx injecté → non fermé par le runtime
+
+
 # --- reporting ------------------------------------------------------------------
 
 

--- a/tests/test_sampling_ctx.py
+++ b/tests/test_sampling_ctx.py
@@ -1,0 +1,209 @@
+"""Tests du ctx de sampling offline (A1) — collegue/core/llm/sampling_ctx.py."""
+
+from __future__ import annotations
+
+from collections import deque
+from types import SimpleNamespace
+
+import pytest
+
+from collegue.core.llm.sampling_ctx import (
+    DEFAULT_MAX_TOKENS,
+    LocalSamplingContext,
+    PerModelRateLimiter,
+    SampleResult,
+    _coerce,
+    _pick_model,
+    to_openai_messages,
+)
+
+# --- faux client OpenAI-compatible ---------------------------------------------
+
+
+def _resp(content, *, model="m", usage=None):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+        model=model,
+        usage=usage,
+    )
+
+
+class _FakeClient:
+    def __init__(self, resp):
+        self._resp = resp
+        self.calls = []
+        self.closed = False
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
+
+    async def _create(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._resp
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _neutralize_budget_usage(monkeypatch):
+    """Défaut : budget no-op + usage avalé (les tests qui veulent l'inverse re-patchent)."""
+    monkeypatch.setattr("collegue.monitoring.metrics.enforce_budget", lambda: None)
+    monkeypatch.setattr("collegue.monitoring.sampling_usage.record_usage", lambda *a, **k: None)
+
+
+# --- normalisation des messages ------------------------------------------------
+
+
+def test_to_openai_messages_string_plus_system():
+    msgs = to_openai_messages("salut", "tu es X")
+    assert msgs == [{"role": "system", "content": "tu es X"}, {"role": "user", "content": "salut"}]
+
+
+def test_to_openai_messages_list_roles_and_list_content():
+    msgs = to_openai_messages(
+        [{"role": "system", "content": "S"}, {"role": "user", "content": [{"text": "a"}, "b"]}],
+        None,
+    )
+    assert msgs == [{"role": "system", "content": "S"}, {"role": "user", "content": "a b"}]
+
+
+def test_to_openai_messages_guarantees_user_turn():
+    msgs = to_openai_messages("", "S")  # system seul → un tour user est garanti
+    assert msgs[0]["role"] == "system"
+    assert any(m["role"] == "user" for m in msgs)
+
+
+def test_to_openai_messages_none_content_becomes_empty_string():
+    # content=None explicite → "" (jamais le littéral "None" envoyé au modèle).
+    msgs = to_openai_messages([{"role": "user", "content": None}], None)
+    assert msgs == [{"role": "user", "content": ""}]
+
+
+# --- choix du modèle + coercition ---------------------------------------------
+
+
+def test_pick_model_prefers_first_preference():
+    assert _pick_model(["gpt-x"], "default") == "gpt-x"
+    assert _pick_model([], "default") == "default"
+    assert _pick_model(None, "default") == "default"
+
+
+class _Spec:
+    def __init__(self, title):
+        self.title = title
+
+    @classmethod
+    def model_validate(cls, data):
+        return cls(data["title"])
+
+
+def test_coerce_parses_json_into_result_type():
+    out = _coerce('{"title": "T"}', _Spec)
+    assert isinstance(out, _Spec) and out.title == "T"
+
+
+def test_coerce_falls_back_to_text_on_unparsable():
+    assert _coerce("pas du json", _Spec) == "pas du json"
+
+
+# --- sample() ------------------------------------------------------------------
+
+
+async def test_sample_returns_text_and_records_usage(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        "collegue.monitoring.sampling_usage.record_usage",
+        lambda p, c, m: seen.update(p=p, c=c, m=m),
+    )
+    usage = SimpleNamespace(prompt_tokens=12, completion_tokens=3)
+    client = _FakeClient(_resp("bonjour", model="gemma-x", usage=usage))
+    ctx = LocalSamplingContext(default_model="d", client=client)
+
+    res = await ctx.sample("hi", model_preferences=["gemma-x"], max_tokens=2000)
+
+    assert isinstance(res, SampleResult)
+    assert res.text == "bonjour"
+    assert res.result is None  # pas de result_type
+    assert client.calls[0]["model"] == "gemma-x"
+    assert client.calls[0]["max_tokens"] == 2000  # cap explicite de l'appelant RESPECTÉ
+    assert seen == {"p": 12, "c": 3, "m": "gemma-x"}
+
+
+async def test_sample_defaults_max_tokens_when_absent():
+    client = _FakeClient(_resp("ok"))
+    ctx = LocalSamplingContext(default_model="d", client=client)
+    await ctx.sample("hi")  # aucun max_tokens → défaut généreux
+    assert client.calls[0]["max_tokens"] == DEFAULT_MAX_TOKENS
+
+
+async def test_sample_coerces_result_type():
+    client = _FakeClient(_resp('{"title": "T"}'))
+    ctx = LocalSamplingContext(default_model="d", client=client)
+    res = await ctx.sample("x", result_type=_Spec)
+    assert isinstance(res.result, _Spec) and res.result.title == "T"
+
+
+async def test_sample_enforces_budget_before_call(monkeypatch):
+    class _Stop(BaseException):
+        pass
+
+    def _boom():
+        raise _Stop()
+
+    monkeypatch.setattr("collegue.monitoring.metrics.enforce_budget", _boom)
+    client = _FakeClient(_resp("never"))
+    ctx = LocalSamplingContext(default_model="d", client=client)
+    with pytest.raises(_Stop):
+        await ctx.sample("hi")
+    assert client.calls == []  # le budget coupe AVANT l'appel LLM
+
+
+async def test_noop_stubs_are_awaitable():
+    ctx = LocalSamplingContext(default_model="d", client=_FakeClient(_resp("x")))
+    assert await ctx.info("m") is None
+    assert await ctx.debug("m") is None
+    assert await ctx.warning("m") is None
+    assert await ctx.error("m") is None
+    assert await ctx.report_progress(1, 2) is None
+
+
+async def test_aclose_closes_client():
+    client = _FakeClient(_resp("x"))
+    ctx = LocalSamplingContext(default_model="d", client=client)
+    await ctx.aclose()
+    assert client.closed is True
+
+
+# --- from_settings -------------------------------------------------------------
+
+
+def test_from_settings_resolves_endpoint_without_limiter(monkeypatch):
+    # Les LLM_RATE_LIMIT_* (middleware serveur par-client) NE doivent PAS throttler
+    # le ctx du moteur : aucun limiter assemblé depuis la config, même si définis.
+    monkeypatch.setattr(
+        "collegue.core.llm.sampling_handler.resolve_openai_endpoint",
+        lambda s: ("modX", "k", "http://bu/"),
+    )
+    settings = SimpleNamespace(LLM_RATE_LIMIT_PER_MINUTE=5, LLM_RATE_LIMIT_PER_DAY=500)
+    ctx = LocalSamplingContext.from_settings(settings)
+    assert ctx._default_model == "modX"
+    assert ctx._api_key == "k"
+    assert ctx._base_url == "http://bu/"
+    assert ctx._limiter is None  # pas de throttle moteur par défaut
+
+
+def test_rate_limiter_injectable_via_constructor():
+    rl = PerModelRateLimiter(per_minute=15, per_day=1500)
+    ctx = LocalSamplingContext(default_model="m", rate_limiter=rl)
+    assert ctx._limiter is rl  # cadençage opt-in pour qui le veut
+
+
+# --- rate limiter (maths, sans dormir) -----------------------------------------
+
+
+def test_rate_limiter_wait_needed_when_minute_full():
+    rl = PerModelRateLimiter(per_minute=1, per_day=0)
+    now = 1000.0
+    rl._minute["m"] = deque([now])
+    rl._day["m"] = deque([now])
+    assert rl._wait_needed("m", now + 1) > 0  # créneau pris → attente
+    assert rl._wait_needed("m", now + 61) == 0  # après 60 s → libre


### PR DESCRIPTION
## Landing `pre-main` → `main` — campagne « end-to-end par le produit » (#404 et §4.7)

Reporte sur `main` la campagne complète (7 PR, +1915/−82) qui rend le cycle de vie autonome exécutable **par le produit** et ferme des trous du brief. **Sûr par défaut** : aucun changement de comportement par défaut (B opt-in OFF, auto-merge non câblé, A additif, D infra/CI).

### Phase A — end-to-end par le produit (plus de dépendance au harnais gitignoré)
- **#561 (A1)** `LocalSamplingContext` : ctx de sampling **offline** multi-provider (OpenAI-compat) → `python -m collegue.pilot` utilisable hors serveur MCP.
- **#562 (A2)** sous-commande `plan` : problème → SPEC → DAG → issues GitHub.
- **#563 (A3)** commit de `SPEC.md` dans le repo cible (le contrat, §4.2).
- **#564 (A4)** test d'intégration du handoff `plan → run` par le produit.

### Phase B — §4.7 anti-vérification circulaire
- **#565** tests d'acceptation **exécutables** dérivés du SPEC, écrits par un rôle **indépendant du coder** (REVIEWER) et lancés en sandbox → verdict **objectif** (exit code). Opt-in (`GATE_ACCEPTANCE_TESTS`, **OFF** par défaut).

### Phase C2 — fidélité de la doc
- **#566** auto-merge/revert décrits honnêtement (politique non câblée, merge humain §6 = défaut) ; budget coder #495 corrigé.

### Phase D — image OpenHands #404
- **#567** `Dockerfile.openhands` committé + constructible depuis les sources committées (COPY conditionnel) + job nightly qui le construit et vérifie `openhands.core.main`.

**Reporté (suivi)** : C1 (câblage auto-merge CI-aware — le merge humain §6 reste le défaut sûr) ; le smoke e2e **réel** (plan→execute→PR sur fixture, secret-gated).

CI verte sur chaque PR. Cible : `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
