### PR TITLE
docs: cycle produit V11 — merge-bot build, abonnement, gate advisory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,8 +130,10 @@ LLM_API_KEY="votre_clé_api_gemini"
 # Moteur de développement autonome (pilote)
 # =========================================
 # Voir docs/moteur_autonome.md pour l'architecture et les garde-fous.
-# Posture par défaut : SÛR. dry_run par défaut, merge humain (§6), capacités
-# dangereuses (auto-merge/revert, outil MCP du pilote) désactivées et fail-closed.
+# Posture par défaut : SÛR. dry_run par défaut. En BUILD réel, le merge-bot
+# auto-merge chaque tâche pour construire le MVP (BUILD_AUTO_MERGE=true) ; la phase
+# AMÉLIORATION laisse ses PR ouvertes pour merge HUMAIN (§6). L'auto-merge
+# RISK-GATED, l'auto-revert et l'outil MCP du pilote restent désactivés/fail-closed.
 
 # --- État durable (requis pour un run réel) ---
 # Postgres recommandé en prod ; SQLite suffit en local.
@@ -157,12 +159,33 @@ LLM_API_KEY="votre_clé_api_gemini"
 # Cache pip persistant du sandbox (chemin HÔTE) : évite de retélécharger PyPI à
 # chaque passe réseau du gate. Vide (défaut) = aucun cache.
 # SANDBOX_PIP_CACHE_DIR=/chemin/hote/.pip_cache
-# Creds d'abonnement OpenHands (coder via abonnement, sans coût API) : chemin HÔTE
-# (ex. ~/.openhands) monté en lecture-écriture dans le sandbox du worker. Vide
+# Ressources/réseau du conteneur coder (sandbox Docker).
+# SANDBOX_NETWORK=bridge               # bridge (défaut) | host (si le bridge stalle les gros transferts)
+# SANDBOX_MEMORY=6g                    # plafond mémoire du conteneur coder
+# SANDBOX_CPUS=2.0                     # plafond CPU du conteneur coder
+# SANDBOX_TIMEOUT=2400                 # timeout d'une exécution coder en sandbox, s
+
+# --- Codage par ABONNEMENT (ChatGPT/Codex, coût API $0) ---
+# Au lieu d'une clé API, le coder passe par l'abonnement OpenHands (subscription_login).
+# Le reviewer/juge suit aussi l'abonnement si son modèle n'est pas un modèle Gemini
+# (LLM_MODEL_REVIEWER=gpt-5.4 -> échantillonné dans le sandbox).
+# CODER_SUBSCRIPTION=false
+# CODER_SUBSCRIPTION_MODEL=gpt-5.5     # modèle coder via l'abonnement
+# CODER_SUBSCRIPTION_FALLBACK=gpt-5.4  # modèle(s) de repli (CSV)
+# Creds d'abonnement OpenHands : chemin HÔTE (ex. ~/.openhands) monté en
+# lecture-écriture dans le sandbox. Requis si CODER_SUBSCRIPTION=true. Vide
 # (défaut) = aucun montage (mode clé API inchangé).
 # SANDBOX_SUBSCRIPTION_AUTH_DIR=/home/vous/.openhands
 
-# --- Auto-merge progressif (opt-in, OFF par défaut) ---
+# --- Merge-bot de la phase BUILD (ON par défaut) ---
+# Pendant la construction du MVP, chaque PR de tâche est auto-mergée (squash) puis le
+# clone local resynchronisé avant la tâche suivante (sinon 1 PR en vol + deps strictes
+# figent le build `awaiting_merge`). La phase AMÉLIORATION n'est JAMAIS auto-mergée.
+# Mettre à false pour un build entièrement à merge humain.
+# BUILD_AUTO_MERGE=true
+# DEPS_REQUIRE_MERGED=false            # forcé à true quand BUILD_AUTO_MERGE est actif
+
+# --- Auto-merge RISK-GATED (politique distincte, opt-in, OFF par défaut) ---
 # §6 reste le défaut : approbation humaine avant chaque merge. L'auto-merge ne
 # s'active que si activé ET le diff est faible risque (chemins non exécutables +
 # plafond LOC + toutes les vérifs CI vertes). Garde dure : code/secret/CI bloqués.

