### PR TITLE
Avoid publishing MCP port in production (compose, docs, tests)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,15 @@
+# Exemple de configuration production pour Collègue MCP.
+# Ne pas publier directement le port MCP 4121 en production sans garde explicite.
+
+LLM_API_KEY=replace-me
+LLM_PROVIDER=gemini
+LLM_MODEL=gemini-2.5-flash
+
+# OAuth est obligatoire dès que le serveur MCP est accessible hors machine locale.
+OAUTH_ENABLED=true
+OAUTH_JWKS_URI=https://auth.example.com/realms/collegue/protocol/openid-connect/certs
+OAUTH_ISSUER=https://auth.example.com/realms/collegue
+OAUTH_AUDIENCE=collegue-mcp
+
+SENTRY_ENVIRONMENT=production
+SENTRY_DSN=

--- a/README.md
+++ b/README.md
@@ -14,10 +14,14 @@ Un **collectif d'experts IA spécialisés** sous forme de serveur MCP (Model Con
 git clone https://github.com/VynoDePal/Collegue.git
 cd Collegue
 cp .env.example .env   # renseigner LLM_API_KEY (Gemini)
-docker compose up -d
+docker compose --profile local up -d
 ```
 
-Endpoints :
+Le profil `local` démarre un sidecar qui publie `4121:4121` pour les IDE. Sans ce
+profil, `docker-compose.yml` ne publie pas directement le port MCP sur l'hôte : en
+production, exposez-le uniquement derrière votre reverse proxy/authentification.
+
+Endpoints locaux :
 
 | URL | Rôle |
 |-----|------|
@@ -147,7 +151,7 @@ Aperçu **par thème** (liste exhaustive et valeurs par défaut dans
 | `LLM_MODEL_*` / `LLM_PROVIDER_*` | Modèle/provider par **rôle** (CODER, QA, PLANNER, REVIEWER) | |
 | `LLM_RATE_LIMIT_*` | Limites d'appels LLM par client (minute / jour) | |
 | `CACHE_ENABLED` / `CACHE_TTL` | Cache des réponses d'outils | |
-| `OAUTH_ENABLED` (+ `OAUTH_*`, Keycloak) | Authentification OAuth (**off** par défaut) | |
+| `OAUTH_ENABLED` (+ `OAUTH_*`, Keycloak) | Authentification OAuth (`false` uniquement en local/dev ; `true` en production) | |
 | `GITHUB_TOKEN` / `GITHUB_OWNER` / `GITHUB_REPO` | Intégration GitHub (watchdog, PR) | |
 | `SENTRY_DSN` / `SENTRY_ENVIRONMENT` | Observabilité Sentry | |
 | `STATE_DATABASE_URL` | État durable du moteur autonome (Postgres/SQLite) | |
@@ -160,6 +164,31 @@ Aperçu **par thème** (liste exhaustive et valeurs par défaut dans
 
 > Réglages détaillés du moteur autonome (budget, auto-merge/revert, outil MCP du pilote) :
 > [docs/moteur_autonome.md](docs/moteur_autonome.md#réglages-env).
+
+### Sécurité Docker Compose en production
+
+`OAUTH_ENABLED=false` est réservé aux essais locaux sur une machine de développement.
+N'utilisez jamais ce réglage pour un serveur MCP accessible depuis un réseau partagé
+ou Internet. Le mapping direct `4121:4121` est isolé dans le profil Compose
+`local`/`dev` via le service `collegue-mcp-local-port` ; ne lancez pas ce profil en
+production.
+
+Exemple de démarrage production :
+
+```bash
+cp .env.production.example .env.production
+# renseigner LLM_API_KEY et les valeurs OAuth réelles
+docker compose --env-file .env.production up -d
+```
+
+Variables OAuth minimales en production :
+
+```dotenv
+OAUTH_ENABLED=true
+OAUTH_JWKS_URI=https://auth.example.com/realms/collegue/protocol/openid-connect/certs
+OAUTH_ISSUER=https://auth.example.com/realms/collegue
+OAUTH_AUDIENCE=collegue-mcp
+```
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,12 @@ services:
       dockerfile: docker/collegue/Dockerfile
     image: collegue-app:latest
     restart: always
-    # Exposer directement le port MCP pour contourner Traefik (version incompatible)
+    # Production : ne pas publier directement le port MCP (4121).
+    # Utiliser nginx / un reverse proxy authentifié ; le mapping local 4121:4121
+    # est isolé dans le service `collegue-mcp-local-port` sous profil `local`.
+    expose:
+      - "4121"
     ports:
-      - "4121:4121"
       - "4122:4122"
     environment:
       PYTHONUNBUFFERED: 1
@@ -39,6 +42,21 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+
+  # Profil local/dev uniquement : publie le port MCP sur l'hôte pour les IDE.
+  # Ne pas activer ce profil en production ; garder OAUTH_ENABLED=true et passer
+  # par un reverse proxy/authentification OAuth.
+  collegue-mcp-local-port:
+    image: alpine/socat:1.8.0.3
+    profiles:
+      - local
+      - dev
+    command: ["tcp-listen:4121,fork,reuseaddr", "tcp-connect:collegue-app:4121"]
+    ports:
+      - "4121:4121"
+    depends_on:
+      collegue-app:
+        condition: service_healthy
 
   collegue-dashboard:
     build:

--- a/docs/guide_integration.md
+++ b/docs/guide_integration.md
@@ -24,12 +24,37 @@ Toutes les intégrations ci-dessous supposent que le serveur Collègue tourne en
 git clone https://github.com/VynoDePal/Collegue.git
 cd Collegue
 cp .env.example .env   # renseigner LLM_API_KEY (Gemini)
-docker compose up -d
+docker compose --profile local up -d
 ```
 
