### PR TITLE
Preserve safe_read_file exceptions after fdopen

### DIFF
--- a/collegue/core/file_security.py
+++ b/collegue/core/file_security.py
@@ -57,6 +57,7 @@ def safe_read_file(filepath: str, max_size: int, base_dir: Optional[str] = None)
             raise FileSecurityError(f"Symlink detected and blocked: {filepath}") from e
         raise
 
+    fd_owned = True
     try:
         # Vérifier les stats via le file descriptor (pas de race condition)
         stat_info = os.fstat(fd)
@@ -78,7 +79,9 @@ def safe_read_file(filepath: str, max_size: int, base_dir: Optional[str] = None)
             pass  # Si le fichier a été supprimé entre-temps, on continuera avec le fd
 
         # Lire le contenu avec verrouillage partagé
-        with os.fdopen(fd, "r", encoding="utf-8", errors="ignore") as f:
+        f = os.fdopen(fd, "r", encoding="utf-8", errors="ignore")
+        fd_owned = False
+        with f:
             # Verrouiller le fichier pendant la lecture (optionnel, mais plus sûr)
             try:
                 fcntl.flock(f.fileno(), fcntl.LOCK_SH)
@@ -93,7 +96,11 @@ def safe_read_file(filepath: str, max_size: int, base_dir: Optional[str] = None)
             finally:
                 fcntl.flock(f.fileno(), fcntl.LOCK_UN)
     except:
-        os.close(fd)
+        if fd_owned:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
         raise
 
 

--- a/tests/test_file_security.py
+++ b/tests/test_file_security.py
@@ -74,6 +74,40 @@ class TestFileSecurity:
             with pytest.raises(FileSecurityError, match="Not a regular file"):
                 safe_read_file(tmpdir, max_size=1024)
 
+
+    def test_safe_read_file_preserves_exception_after_fdopen(self):
+        """Test qu'une erreur après fdopen n'est pas masquée par os.close."""
+
+        class FailingFile:
+            def __init__(self, fd):
+                self.fd = fd
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                os.close(self.fd)
+
+            def fileno(self):
+                return self.fd
+
+            def read(self, size):
+                raise ValueError("initial read failure")
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write("content")
+            temp_path = f.name
+
+        def failing_fdopen(fd, *args, **kwargs):
+            return FailingFile(fd)
+
+        try:
+            with patch("os.fdopen", side_effect=failing_fdopen):
+                with pytest.raises(ValueError, match="initial read failure"):
+                    safe_read_file(temp_path, max_size=1024)
+        finally:
+            os.unlink(temp_path)
+
     def test_safe_getsize_success(self):
         """Test l'obtention de la taille d'un fichier."""
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:

--- a/tests/test_file_security.py
+++ b/tests/test_file_security.py
@@ -74,7 +74,6 @@ class TestFileSecurity:
             with pytest.raises(FileSecurityError, match="Not a regular file"):
                 safe_read_file(tmpdir, max_size=1024)
 
-
     def test_safe_read_file_preserves_exception_after_fdopen(self):
         """Test qu'une erreur après fdopen n'est pas masquée par os.close."""
 


### PR DESCRIPTION
### Motivation
- Prevent closing the raw file descriptor twice after ownership is transferred to the Python file object and avoid masking an original exception with a secondary `close()` failure.

### Description
- Track descriptor ownership with `fd_owned = True` and set `fd_owned = False` after `os.fdopen` so the raw `fd` is not closed a second time once the Python file object owns it.
- Replace the inline `with os.fdopen(...) as f:` with `f = os.fdopen(...); fd_owned = False; with f:` and guard the fallback `os.close(fd)` inside the exception handler so `close()` failures cannot mask the primary exception.
- Add `test_safe_read_file_preserves_exception_after_fdopen` in `tests/test_file_security.py` which patches `os.fdopen` to simulate a post-`fdopen` read error and verifies the original exception is preserved.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_file_security.py` and the test suite passed (all tests green).
- Ran `python -m ruff check collegue/core/file_security.py tests/test_file_security.py` with no linter issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38690fd38083288979433afa98f257)