### PR TITLE
feat(moteur): cycle produit end-to-end (abonnement) + merge-bot build + gate advisory

### DIFF
--- a/collegue/config.py
+++ b/collegue/config.py
@@ -90,6 +90,15 @@ class Settings(BaseSettings):
     # sœurs ne sont plus construites depuis la même base → plus de PRs sœurs en
     # conflit (merge 405 irrécupérable). Ignoré si DEPS_REQUIRE_MERGED est faux.
     STRICT_MAX_INFLIGHT_PRS: int = 1
+    # Merge-bot de la phase BUILD : si vrai (défaut), une tâche dont la PR est
+    # ouverte est AUTO-MERGÉE (squash) puis le clone local est resynchronisé sur
+    # `origin/<base>` AVANT de passer à la tâche suivante — sinon, avec 1 PR en vol
+    # + deps strictes, le build s'arrête `awaiting_merge` et n'avance pas (et des
+    # tâches reconstruites sur une base périmée entrent en conflit). C'est le rôle
+    # du merge humain SIMULÉ pendant la construction autonome du MVP. La phase
+    # d'AMÉLIORATION (Phase 4), elle, n'auto-merge jamais : ses PR restent ouvertes
+    # pour relecture/merge HUMAIN (§6). Mettre à faux pour un build à merge humain.
+    BUILD_AUTO_MERGE: bool = True
     # Gate qualité multi-écosystème (#438) : si le workspace a un package.json,
     # enchaîner npm install + build/type-check + tests front dans le même
     # conteneur, fail-closed comme pytest (l'image sandbox doit fournir npm).
@@ -172,6 +181,16 @@ class Settings(BaseSettings):
     # du worker : permet au coder d'utiliser l'abo (sans coût API) et de persister le
     # token rafraîchi. Vide (défaut) = aucun montage (mode clé API inchangé).
     SANDBOX_SUBSCRIPTION_AUTH_DIR: str = ""
+    # Réseau du sandbox réel (coder OpenHands + passes réseau du gate). Le coder a
+    # besoin du réseau (le défaut DURCI de DockerSandbox est "none"). "host" est
+    # éprouvé contre la flakiness des transferts pip via le bridge Docker (NAT/MTU,
+    # run v6) ; "bridge" reste possible. Avec "host", ne pas définir SANDBOX_DNS.
+    SANDBOX_NETWORK: str = "bridge"
+    # Ressources du conteneur sandbox (coder + gate). Les défauts de DockerSandbox
+    # (512m/1cpu/120s) sont trop bas pour un run réel OpenHands → on remonte ici.
+    SANDBOX_MEMORY: str = "6g"
+    SANDBOX_CPUS: str = "2.0"
+    SANDBOX_TIMEOUT: float = 2400.0
 
     ENGINE_INIT_TIMEOUT: float = 10.0
     ENGINE_WAIT_TIMEOUT: float = 30.0
@@ -200,6 +219,16 @@ class Settings(BaseSettings):
     CODER_LLM_RETRY_MIN_WAIT: int = 8
     CODER_LLM_RETRY_MAX_WAIT: int = 90
     CODER_MIN_INTERVAL_SECONDS: float = 0.0
+
+    # --- Coder par ABONNEMENT (Codex via ChatGPT Plus/Pro, sans coût API) ---
+    # Opt-in : le coder OpenHands SDK (oh_runner) s'authentifie via subscription_login
+    # (creds montées depuis SANDBOX_SUBSCRIPTION_AUTH_DIR, ex. ~/.openhands) au lieu
+    # d'une clé API. Le backend ChatGPT sert les modèles GÉNÉRAUX (gpt-5.5/gpt-5.4),
+    # pas les SKU *-codex → modèle NU (pas de préfixe gemini/). En abonnement, le run
+    # n'est PAS facturé au token (coût $ autoritaire = 0, #504).
+    CODER_SUBSCRIPTION: bool = False
+    CODER_SUBSCRIPTION_MODEL: str = "gpt-5.5"
+    CODER_SUBSCRIPTION_FALLBACK: str = "gpt-5.4"
 
     # --- Budget DUR global (coût $ / tokens) + auto-pause (garde-fou brief §6) ---
     # Plafond DUR sur la dépense cumulée, distinct du rate limiter (fréquence) et

--- a/collegue/core/llm/sampling_ctx.py
+++ b/collegue/core/llm/sampling_ctx.py
@@ -32,6 +32,10 @@ n'échantillonnent pas restent inertes).
 from __future__ import annotations
 
 import asyncio
+import json
+import os
+import re
+import subprocess
 import threading
 import time
 from collections import deque
@@ -39,6 +43,9 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 DEFAULT_MAX_TOKENS = 8192
+
+# Sortie du sampler d'abonnement (oh_sampler.py) — texte entre marqueurs.
+_SAMPLE_RE = re.compile(r"<<<SAMPLE_BEGIN>>>(.*)<<<SAMPLE_END>>>", re.S)
 
 
 @dataclass
@@ -164,6 +171,12 @@ class LocalSamplingContext:
         default_max_tokens: int = DEFAULT_MAX_TOKENS,
         max_retries: int = 4,
         client: Any = None,
+        subscription_enabled: bool = False,
+        subscription_auth_dir: Optional[str] = None,
+        sampler_image: str = "collegue-sandbox:latest",
+        sampler_script: Optional[str] = None,
+        sampler_timeout: float = 240.0,
+        runner: Any = None,
     ):
         self._default_model = default_model or ""
         self._api_key = api_key
@@ -172,6 +185,14 @@ class LocalSamplingContext:
         self._default_max_tokens = int(default_max_tokens)
         self._max_retries = int(max_retries)
         self._client = client
+        # Abonnement (Codex/ChatGPT) : un modèle NON-Gemini (ex. gpt-5.4) est échantillonné
+        # via le sandbox (le SDK subscription_login n'est PAS dans le process principal).
+        self._subscription_enabled = bool(subscription_enabled and subscription_auth_dir and sampler_script)
+        self._subscription_auth_dir = subscription_auth_dir
+        self._sampler_image = sampler_image
+        self._sampler_script = sampler_script
+        self._sampler_timeout = float(sampler_timeout)
+        self._runner = runner  # injection de test : callable(argv, input) -> (rc, stdout, stderr)
         # Stubs ctx attendus par les outils (no-op async).
         self.info = self._noop
         self.debug = self._noop
@@ -193,7 +214,27 @@ class LocalSamplingContext:
         from collegue.core.llm.sampling_handler import resolve_openai_endpoint
 
         default_model, api_key, base_url = resolve_openai_endpoint(settings_obj)
-        return cls(default_model=default_model, api_key=api_key, base_url=base_url)
+        # Abonnement : un rôle dont le modèle est NON-Gemini (ex. reviewer=gpt-5.4) est
+        # routé vers le sampler d'abonnement (sandbox), comme le coder. Gaté par
+        # ``CODER_SUBSCRIPTION`` + creds montées (``SANDBOX_SUBSCRIPTION_AUTH_DIR``).
+        sub = bool(getattr(settings_obj, "CODER_SUBSCRIPTION", False))
+        auth = ""
+        if sub:
+            auth = os.path.expanduser(str(getattr(settings_obj, "SANDBOX_SUBSCRIPTION_AUTH_DIR", "") or "").strip())
+        # oh_sampler.py committé : collegue/executor/oh_sampler.py (ce fichier = collegue/core/llm/).
+        sampler_script = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+            "executor",
+            "oh_sampler.py",
+        )
+        return cls(
+            default_model=default_model,
+            api_key=api_key,
+            base_url=base_url,
+            subscription_enabled=sub,
+            subscription_auth_dir=auth or None,
+            sampler_script=sampler_script,
+        )
 
     async def _noop(self, *args: Any, **kwargs: Any) -> None:  # ctx.info/debug/...
         return None
@@ -218,18 +259,95 @@ class LocalSamplingContext:
     ) -> SampleResult:
         model = _pick_model(model_preferences, self._default_model)
         oai_messages = to_openai_messages(messages, system_prompt)
-        # On RESPECTE le ``max_tokens`` explicite de l'appelant (parité avec le handler
-        # serveur — sinon on inflerait ×4 les caps voulus, ex. 2000) ; seul un appel SANS
-        # cap retombe sur ``_default_max_tokens`` (généreux : un modèle « raisonnant »
-        # type gemma coupé trop tôt rend un contenu vide).
-        eff_max = int(max_tokens) if max_tokens else self._default_max_tokens
-        if self._limiter is not None:
-            await self._limiter.acquire(model)
-        text = await self._create(model, oai_messages, temperature, eff_max)
+        if self._is_subscription_model(model):
+            # Modèle d'abonnement (ex. gpt-5.4) → sampler dans le sandbox (subscription_login).
+            text = await self._sample_subscription(model, oai_messages)
+        else:
+            # On RESPECTE le ``max_tokens`` explicite de l'appelant (parité avec le handler
+            # serveur — sinon on inflerait ×4 les caps voulus, ex. 2000) ; seul un appel SANS
+            # cap retombe sur ``_default_max_tokens`` (généreux : un modèle « raisonnant »
+            # type gemma coupé trop tôt rend un contenu vide).
+            eff_max = int(max_tokens) if max_tokens else self._default_max_tokens
+            if self._limiter is not None:
+                await self._limiter.acquire(model)
+            text = await self._create(model, oai_messages, temperature, eff_max)
         res = SampleResult(text=text)
         if result_type is not None:
             res.result = _coerce(text, result_type)
         return res
