### PR TITLE
feat(moteur): land cycle V11 + 4 fixes révélés par TopoAudit (coercion planner, SANDBOX_IMAGE, calibration reviewer)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,8 +130,10 @@ LLM_API_KEY="votre_clé_api_gemini"
 # Moteur de développement autonome (pilote)
 # =========================================
 # Voir docs/moteur_autonome.md pour l'architecture et les garde-fous.
-# Posture par défaut : SÛR. dry_run par défaut, merge humain (§6), capacités
-# dangereuses (auto-merge/revert, outil MCP du pilote) désactivées et fail-closed.
+# Posture par défaut : SÛR. dry_run par défaut. En BUILD réel, le merge-bot
+# auto-merge chaque tâche pour construire le MVP (BUILD_AUTO_MERGE=true) ; la phase
+# AMÉLIORATION laisse ses PR ouvertes pour merge HUMAIN (§6). L'auto-merge
+# RISK-GATED, l'auto-revert et l'outil MCP du pilote restent désactivés/fail-closed.
 
 # --- État durable (requis pour un run réel) ---
 # Postgres recommandé en prod ; SQLite suffit en local.
@@ -157,12 +159,33 @@ LLM_API_KEY="votre_clé_api_gemini"
 # Cache pip persistant du sandbox (chemin HÔTE) : évite de retélécharger PyPI à
 # chaque passe réseau du gate. Vide (défaut) = aucun cache.
 # SANDBOX_PIP_CACHE_DIR=/chemin/hote/.pip_cache
-# Creds d'abonnement OpenHands (coder via abonnement, sans coût API) : chemin HÔTE
-# (ex. ~/.openhands) monté en lecture-écriture dans le sandbox du worker. Vide
+# Ressources/réseau du conteneur coder (sandbox Docker).
+# SANDBOX_NETWORK=bridge               # bridge (défaut) | host (si le bridge stalle les gros transferts)
+# SANDBOX_MEMORY=6g                    # plafond mémoire du conteneur coder
+# SANDBOX_CPUS=2.0                     # plafond CPU du conteneur coder
+# SANDBOX_TIMEOUT=2400                 # timeout d'une exécution coder en sandbox, s
+
+# --- Codage par ABONNEMENT (ChatGPT/Codex, coût API $0) ---
+# Au lieu d'une clé API, le coder passe par l'abonnement OpenHands (subscription_login).
+# Le reviewer/juge suit aussi l'abonnement si son modèle n'est pas un modèle Gemini
+# (LLM_MODEL_REVIEWER=gpt-5.4 -> échantillonné dans le sandbox).
+# CODER_SUBSCRIPTION=false
+# CODER_SUBSCRIPTION_MODEL=gpt-5.5     # modèle coder via l'abonnement
+# CODER_SUBSCRIPTION_FALLBACK=gpt-5.4  # modèle(s) de repli (CSV)
+# Creds d'abonnement OpenHands : chemin HÔTE (ex. ~/.openhands) monté en
+# lecture-écriture dans le sandbox. Requis si CODER_SUBSCRIPTION=true. Vide
 # (défaut) = aucun montage (mode clé API inchangé).
 # SANDBOX_SUBSCRIPTION_AUTH_DIR=/home/vous/.openhands
 
-# --- Auto-merge progressif (opt-in, OFF par défaut) ---
+# --- Merge-bot de la phase BUILD (ON par défaut) ---
+# Pendant la construction du MVP, chaque PR de tâche est auto-mergée (squash) puis le
+# clone local resynchronisé avant la tâche suivante (sinon 1 PR en vol + deps strictes
+# figent le build `awaiting_merge`). La phase AMÉLIORATION n'est JAMAIS auto-mergée.
+# Mettre à false pour un build entièrement à merge humain.
+# BUILD_AUTO_MERGE=true
+# DEPS_REQUIRE_MERGED=false            # forcé à true quand BUILD_AUTO_MERGE est actif
+
+# --- Auto-merge RISK-GATED (politique distincte, opt-in, OFF par défaut) ---
 # §6 reste le défaut : approbation humaine avant chaque merge. L'auto-merge ne
 # s'active que si activé ET le diff est faible risque (chemins non exécutables +
 # plafond LOC + toutes les vérifs CI vertes). Garde dure : code/secret/CI bloqués.