--- a/README.en.md
+++ b/README.en.md
@@ -153,7 +153,10 @@ Overview **by theme** (full list and default values in
 | `STATE_DATABASE_URL` | Autonomous engine durable state (Postgres/SQLite) | |
 | `MAX_COST_USD` / `MAX_TOKENS_BUDGET` / `COLLEGUE_RUN_DEADLINE_SECONDS` | Hard run budget (auto-pause) | |
 | `COLLEGUE_HOME` | Persistence root (budget, metrics, checkpoints) | |
-| `AUTO_MERGE_ENABLED` / `AUTO_REVERT_ENABLED` / `PILOT_TOOL_ENABLED` | Autonomous capabilities (opt-in, **off** by default) | |
+| `CODER_SUBSCRIPTION` (+ `CODER_SUBSCRIPTION_MODEL`, `SANDBOX_SUBSCRIPTION_AUTH_DIR`) | Code via a ChatGPT/Codex **subscription** (`$0` API cost) instead of an API key | |
+| `BUILD_AUTO_MERGE` | **Build-phase merge-bot** (auto-merges task PRs; **on** by default). Improvement stays human-merge | |
+| `SANDBOX_NETWORK` / `SANDBOX_MEMORY` / `SANDBOX_CPUS` / `SANDBOX_TIMEOUT` | Coder container network and resources | |
+| `AUTO_MERGE_ENABLED` / `AUTO_REVERT_ENABLED` / `PILOT_TOOL_ENABLED` | Risk-gated autonomous capabilities (opt-in, **off** by default) | |
 
 > Detailed autonomous-engine settings (budget, auto-merge/revert, pilot MCP tool):
 > [docs/moteur_autonome.md](docs/moteur_autonome.md#réglages-env) (FR).
@@ -167,9 +170,12 @@ Beyond the **reactive** experts, Collègue can drive end-to-end development:
 Stages: `planner` → `pilote` → `executor` → `improve`, on a durable-state
 (Postgres/SQLite) + Docker-sandbox foundation.
 
-**Safe by default**: `dry_run` (no writes) until you pass `--execute`; **no merge to
-`main` without a human** (§6); hard auto-paused budget; auto-merge, auto-revert and the
-pilot MCP tool are **off by default** and fail-closed.
+**Safe by default**: `dry_run` (no writes) until you pass `--execute`; hard
+auto-paused budget. In a real BUILD, a **merge-bot** auto-merges each task to
+construct the MVP (`BUILD_AUTO_MERGE`, on by default); the **improvement** phase
+leaves its PRs **open for human merge** (§6). Risk-gated auto-merge, auto-revert and
+the pilot MCP tool stay **off by default** and fail-closed. The coder can run via a
+ChatGPT/Codex **subscription** (`$0` API cost).
 
 ```bash
 # Preview (dry_run), then real execution

--- a/README.md
+++ b/README.md
@@ -153,7 +153,10 @@ Aperçu **par thème** (liste exhaustive et valeurs par défaut dans
 | `STATE_DATABASE_URL` | État durable du moteur autonome (Postgres/SQLite) | |
 | `MAX_COST_USD` / `MAX_TOKENS_BUDGET` / `COLLEGUE_RUN_DEADLINE_SECONDS` | Budget dur du run (auto-pause) | |
 | `COLLEGUE_HOME` | Racine de persistance (budget, métriques, checkpoints) | |
-| `AUTO_MERGE_ENABLED` / `AUTO_REVERT_ENABLED` / `PILOT_TOOL_ENABLED` | Capacités autonomes (opt-in, **off** par défaut) | |
+| `CODER_SUBSCRIPTION` (+ `CODER_SUBSCRIPTION_MODEL`, `SANDBOX_SUBSCRIPTION_AUTH_DIR`) | Codage par **abonnement** ChatGPT/Codex (coût API `$0`) au lieu d'une clé | |
+| `BUILD_AUTO_MERGE` | **Merge-bot de la phase build** (auto-merge des PR de tâches ; **on** par défaut). L'amélioration reste à merge humain | |
+| `SANDBOX_NETWORK` / `SANDBOX_MEMORY` / `SANDBOX_CPUS` / `SANDBOX_TIMEOUT` | Réseau et ressources du conteneur coder | |
+| `AUTO_MERGE_ENABLED` / `AUTO_REVERT_ENABLED` / `PILOT_TOOL_ENABLED` | Capacités autonomes risk-gated (opt-in, **off** par défaut) | |
 
 > Réglages détaillés du moteur autonome (budget, auto-merge/revert, outil MCP du pilote) :
 > [docs/moteur_autonome.md](docs/moteur_autonome.md#réglages-env).
@@ -168,8 +171,11 @@ substrat. Étages : `planner` → `pilote` → `executor` → `improve`, sur un 
 durable (Postgres/SQLite) et de sandbox Docker.
 
 **Sûr par défaut** : `dry_run` (aucune écriture) tant qu'on ne passe pas `--execute` ;
-**aucun merge dans `main` sans humain** (§6) ; budget dur auto-pausé ; auto-merge,
-auto-revert et outil MCP du pilote **désactivés par défaut** et fail-closed.
+budget dur auto-pausé. En BUILD réel, un **merge-bot** auto-merge chaque tâche pour
+construire le MVP (`BUILD_AUTO_MERGE`, on par défaut) ; la phase **amélioration**
+laisse ses PR **ouvertes pour merge humain** (§6). L'auto-merge risk-gated,
+l'auto-revert et l'outil MCP du pilote restent **désactivés par défaut** et fail-closed.
+Le codeur peut tourner via **abonnement** ChatGPT/Codex (coût API `$0`).
 
 ```bash
 # Aperçu (dry_run) puis exécution réelle

--- a/docs/moteur_autonome.md
+++ b/docs/moteur_autonome.md
@@ -63,12 +63,13 @@ ou on refuse) :
 
 | Garde-fou | Comportement |
 |-----------|--------------|
-| **Merge humain (§6)** | C'est le **défaut**. Une tâche réussie passe `in_review` (PR ouverte), **jamais** `done`/`merged` automatiquement. Un humain merge. |
-| **`dry_run` par défaut** | Sans `--execute`, le pipeline va jusqu'aux **aperçus** de PR sans **aucune** écriture (ni GitHub ni état). |
+| **Merge-bot (phase BUILD)** | Pendant la **construction du MVP**, une tâche réussie est **auto-mergée** (squash) puis le clone local est resynchronisé sur `origin/<base>` avant la tâche suivante (`BUILD_AUTO_MERGE=true` par défaut). Sans lui, avec 1 PR en vol + dépendances strictes, le build se figerait `awaiting_merge` (et des bases périmées créeraient des conflits). C'est le merge humain **simulé** pendant la construction autonome. Mettre `BUILD_AUTO_MERGE=false` ramène tout au merge humain. |
+| **Merge humain (phase AMÉLIORATION, §6)** | Les PR d'**amélioration** (Phase 4) restent **ouvertes** : elles ne sont **jamais** auto-mergées — relecture/merge par un **humain**. C'est le défaut sûr pour faire évoluer un produit déjà construit. |
+| **`dry_run` par défaut** | Sans `--execute`, le pipeline va jusqu'aux **aperçus** de PR sans **aucune** écriture (ni GitHub ni état) — et **aucun** auto-merge. |
 | **Budget dur** | `MAX_COST_USD` / `MAX_TOKENS_BUDGET` atteints → **auto-pause** (les appels LLM sont stoppés). `COLLEGUE_RUN_DEADLINE_SECONDS` borne la durée mur. |
-| **Gate qualité** | Un diff dont les tests sont rouges, ou qui n'améliore pas le score, **n'ouvre pas de PR** (il est jeté). |
-| **Auto-merge (politique, opt-in)** | Moteur de **politique** implémenté et testé (`AUTO_MERGE_ENABLED=false` par défaut ; activé, n'autoriserait **que** du faible risque : allowlist de chemins **non exécutables**, plafond de LOC, **toutes** les vérifs CI vertes ; garde dure code/exécutable/secret/CI insensible à la casse). ⚠️ **Pas encore câblé dans la boucle du pilote** — le **merge humain (§6) reste le mode opérant** ; le câblage exige une passe CI-aware (suivi). |
-| **Auto-revert (politique)** | Filet prévu de l'auto-merge : si `main` devenait rouge après un auto-merge (santé en sandbox), un revert serait préparé (fail-closed : santé non concluante = rouge ; un revert en échec **escalade**). Inactif tant que l'auto-merge n'est pas câblé. |
+| **Gate qualité** | Un diff dont les tests sont rouges, qui retire une exigence, ou qui porte un finding **critical/error** de la revue (sécurité réelle, défaut signalé par le reviewer LLM) **n'ouvre pas / ne merge pas** de PR. Les findings d'heuristiques crues de style/maintenabilité (complexité, duplication, nommage, exception silencieuse) sont **advisory** (informent la PR, ne bloquent pas un code aux tests verts). |
+| **Auto-merge RISK-GATED (politique, opt-in, distinct)** | Politique séparée du merge-bot ci-dessus : merge **fin** par risque (`AUTO_MERGE_ENABLED=false` par défaut ; activée, n'autoriserait **que** du faible risque : allowlist de chemins **non exécutables**, plafond de LOC, **toutes** les vérifs CI vertes ; garde dure code/exécutable/secret/CI insensible à la casse). ⚠️ **Pas encore câblée dans la boucle du pilote** (le câblage exige une passe CI-aware — suivi). |
+| **Auto-revert (politique)** | Filet prévu de l'auto-merge risk-gated : si `main` devenait rouge après un auto-merge (santé en sandbox), un revert serait préparé (fail-closed : santé non concluante = rouge ; un revert en échec **escalade**). Inactif tant que cette politique n'est pas câblée. |
 | **Outil MCP du pilote** | Exposé en MCP **uniquement** si `PILOT_TOOL_ENABLED=true` **et** `OAUTH_ENABLED=true` (sinon **refus de démarrer**). Allowlist d'appelants (sujets OAuth vérifiés, jamais un en-tête client). Jamais auto-découvert. `dry_run` par défaut. |
 
 ---
@@ -234,6 +235,15 @@ L'exécution réelle de bout en bout (Docker + OpenHands + LLM + écritures GitH
 nécessite `STATE_DATABASE_URL`, un `GITHUB_TOKEN`, Docker, et un provider LLM
 configurés (voir [Réglages](#réglages-env)).
 
+**Codage par abonnement (coût API `$0`).** Au lieu d'une clé API, le codeur peut
+passer par un **abonnement** ChatGPT/Codex : mettre `CODER_SUBSCRIPTION=true` +
+`SANDBOX_SUBSCRIPTION_AUTH_DIR=~/.openhands` (creds OpenHands montées dans le
+sandbox). Le reviewer/juge suit le même chemin quand son modèle n'est pas un
+modèle Gemini (`LLM_MODEL_REVIEWER=gpt-5.4` → échantillonné dans le sandbox).
+Avec `BUILD_AUTO_MERGE=true` (défaut), un seul `--execute` construit **tout le
+MVP** (merge-bot enchaîne les tâches) ; `--improve` ajoute ensuite des PR
+d'amélioration **laissées ouvertes** pour merge humain.
+
 ---
 
 ## Réglages (.env)
@@ -253,8 +263,17 @@ lit :
 | `COLLEGUE_RUN_DEADLINE_SECONDS` | Durée mur max d'un run (`0` = pas de deadline). | `0` |
 | `TASK_MAX_ATTEMPTS` | Tentatives max par tâche — retry avec backoff sur échec transitoire (`1` = pas de retry). | `3` |
 | `TASK_RETRY_BACKOFF_SECONDS` | Base du backoff linéaire entre tentatives (plafonné à 90 s). | `15` |
-| `DEPS_REQUIRE_MERGED` | Exige le **merge** d'une dépendance avant de débloquer ses dépendants (sinon le démarrage sur PR non mergée est signalé) ; arrêt `awaiting_merge` quand seuls des merges manquent. | `false` |
+| `DEPS_REQUIRE_MERGED` | Exige le **merge** d'une dépendance avant de débloquer ses dépendants (sinon le démarrage sur PR non mergée est signalé) ; arrêt `awaiting_merge` quand seuls des merges manquent. **Forcé à vrai** quand `BUILD_AUTO_MERGE` est actif. | `false` |
+| `BUILD_AUTO_MERGE` | **Merge-bot de la phase build** : auto-merge (squash) de chaque PR de tâche + resync du clone avant la suivante (+ drain de la dernière PR). `false` → tout au merge humain. La phase amélioration n'est **jamais** auto-mergée. | `true` |
 | `LLM_CALL_TIMEOUT` | Timeout par appel LLM, secondes (`0` = off). | `0` |
+| `CODER_SUBSCRIPTION` | Code via un **abonnement** ChatGPT/Codex (OpenHands `subscription_login`, coût API `$0`) au lieu d'une clé API. Le **reviewer/juge** suit aussi l'abonnement si son modèle n'est pas un modèle Gemini (échantillonné dans le sandbox). | `false` |
+| `CODER_SUBSCRIPTION_MODEL` | Modèle codeur via l'abonnement. | `gpt-5.5` |
+| `CODER_SUBSCRIPTION_FALLBACK` | Modèle(s) de repli de l'abonnement (CSV). | `gpt-5.4` |
+| `SANDBOX_SUBSCRIPTION_AUTH_DIR` | Dossier des creds d'abonnement OpenHands, monté en lecture/écriture dans le sandbox (ex. `~/.openhands`). Requis si `CODER_SUBSCRIPTION`. | — |
+| `SANDBOX_NETWORK` | Réseau Docker du sandbox coder (`bridge` / `host`). `host` si le bridge stalle les gros transferts. | `bridge` |
+| `SANDBOX_MEMORY` | Plafond mémoire du conteneur coder. | `6g` |
+| `SANDBOX_CPUS` | Plafond CPU du conteneur coder. | `2.0` |
+| `SANDBOX_TIMEOUT` | Timeout d'une exécution coder en sandbox, secondes. | `2400` |
 | `AUTO_MERGE_ENABLED` | Active l'auto-merge progressif (opt-in). | `false` |
 | `AUTO_MERGE_MAX_LOC` | Plafond de lignes nettes pour l'auto-merge. | `50` |
 | `AUTO_MERGE_PATH_ALLOWLIST` | Motifs de chemins **faible risque** (CSV ; `**` = sous-dossiers). | `docs/**,**/*.md,**/*.rst` |


### PR DESCRIPTION
## Documentation : cycle produit V11 (merge-bot build, abonnement, gate advisory)

Aligne la doc sur ce qui a été livré par #569 / #570 (déjà mergé dans `main`).

### Doc diff
- **docs/moteur_autonome.md** : garde-fous — **merge-bot phase build** (auto-merge squash + resync du clone, `BUILD_AUTO_MERGE` on par défaut) distingué de l'auto-merge **risk-gated** (`AUTO_MERGE_ENABLED`, toujours non câblé) ; **amélioration = merge humain** (§6) ; **gate** : heuristiques crues de style/maintenabilité (complexité, duplication, nommage, exception silencieuse) rendues **advisory** ; **codage par abonnement** ; table Réglages .env enrichie (`BUILD_AUTO_MERGE`, `CODER_SUBSCRIPTION*`, `SANDBOX_NETWORK/MEMORY/CPUS/TIMEOUT`).
- **.env.example** : flag `CODER_SUBSCRIPTION` + modèles, ressources sandbox, section merge-bot build, entête « sûr par défaut » corrigé.
- **README.md / README.en.md** : tables de config (abonnement, merge-bot, sandbox) + paragraphe « sûr par défaut » corrigé (build auto-merge vs amélioration merge humain).

### Contexte
Le cycle produit `plan → build → improve` a été validé en réel (MVP FacNor 17/17 mergées, abonnement, `$0` API). CHANGELOG/VERSION/TODOS absents du dépôt → non concernés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)