+
+    def _is_subscription_model(self, model: str) -> bool:
+        """Vrai si ``model`` doit passer par l'abonnement (sandbox) plutôt que l'endpoint Gemini.
+
+        Heuristique générique : abonnement activé + creds + le modèle n'est PAS un modèle
+        Gemini (``gemma*``/``gemini*``). Les modèles ChatGPT (``gpt-*``) y matchent.
+        """
+        if not self._subscription_enabled:
+            return False
+        m = (model or "").strip().lower()
+        return bool(m) and not (m.startswith("gemma") or m.startswith("gemini"))
+
+    async def _sample_subscription(self, model: str, oai_messages: List[Dict[str, str]]) -> str:
+        """Échantillonne ``model`` via l'abonnement (Codex/ChatGPT) en lançant ``oh_sampler.py``
+        dans le sandbox (le ``subscription_login`` du SDK n'est pas dans le process principal).
+
+        Mêmes invariants que le coder : creds ``~/.openhands`` montées, ``LLM_SUBSCRIPTION=1`` ;
+        coût 0 (abonnement). Le runner est injectable en test.
+
+        Durcissement : ``--cap-drop ALL`` + ``--security-opt no-new-privileges`` (le conteneur
+        ne lance que le SDK LLM, aucun code projet) ; il tourne sous l'utilisateur ``sandbox``
+        (uid 1000) de l'image, le script est monté en lecture seule. ``--network host`` est
+        requis (le bridge Docker stalle les transferts LLM — chemin réseau prouvé du harnais) ;
+        le montage des creds est RW (rafraîchissement éventuel du jeton d'abonnement).
+        """
+        system_text = "\n\n".join(m["content"] for m in oai_messages if m["role"] == "system")
+        user_text = "\n\n".join(m["content"] for m in oai_messages if m["role"] != "system")
+        payload = json.dumps({"system": system_text, "prompt": user_text})
+        argv = [
+            "docker",
+            "run",
+            "--rm",
+            "-i",
+            "--cap-drop",
+            "ALL",
+            "--security-opt",
+            "no-new-privileges",
+            "--network",
+            "host",
+            "-e",
+            "HOME=/home/sandbox",
+            "-e",
+            f"LLM_MODEL={model}",
+            "-e",
+            "LLM_SUBSCRIPTION=1",
+            "-e",
+            "OPENHANDS_SUPPRESS_BANNER=1",
+            "-v",
+            f"{self._subscription_auth_dir}:/home/sandbox/.openhands",
+            "-v",
+            f"{self._sampler_script}:/oh_sampler.py:ro",
+            self._sampler_image,
+            "python",
+            "/oh_sampler.py",
+        ]
+        rc, out, err = await self._run_sampler(argv, payload)
+        match = _SAMPLE_RE.search(out or "")
+        if rc != 0 or not match:
+            raise RuntimeError(f"sampler abonnement {model} en échec (rc={rc}) : {((err or out) or '')[:300]}")
+        text = match.group(1)
+        # Un verdict VIDE (stream + LLMResponse final tous deux vides, rc=0) serait mal
+        # interprété en aval (reviewer/juge) → fail-closed plutôt que rendre "".
+        if not text.strip():
+            raise RuntimeError(f"sampler abonnement {model} : réponse vide")
+        return text
+
+    async def _run_sampler(self, argv: List[str], payload: str):
+        if self._runner is not None:
+            return self._runner(argv, payload)
+        proc = await asyncio.to_thread(
+            subprocess.run, argv, input=payload, capture_output=True, text=True, timeout=self._sampler_timeout
+        )
+        return proc.returncode, proc.stdout, proc.stderr
 
     async def _create(self, model: str, messages: List[Dict[str, str]], temperature: float, max_tokens: int) -> str:
         # Garde budget dur (C4) + capture d'usage AU MÊME chokepoint que le handler

--- a/collegue/executor/__init__.py
+++ b/collegue/executor/__init__.py
@@ -14,6 +14,7 @@ reste donc importable partout sans installer OpenHands.
 from collegue.executor.agent import AgentResult, CodeAgent, FakeCodeAgent, IssueSpec
 from collegue.executor.command import CommandRunner, LocalCommandRunner
 from collegue.executor.openhands_agent import OpenHandsAgent