-Le serveur est accessible sur `http://localhost:4121/mcp/`.
+Le serveur est accessible sur `http://localhost:4121/mcp/` uniquement quand le profil
+`local` ou `dev` est activé. Ce profil publie le port MCP directement sur l'hôte pour
+les IDE locaux ; il ne doit pas être utilisé en production.
 
 > **Mode stdio** (alternative) : vous pouvez aussi laisser votre IDE spawner un container à la volée, voir le README pour la config `docker run`.
+
+### Note de sécurité production
+
+`OAUTH_ENABLED=false` est uniquement acceptable pour un environnement local/dev non
+exposé. En production, gardez le port MCP `4121` non publié directement par Docker
+Compose et passez par un reverse proxy ou une couche d'authentification. Utilisez un
+fichier d'environnement de production (voir `.env.production.example`) avec au
+minimum :
+
+```dotenv
+OAUTH_ENABLED=true
+OAUTH_JWKS_URI=https://auth.example.com/realms/collegue/protocol/openid-connect/certs
+OAUTH_ISSUER=https://auth.example.com/realms/collegue
+OAUTH_AUDIENCE=collegue-mcp
+```
+
+Démarrage production type :
+
+```bash
+docker compose --env-file .env.production up -d
+```
+
+N'ajoutez `--profile local` ou `--profile dev` que sur votre poste de développement.
 
 ---
 

--- a/tests/test_docker_compose_config.py
+++ b/tests/test_docker_compose_config.py
@@ -90,12 +90,11 @@ class TestDockerComposeConfig:
             condition = depends_on.get("collegue-app", {}).get("condition", "")
             assert condition == "service_healthy", f"nginx should wait for collegue-app to be healthy, got: {condition}"
 
-    def test_collegue_app_ports_exposed(self, compose_file):
-        """Test que les ports MCP sont exposés directement (contournement Traefik)."""
+    def test_collegue_app_does_not_publish_mcp_port_by_default(self, compose_file):
+        """Test que le port MCP n'est pas publié directement par le service de production."""
         collegue_app = compose_file["services"]["collegue-app"]
         ports = collegue_app.get("ports", [])
 
-        # Vérifier que les ports sont exposés
         port_mappings = []
         for port in ports:
             if isinstance(port, str):
@@ -103,10 +102,19 @@ class TestDockerComposeConfig:
             elif isinstance(port, dict):
                 port_mappings.append(f"{port.get('published')}:{port.get('target')}")
 