--- a/.gitignore
+++ b/.gitignore
@@ -280,3 +280,9 @@ scripts/facnor_run/
 # NB : docker/sandbox/Dockerfile.openhands est désormais COMMITTÉ (#404) — image
 # produit constructible depuis les sources committées (n'embarque oh_runner.py du
 # harnais que s'il est présent dans le contexte de build).
+.gstack/
+# Secrets et données réelles — NE JAMAIS committer (clés API/token GitHub ;
+# scans/levées foncières réelles ; workspace de run TopoAudit dérivé).
+.env.test
+Levees/
+.topoaudit_run/

--- a/README.en.md
+++ b/README.en.md
@@ -153,7 +153,10 @@ Overview **by theme** (full list and default values in
 | `STATE_DATABASE_URL` | Autonomous engine durable state (Postgres/SQLite) | |
 | `MAX_COST_USD` / `MAX_TOKENS_BUDGET` / `COLLEGUE_RUN_DEADLINE_SECONDS` | Hard run budget (auto-pause) | |
 | `COLLEGUE_HOME` | Persistence root (budget, metrics, checkpoints) | |
-| `AUTO_MERGE_ENABLED` / `AUTO_REVERT_ENABLED` / `PILOT_TOOL_ENABLED` | Autonomous capabilities (opt-in, **off** by default) | |
+| `CODER_SUBSCRIPTION` (+ `CODER_SUBSCRIPTION_MODEL`, `SANDBOX_SUBSCRIPTION_AUTH_DIR`) | Code via a ChatGPT/Codex **subscription** (`$0` API cost) instead of an API key | |
+| `BUILD_AUTO_MERGE` | **Build-phase merge-bot** (auto-merges task PRs; **on** by default). Improvement stays human-merge | |
+| `SANDBOX_NETWORK` / `SANDBOX_MEMORY` / `SANDBOX_CPUS` / `SANDBOX_TIMEOUT` | Coder container network and resources | |
+| `AUTO_MERGE_ENABLED` / `AUTO_REVERT_ENABLED` / `PILOT_TOOL_ENABLED` | Risk-gated autonomous capabilities (opt-in, **off** by default) | |
 
 > Detailed autonomous-engine settings (budget, auto-merge/revert, pilot MCP tool):
 > [docs/moteur_autonome.md](docs/moteur_autonome.md#réglages-env) (FR).
@@ -167,9 +170,12 @@ Beyond the **reactive** experts, Collègue can drive end-to-end development:
 Stages: `planner` → `pilote` → `executor` → `improve`, on a durable-state
 (Postgres/SQLite) + Docker-sandbox foundation.
 
-**Safe by default**: `dry_run` (no writes) until you pass `--execute`; **no merge to
-`main` without a human** (§6); hard auto-paused budget; auto-merge, auto-revert and the
-pilot MCP tool are **off by default** and fail-closed.
+**Safe by default**: `dry_run` (no writes) until you pass `--execute`; hard
+auto-paused budget. In a real BUILD, a **merge-bot** auto-merges each task to
+construct the MVP (`BUILD_AUTO_MERGE`, on by default); the **improvement** phase
+leaves its PRs **open for human merge** (§6). Risk-gated auto-merge, auto-revert and
+the pilot MCP tool stay **off by default** and fail-closed. The coder can run via a
+ChatGPT/Codex **subscription** (`$0` API cost).
 
 ```bash
 # Preview (dry_run), then real execution

--- a/README.md
+++ b/README.md
@@ -153,7 +153,10 @@ Aperçu **par thème** (liste exhaustive et valeurs par défaut dans
 | `STATE_DATABASE_URL` | État durable du moteur autonome (Postgres/SQLite) | |
 | `MAX_COST_USD` / `MAX_TOKENS_BUDGET` / `COLLEGUE_RUN_DEADLINE_SECONDS` | Budget dur du run (auto-pause) | |
 | `COLLEGUE_HOME` | Racine de persistance (budget, métriques, checkpoints) | |
-| `AUTO_MERGE_ENABLED` / `AUTO_REVERT_ENABLED` / `PILOT_TOOL_ENABLED` | Capacités autonomes (opt-in, **off** par défaut) | |
+| `CODER_SUBSCRIPTION` (+ `CODER_SUBSCRIPTION_MODEL`, `SANDBOX_SUBSCRIPTION_AUTH_DIR`) | Codage par **abonnement** ChatGPT/Codex (coût API `$0`) au lieu d'une clé | |
+| `BUILD_AUTO_MERGE` | **Merge-bot de la phase build** (auto-merge des PR de tâches ; **on** par défaut). L'amélioration reste à merge humain | |
+| `SANDBOX_NETWORK` / `SANDBOX_MEMORY` / `SANDBOX_CPUS` / `SANDBOX_TIMEOUT` | Réseau et ressources du conteneur coder | |
+| `AUTO_MERGE_ENABLED` / `AUTO_REVERT_ENABLED` / `PILOT_TOOL_ENABLED` | Capacités autonomes risk-gated (opt-in, **off** par défaut) | |
 
 > Réglages détaillés du moteur autonome (budget, auto-merge/revert, outil MCP du pilote) :
 > [docs/moteur_autonome.md](docs/moteur_autonome.md#réglages-env).
@@ -168,8 +171,11 @@ substrat. Étages : `planner` → `pilote` → `executor` → `improve`, sur un 
 durable (Postgres/SQLite) et de sandbox Docker.
 
 **Sûr par défaut** : `dry_run` (aucune écriture) tant qu'on ne passe pas `--execute` ;
-**aucun merge dans `main` sans humain** (§6) ; budget dur auto-pausé ; auto-merge,
-auto-revert et outil MCP du pilote **désactivés par défaut** et fail-closed.
+budget dur auto-pausé. En BUILD réel, un **merge-bot** auto-merge chaque tâche pour
+construire le MVP (`BUILD_AUTO_MERGE`, on par défaut) ; la phase **amélioration**
+laisse ses PR **ouvertes pour merge humain** (§6). L'auto-merge risk-gated,
+l'auto-revert et l'outil MCP du pilote restent **désactivés par défaut** et fail-closed.
+Le codeur peut tourner via **abonnement** ChatGPT/Codex (coût API `$0`).
 
 ```bash
 # Aperçu (dry_run) puis exécution réelle

--- a/collegue/config.py
+++ b/collegue/config.py
@@ -106,6 +106,14 @@ class Settings(BaseSettings):
     # Commande de tests du gate (vide → défaut `COLUMNS=220 python -m pytest -q`).
     # Une commande custom doit forcer elle-même sa largeur de summary (#478).
     GATE_TEST_COMMAND: str = ""
+    # Calibration de la REVUE experte au PROJET. GATE_REVIEW_CONTEXT : consigne libre
+    # injectée dans le prompt du reviewer (ex. « prototype, auth différée P2 : ne bloque
+    # pas sur l'absence d'auth/IDOR/contrôle d'accès utilisateur, l'isolation par projet
+    # suffit ; bloque sur les vrais bugs : crash, injection, secrets en dur »). Vide =
+    # comportement strict par défaut. GATE_OWNERSHIP_REVIEW : injecter (défaut) ou non la
+    # consigne IDOR auto (#500) — à couper pour un projet dont l'auth est différée.
+    GATE_REVIEW_CONTEXT: str = ""
+    GATE_OWNERSHIP_REVIEW: bool = True
     # Installabilité (#439). REQUIRE_DEPS_INSTALL : l'échec d'installation des
     # deps déclarées rend le gate ROUGE (au lieu d'un signal toléré). CHECK_
     # INSTALLABILITY : passe venv NU (install -r requirements + collecte pytest)
@@ -181,6 +189,10 @@ class Settings(BaseSettings):
     # du worker : permet au coder d'utiliser l'abo (sans coût API) et de persister le
     # token rafraîchi. Vide (défaut) = aucun montage (mode clé API inchangé).
     SANDBOX_SUBSCRIPTION_AUTH_DIR: str = ""
+    # Image Docker du sandbox (coder, gate, sampler d'abonnement). Permet une image
+    # PAR PROJET : un projet à stack lourde (ex. PostGIS + géo + WeasyPrint) builde sa
+    # propre image dérivée de collegue-sandbox sans polluer l'image partagée.
+    SANDBOX_IMAGE: str = "collegue-sandbox:latest"
     # Réseau du sandbox réel (coder OpenHands + passes réseau du gate). Le coder a
     # besoin du réseau (le défaut DURCI de DockerSandbox est "none"). "host" est
     # éprouvé contre la flakiness des transferts pip via le bridge Docker (NAT/MTU,

--- a/collegue/core/llm/sampling_ctx.py
+++ b/collegue/core/llm/sampling_ctx.py
@@ -234,6 +234,10 @@ class LocalSamplingContext:
             subscription_enabled=sub,
             subscription_auth_dir=auth or None,
             sampler_script=sampler_script,
+            # Le sampler d'abonnement (reviewer/juge) tourne dans la MÊME image que le coder.
+            sampler_image=str(
+                getattr(settings_obj, "SANDBOX_IMAGE", "collegue-sandbox:latest") or "collegue-sandbox:latest"
+            ),
         )
 
     async def _noop(self, *args: Any, **kwargs: Any) -> None:  # ctx.info/debug/...

--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -2126,9 +2126,23 @@ class ExpertReviewer:
     (:func:`outcome_from_review`) est, lui, pur et testé en CI.
     """
 
-    def __init__(self, *, min_quality: float = DEFAULT_MIN_QUALITY, tool=None):
+    def __init__(
+        self,
+        *,
+        min_quality: float = DEFAULT_MIN_QUALITY,
+        tool=None,
+        review_context: str = "",
+        ownership_review: bool = True,
+    ):
         self._min_quality = min_quality
         self._tool = tool  # injectable pour les tests ; sinon construit à la volée
+        # Calibration de la revue au PROJET (générique). ``review_context`` : consigne
+        # libre injectée dans le prompt du reviewer (ex. « prototype, auth différée P2 :
+        # ne bloque pas sur l'absence d'auth/IDOR, l'isolation par projet suffit »).
+        # ``ownership_review`` : injecter (ou non) la consigne IDOR auto sur diff
+        # touchant l'auth (#500) — à désactiver pour un projet où l'auth est différée.
+        self._review_context = str(review_context or "")
+        self._ownership_review = bool(ownership_review)
 
     async def review(self, diff: str, ctx, *, issue: Optional[IssueSpec] = None) -> ReviewOutcome:
         from collegue.tools.code_review.models import CodeReviewRequest
@@ -2169,13 +2183,17 @@ class ExpertReviewer:
 
         tool = self._tool or self._build_tool()
         base_context = issue.to_prompt() if issue is not None else None
-        # #500 : si le diff touche l'auth, injecter la consigne ownership/IDOR —
-        # le diff complet (modèle + routes) est déjà envoyé en `code`, seul le
-        # prompt manquait la consigne (run v5 : IDOR clients non détecté).
-        if _diff_touches_auth(diff):
+        # #500 : si le diff touche l'auth, injecter la consigne ownership/IDOR — sauf si
+        # la revue ownership est désactivée pour ce projet (auth différée, prototype).
+        if self._ownership_review and _diff_touches_auth(diff):
             base_context = (
                 f"{base_context}\n\n{_OWNERSHIP_REVIEW_CONSIGNE}" if base_context else _OWNERSHIP_REVIEW_CONSIGNE
             )
+        # Contexte de revue PAR PROJET (calibration au stade de maturité) : appended au
+        # prompt du reviewer pour qu'il juge au bon niveau (ne pas exiger des features
+        # explicitement différées par la spec). Générique, vide par défaut.
+        if self._review_context:
+            base_context = f"{base_context}\n\n{self._review_context}" if base_context else self._review_context
         request = CodeReviewRequest(code=diff or "(diff vide)", language=language, context=base_context)
         response = await tool.execute_async(request, ctx=ctx)
         return outcome_from_review(response, min_quality=self._min_quality)

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -142,14 +142,15 @@ def _coder_sandbox_env(settings_obj) -> dict:
 
 
 def _build_sandbox(settings_obj):  # pragma: no cover - infra réelle (integration)
-    from collegue.sandbox import DockerSandbox
-
     # OpenHands appelle un LLM → le sandbox a besoin du réseau pour ce run précis
     # (défaut durci ``network="none"``). ``SANDBOX_NETWORK`` ("host" éprouvé contre la
     # flakiness pip du bridge, #485) ; ressources remontées (les défauts 512m/1cpu/120s
     # sont trop bas pour OpenHands). Le coder (oh_runner SDK) lit ``env`` + l'abonnement
     # via ``subscription_auth_dir`` ; la clé API passe par ``env_passthrough`` (jamais l'argv).
+    from collegue.sandbox import DEFAULT_SANDBOX_IMAGE, DockerSandbox
+
     return DockerSandbox(
+        image=str(getattr(settings_obj, "SANDBOX_IMAGE", DEFAULT_SANDBOX_IMAGE) or DEFAULT_SANDBOX_IMAGE),
         network=str(getattr(settings_obj, "SANDBOX_NETWORK", "bridge") or "bridge"),
         dns=_sandbox_dns(settings_obj),
         pip_cache_dir=_sandbox_pip_cache(settings_obj),  # #496 : cache pip persistant opt-in
@@ -173,7 +174,12 @@ def _build_agent(sandbox, settings_obj):  # pragma: no cover - infra réelle (in
 def _build_reviewer(settings_obj):  # pragma: no cover - infra réelle (integration)
     from collegue.executor.quality_gate import ExpertReviewer
 
-    return ExpertReviewer()
+    # Calibration de la revue PAR PROJET : contexte libre (maturité/contraintes) +
+    # consigne ownership/IDOR opt-in (à couper pour un projet où l'auth est différée).
+    return ExpertReviewer(
+        review_context=str(getattr(settings_obj, "GATE_REVIEW_CONTEXT", "") or ""),
+        ownership_review=bool(getattr(settings_obj, "GATE_OWNERSHIP_REVIEW", True)),
+    )
 
 
 def _build_clients(github_token):  # pragma: no cover - infra réelle (integration)

--- a/collegue/planner/spec_generator.py
+++ b/collegue/planner/spec_generator.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from typing import Any, List, Optional
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from collegue.core.llm import LLMRole, model_preferences_for_role
 from collegue.core.llm.client import sample_with_timeout
@@ -49,6 +49,44 @@ explicites dans "assumptions" et avance.
 - Reste concis et concret."""
 
 
+def _flatten_to_text(value: Any) -> str:
+    """Aplatit une valeur LLM (str/dict/list) en une chaîne lisible.
+
+    Robustesse : sur une spec riche, le planner LLM renvoie parfois un champ texte
+    (ex. ``scope``) sous forme STRUCTURÉE (``{"inclus": …, "exclus": …}``) au lieu
+    d'une chaîne → la validation Pydantic échouait. On aplatit au lieu de rejeter."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        return "; ".join(f"{k}: {_flatten_to_text(v)}" for k, v in value.items() if v is not None)
+    if isinstance(value, (list, tuple)):
+        return "; ".join(_flatten_to_text(v) for v in value if v is not None)
+    return str(value)
+
+
+def _flatten_to_list(value: Any) -> List[str]:
+    """Normalise une valeur LLM en liste de chaînes (inverse de :func:`_flatten_to_text`)."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    if isinstance(value, dict):
+        return [f"{k}: {_flatten_to_text(v)}" for k, v in value.items() if v is not None]
+    if isinstance(value, (list, tuple)):
+        out: List[str] = []
+        for v in value:
+            if isinstance(v, (dict, list, tuple)):
+                text = _flatten_to_text(v)
+            else:
+                text = str(v) if v is not None else ""
+            if text.strip():
+                out.append(text)
+        return out
+    return [str(value)]
+
+
 class Spec(BaseModel):
     """Contrat de projet structuré, rendu en SPEC.md."""
 
@@ -59,6 +97,18 @@ class Spec(BaseModel):
     constraints: List[str] = Field(default_factory=list)
     assumptions: List[str] = Field(default_factory=list)
     acceptance_criteria: List[str] = Field(default_factory=list)
+
+    # Robustesse au LLM : un champ TEXTE renvoyé en dict/list (ex. scope structuré
+    # « inclus/exclus ») est aplati ; un champ LISTE renvoyé en str/dict est normalisé.
+    @field_validator("title", "summary", "scope", mode="before")
+    @classmethod
+    def _coerce_text(cls, v: Any) -> str:
+        return _flatten_to_text(v)
+
+    @field_validator("objectives", "constraints", "assumptions", "acceptance_criteria", mode="before")
+    @classmethod
+    def _coerce_list(cls, v: Any) -> List[str]:
+        return _flatten_to_list(v)
 
     def to_markdown(self) -> str:
         """Rend le SPEC en Markdown. Chaque champ est mis sur une ligne (anti-injection) ;

--- a/docs/moteur_autonome.md
+++ b/docs/moteur_autonome.md
@@ -63,12 +63,13 @@ ou on refuse) :
 
 | Garde-fou | Comportement |
 |-----------|--------------|
-| **Merge humain (§6)** | C'est le **défaut**. Une tâche réussie passe `in_review` (PR ouverte), **jamais** `done`/`merged` automatiquement. Un humain merge. |
-| **`dry_run` par défaut** | Sans `--execute`, le pipeline va jusqu'aux **aperçus** de PR sans **aucune** écriture (ni GitHub ni état). |
+| **Merge-bot (phase BUILD)** | Pendant la **construction du MVP**, une tâche réussie est **auto-mergée** (squash) puis le clone local est resynchronisé sur `origin/<base>` avant la tâche suivante (`BUILD_AUTO_MERGE=true` par défaut). Sans lui, avec 1 PR en vol + dépendances strictes, le build se figerait `awaiting_merge` (et des bases périmées créeraient des conflits). C'est le merge humain **simulé** pendant la construction autonome. Mettre `BUILD_AUTO_MERGE=false` ramène tout au merge humain. |
+| **Merge humain (phase AMÉLIORATION, §6)** | Les PR d'**amélioration** (Phase 4) restent **ouvertes** : elles ne sont **jamais** auto-mergées — relecture/merge par un **humain**. C'est le défaut sûr pour faire évoluer un produit déjà construit. |
+| **`dry_run` par défaut** | Sans `--execute`, le pipeline va jusqu'aux **aperçus** de PR sans **aucune** écriture (ni GitHub ni état) — et **aucun** auto-merge. |
 | **Budget dur** | `MAX_COST_USD` / `MAX_TOKENS_BUDGET` atteints → **auto-pause** (les appels LLM sont stoppés). `COLLEGUE_RUN_DEADLINE_SECONDS` borne la durée mur. |
-| **Gate qualité** | Un diff dont les tests sont rouges, ou qui n'améliore pas le score, **n'ouvre pas de PR** (il est jeté). |
-| **Auto-merge (politique, opt-in)** | Moteur de **politique** implémenté et testé (`AUTO_MERGE_ENABLED=false` par défaut ; activé, n'autoriserait **que** du faible risque : allowlist de chemins **non exécutables**, plafond de LOC, **toutes** les vérifs CI vertes ; garde dure code/exécutable/secret/CI insensible à la casse). ⚠️ **Pas encore câblé dans la boucle du pilote** — le **merge humain (§6) reste le mode opérant** ; le câblage exige une passe CI-aware (suivi). |
-| **Auto-revert (politique)** | Filet prévu de l'auto-merge : si `main` devenait rouge après un auto-merge (santé en sandbox), un revert serait préparé (fail-closed : santé non concluante = rouge ; un revert en échec **escalade**). Inactif tant que l'auto-merge n'est pas câblé. |
+| **Gate qualité** | Un diff dont les tests sont rouges, qui retire une exigence, ou qui porte un finding **critical/error** de la revue (sécurité réelle, défaut signalé par le reviewer LLM) **n'ouvre pas / ne merge pas** de PR. Les findings d'heuristiques crues de style/maintenabilité (complexité, duplication, nommage, exception silencieuse) sont **advisory** (informent la PR, ne bloquent pas un code aux tests verts). |
+| **Auto-merge RISK-GATED (politique, opt-in, distinct)** | Politique séparée du merge-bot ci-dessus : merge **fin** par risque (`AUTO_MERGE_ENABLED=false` par défaut ; activée, n'autoriserait **que** du faible risque : allowlist de chemins **non exécutables**, plafond de LOC, **toutes** les vérifs CI vertes ; garde dure code/exécutable/secret/CI insensible à la casse). ⚠️ **Pas encore câblée dans la boucle du pilote** (le câblage exige une passe CI-aware — suivi). |
+| **Auto-revert (politique)** | Filet prévu de l'auto-merge risk-gated : si `main` devenait rouge après un auto-merge (santé en sandbox), un revert serait préparé (fail-closed : santé non concluante = rouge ; un revert en échec **escalade**). Inactif tant que cette politique n'est pas câblée. |
 | **Outil MCP du pilote** | Exposé en MCP **uniquement** si `PILOT_TOOL_ENABLED=true` **et** `OAUTH_ENABLED=true` (sinon **refus de démarrer**). Allowlist d'appelants (sujets OAuth vérifiés, jamais un en-tête client). Jamais auto-découvert. `dry_run` par défaut. |
 
 ---
@@ -234,6 +235,15 @@ L'exécution réelle de bout en bout (Docker + OpenHands + LLM + écritures GitH
 nécessite `STATE_DATABASE_URL`, un `GITHUB_TOKEN`, Docker, et un provider LLM
 configurés (voir [Réglages](#réglages-env)).
 
+**Codage par abonnement (coût API `$0`).** Au lieu d'une clé API, le codeur peut
+passer par un **abonnement** ChatGPT/Codex : mettre `CODER_SUBSCRIPTION=true` +
+`SANDBOX_SUBSCRIPTION_AUTH_DIR=~/.openhands` (creds OpenHands montées dans le
+sandbox). Le reviewer/juge suit le même chemin quand son modèle n'est pas un
+modèle Gemini (`LLM_MODEL_REVIEWER=gpt-5.4` → échantillonné dans le sandbox).
+Avec `BUILD_AUTO_MERGE=true` (défaut), un seul `--execute` construit **tout le
+MVP** (merge-bot enchaîne les tâches) ; `--improve` ajoute ensuite des PR
+d'amélioration **laissées ouvertes** pour merge humain.
+
 ---
 
 ## Réglages (.env)
@@ -253,8 +263,17 @@ lit :
 | `COLLEGUE_RUN_DEADLINE_SECONDS` | Durée mur max d'un run (`0` = pas de deadline). | `0` |
 | `TASK_MAX_ATTEMPTS` | Tentatives max par tâche — retry avec backoff sur échec transitoire (`1` = pas de retry). | `3` |
 | `TASK_RETRY_BACKOFF_SECONDS` | Base du backoff linéaire entre tentatives (plafonné à 90 s). | `15` |
-| `DEPS_REQUIRE_MERGED` | Exige le **merge** d'une dépendance avant de débloquer ses dépendants (sinon le démarrage sur PR non mergée est signalé) ; arrêt `awaiting_merge` quand seuls des merges manquent. | `false` |
+| `DEPS_REQUIRE_MERGED` | Exige le **merge** d'une dépendance avant de débloquer ses dépendants (sinon le démarrage sur PR non mergée est signalé) ; arrêt `awaiting_merge` quand seuls des merges manquent. **Forcé à vrai** quand `BUILD_AUTO_MERGE` est actif. | `false` |
+| `BUILD_AUTO_MERGE` | **Merge-bot de la phase build** : auto-merge (squash) de chaque PR de tâche + resync du clone avant la suivante (+ drain de la dernière PR). `false` → tout au merge humain. La phase amélioration n'est **jamais** auto-mergée. | `true` |
 | `LLM_CALL_TIMEOUT` | Timeout par appel LLM, secondes (`0` = off). | `0` |
+| `CODER_SUBSCRIPTION` | Code via un **abonnement** ChatGPT/Codex (OpenHands `subscription_login`, coût API `$0`) au lieu d'une clé API. Le **reviewer/juge** suit aussi l'abonnement si son modèle n'est pas un modèle Gemini (échantillonné dans le sandbox). | `false` |
+| `CODER_SUBSCRIPTION_MODEL` | Modèle codeur via l'abonnement. | `gpt-5.5` |
+| `CODER_SUBSCRIPTION_FALLBACK` | Modèle(s) de repli de l'abonnement (CSV). | `gpt-5.4` |
+| `SANDBOX_SUBSCRIPTION_AUTH_DIR` | Dossier des creds d'abonnement OpenHands, monté en lecture/écriture dans le sandbox (ex. `~/.openhands`). Requis si `CODER_SUBSCRIPTION`. | — |
+| `SANDBOX_NETWORK` | Réseau Docker du sandbox coder (`bridge` / `host`). `host` si le bridge stalle les gros transferts. | `bridge` |
+| `SANDBOX_MEMORY` | Plafond mémoire du conteneur coder. | `6g` |
+| `SANDBOX_CPUS` | Plafond CPU du conteneur coder. | `2.0` |
+| `SANDBOX_TIMEOUT` | Timeout d'une exécution coder en sandbox, secondes. | `2400` |
 | `AUTO_MERGE_ENABLED` | Active l'auto-merge progressif (opt-in). | `false` |
 | `AUTO_MERGE_MAX_LOC` | Plafond de lignes nettes pour l'auto-merge. | `50` |
 | `AUTO_MERGE_PATH_ALLOWLIST` | Motifs de chemins **faible risque** (CSV ; `**` = sous-dossiers). | `docs/**,**/*.md,**/*.rst` |

--- a/tests/test_executor_quality_gate.py
+++ b/tests/test_executor_quality_gate.py
@@ -1297,6 +1297,29 @@ async def test_expert_reviewer_maps_tool_response():
     assert request.language == "python"
 
 
+async def test_expert_reviewer_calibration_context_and_ownership_optout():
+    # Calibration au projet : GATE_REVIEW_CONTEXT injecté dans le prompt + consigne IDOR
+    # désactivable (auth différée / prototype) — sinon le reviewer bloque sur de l'auth
+    # explicitement reportée par la spec (cas réel TopoAudit).
+    auth_diff = "diff --git a/api.py b/api.py\n+user = Depends(get_current_user)\n+def f():\n+    return 1\n"
+    proto_ctx = "Projet PROTOTYPE : authentification differee (P2), isolation par projet suffit."
+    consigne_marker = "ISOLATION PAR PROPRIÉTAIRE"  # phrase distinctive de _OWNERSHIP_REVIEW_CONSIGNE
+
+    # 1) Par défaut : la consigne ownership/IDOR auto est présente sur un diff auth.
+    tool_default = _FakeTool(_response(0.9))
+    await ExpertReviewer(tool=tool_default).review(auth_diff, ctx=None, issue=ISSUE)
+    assert consigne_marker in (tool_default.calls[0][0].context or "")
+
+    # 2) ownership_review=False + review_context : pas de consigne ownership, contexte projet injecté.
+    tool_cal = _FakeTool(_response(0.9))
+    await ExpertReviewer(tool=tool_cal, ownership_review=False, review_context=proto_ctx).review(
+        auth_diff, ctx=None, issue=ISSUE
+    )
+    ctx_sent = tool_cal.calls[0][0].context or ""
+    assert consigne_marker not in ctx_sent  # consigne ownership coupée
+    assert proto_ctx in ctx_sent  # contexte prototype injecté
+
+
 def test_diff_touches_auth_heuristic():
     """#500 : détection (insensible casse) d'un diff qui touche l'auth."""
     from collegue.executor.quality_gate import _diff_touches_auth

--- a/tests/test_spec_generator.py
+++ b/tests/test_spec_generator.py
@@ -77,6 +77,25 @@ def test_to_markdown_empty_assumptions_still_has_section():
     assert "Aucune hypothèse" in md
 
 
+def test_spec_coerces_structured_llm_fields():
+    # Robustesse : sur une spec riche, le planner LLM renvoie parfois `scope` en dict
+    # {inclus, exclus} et des listes mixtes/str au lieu du type attendu → on aplatit
+    # au lieu de lever ValidationError (bug réel découvert sur TopoAudit-Benin).
+    spec = Spec.model_validate(
+        {
+            "title": "TopoAudit",
+            "objectives": "Construire le MVP",  # str -> [str]
+            "scope": {"inclus": "Backend + frontend", "exclus": "Stockage public"},  # dict -> str
+            "constraints": [{"perf": "rapide"}, "pas de scraping"],  # liste mixte
+            "acceptance_criteria": ["pytest vert"],
+        }
+    )
+    assert isinstance(spec.scope, str) and "inclus:" in spec.scope and "exclus:" in spec.scope
+    assert spec.objectives == ["Construire le MVP"]
+    assert spec.constraints == ["perf: rapide", "pas de scraping"]
+    assert spec.to_markdown()  # rendu sans erreur
+
+
 def test_to_markdown_sanitizes_heading_injection():
     # F1 : un titre malveillant ne doit pas injecter de section ni de case cochée.
     spec = Spec(


### PR DESCRIPTION
Land du cycle **V11** (53 commits déjà sur la branche) + 4 fixes moteur révélés par TopoAudit-Benin (1 nouveau commit) :

- **Coercion planner** : `scope` dict/list aplati au lieu de ValidationError.
- **SANDBOX_IMAGE** configurable (image sandbox par projet).
- **Calibration reviewer** : `GATE_REVIEW_CONTEXT` + `GATE_OWNERSHIP_REVIEW` (opt-in IDOR), strict par défaut.
- `.gitignore` protège `.env.test` / `Levees/` / `.topoaudit_run/`.

Gate local : 175 passed, ruff check + format OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)