### PR TITLE
fix(moteur): boucle improve propage GATE_TEST_COMMAND à measure (#573)

### DIFF
--- a/collegue/improve/loop.py
+++ b/collegue/improve/loop.py
@@ -24,7 +24,14 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
 from collegue.improve.gate import DEFAULT_MIN_GAIN, evaluate
-from collegue.improve.metrics import DEFAULT_WEIGHTS, CompositeWeights, autofix_lint, measure, persist
+from collegue.improve.metrics import (
+    DEFAULT_COVERAGE_COMMAND,
+    DEFAULT_WEIGHTS,
+    CompositeWeights,
+    autofix_lint,
+    measure,
+    persist,
+)
 from collegue.improve.proposer import AttemptRecord, build_improvement_task, next_dimension
 
 # Raisons d'arrêt.
@@ -153,6 +160,7 @@ async def run_improvement(
     min_gain: float = DEFAULT_MIN_GAIN,
     max_iterations: int = 50,
     weights: CompositeWeights = DEFAULT_WEIGHTS,
+    coverage_command: str = DEFAULT_COVERAGE_COMMAND,
     measure_fn=measure,
 ) -> ImprovementResult:
     """Fait tourner la boucle d'amélioration jusqu'au plateau ou au budget.
@@ -190,6 +198,20 @@ async def run_improvement(
     plateau = 0
     round_num = 0
 
+    # #573 : transmettre la commande de test configurée (``GATE_TEST_COMMAND``, alias
+    # ``coverage_command`` ici, acheminée par le driver) à ``measure()`` pour que
+    # ``tests_passed`` reflète le code de sortie de la VRAIE commande de test du projet.
+    # Sans ça, ``measure()`` retombe sur ``DEFAULT_COVERAGE_COMMAND`` (pytest --cov en dur)
+    # → tests rouges sur un projet à setup non trivial (make, monorepo, service DB) → garde
+    # dure G2 rejette TOUTE amélioration. (Limite connue, suivi #577 : une commande custom
+    # sans rapport pytest-cov rend la couverture non mesurable → terme conservateur 0.) Le
+    # kwarg n'est émis qu'en override (≠ défaut) → chemin par défaut (et mesures scriptées
+    # en CI) inchangé (symétrie avec ``_gate_options`` qui n'émet ``test_command`` qu'en
+    # override).
+    measure_extra: dict = {}
+    if coverage_command and coverage_command != DEFAULT_COVERAGE_COMMAND:
+        measure_extra["coverage_command"] = coverage_command
+
     while True:
         if round_num >= max_iterations:
             result.stop_reason = STOP_SAFETY_CAP
@@ -211,7 +233,9 @@ async def run_improvement(
 
         # Levier 1 (#541) : la mesure baseline porte sur le WORKSPACE sur disque, pas
         # sur un diff (il n'y en a pas encore) — objectif symétrique avant/après.
-        before = await measure_fn(workspace.path, ctx, sandbox=sandbox, reviewer=reviewer, weights=weights)
+        before = await measure_fn(
+            workspace.path, ctx, sandbox=sandbox, reviewer=reviewer, weights=weights, **measure_extra
+        )
 
         # Baseline non fiable (composite non fini, ex. scan sécu en échec → inf) :
         # round à vide. On NE lance PAS l'agent (coûteux) pour rien et on n'enregistre
@@ -251,7 +275,7 @@ async def run_improvement(
         final_diff, final_files = capture_diff(workspace)
 
         after = await measure_fn(
-            workspace.path, ctx, sandbox=sandbox, reviewer=reviewer, diff=final_diff, weights=weights
+            workspace.path, ctx, sandbox=sandbox, reviewer=reviewer, diff=final_diff, weights=weights, **measure_extra
         )
         result.final_score = after.composite
         gate = evaluate(before, after, min_gain=min_gain)

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -1103,6 +1103,16 @@ async def run_project(
     improvement = None
     if mvp_built and improve:
         run_imp = run_improvement_fn or _default_run_improvement
+        # #573 : la Phase 4 doit mesurer avec la commande de test du projet
+        # (``gate_options['test_command']`` = ``GATE_TEST_COMMAND``), pas pytest --cov en
+        # dur — sinon les tests virent au rouge sur un projet à setup non trivial (make,
+        # monorepo, service DB) et la garde dure G2 rejette toute amélioration. Symétrie
+        # avec ``execute_issue`` qui reçoit déjà ``gate_options``.
+        improve_extra: dict = {}
+        if gate_options:
+            improve_test_command = gate_options.get("test_command")
+            if improve_test_command:
+                improve_extra["coverage_command"] = str(improve_test_command)
         improvement = await run_imp(
             project_id,
             repo_source,
@@ -1118,6 +1128,7 @@ async def run_project(
             runner=runner,
             base=base,
             dry_run=dry_run,
+            **improve_extra,
         )
 
     return ProjectRunResult(

--- a/tests/test_improve_loop.py
+++ b/tests/test_improve_loop.py
@@ -419,3 +419,35 @@ async def test_safety_cap(git_repo, manager):
     result = await _run(git_repo, manager, measure_seq=seq, max_iterations=1, plateau_rounds=9)
     assert result.stop_reason == "safety_cap"
     assert result.rounds == 1
+
+
+# --- propagation de la commande de test (#573) ----------------------------------
+
+
+async def test_forwards_configured_test_command_to_measure(git_repo, manager):
+    # #573 : la commande de test du projet (GATE_TEST_COMMAND) doit atteindre measure()
+    # à CHAQUE mesure (avant ET après le diff). Sans ça, measure() retombe sur
+    # DEFAULT_COVERAGE_COMMAND (pytest --cov en dur) → tests rouges sur un projet à setup
+    # non trivial (make, monorepo, service DB) → garde dure G2 rejette TOUTE amélioration.
+    seen = []
+
+    async def spy_measure(workspace, ctx, *, sandbox=None, reviewer=None, diff="", weights=None, coverage_command=None):
+        seen.append(coverage_command)
+        return _metrics(1.0)  # baseline finie → la boucle déroule un round complet
+
+    await run_improvement(
+        manager.create_project(name="cmd"),
+        git_repo,
+        ctx=None,
+        agent=FakeCodeAgent(),
+        owner="o",
+        repo="r",
+        manager=manager,
+        budget=_Budget([CONT, PAUSE]),
+        clients=_clients(),
+        dry_run=True,
+        coverage_command="make check",
+        measure_fn=spy_measure,
+    )
+    assert seen, "measure_fn jamais appelé"
+    assert set(seen) == {"make check"}, f"measure() doit recevoir la commande de test configurée, reçu {seen}"

--- a/tests/test_pilot_resume.py
+++ b/tests/test_pilot_resume.py
@@ -155,6 +155,39 @@ async def test_improving_mode_chains_run_improvement(repo, manager):
     assert seen["dry_run"] is False
 
 
+async def test_improving_forwards_gate_test_command_as_coverage_command(repo, manager):
+    # #573 : le test command du gate (gate_options["test_command"]) doit être transmis à
+    # run_improvement comme coverage_command, pour que la Phase 4 mesure avec la VRAIE
+    # commande de test du projet. Sinon measure() lance pytest --cov en dur → tests rouges
+    # sur un projet à setup non trivial → garde G2 rejette toute amélioration (improve mort).
+    pid = manager.create_project(name="mvp")
+    manager.add_task(pid, title="T0")
+    seen = {}
+
+    async def fake_run_improvement(project_id, repo_source, ctx, **kw):
+        seen["coverage_command"] = kw.get("coverage_command")
+        return SimpleNamespace(stop_reason="plateau")
+
+    await run_project(
+        pid,
+        repo,
+        ctx=None,
+        agent=FakeCodeAgent(),
+        owner="o",
+        repo="r",
+        manager=manager,
+        budget=_Budget([ContinueDecision(action=ACTION_CONTINUE, reason="ok")]),
+        sandbox=_Sandbox(),
+        reviewer=FakeReviewer(),
+        clients=_clients(),
+        dry_run=False,
+        improve=True,
+        gate_options={"test_command": "make check"},
+        run_improvement_fn=fake_run_improvement,
+    )
+    assert seen["coverage_command"] == "make check"
+
+
 async def test_improving_not_chained_when_improve_false(repo, manager):
     # improve=False (défaut) → pas d'enchaînement, comportement inchangé.
     pid = manager.create_project(name="noimp")


### PR DESCRIPTION
## Problème (#573)

La boucle d'amélioration **Phase 4** (`collegue/improve/loop.py:run_improvement`) appelait `measure()` **sans transmettre la commande de test configurée** (`GATE_TEST_COMMAND`). `measure()` retombait donc sur `DEFAULT_COVERAGE_COMMAND` (`pytest -q --cov --cov-report=term-missing`) **en dur**.

Sur tout projet à setup de tests **non trivial** (`make check`, monorepo `cd backend && pytest`, démarrage d'un service DB) :
`measure()` lance pytest --cov → la commande échoue (ou ne trouve pas les tests) → `tests_passed=False` → **garde dure G2** (`collegue/improve/gate.py:84`) rejette **CHAQUE** round → plateau → **0 amélioration promue**.

→ Le moteur sait **construire** le MVP mais est **structurellement incapable de l'améliorer** dès qu'un projet réel personnalise sa commande de test. Découvert en testant le 2ᵉ vrai projet **TopoAudit** (stack PostGIS).

Asymétrie vérifiée : le pipeline de **build** propage bien `test_command` (`pipeline.py` `**dict(gate_options)`), mais la chaîne **improve** ne le faisait jamais.

## Correctif

Propagation de bout en bout, **symétrique** avec `execute_issue` :

- **`loop.py`** : `run_improvement` gagne `coverage_command: str = DEFAULT_COVERAGE_COMMAND`, propagé aux **deux** sites de mesure (avant + après diff). Émission **conditionnelle** (kwarg émis seulement si ≠ défaut) → chemin par défaut **byte-identique** et mocks scriptés en CI intacts (même idiome que `_gate_options`).
- **`driver.py`** : `run_project` extrait `gate_options['test_command']` et le passe à `run_improvement(coverage_command=…)`.
- Chaîne CLI complète : `GATE_TEST_COMMAND` → `_gate_options` → `run_project(gate_options=)` → `run_improvement(coverage_command=)` → `measure(coverage_command=)` → `sandbox.run_tests(...)`.

## Tests (TDD, RED→GREEN)

- `tests/test_improve_loop.py::test_forwards_configured_test_command_to_measure` — la commande atteint `measure()` aux deux mesures.
- `tests/test_pilot_resume.py::test_improving_forwards_gate_test_command_as_coverage_command` — le driver transmet `gate_options['test_command']`.
- **Suite non-integration entière verte (1904 tests)**, `ruff check` + `ruff format --check` OK.

## Revue

Revue multi-lentilles (correction adversariale + sécurité + complétude) : verdict **ship**, **0 must-fix**, **0 finding confirmé réel**. Sécurité : aucune nouvelle surface — `test_command` = config opérateur (`GATE_TEST_COMMAND`), même valeur/même sink (`sandbox.run_tests`, Docker isolé) que le build.

## Suivi

Limite connue tracée en **#577** : si `GATE_TEST_COMMAND` n'émet pas de rapport `pytest-cov`, la couverture n'est pas mesurable → terme conservateur 0 (le fix débloque G2 mais la dimension couverture du composite reste neutralisée). À adresser hors de cette PR.

Closes #573

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)