+from collegue.executor.openhands_sdk_agent import OHSdkAgent
 from collegue.executor.pipeline import ExecutionOutcome, execute_issue
 from collegue.executor.pr import PrClients, PrResult, build_pr_body, exec_marker, open_pr
 from collegue.executor.quality_gate import (
@@ -64,6 +65,7 @@ __all__ = [
     "CodeAgent",
     "FakeCodeAgent",
     "OpenHandsAgent",
+    "OHSdkAgent",
     # E2 — workspace + exécution
     "CommandRunner",
     "LocalCommandRunner",

--- a/collegue/executor/oh_runner.py
+++ b/collegue/executor/oh_runner.py
@@ -1,0 +1,147 @@
+"""Runner headless OpenHands (SDK 1.7) — exécuté DANS le sandbox Docker.
+
+OpenHands 1.7 est SDK-first (plus de CLI ``openhands.core.main``). Ce script est
+l'entrypoint headless : il lit une tâche (``-t``), configure le LLM gemma via env
+(``LLM_MODEL`` au format LiteLLM ``gemini/...`` + ``LLM_API_KEY``), construit
+l'agent par défaut (tools terminal/éditeur/grep/glob) et fait tourner la
+conversation sur le workspace monté (``/workspace``). L'agent édite les fichiers
+en place ; l'exécuteur Collègue capture ensuite le diff autoritatif via git.
+
+Sortie : ``OH_RUNNER_DONE`` (succès) ou un message d'erreur sur stderr + code != 0.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import threading
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="oh_runner")
+    ap.add_argument("-t", "--task", required=True, help="Consigne donnée à l'agent.")
+    ap.add_argument("--workspace", default=os.environ.get("OH_WORKSPACE", "/workspace"))
+    ap.add_argument("--max-iterations", type=int, default=int(os.environ.get("OH_MAX_ITER", "40")))
+    args = ap.parse_args()
+
+    os.environ.setdefault("OPENHANDS_SUPPRESS_BANNER", "1")
+
+    from openhands.sdk import LLM, Conversation
+    from openhands.tools.preset.default import get_default_agent
+
+    primary = os.environ.get("LLM_MODEL", "gemini/gemma-4-31b-it")
+    # Fallback (CSV) : si le primaire échoue (ex. 503 persistants après retries), on
+    # relance la conversation sur le MÊME workspace avec le modèle suivant (l'agent
+    # repart de l'état courant des fichiers). gemma-4-31b-it étant flaky ("high
+    # demand"), le défaut bascule sur le 26b.
+    fallbacks = [
+        m.strip() for m in os.environ.get("OH_FALLBACK_MODELS", "gemini/gemma-4-26b-a4b-it").split(",") if m.strip()
+    ]
+    # Mode abonnement (Codex via ChatGPT Plus/Pro) : pas de clé API, OpenHands
+    # s'authentifie via subscription_login (creds en cache ~/.openhands/auth,
+    # montées depuis l'hôte ; login fait en amont en device_code). Opt-in strict :
+    # sans LLM_SUBSCRIPTION=1, le chemin clé-API (gemma) reste inchangé.
+    subscription = os.environ.get("LLM_SUBSCRIPTION", "") == "1"
+    api_key = os.environ.get("LLM_API_KEY") or os.environ.get("GEMINI_API_KEY")
+    if not subscription and not api_key:
+        print("oh_runner: LLM_API_KEY/GEMINI_API_KEY manquante", file=sys.stderr)
+        return 2
+
+    def run_with(model: str) -> None:
+        # Résilience 503 : on retente longtemps (le budget-temps global du run borne).
+        common = dict(
+            service_id="coder",
+            num_retries=int(os.environ.get("OH_NUM_RETRIES", "8")),
+            retry_min_wait=int(os.environ.get("OH_RETRY_MIN", "8")),
+            retry_max_wait=int(os.environ.get("OH_RETRY_MAX", "90")),
+            timeout=int(os.environ.get("OH_LLM_TIMEOUT", "300")),
+        )
+        if subscription:
+            # L'allow-list client d'OpenHands (OPENAI_CODEX_MODELS) est désynchronisée
+            # du backend ChatGPT : elle liste des SKU *-codex que le serveur REFUSE et
+            # EXCLUT gpt-5.5/gpt-5.4 que le compte sert réellement (vérifié au smoke v6).
+            # On laisse le SERVEUR être l'autorité : on étend l'allow-list avec le
+            # modèle demandé (le serveur valide de toute façon ; un modèle non servi
+            # lève une BadRequestError explicite).
+            try:
+                import openhands.sdk.llm.auth.openai as _oa
+
+                _oa.OPENAI_CODEX_MODELS = frozenset(set(_oa.OPENAI_CODEX_MODELS) | {model})
+            except Exception:
+                pass
+            # open_browser=False : headless, on réutilise les creds en cache (le
+            # login interactif device_code a déjà eu lieu hors-run).
+            llm = LLM.subscription_login(vendor="openai", model=model, open_browser=False, **common)
+        else:
+            llm = LLM(model=model, api_key=api_key, **common)
+        agent = get_default_agent(llm=llm, cli_mode=True)
+        conv = Conversation(agent=agent, workspace=args.workspace, max_iteration_per_run=args.max_iterations)
+        conv.send_message(args.task)
+        # Contrat #464 : émission INCRÉMENTALE (deltas périodiques) — un agrégat
+        # final unique dans un finally perd TOUT au docker-kill (timeout sandbox).
+        stop = threading.Event()
+        pump = threading.Thread(target=_pump_usage, args=(llm, stop), daemon=True)
+        pump.start()
+        try:
+            conv.run()
+        finally:
+            stop.set()
+            pump.join(timeout=10)
+            _emit_usage_delta(llm)  # flush final (delta restant)
+
+    _last_emitted = {"prompt": 0, "completion": 0, "cost": 0.0}
+
+    def _emit_usage_delta(llm) -> None:
+        # Contrat moteur #441/#464 : lignes `[collegue-usage] {json}` en DELTAS
+        # (parse_usage_from_logs SOMME les occurrences — émettre des cumuls
+        # compterait double). Best-effort : télémétrie, jamais une cause d'échec.
+        try:
+            metrics = getattr(llm, "metrics", None)
+            usage = getattr(metrics, "accumulated_token_usage", None)
+            prompt = int(getattr(usage, "prompt_tokens", 0) or 0)
+            completion = int(getattr(usage, "completion_tokens", 0) or 0)
+            # En abonnement (Codex/ChatGPT), il n'y a AUCUNE facturation au token :
+            # litellm estime quand même un prix API (fantôme). On force 0 pour que le
+            # ledger $ du run reflète la réalité (les tokens, eux, restent comptés).
+            cost = 0.0 if subscription else float(getattr(metrics, "accumulated_cost", 0.0) or 0.0)
+            payload = {
+                "prompt_tokens": max(0, prompt - _last_emitted["prompt"]),
+                "completion_tokens": max(0, completion - _last_emitted["completion"]),
+                "cost_usd": max(0.0, cost - _last_emitted["cost"]),
+                # #504 : en abonnement, le run n'est PAS facturé → cost_usd=0 est
+                # AUTORITAIRE. Le flag dit au moteur de NE PAS re-tarifer ce 0 au prix
+                # de secours #484 (sinon coût fantôme). Hors abonnement, billable=true
+                # → un cost=0 reste « inconnu » (modèle non mappé) → #484 légitime.
+                "billable": not subscription,
+            }
+            if payload["prompt_tokens"] or payload["completion_tokens"] or payload["cost_usd"]:
+                print(f"[collegue-usage] {json.dumps(payload)}", flush=True)
+                _last_emitted.update(prompt=prompt, completion=completion, cost=cost)
+        except Exception as exc:  # noqa: BLE001
+            print(f"oh_runner: usage indisponible ({exc})", file=sys.stderr)
+
+    def _pump_usage(llm, stop: "threading.Event") -> None:
+        # Un delta toutes les 30 s : au pire, un docker-kill ne perd que la
+        # dernière fenêtre (vs la tentative ENTIÈRE avant #464).
+        while not stop.wait(30.0):
+            _emit_usage_delta(llm)
+
+    chain = [primary, *[m for m in fallbacks if m != primary]]
+    last_exc = None
+    for idx, model in enumerate(chain):
+        try:
+            print(f"oh_runner: modèle {model} (essai {idx + 1}/{len(chain)})", file=sys.stderr)
+            run_with(model)
+            print("OH_RUNNER_DONE")
+            return 0
+        except Exception as exc:  # noqa: BLE001 - on bascule sur le fallback
+            last_exc = exc
+            print(f"oh_runner: échec avec {model}: {exc}", file=sys.stderr)
+    print(f"oh_runner: tous les modèles ont échoué ({last_exc})", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/collegue/executor/oh_sampler.py
+++ b/collegue/executor/oh_sampler.py
@@ -1,0 +1,113 @@
+"""Échantillonneur LLM one-shot via ABONNEMENT ChatGPT (Codex) — exécuté DANS le sandbox.
+
+Le processus principal ne peut pas appeler ``LLM.subscription_login`` (le SDK OpenHands
+n'est présent que dans l'image sandbox). Ce script généralise le chemin prouvé du coder
+(``oh_runner``) à un appel LLM one-shot : il lit ``{"system": ..., "prompt": ...}`` en JSON
+sur stdin, fait UNE complétion via l'abonnement (modèle fort, ex. gpt-5.4, 0 coût API) et
+imprime la réponse entre ``<<<SAMPLE_BEGIN>>>…<<<SAMPLE_END>>>`` (robuste au bruit/bannière).
+Sert au reviewer/juge du produit (``SubscriptionSampler`` dans le ctx offline). Code != 0 sur échec.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def _extract_text(resp) -> str:
+    """Extraction défensive du texte d'un ``LLMResponse`` OpenHands."""
+    # 1) LLMResponse.message.content (list[TextContent])
+    msg = getattr(resp, "message", None)
+    if msg is not None:
+        content = getattr(msg, "content", None)
+        if isinstance(content, str) and content.strip():
+            return content
+        if isinstance(content, (list, tuple)):
+            parts = []
+            for c in content:
+                t = getattr(c, "text", None)
+                if t:
+                    parts.append(t)
+            if parts:
+                return "\n".join(parts)
+    # 2) litellm raw : resp.choices[0].message.content
+    try:
+        return resp.choices[0].message.content or ""
+    except Exception:  # noqa: BLE001
+        pass
+    # 3) dernier recours
+    return str(resp)
+
+
+def main() -> int:
+    os.environ.setdefault("OPENHANDS_SUPPRESS_BANNER", "1")
+    from openhands.sdk import LLM
+    from openhands.sdk.llm import Message, TextContent
+
+    model = os.environ.get("LLM_MODEL", "gpt-5.4")
+    # L'allow-list client (OPENAI_CODEX_MODELS) est désynchronisée du backend
+    # ChatGPT (cf. oh_runner) : on l'étend avec le modèle demandé, le serveur
+    # reste l'autorité (un modèle non servi lève une BadRequestError explicite).
+    try:
+        import openhands.sdk.llm.auth.openai as _oa
+
+        _oa.OPENAI_CODEX_MODELS = frozenset(set(_oa.OPENAI_CODEX_MODELS) | {model})
+    except Exception:  # noqa: BLE001
+        pass
+
+    data = json.load(sys.stdin)
+    system = str(data.get("system", ""))
+    prompt = str(data.get("prompt", ""))
+
+    llm = LLM.subscription_login(
+        vendor="openai",
+        model=model,
+        open_browser=False,
+        service_id="sampler",
+        num_retries=int(os.environ.get("OH_NUM_RETRIES", "6")),
+        retry_min_wait=int(os.environ.get("OH_RETRY_MIN", "5")),
+        retry_max_wait=int(os.environ.get("OH_RETRY_MAX", "60")),
+        timeout=int(os.environ.get("OH_LLM_TIMEOUT", "180")),
+    )
+    messages = [
+        Message(role="system", content=[TextContent(text=system)]),
+        Message(role="user", content=[TextContent(text=prompt)]),
+    ]
+    # Le backend Codex/ChatGPT FORCE le streaming (self.stream=True) → completion
+    # exige un on_token. On accumule les deltas (source de vérité), repli sur le
+    # LLMResponse final si jamais le stream ressort vide.
+    chunks: list[str] = []
+
+    def _on_token(chunk) -> None:
+        try:
+            delta = chunk.choices[0].delta
+            piece = getattr(delta, "content", None)
+            if piece:
+                chunks.append(piece)
+        except Exception:  # noqa: BLE001
+            pass
+
+    # gpt-5.x via Codex/ChatGPT passe par l'API RESPONSES (/responses), pas
+    # /chat/completions (qui renvoie 404 sur ce backend). On route dynamiquement.
+    use_responses = False
+    try:
+        use_responses = bool(llm.uses_responses_api())
+    except Exception:  # noqa: BLE001
+        use_responses = False
+    call = llm.responses if use_responses else llm.completion
+    resp = call(messages=messages, on_token=_on_token)
+    text = _extract_text(resp)
+    if not (text or "").strip():
+        text = "".join(chunks)
+    sys.stdout.write("<<<SAMPLE_BEGIN>>>" + text + "<<<SAMPLE_END>>>")
+    sys.stdout.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:  # noqa: BLE001
+        print(f"oh_sampler: échec ({exc!r})", file=sys.stderr)
+        sys.exit(1)

--- a/collegue/executor/openhands_sdk_agent.py
+++ b/collegue/executor/openhands_sdk_agent.py
@@ -1,0 +1,101 @@
+"""Agent codeur OpenHands **SDK 1.7** — implémente le contrat ``CodeAgent`` via le sandbox.
+
+OpenHands 1.7 est **SDK-first** : la CLI headless ``openhands.core.main`` (que cible
+l'ancien adaptateur :mod:`collegue.executor.openhands_agent`) **n'existe plus**. Cet
+agent la remplace pour le run réel : il lance :mod:`collegue.executor.oh_runner`
+(``oh_runner.py``, baké dans l'image sandbox via ``docker/sandbox/Dockerfile.openhands``)
+sur le workspace monté, et fait fonctionner le **coder par abonnement** (Codex/ChatGPT,
+gpt-5.5, sans coût API) quand il est activé — le runner appelle ``subscription_login``.
+
+Le **modèle CODER** et la **clé API** (ou l'abonnement) sont fournis par
+l'**environnement du sandbox** (injectés par ``DockerSandbox`` : ``env`` /
+``env_passthrough`` / ``subscription_auth_dir``), **jamais** dans l'argv. L'agent mute
+le workspace ; la **capture autoritative du diff** revient à l'exécuteur Collègue (E2).
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from collegue.core.llm.roles import LLMRole, resolve_role
+from collegue.executor.agent import AgentResult, IssueSpec
+from collegue.executor.openhands_agent import parse_usage_from_logs
+
+# Chemin du runner headless baké dans l'image sandbox (cf. Dockerfile.openhands).
+RUNNER_PATH = "/opt/oh_runner.py"
+
+
+class OHSdkAgent:
+    """:class:`CodeAgent` pilotant OpenHands 1.7 (SDK) en headless dans le ``DockerSandbox``.
+
+    ``sandbox`` expose ``run_command(argv, workspace) -> SandboxResult`` (duck-typing).
+    ``role`` (défaut ``CODER``) résout le modèle via :func:`resolve_role`.
+    """
+
+    def __init__(
+        self,
+        sandbox,
+        *,
+        settings_obj: Optional[object] = None,
+        role: LLMRole = LLMRole.CODER,
+        runner_path: str = RUNNER_PATH,
+        max_iterations: int = 40,
+        python_bin: str = "python",
+    ):
+        self._sandbox = sandbox
+        self._settings = settings_obj
+        self._role = role
+        self._runner_path = runner_path
+        self._max_iterations = int(max_iterations)
+        self._python_bin = python_bin
+
+    def litellm_model(self) -> str:
+        """Modèle CODER au format LiteLLM (``gemini/<modèle>``) pour OpenHands.
+
+        Préfixe ``gemini/`` ajouté si absent (LiteLLM route le provider par préfixe) ;
+        un modèle déjà préfixé (``provider/modèle``) est laissé tel quel. Sert au mode
+        **clé API** ; en mode abonnement, le modèle (gpt-5.5 nu) vient de l'env du sandbox.
+        """
+        _provider, model = resolve_role(self._role, self._settings)
+        if not model:
+            model = "gemma-4-31b-it"
+        return model if "/" in model else f"gemini/{model}"
+
+    def build_command(self, issue: IssueSpec) -> List[str]:
+        """Argv lançant le runner headless OpenHands sur le workspace (pur, testable).
+
+        Le **nom du modèle** (non secret) et l'éventuel ``LLM_SUBSCRIPTION`` sont injectés
+        par le sandbox via l'environnement ; la clé API via ``env_passthrough``. La consigne
+        est ``issue.to_prompt()`` (déjà sanitizée). On passe un **argv** (pas de ``sh -c``) :
+        aucune injection shell.
+        """
+        return [
+            self._python_bin,
+            self._runner_path,
+            "--max-iterations",
+            str(self._max_iterations),
+            "-t",
+            issue.to_prompt(),
+        ]
+
+    def implement_issue(self, workspace: str, issue: IssueSpec) -> AgentResult:
+        """Lance OpenHands (SDK) dans le sandbox sur ``workspace`` pour ``issue``.
+
+        Le diff autoritatif est capturé par l'exécuteur (E2) ; ici on ne renvoie que le
+        statut (code de sortie du sandbox) et les logs (bornés). Un runner qui crashe
+        (ex. 503 LLM après retries) ⇒ ``success=False`` (fail-closed amont). L'usage
+        ``[collegue-usage]`` émis par le runner remonte au ledger du run (#441/#464/#504 :
+        ``cost_authoritative`` = abonnement non facturé → coût 0 à NE PAS re-tarifer #484).
+        """
+        result = self._sandbox.run_command(self.build_command(issue), workspace)
+        logs = "\n".join(part for part in (result.stdout, result.stderr) if part).strip()
+        prompt_tokens, completion_tokens, cost_usd, cost_authoritative = parse_usage_from_logs(logs)
+        return AgentResult(
+            success=result.ok,
+            logs=logs[-8000:],
+            summary=f"OpenHands SDK sur l'issue #{issue.number}",
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            cost_usd=cost_usd,
+            cost_authoritative=cost_authoritative,
+        )

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -114,25 +114,60 @@ def _sandbox_subscription_auth(settings_obj):
     return os.path.expanduser(raw)
 
 
+def _coder_sandbox_env(settings_obj) -> dict:
+    """Env du sandbox pour le coder OpenHands SDK (``oh_runner``) — parité harnais↔produit.
+
+    Politique retries du canal coder (#422), puis selon ``CODER_SUBSCRIPTION`` : soit le
+    modèle d'**abonnement** nu (gpt-5.5 + ``LLM_SUBSCRIPTION=1`` + fallback gpt-5.4 ;
+    le runner appelle ``subscription_login`` avec les creds montées), soit le modèle
+    **CODER** au format LiteLLM (``gemini/<modèle>``) avec clé API. ``HOME`` hors /tmp est
+    requis par le montage des creds d'abonnement.
+    """
+    from collegue.executor.openhands_sdk_agent import OHSdkAgent
+
+    env = {
+        "HOME": "/home/sandbox",
+        "OPENHANDS_SUPPRESS_BANNER": "1",
+        "OH_NUM_RETRIES": str(getattr(settings_obj, "CODER_LLM_NUM_RETRIES", 8)),
+        "OH_RETRY_MIN": str(getattr(settings_obj, "CODER_LLM_RETRY_MIN_WAIT", 8)),
+        "OH_RETRY_MAX": str(getattr(settings_obj, "CODER_LLM_RETRY_MAX_WAIT", 90)),
+    }
+    if bool(getattr(settings_obj, "CODER_SUBSCRIPTION", False)):
+        env["LLM_MODEL"] = str(getattr(settings_obj, "CODER_SUBSCRIPTION_MODEL", "gpt-5.5") or "gpt-5.5")
+        env["LLM_SUBSCRIPTION"] = "1"
+        env["OH_FALLBACK_MODELS"] = str(getattr(settings_obj, "CODER_SUBSCRIPTION_FALLBACK", "gpt-5.4") or "gpt-5.4")
+    else:
+        env["LLM_MODEL"] = OHSdkAgent(object(), settings_obj=settings_obj).litellm_model()
+    return env
+
+
 def _build_sandbox(settings_obj):  # pragma: no cover - infra réelle (integration)
     from collegue.sandbox import DockerSandbox
 
     # OpenHands appelle un LLM → le sandbox a besoin du réseau pour ce run précis
-    # (le défaut durci est ``network="none"``). #485 : résolveurs DNS explicites
-    # opt-in (SANDBOX_DNS) — le résolveur Docker par défaut était instable en
-    # run réel (gate ET coder, le sandbox est partagé).
+    # (défaut durci ``network="none"``). ``SANDBOX_NETWORK`` ("host" éprouvé contre la
+    # flakiness pip du bridge, #485) ; ressources remontées (les défauts 512m/1cpu/120s
+    # sont trop bas pour OpenHands). Le coder (oh_runner SDK) lit ``env`` + l'abonnement
+    # via ``subscription_auth_dir`` ; la clé API passe par ``env_passthrough`` (jamais l'argv).
     return DockerSandbox(
-        network="bridge",
+        network=str(getattr(settings_obj, "SANDBOX_NETWORK", "bridge") or "bridge"),
         dns=_sandbox_dns(settings_obj),
         pip_cache_dir=_sandbox_pip_cache(settings_obj),  # #496 : cache pip persistant opt-in
         subscription_auth_dir=_sandbox_subscription_auth(settings_obj),  # creds abo Codex/ChatGPT
+        env=_coder_sandbox_env(settings_obj),
+        env_passthrough=("LLM_API_KEY", "GEMINI_API_KEY"),
+        memory=str(getattr(settings_obj, "SANDBOX_MEMORY", "6g") or "6g"),
+        cpus=str(getattr(settings_obj, "SANDBOX_CPUS", "2.0") or "2.0"),
+        timeout=float(getattr(settings_obj, "SANDBOX_TIMEOUT", 2400.0) or 2400.0),
     )
 
 
 def _build_agent(sandbox, settings_obj):  # pragma: no cover - infra réelle (integration)
-    from collegue.executor import OpenHandsAgent
+    # OpenHands 1.7 est SDK-first : ``openhands.core.main`` n'existe plus → on utilise
+    # l'agent SDK (``oh_runner`` baké dans l'image), qui gère aussi l'abonnement gpt-5.5.
+    from collegue.executor import OHSdkAgent
 
-    return OpenHandsAgent(sandbox, settings_obj=settings_obj)
+    return OHSdkAgent(sandbox, settings_obj=settings_obj)
 
 
 def _build_reviewer(settings_obj):  # pragma: no cover - infra réelle (integration)
@@ -228,6 +263,98 @@ def _build_acceptance_checker(settings_obj):  # pragma: no cover - infra réelle
 # ── point d'entrée assemblé ────────────────────────────────────────────────────
 
 
+# ── merge-bot de la phase BUILD (#411/#434) ────────────────────────────────────
+# Garde-fou anti-boucle de la boucle d'orchestration (driver ↔ merge), au-delà du
+# nombre de tâches (chaque passe traite ~1 PR en mode strict 1-en-vol).
+_MERGE_BOT_OUTER_CAP = 500
+
+
+async def _try_merge_pr(prs, owner, repo, number, *, attempts: int = 5, sleep_fn=None):
+    """Merge (squash) avec relances courtes — GitHub calcule la mergeabilité en différé.
+
+    Retourne ``(True, result)`` au premier succès (ou PR déjà mergée), sinon
+    ``(False, dernière_raison)``. Une non-mergeabilité / erreur HTTP est journalisée
+    par l'appelant (le moteur réconciliera au prochain démarrage, #442)."""
+    sleep_fn = sleep_fn or asyncio.sleep
+    last = None
+    for i in range(attempts):
+        try:
+            res = prs.merge_pr(owner, repo, number, method="squash")
+            if getattr(res, "merged", False) or getattr(res, "already_merged", False):
+                return True, res
+            last = getattr(res, "message", None) or getattr(res, "reason", None) or "non mergée"
+        except Exception as exc:  # noqa: BLE001 - non-mergeable/HTTP : journalisé, réconcilié plus tard
+            last = str(exc)
+        await sleep_fn(min(5 * (i + 1), 20))
+    return False, last
+
+
+def _resync_repo_source(repo_source: str, base: str, *, git_runner=None) -> bool:
+    """Resynchronise le clone LOCAL sur ``origin/<base>`` (plomberie git locale).
+
+    Après un merge sur GitHub, le ``repo_source`` local est PÉRIMÉ ; la tâche
+    suivante (qui le clone) ne contiendrait pas le code mergé → conflits. On
+    ``fetch`` + ``reset --hard`` pour que la base reparte du MVP en cours."""
+    from collegue.executor.command import LocalCommandRunner
+
+    runner = git_runner or LocalCommandRunner()
+    fetched = runner.run_command(["git", "fetch", "origin", base], repo_source)
+    reset = runner.run_command(["git", "reset", "--hard", f"origin/{base}"], repo_source)
+    return bool(getattr(fetched, "ok", False) and getattr(reset, "ok", False))
+
+
+async def _merge_in_review_prs(
+    manager,
+    clients,
+    *,
+    project_id: int,
+    owner: str,
+    repo: str,
+    repo_source: str,
+    base: str,
+    git_runner=None,
+    sleep_fn=None,
+) -> int:
+    """Merge-bot du BUILD : merge les PR des tâches ``in_review`` puis resync le clone.
+
+    Simule le merge HUMAIN pendant la construction autonome du MVP — sans lui, avec
+    1 PR en vol (#434) + deps strictes (#411), le driver s'arrête ``awaiting_merge``
+    et le build n'avance pas. **N'est appelé que par la phase build** : la phase
+    d'amélioration laisse ses PR ouvertes pour merge humain (§6). Retourne le nombre
+    de PR mergées sur cette passe."""
+    from collegue.executor.workspace import branch_for_issue
+    from collegue.pilot.driver import TASK_STATUS_IN_REVIEW, TASK_STATUS_MERGED
+
+    prs = clients.prs
+    merged = 0
+    for task in manager.get_tasks(project_id):
+        if getattr(task, "status", None) != TASK_STATUS_IN_REVIEW:
+            continue
+        branch = branch_for_issue(getattr(task, "issue_number", None) or task.id)
+        number = getattr(task, "pr_number", None)
+        if not number:
+            found = prs.find_pr_by_head(owner, repo, branch, base=base)
+            number = getattr(found, "number", None)
+        if not number:
+            logger.warning("merge-bot: aucune PR trouvée pour la tâche %s (%s)", task.id, branch)
+            continue
+        ok, info = await _try_merge_pr(prs, owner, repo, number, sleep_fn=sleep_fn)
+        if ok:
+            manager.update_task_status(task.id, TASK_STATUS_MERGED)
+            merged += 1
+            if not _resync_repo_source(repo_source, base, git_runner=git_runner):
+                logger.warning(
+                    "merge-bot: resync git du clone (%s) sur origin/%s a ÉCHOUÉ — la tâche "
+                    "suivante pourrait partir d'une base périmée (conflit possible).",
+                    repo_source,
+                    base,
+                )
+            logger.info("merge-bot: PR #%s mergée (tâche %s) → clone resync sur %s", number, task.id, base)
+        else:
+            logger.warning("merge-bot: merge PR #%s (tâche %s) échoué: %s", number, task.id, str(info)[:200])
+    return merged
+
+
 async def run_project_from_settings(
     project_id: int,
     repo_source: str,
@@ -298,40 +425,100 @@ async def run_project_from_settings(
     if ctx is None:
         ctx = _build_ctx(settings_obj)
 
+    # Merge-bot de la phase BUILD (§6 : auto-merge build, merge humain en amélioration).
+    # En dry_run, jamais d'auto-merge (aucune écriture). Off → 1 seule passe (comportement
+    # historique : arrêt `awaiting_merge`, le merge humain reprend au prochain run).
+    auto_merge = bool(getattr(settings_obj, "BUILD_AUTO_MERGE", True)) and not dry_run
+    # En auto-merge, on EXIGE le merge des deps (le merge-bot le fournit) — un dépendant
+    # ne doit pas partir d'une base sans le code mergé de sa dépendance (#411).
+    require_merged = True if auto_merge else bool(getattr(settings_obj, "DEPS_REQUIRE_MERGED", False))
+
+    run_kwargs = dict(
+        agent=agent,
+        owner=owner,
+        repo=repo,
+        manager=manager,
+        base=base,
+        budget=budget,
+        sandbox=sandbox,
+        reviewer=reviewer,
+        clients=clients,
+        dry_run=dry_run,
+        max_iterations=max_iterations,
+        # improve ne se déclenche qu'à la COMPLÉTION du build (jamais sur un arrêt
+        # `awaiting_merge`) → on peut le passer à chaque passe : il ne s'amorce qu'au
+        # dernier tour, une fois tout mergé. La phase improve n'auto-merge pas ses PR.
+        improve=improve,
+        run_improvement_fn=run_improvement_fn,
+        # Retry au niveau tâche (#420) : le chemin assemblé est résilient par défaut
+        # (TASK_MAX_ATTEMPTS=3 en config) ; le module driver isolé reste, lui, à 1.
+        max_task_attempts=getattr(settings_obj, "TASK_MAX_ATTEMPTS", 3),
+        retry_backoff_seconds=getattr(settings_obj, "TASK_RETRY_BACKOFF_SECONDS", 15.0),
+        # Cohérence inter-tâches (#411) : forcé en auto-merge, sinon opt-in config.
+        require_merged_deps=require_merged,
+        # Intégration sérielle en mode strict (#434) : 1 PR en vol par défaut.
+        max_inflight_reviews=getattr(settings_obj, "STRICT_MAX_INFLIGHT_PRS", 1),
+        # Gate configurable par projet (#438) : commande de tests + passe frontend.
+        gate_options=_gate_options(settings_obj),
+        # Gouvernance de coût (#441) : ledger + source process branchés en réel.
+        audit=audit,
+        cost_source=cost_source,
+        # #502 : refus opt-in de démarrer si le prix coder n'est pas résolvable.
+        require_cost_pricing=bool(getattr(settings_obj, "REQUIRE_COST_PRICING", False)),
+    )
+
     try:
-        result = await run_project(
-            project_id,
-            repo_source,
-            ctx,
-            agent=agent,
-            owner=owner,
-            repo=repo,
-            manager=manager,
-            base=base,
-            budget=budget,
-            sandbox=sandbox,
-            reviewer=reviewer,
-            clients=clients,
-            dry_run=dry_run,
-            max_iterations=max_iterations,
-            improve=improve,
-            run_improvement_fn=run_improvement_fn,
-            # Retry au niveau tâche (#420) : le chemin assemblé est résilient par défaut
-            # (TASK_MAX_ATTEMPTS=3 en config) ; le module driver isolé reste, lui, à 1.
-            max_task_attempts=getattr(settings_obj, "TASK_MAX_ATTEMPTS", 3),
-            retry_backoff_seconds=getattr(settings_obj, "TASK_RETRY_BACKOFF_SECONDS", 15.0),
-            # Cohérence inter-tâches (#411) : opt-in pour exiger le merge des deps.
-            require_merged_deps=bool(getattr(settings_obj, "DEPS_REQUIRE_MERGED", False)),
-            # Intégration sérielle en mode strict (#434) : 1 PR en vol par défaut.
-            max_inflight_reviews=getattr(settings_obj, "STRICT_MAX_INFLIGHT_PRS", 1),
-            # Gate configurable par projet (#438) : commande de tests + passe frontend.
-            gate_options=_gate_options(settings_obj),
-            # Gouvernance de coût (#441) : ledger + source process branchés en réel.
-            audit=audit,
-            cost_source=cost_source,
-            # #502 : refus opt-in de démarrer si le prix coder n'est pas résolvable.
-            require_cost_pricing=bool(getattr(settings_obj, "REQUIRE_COST_PRICING", False)),
-        )
+        from collegue.pilot.driver import STOP_AWAITING_MERGE
+
+        all_processed: List[Any] = []
+        no_merge_streak = 0
+        outer = 0
+        while True:
+            outer += 1
+            result = await run_project(project_id, repo_source, ctx, **run_kwargs)
+            all_processed.extend(result.processed)
+            # Fin : pas d'auto-merge, ou arrêt pour une autre raison que « merges manquants ».
+            if not auto_merge or result.stop_reason != STOP_AWAITING_MERGE:
+                break
+            merged = await _merge_in_review_prs(
+                manager,
+                clients,
+                project_id=project_id,
+                owner=owner,
+                repo=repo,
+                repo_source=repo_source,
+                base=base,
+            )
+            if merged == 0:
+                # Aucune PR mergeable sur 2 passes consécutives → on n'insiste pas
+                # (PR réellement non mergeable : laissée au merge humain / réconciliation).
+                no_merge_streak += 1
+                if no_merge_streak >= 2:
+                    logger.warning("merge-bot: aucun merge sur 2 passes — arrêt en awaiting_merge.")
+                    break
+            else:
+                no_merge_streak = 0
+            if outer >= _MERGE_BOT_OUTER_CAP:
+                logger.warning("merge-bot: plafond d'itérations (%d) atteint — arrêt.", _MERGE_BOT_OUTER_CAP)
+                break
+        if auto_merge:
+            # Drain final : à la COMPLÉTION, la DERNIÈRE tâche reste `in_review` — le build
+            # complète dès que sa PR est ouverte (plus aucune tâche prête), SANS repasser par
+            # `awaiting_merge` → la boucle ci-dessus ne l'aurait pas mergée. On draine les PR
+            # in_review résiduelles (travail validé) pour finir le MVP à 100%. Idempotent.
+            await _merge_in_review_prs(
+                manager,
+                clients,
+                project_id=project_id,
+                owner=owner,
+                repo=repo,
+                repo_source=repo_source,
+                base=base,
+            )
+            # Le reporting reflète TOUTES les tâches traitées sur l'ensemble des passes
+            # (sinon `processed`/`iterations` ne refléteraient que la dernière passe).
+            result.processed = all_processed
+            result.iterations = len(all_processed)
 
         # Reporting (journal de décisions) — réel uniquement (dry_run n'écrit rien).
         if not dry_run:

--- a/collegue/tools/code_review/config.py
+++ b/collegue/tools/code_review/config.py
@@ -61,13 +61,18 @@ NAMING_CONVENTIONS = {
     },
 }
 
+# NB : ``(?<!hashed_)`` sur ``password`` — un mot de passe **HACHÉ**
+# (``hashed_password="..."``) est le stockage SÉCURISÉ d'un HASH, pas un secret en
+# clair : il était flaggé CRITICAL à tort et bloquait le gate sur des fixtures de test
+# (run V11). Les vrais secrets préfixés (``db_password=``, ``AWS_SECRET=``) restent
+# flaggés ; les vrais secrets sont aussi couverts par ``secret_scan`` et la revue LLM.
 SECURITY_PATTERNS = {
     "python": [
         r"eval\s*\(",
         r"exec\s*\(",
         r"os\.system\s*\(",
         r"subprocess\.call\s*\(.*shell\s*=\s*True",
-        r"(?i)password\s*=\s*['\"]",
+        r"(?i)(?<!hashed_)password\s*=\s*['\"]",
         r"(?i)api_key\s*=\s*['\"]",
         r"(?i)secret\s*=\s*['\"]",
     ],
@@ -75,7 +80,7 @@ SECURITY_PATTERNS = {
         r"eval\s*\(",
         r"innerHTML\s*=",
         r"document\.write\s*\(",
-        r"(?i)password\s*[=:]\s*['\"]",
+        r"(?i)(?<!hashed_)password\s*[=:]\s*['\"]",
         r"(?i)apiKey\s*[=:]\s*['\"]",
     ],
 }

--- a/collegue/tools/code_review/engine.py
+++ b/collegue/tools/code_review/engine.py
@@ -16,6 +16,19 @@ from .config import (
 )
 from .models import ReviewFinding
 
+# Lignes DÉCLARATIVES dont la répétition est LÉGITIME (pas de la duplication de
+# logique) : imports, décorateurs, déclarations de colonnes/champs ORM et opérations
+# de migration. Un schéma multi-tables a NORMALEMENT ``id``/``created_at``/
+# ``PrimaryKeyConstraint`` répétés par table — ``analyze_dry`` les flaggait en masse
+# (42 faux-positifs sur une migration Alembic), faisant chuter le score du gate (run V11).
+_DRY_BOILERPLATE_RE = re.compile(
+    r"^(?:from|import)\s"  # imports
+    r"|^@"  # décorateurs
+    r"|\bop\.\w+\("  # opérations de migration Alembic (op.create_table, op.create_index…)
+    r"|\b(?:sa\.|db\.)?(?:Column|mapped_column|relationship|Field)\s*\("  # colonnes/champs ORM
+    r"|\b(?:sa\.|db\.)?(?:PrimaryKeyConstraint|ForeignKeyConstraint|UniqueConstraint|Index)\s*\("  # contraintes
+)
+
 
 class CodeReviewEngine:
     """Moteur d'analyse de code pour les revues."""
@@ -107,7 +120,12 @@ class CodeReviewEngine:
                     findings.append(
                         ReviewFinding(
                             category="complexity",
-                            severity="error" if func_complexity > 15 else "warning",
+                            # Maintenabilité (complexité cyclomatique) = ADVISORY, jamais
+                            # bloquant : une fonction inhéremment complexe dont les tests
+                            # sont VERTS ne doit pas faire échouer terminalement le build
+                            # autonome (run V11, tâche PDF #63). La revue LLM (rôle REVIEWER)
+                            # reste le juge des vrais défauts ; ce finding informe le PR.
+                            severity="warning",
                             line=func_start,
                             title=f"Complexité élevée: '{func_name}' (score={func_complexity})",
                             description=(
@@ -148,7 +166,8 @@ class CodeReviewEngine:
             findings.append(
                 ReviewFinding(
                     category="complexity",
-                    severity="error" if func_complexity > 15 else "warning",
+                    # Maintenabilité = ADVISORY (cf. ci-dessus, run V11 #63) — jamais bloquant.
+                    severity="warning",
                     line=func_start,
                     title=f"Complexité élevée: '{func_name}' (score={func_complexity})",
                     description=(
@@ -188,21 +207,27 @@ class CodeReviewEngine:
 
         seen = {}
         for i, line in enumerate(lines):
-            if len(line) > 20 and not line.startswith("#") and not line.startswith("//"):
-                if line in seen:
-                    findings.append(
-                        ReviewFinding(
-                            category="dry",
-                            severity="warning",
-                            line=i + 1,
-                            title="Code dupliqué",
-                            description=(
-                                f"Ligne identique trouvée aux lignes {seen[line]} et {i + 1}: '{line[:60]}...'"
-                            ),
-                        )
+            # On compare le CONTENU (marqueur de diff +/- retiré) : une migration/un
+            # schéma est souvent revu sous forme de diff.
+            bare = line[1:].strip() if line[:1] in "+-" else line
+            if len(bare) <= 20 or bare.startswith("#") or bare.startswith("//"):
+                continue
+            # Répétition LÉGITIME de boilerplate déclarative (colonnes ORM, contraintes,
+            # opérations Alembic, imports) ≠ duplication de logique → on n'en fait pas un finding.
+            if _DRY_BOILERPLATE_RE.search(bare):
+                continue
+            if bare in seen:
+                findings.append(
+                    ReviewFinding(
+                        category="dry",
+                        severity="warning",
+                        line=i + 1,
+                        title="Code dupliqué",
+                        description=(f"Ligne identique trouvée aux lignes {seen[bare]} et {i + 1}: '{bare[:60]}...'"),
                     )
-                else:
-                    seen[line] = i + 1
+                )
+            else:
+                seen[bare] = i + 1
 
         return findings
 
@@ -230,7 +255,12 @@ class CodeReviewEngine:
                         findings.append(
                             ReviewFinding(
                                 category="error_handling",
-                                severity="error",
+                                # ADVISORY (pas bloquant) : l'heuristique `except…: pass` a des
+                                # faux-positifs (best-effort/cleanup intentionnel, marqueurs de
+                                # diff) et reste de la robustesse, pas une faute de correction —
+                                # ne pas faire échouer terminalement un build aux tests VERTS. La
+                                # revue LLM signale les silences réellement dangereux.
+                                severity="warning",
                                 line=i,
                                 title="Exception silencieuse",
                                 description="Exception attrapée et ignorée (pass). Loggez ou re-lancez l'erreur.",
@@ -244,10 +274,17 @@ class CodeReviewEngine:
         if total_lines == 0:
             return 1.0
 
+        # Seules les sévérités BLOQUANTES (critical/error) pèsent sur le score qui GATE
+        # le build : un finding advisory (info/warning) est déclaré non-bloquant (cf.
+        # ``BLOCKING_SEVERITIES`` côté gate). Le laisser faire chuter le score le faisait
+        # bloquer INDIRECTEMENT — incohérent — et des nits de style crus (boilerplate de
+        # migration comptée comme duplication, run V11) suffisaient à couler un diff sain.
+        # Les findings advisory restent listés (corps de PR / dashboard), informatifs.
         penalty = 0.0
         for f in findings:
-            weight = SEVERITY_WEIGHTS.get(f.severity, 0.1)
-            penalty += weight
+            if f.severity not in ("critical", "error"):
+                continue
+            penalty += SEVERITY_WEIGHTS.get(f.severity, 0.1)
 
         # Normaliser par la taille du code (codes plus grands tolèrent plus de findings)
         size_factor = max(1.0, total_lines / 50.0)

--- a/docker/sandbox/Dockerfile.openhands
+++ b/docker/sandbox/Dockerfile.openhands
@@ -73,17 +73,16 @@ ENV RUNTIME=process \
     OPENHANDS_DISABLE_BROWSER=1 \
     OPENHANDS_SUPPRESS_BANNER=1
 
-# Runner SDK du HARNAIS (scripts/facnor_run/oh_runner.py, gitignoré) baké SI présent
-# dans le contexte de build — utilisé par l'OHSdkAgent du harnais. Le PRODUIT
-# (collegue/executor/openhands_agent.py → openhands.core.main) n'en a PAS besoin :
-# l'image se construit donc depuis les **sources committées seules** (CI / #404).
-# `scripts/` est committé (le COPY ne casse jamais) ; oh_runner.py n'y apparaît que
-# dans l'arbre du harnais (pas de .dockerignore → inclus au contexte quand présent).
-COPY scripts/ /tmp/_collegue_scripts/
-RUN if [ -f /tmp/_collegue_scripts/facnor_run/oh_runner.py ]; then \
-        cp /tmp/_collegue_scripts/facnor_run/oh_runner.py /opt/oh_runner.py; \
-    fi; \
-    rm -rf /tmp/_collegue_scripts
+# Runner headless OpenHands SDK, baké depuis la source COMMITTÉE du produit
+# (collegue/executor/oh_runner.py) → lancé par OHSdkAgent (collegue.executor.
+# openhands_sdk_agent). OpenHands 1.7 étant SDK-first (plus de openhands.core.main),
+# c'est le coder réel du produit ET du harnais ; l'image se construit depuis les
+# sources committées seules (CI / #404).
+COPY collegue/executor/oh_runner.py /opt/oh_runner.py
+# Échantillonneur one-shot par abonnement (reviewer/juge gpt-5.4) — lancé par le ctx
+# offline (SubscriptionSampler) via ``docker run``. Le ctx le monte par défaut depuis la
+# source committée ; baké ici pour les images self-contained.
+COPY collegue/executor/oh_sampler.py /opt/oh_sampler.py
 
 # Utilisateur non-root (le `docker run` surcharge --user pour matcher l'UID hôte).
 RUN useradd --create-home --uid 1000 sandbox

--- a/tests/test_code_review.py
+++ b/tests/test_code_review.py
@@ -68,6 +68,13 @@ class TestComplexityAnalysis:
         findings = engine.analyze_complexity(code, "python")
         assert any("complexité" in f.title.lower() or "imbrication" in f.title.lower() for f in findings)
 
+    def test_high_complexity_is_advisory_not_blocking(self, engine):
+        # Complexité élevée = maintenabilité ADVISORY (warning), jamais `error` bloquant —
+        # une fonction complexe aux tests verts ne doit pas échouer terminalement le build (V11 #63).
+        code = "def f(x):\n" + "".join(f"    if x=={i}:\n        return {i}\n" for i in range(20))
+        complexity = [f for f in engine.analyze_complexity(code, "python") if f.category == "complexity"]
+        assert complexity and all(f.severity == "warning" for f in complexity)
+
     def test_simple_function(self, engine):
         code = "def hello():\n    print('hello')"
         findings = engine.analyze_complexity(code, "python")
@@ -95,6 +102,17 @@ class TestSecurityAnalysis:
         code = "x = 1 + 2\nprint(x)"
         findings = engine.analyze_security(code, "python")
         assert len(findings) == 0
+
+    def test_hashed_password_not_flagged(self, engine):
+        # Un mot de passe HACHÉ (stockage sécurisé) ne doit PAS être flaggé CRITICAL —
+        # faux-positif qui bloquait le gate sur des fixtures de test (run V11).
+        code = 'user = User(email="a@b.c", hashed_password="hashed")'
+        assert engine.analyze_security(code, "python") == []
+
+    def test_real_prefixed_secret_still_flagged(self, engine):
+        # Un VRAI secret préfixé (db_password en clair) reste flaggé — on n'exclut QUE le hash.
+        findings = engine.analyze_security('db_password = "S3cr3t!"', "python")
+        assert any(f.category == "security" and f.severity == "critical" for f in findings)
 
     def test_uppercase_password_detected(self, engine):
         findings = engine.analyze_security('PASSWORD = "admin123"', "python")
@@ -135,6 +153,29 @@ class TestDryAnalysis:
         findings = engine.analyze_dry(code, "python")
         assert len(findings) == 0
 
+    def test_orm_and_migration_boilerplate_not_flagged(self, engine):
+        # Une migration/un schéma multi-tables répète LÉGITIMEMENT colonnes, contraintes
+        # et opérations (id/created_at par table) — ce n'est pas de la duplication de
+        # logique. Flaggé en masse, ça coulait le score du gate (run V11).
+        diff = (
+            '+    op.create_table("users",\n'
+            '+        sa.Column("id", sa.Integer(), nullable=False),\n'
+            '+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),\n'
+            '+        sa.PrimaryKeyConstraint("id"),\n'
+            '+    op.create_table("clients",\n'
+            '+        sa.Column("id", sa.Integer(), nullable=False),\n'
+            '+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),\n'
+            '+        sa.PrimaryKeyConstraint("id"),\n'
+            "+from sqlalchemy import Column, Integer\n"
+            "+from sqlalchemy import Column, Integer\n"
+        )
+        assert engine.analyze_dry(diff, "python") == []
+
+    def test_real_logic_duplication_still_flagged_in_diff(self, engine):
+        # Une vraie duplication de LOGIQUE (même sous forme de diff) reste détectée.
+        diff = "+    total = compute_total(x) + tax_amount(x)\n+    total = compute_total(x) + tax_amount(x)\n"
+        assert any(f.category == "dry" for f in engine.analyze_dry(diff, "python"))
+
 
 # --- Engine: Error Handling ---
 
@@ -149,6 +190,13 @@ class TestErrorHandlingAnalysis:
         code = "try:\n    do_something()\nexcept Exception:\n    pass"
         findings = engine.analyze_error_handling(code, "python")
         assert any("silencieuse" in f.title.lower() or "except" in f.title.lower() for f in findings)
+
+    def test_error_handling_findings_are_advisory(self, engine):
+        # `except: pass` reste signalé mais ADVISORY (warning) — heuristique crue à
+        # faux-positifs (best-effort intentionnel) : ne bloque pas un build aux tests verts.
+        code = "try:\n    x()\nexcept:\n    pass"
+        findings = engine.analyze_error_handling(code, "python")
+        assert findings and all(f.severity != "error" for f in findings)
 
 
 # --- Engine: Scores ---
@@ -167,6 +215,20 @@ class TestScores:
         score = engine.calculate_quality_score(findings, 50)
         assert 0.0 <= score <= 1.0
         assert score < 1.0
+
+    def test_quality_score_ignores_advisory_findings(self, engine):
+        # Des findings advisory (info/warning) seuls ne font PAS chuter le score qui gate
+        # le build — cohérence avec BLOCKING_SEVERITIES (sinon des nits de style bloquent).
+        findings = [
+            ReviewFinding(category="dry", severity="warning", title=f"w{i}", description="d") for i in range(20)
+        ]
+        findings.append(ReviewFinding(category="naming", severity="info", title="i", description="d"))
+        assert engine.calculate_quality_score(findings, 50) == 1.0
+
+    def test_quality_score_driven_by_blocking_severities(self, engine):
+        # À l'inverse, un finding critical/error (vrai défaut, ex. de la revue LLM) coule le score.
+        err = [ReviewFinding(category="bug", severity="error", title="e", description="d")]
+        assert engine.calculate_quality_score(err, 50) < 1.0
 
     def test_category_scores(self, engine):
         findings = [

--- a/tests/test_openhands_sdk_agent.py
+++ b/tests/test_openhands_sdk_agent.py
@@ -1,0 +1,87 @@
+"""Tests de l'agent codeur OpenHands SDK 1.7 (``OHSdkAgent``) — construction pure, sans OpenHands.
+
+OpenHands 1.7 est SDK-first : ``openhands.core.main`` n'existe plus → le coder réel
+lance ``oh_runner.py`` (baké dans l'image). Modèle/clé/abonnement passent par l'env du
+sandbox (jamais l'argv). L'exécution réelle est derrière le marqueur ``integration``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from collegue.executor import CodeAgent, IssueSpec, OHSdkAgent
+from collegue.sandbox import SandboxResult
+
+
+def _settings(**kw):
+    base = {"LLM_PROVIDER": "gemini", "LLM_MODEL": "global-model"}
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+# --- résolution du modèle (format LiteLLM) -------------------------------------
+
+
+def test_litellm_model_prefixes_gemini_when_unprefixed():
+    agent = OHSdkAgent(object(), settings_obj=_settings(LLM_MODEL_CODER="gemma-x"))
+    assert agent.litellm_model() == "gemini/gemma-x"
+
+
+def test_litellm_model_keeps_already_prefixed():
+    agent = OHSdkAgent(object(), settings_obj=_settings(LLM_MODEL_CODER="openai/gpt-5.5"))
+    assert agent.litellm_model() == "openai/gpt-5.5"
+
+
+def test_litellm_model_falls_back_to_global():
+    assert OHSdkAgent(object(), settings_obj=_settings()).litellm_model() == "gemini/global-model"
+
+
+# --- build_command : lance le runner, rien de secret dans l'argv ----------------
+
+
+def test_build_command_runs_runner_with_task():
+    agent = OHSdkAgent(object(), settings_obj=_settings(), max_iterations=12)
+    issue = IssueSpec(number=9, title="Faire la chose")
+    argv = agent.build_command(issue)
+    assert argv == ["python", "/opt/oh_runner.py", "--max-iterations", "12", "-t", issue.to_prompt()]
+    # ni modèle ni clé dans l'argv (injectés par l'env du sandbox) → pas de fuite via ps.
+    assert not any("API_KEY" in part or "LLM_MODEL" in part for part in argv)
+
+
+# --- implement_issue : statut + usage ------------------------------------------
+
+
+class _Sandbox:
+    def __init__(self, result):
+        self._result = result
+        self.calls = []
+
+    def run_command(self, argv, workspace):
+        self.calls.append((argv, workspace))
+        return self._result
+
+
+def test_implement_issue_parses_usage_and_subscription_authoritative():
+    out = (
+        "oh_runner: modèle gpt-5.5\n"
+        '[collegue-usage] {"prompt_tokens": 100, "completion_tokens": 20, "cost_usd": 0.0, "billable": false}\n'
+        "OH_RUNNER_DONE"
+    )
+    sandbox = _Sandbox(SandboxResult(exit_code=0, stdout=out, stderr=""))
+    res = OHSdkAgent(sandbox, settings_obj=_settings()).implement_issue("/ws", IssueSpec(number=3, title="T"))
+    assert res.success is True
+    assert res.prompt_tokens == 100 and res.completion_tokens == 20
+    assert res.cost_usd == 0.0
+    assert res.cost_authoritative is True  # billable:false (abonnement) → coût 0 autoritaire (#504)
+    assert sandbox.calls[0][1] == "/ws"
+
+
+def test_implement_issue_failure_is_fail_closed():
+    res = OHSdkAgent(_Sandbox(SandboxResult(exit_code=1, stdout="", stderr="boom"))).implement_issue(
+        "/ws", IssueSpec(number=1, title="T")
+    )
+    assert res.success is False
+
+
+def test_sdk_agent_satisfies_codeagent_protocol():
+    assert isinstance(OHSdkAgent(object()), CodeAgent)

--- a/tests/test_pilot_e2e.py
+++ b/tests/test_pilot_e2e.py
@@ -133,12 +133,15 @@ async def test_plan_then_run_handoff_via_product(monkeypatch, manager, git_repo)
     assert all(t.status == "todo" for t in manager.get_tasks(plan.project_id))
 
     # 2) RUN (doubles infra) sur le MÊME project_id : les tâches passent in_review.
+    # On ISOLE le handoff du merge-bot (BUILD_AUTO_MERGE=False) — le merge-bot a ses
+    # tests dédiés (test_pilot_runtime) et les doubles ici ne gèrent pas le merge.
     result = await run_project_from_settings(
         plan.project_id,
         git_repo,
         owner="o",
         repo="r",
         dry_run=False,
+        settings_obj=SimpleNamespace(BUILD_AUTO_MERGE=False),
         manager=manager,
         sandbox=_Sandbox(),
         agent=FakeCodeAgent(),

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -160,6 +160,39 @@ async def test_real_run_wires_cost_governance_by_default(git_repo, manager):
     assert any("coût≈" in d.summary for d in manager.get_decisions(pid))
 
 
+# --- coder OpenHands SDK + abonnement (env du sandbox) --------------------------
+
+
+def test_coder_sandbox_env_subscription_mode():
+    import collegue.pilot.runtime as runtime
+
+    settings = SimpleNamespace(
+        CODER_SUBSCRIPTION=True, CODER_SUBSCRIPTION_MODEL="gpt-5.5", CODER_SUBSCRIPTION_FALLBACK="gpt-5.4"
+    )
+    env = runtime._coder_sandbox_env(settings)
+    assert env["LLM_MODEL"] == "gpt-5.5"  # modèle d'abonnement NU (pas de préfixe gemini/)
+    assert env["LLM_SUBSCRIPTION"] == "1"
+    assert env["OH_FALLBACK_MODELS"] == "gpt-5.4"
+    assert env["HOME"] == "/home/sandbox"  # hors /tmp (requis par le montage des creds)
+
+
+def test_coder_sandbox_env_api_key_mode():
+    import collegue.pilot.runtime as runtime
+
+    settings = SimpleNamespace(LLM_PROVIDER="gemini", LLM_MODEL="gemma-x")  # CODER_SUBSCRIPTION absent → False
+    env = runtime._coder_sandbox_env(settings)
+    assert env["LLM_MODEL"] == "gemini/gemma-x"  # format LiteLLM
+    assert "LLM_SUBSCRIPTION" not in env
+
+
+def test_build_agent_uses_sdk_coder():
+    import collegue.pilot.runtime as runtime
+    from collegue.executor import OHSdkAgent
+
+    agent = runtime._build_agent(sandbox=object(), settings_obj=SimpleNamespace(LLM_PROVIDER="gemini", LLM_MODEL="m"))
+    assert isinstance(agent, OHSdkAgent)
+
+
 # --- ctx de sampling offline (A1) ----------------------------------------------
 
 
@@ -231,6 +264,170 @@ async def test_injected_ctx_is_not_closed(monkeypatch, manager, git_repo):
         budget=_Budget(),
     )
     assert closed["v"] is False  # ctx injecté → non fermé par le runtime
+
+
+# --- merge-bot de la phase BUILD (#411/#434) ------------------------------------
+
+
+async def _noop_sleep(_s):
+    return None
+
+
+async def test_merge_in_review_prs_merges_sets_status_and_resyncs(manager, git_repo):
+    """Le merge-bot du build merge la PR d'une tâche in_review, la passe `merged`, resync le clone."""
+    import collegue.pilot.runtime as runtime
+
+    pid = manager.create_project(name="demo")
+    tid = manager.add_task(pid, title="T1")
+    manager.update_task_status(tid, "in_review")
+
+    calls = {"merge": [], "git": []}
+
+    class _PRs2:
+        def find_pr_by_head(self, owner, repo, head, base=None, state="open"):
+            return SimpleNamespace(number=77)
+
+        def merge_pr(self, owner, repo, number, method="squash", expected_head_sha=None):
+            calls["merge"].append((number, method))
+            return SimpleNamespace(merged=True, already_merged=False)
+
+    class _Runner:
+        def run_command(self, cmd, ws):
+            calls["git"].append(" ".join(cmd) if isinstance(cmd, list) else cmd)
+            return SandboxResult(exit_code=0, stdout="", stderr="")
+
+    clients = PrClients(branches=_Branches(), files=_Files(), prs=_PRs2())
+    merged = await runtime._merge_in_review_prs(
+        manager,
+        clients,
+        project_id=pid,
+        owner="o",
+        repo="r",
+        repo_source=git_repo,
+        base="main",
+        git_runner=_Runner(),
+        sleep_fn=_noop_sleep,
+    )
+    assert merged == 1
+    assert calls["merge"] == [(77, "squash")]  # squash
+    assert manager.get_task(tid).status == "merged"  # statut avancé
+    assert any("fetch origin main" in g for g in calls["git"])  # resync
+    assert any("reset --hard origin/main" in g for g in calls["git"])
+
+
+async def test_build_auto_merge_loops_until_complete(monkeypatch, manager, git_repo):
+    """auto-merge ON : driver ↔ merge-bot bouclent jusqu'à `completed` (1 PR mergée par passe)."""
+    import collegue.pilot.runtime as runtime
+
+    pid = _linear(manager, 2)
+    calls = {"run": 0, "merge": 0, "require_merged": []}
+
+    async def _fake_run_project(p, src, ctx, **kw):
+        calls["run"] += 1
+        calls["require_merged"].append(kw.get("require_merged_deps"))
+        if calls["run"] < 3:
+            return ProjectRunResult(stop_reason="awaiting_merge", iterations=1, processed=[])
+        return ProjectRunResult(stop_reason="completed", iterations=0, processed=[])
+
+    async def _fake_merge(mgr, cli, **kw):
+        calls["merge"] += 1
+        return 1
+
+    class _Ctx:
+        async def aclose(self):
+            return None
+
+    monkeypatch.setattr(runtime, "run_project", _fake_run_project)
+    monkeypatch.setattr(runtime, "_merge_in_review_prs", _fake_merge)
+    monkeypatch.setattr("collegue.executor.openhands_agent.coder_pricing_resolvable", lambda s: True)
+
+    await run_project_from_settings(
+        pid,
+        git_repo,
+        owner="o",
+        repo="r",
+        dry_run=False,  # active l'auto-merge
+        settings_obj=SimpleNamespace(BUILD_AUTO_MERGE=True),
+        manager=manager,
+        sandbox=_Sandbox(),
+        agent=FakeCodeAgent(),
+        reviewer=FakeReviewer(),
+        clients=_clients(),
+        budget=_Budget(),
+        ctx=_Ctx(),
+        audit=SimpleNamespace(cost_summary=lambda: {"usd": 0.0, "tokens": 0}),
+        cost_source=lambda: (0.0, 0),
+    )
+    assert calls["run"] == 3  # 2 passes awaiting_merge + 1 completed
+    assert calls["merge"] == 3  # 2 merges entre passes + 1 drain final (dernière tâche)
+    assert all(calls["require_merged"])  # deps strictes forcées en auto-merge
+
+
+async def test_build_auto_merge_drains_last_pr_on_complete(monkeypatch, manager, git_repo):
+    """Drain final : build qui COMPLÈTE direct (sans awaiting_merge) → la dernière PR in_review est mergée."""
+    import collegue.pilot.runtime as runtime
+
+    pid = _linear(manager, 1)
+    calls = {"run": 0, "merge": 0}
+
+    async def _fake_run_project(p, src, ctx, **kw):
+        calls["run"] += 1
+        return ProjectRunResult(stop_reason="completed", iterations=1, processed=[])
+
+    async def _fake_merge(mgr, cli, **kw):
+        calls["merge"] += 1
+        return 1
+
+    class _Ctx:
+        async def aclose(self):
+            return None
+
+    monkeypatch.setattr(runtime, "run_project", _fake_run_project)
+    monkeypatch.setattr(runtime, "_merge_in_review_prs", _fake_merge)
+    monkeypatch.setattr("collegue.executor.openhands_agent.coder_pricing_resolvable", lambda s: True)
+
+    await run_project_from_settings(
+        pid,
+        git_repo,
+        owner="o",
+        repo="r",
+        dry_run=False,
+        settings_obj=SimpleNamespace(BUILD_AUTO_MERGE=True),
+        manager=manager,
+        sandbox=_Sandbox(),
+        agent=FakeCodeAgent(),
+        reviewer=FakeReviewer(),
+        clients=_clients(),
+        budget=_Budget(),
+        ctx=_Ctx(),
+        audit=SimpleNamespace(cost_summary=lambda: {"usd": 0.0, "tokens": 0}),
+        cost_source=lambda: (0.0, 0),
+    )
+    assert calls["run"] == 1  # pas d'awaiting_merge → 1 passe
+    assert calls["merge"] == 1  # drain final exécuté quand même (dernière PR)
+
+
+async def test_build_auto_merge_off_single_pass(monkeypatch, manager, git_repo):
+    """auto-merge OFF (dry_run) : 1 seule passe, pas de merge-bot (merge humain au prochain run)."""
+    import collegue.pilot.runtime as runtime
+
+    pid = _linear(manager, 2)
+    calls = {"run": 0, "merge": 0}
+
+    async def _fake_run_project(p, src, ctx, **kw):
+        calls["run"] += 1
+        return ProjectRunResult(stop_reason="awaiting_merge", iterations=1, processed=[])
+
+    async def _fake_merge(mgr, cli, **kw):
+        calls["merge"] += 1
+        return 1
+
+    monkeypatch.setattr(runtime, "run_project", _fake_run_project)
+    monkeypatch.setattr(runtime, "_merge_in_review_prs", _fake_merge)
+
+    await _run(manager, git_repo, pid, dry_run=True)
+    assert calls["run"] == 1  # pas de boucle en dry_run
+    assert calls["merge"] == 0  # aucun auto-merge
 
 
 # --- reporting ------------------------------------------------------------------

--- a/tests/test_sampling_ctx.py
+++ b/tests/test_sampling_ctx.py
@@ -207,3 +207,85 @@ def test_rate_limiter_wait_needed_when_minute_full():
     rl._day["m"] = deque([now])
     assert rl._wait_needed("m", now + 1) > 0  # créneau pris → attente
     assert rl._wait_needed("m", now + 61) == 0  # après 60 s → libre
+
+
+# --- routage abonnement (modèle non-Gemini → sampler sandbox) -------------------
+
+
+def _sub_ctx(runner):
+    return LocalSamplingContext(
+        default_model="d",
+        subscription_enabled=True,
+        subscription_auth_dir="/home/u/.openhands",
+        sampler_script="/repo/collegue/executor/oh_sampler.py",
+        runner=runner,
+    )
+
+
+def test_is_subscription_model_routes_non_gemini_only():
+    ctx = _sub_ctx(runner=lambda a, p: (0, "", ""))
+    assert ctx._is_subscription_model("gpt-5.4") is True
+    assert ctx._is_subscription_model("gemma-4-26b-a4b-it") is False
+    assert ctx._is_subscription_model("gemini-2.5-pro") is False
+
+
+def test_subscription_disabled_never_routes():
+    ctx = LocalSamplingContext(default_model="d")  # subscription_enabled=False
+    assert ctx._is_subscription_model("gpt-5.4") is False
+
+
+async def test_sample_gpt_model_goes_through_subscription_sampler(monkeypatch):
+    captured = {}
+
+    def _runner(argv, payload):
+        captured["argv"] = argv
+        captured["payload"] = payload
+        return (0, "bannière...\n<<<SAMPLE_BEGIN>>>verdict du juge<<<SAMPLE_END>>>", "")
+
+    ctx = _sub_ctx(_runner)
+    res = await ctx.sample("revois ce diff", system_prompt="Tu es QA", model_preferences=["gpt-5.4"])
+    assert res.text == "verdict du juge"  # texte extrait des marqueurs
+    # docker run avec abonnement + creds + sampler montés
+    argv = captured["argv"]
+    assert argv[:3] == ["docker", "run", "--rm"] or argv[0] == "docker"
+    assert "LLM_MODEL=gpt-5.4" in argv and "LLM_SUBSCRIPTION=1" in argv
+    assert any("/home/u/.openhands:" in a for a in argv)
+    assert any("oh_sampler.py:ro" in a for a in argv)
+    # Durcissement du conteneur sampler (M1 revue) : caps droppées + no-new-privileges.
+    assert "ALL" in argv and "no-new-privileges" in argv
+    payload = __import__("json").loads(captured["payload"])
+    assert payload["system"] == "Tu es QA" and "revois ce diff" in payload["prompt"]
+
+
+async def test_sample_subscription_failure_raises(monkeypatch):
+    ctx = _sub_ctx(runner=lambda a, p: (1, "", "auth expirée"))
+    import pytest as _pytest
+
+    with _pytest.raises(RuntimeError) as exc:
+        await ctx.sample("x", model_preferences=["gpt-5.4"])
+    assert "auth expirée" in str(exc.value)
+
+
+async def test_sample_subscription_empty_verdict_raises():
+    # rc=0 mais verdict VIDE entre marqueurs → fail-closed (ne pas rendre "" au reviewer).
+    import pytest as _pytest
+
+    ctx = _sub_ctx(runner=lambda a, p: (0, "<<<SAMPLE_BEGIN>>>   <<<SAMPLE_END>>>", ""))
+    with _pytest.raises(RuntimeError) as exc:
+        await ctx.sample("x", model_preferences=["gpt-5.4"])
+    assert "vide" in str(exc.value)
+
+
+async def test_sample_gemini_model_does_not_use_subscription():
+    # Même avec l'abonnement activé, un modèle Gemini reste sur l'endpoint OpenAI-compat.
+    client = _FakeClient(_resp("réponse gemma"))
+    ctx = LocalSamplingContext(
+        default_model="d",
+        subscription_enabled=True,
+        subscription_auth_dir="/a",
+        sampler_script="/s",
+        client=client,
+        runner=lambda a, p: (_ for _ in ()).throw(AssertionError("ne doit pas sampler")),
+    )
+    res = await ctx.sample("hi", model_preferences=["gemma-4-26b-a4b-it"])
+    assert res.text == "réponse gemma"  # passé par le client OpenAI-compat, pas le sampler


### PR DESCRIPTION
## Cycle produit end-to-end (abonnement) + merge-bot build + gate heuristiques advisory

Rend le cycle **plan → build → merge** exécutable PAR LE PRODUIT (`python -m collegue.pilot`) avec l'abonnement ChatGPT (coût API $0). **Validé en réel sur FacNor : MVP 17/17 tâches mergées** (backend Python 19 .py + 8 suites de tests, frontend Vite/TS).

### Contenu
1. **Coder/reviewer abonnement** — `OHSdkAgent` (`oh_runner`, SDK OpenHands 1.7, plus de `openhands.core.main`) + sampler one-shot dans le sandbox (`oh_sampler`) ; `LocalSamplingContext` route un modèle non-Gemini (ex. gpt-5.4) vers le sampler abonnement (docker durci cap-drop/no-new-privileges), les modèles Gemini restent sur l'endpoint OpenAI-compat.
2. **Merge-bot phase BUILD** (`run_project_from_settings`) — tâche finie → PR → auto-merge squash → `git fetch+reset` du clone → tâche suivante (+ drain final). Gaté par `BUILD_AUTO_MERGE` (défaut on). **La phase amélioration n'auto-merge jamais** : PR ouvertes pour merge humain (§6).
3. **Gate** — les heuristiques crues de `code_review` ne hard-bloquent plus du code aux tests VERTS (faux-positifs récurrents) : `analyze_security` ignore `hashed_password` (garde les vrais secrets), `analyze_dry` ignore la boilerplate déclarative, `calculate_quality_score` ne pénalise que critical/error, complexité + exception silencieuse = advisory. Seuls tests, sécurité réelle, findings critical/error du reviewer LLM et e2e/smoke/acceptance bloquent (reviewer LLM = gate dur, **fail-closed** si indisponible).

### Revue adversariale (contexte frais) — traitée
- **M1** : sampler docker durci (`--cap-drop ALL` + `--security-opt no-new-privileges`).
- **m1/m2/m3** : `result.iterations` cohérent ; warning si le resync git échoue ; fail-closed sur verdict d'abonnement vide.
- **M2** (gate statique advisory) : décision produit assumée — un échec du reviewer LLM est fail-closed (le gate bloque).

### Tests
Suite verte (**1870 passed**), `ruff check` + `ruff format --check` clean. Nouveaux tests : routage abonnement (`sampling_ctx`), merge-bot/drain (`pilot_runtime`), faux-positifs (`code_review`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)