-        # Port 4121 (MCP) doit être exposé
-        assert any("4121" in p for p in port_mappings), "MCP port 4121 should be exposed"
-        # Port 4122 (health) doit être exposé
-        assert any("4122" in p for p in port_mappings), "Health port 4122 should be exposed"
+        assert not any("4121" in p for p in port_mappings), "MCP port 4121 must not be published by default"
+        assert any("4122" in p for p in port_mappings), "Health port 4122 should remain exposed"
+        assert "4121" in [str(port) for port in collegue_app.get("expose", [])], "MCP port should be exposed internally"
+
+    def test_mcp_port_publication_is_isolated_in_local_profile(self, compose_file):
+        """Test que l'exposition directe du port MCP est isolée dans un profil local/dev documenté."""
+        services = compose_file.get("services", {})
+        local_proxy = services.get("collegue-mcp-local-port")
+
+        assert local_proxy is not None, "A local/dev profile service should document direct MCP publication"
+        assert set(local_proxy.get("profiles", [])) >= {"local", "dev"}, "MCP port publication should require local/dev profile"
+        assert "4121:4121" in local_proxy.get("ports", []), "Local/dev profile should publish MCP port for IDEs"
+        assert "collegue-app" in local_proxy.get("depends_on", {}), "Local/dev port proxy should depend on collegue-app"
 
     def test_collegue_app_environment_variables(self, compose_file):
         """Test que les variables d'environnement essentielles sont présentes."""

--- a/tests/test_docker_compose_config.py
+++ b/tests/test_docker_compose_config.py
@@ -112,7 +112,9 @@ class TestDockerComposeConfig:
         local_proxy = services.get("collegue-mcp-local-port")
 
         assert local_proxy is not None, "A local/dev profile service should document direct MCP publication"
-        assert set(local_proxy.get("profiles", [])) >= {"local", "dev"}, "MCP port publication should require local/dev profile"
+        assert set(local_proxy.get("profiles", [])) >= {"local", "dev"}, (
+            "MCP port publication should require local/dev profile"
+        )
         assert "4121:4121" in local_proxy.get("ports", []), "Local/dev profile should publish MCP port for IDEs"
         assert "collegue-app" in local_proxy.get("depends_on", {}), "Local/dev port proxy should depend on collegue-app"
 


### PR DESCRIPTION
### Motivation

- Empêcher l'exposition directe du port MCP (`4121`) en production pour réduire la surface d'attaque et forcer l'usage d'un reverse-proxy/authentification. 
- Fournir un mécanisme documenté pour les développeurs locaux afin de continuer à utiliser `4121:4121` sans rendre cette configuration par défaut en production.
- Clarifier le rôle de `OAUTH_ENABLED` et ajouter un exemple d'environnement production avec les variables OAuth minimales.

### Description

- Modifié `docker-compose.yml` pour ne plus publier `4121:4121` depuis le service `collegue-app` et ajouter `expose: "4121"` pour communication interne uniquement.  
- Ajouté un service sidecar `collegue-mcp-local-port` (image `alpine/socat`) sous les profils `local` et `dev` qui réalise le mapping `4121:4121` uniquement quand ces profils sont activés.  
- Mis à jour `README.md` et `docs/guide_integration.md` pour recommander `docker compose --profile local up -d`, documenter que `OAUTH_ENABLED=false` est réservé au local/dev et fournir les instructions OAuth de production.  
- Ajouté `.env.production.example` contenant `OAUTH_ENABLED=true` et les variables `OAUTH_JWKS_URI`, `OAUTH_ISSUER`, et `OAUTH_AUDIENCE`.  
- Adapté `tests/test_docker_compose_config.py` pour vérifier que `collegue-app` ne publie pas `4121` par défaut, que `4121` reste exposé en interne, et que la publication directe est isolée dans le service profil `collegue-mcp-local-port` (profils `local`/`dev`).

### Testing

- Exécuté `pytest -q tests/test_docker_compose_config.py`, qui a réussi (tests unitaires/validation statique verts).  
- Tentative d'exécuter `docker compose config` pour valider la configuration runtime, mais la commande a échoué dans l'environnement CI local car `docker` n'est pas installé (`/bin/bash: line 1: docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a385ea3bfd083288161ae3272208dfc)