### PR TITLE
fix(moteur): parsing de couverture multi-écosystèmes pour la Phase 4 (#577)

### DIFF
--- a/collegue/improve/loop.py
+++ b/collegue/improve/loop.py
@@ -203,11 +203,11 @@ async def run_improvement(
     # ``tests_passed`` reflète le code de sortie de la VRAIE commande de test du projet.
     # Sans ça, ``measure()`` retombe sur ``DEFAULT_COVERAGE_COMMAND`` (pytest --cov en dur)
     # → tests rouges sur un projet à setup non trivial (make, monorepo, service DB) → garde
-    # dure G2 rejette TOUTE amélioration. (Limite connue, suivi #577 : une commande custom
-    # sans rapport pytest-cov rend la couverture non mesurable → terme conservateur 0.) Le
-    # kwarg n'est émis qu'en override (≠ défaut) → chemin par défaut (et mesures scriptées
-    # en CI) inchangé (symétrie avec ``_gate_options`` qui n'émet ``test_command`` qu'en
-    # override).
+    # dure G2 rejette TOUTE amélioration. (#577 : ``parse_coverage`` reconnaît désormais
+    # aussi go / JS-TS / lcov / cobertura, donc une commande custom à format non pytest-cov
+    # rend quand même la couverture mesurable ; sinon terme conservateur 0.) Le kwarg n'est
+    # émis qu'en override (≠ défaut) → chemin par défaut (et mesures scriptées en CI)
+    # inchangé (symétrie avec ``_gate_options`` qui n'émet ``test_command`` qu'en override).
     measure_extra: dict = {}
     if coverage_command and coverage_command != DEFAULT_COVERAGE_COMMAND:
         measure_extra["coverage_command"] = coverage_command

--- a/collegue/improve/metrics.py
+++ b/collegue/improve/metrics.py
@@ -6,7 +6,8 @@ disque** (et non sur le diff d'une itération) pour rester **symétrique** avant
 — c'est ce qui permet à la boucle G4 de promouvoir un vrai gain sans faux-rejet
 (cf. #541) :
 
-* **couverture de tests ↑** (parsée de la sortie pytest-cov) ;
+* **couverture de tests ↑** (parsée de la sortie : pytest-cov/coverage.py, go, JS-TS
+  istanbul/jest/vitest, lcov, cobertura XML — cf. ``parse_coverage``, #577) ;
 * **sécurité ↓** : compte de secrets **pondéré par sévérité**, issu d'un scan
   **statique** (``secret_scan``, moteur regex, zéro LLM) sur le répertoire du
   projet — déterministe par construction ;
@@ -34,8 +35,10 @@ import sys
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
-# Commande de couverture par défaut (parsée depuis la sortie pytest-cov).
-DEFAULT_COVERAGE_COMMAND = "pytest -q --cov --cov-report=term-missing"
+# Commande de couverture par défaut. ``python -m pytest`` (et non ``pytest`` nu) met le
+# CWD sur ``sys.path`` → un projet src-layout (imports ``from app…``) est collectable sans
+# install editable (#577) ; cohérent avec le gate de build qui utilise déjà ``python -m``.
+DEFAULT_COVERAGE_COMMAND = "python -m pytest -q --cov --cov-report=term-missing"
 
 # Pondération par sévérité des findings de sécurité (secret_scan). Le critique pèse
 # le plus ; le composite et le gate (tolérance 0) raisonnent sur ce total pondéré.
@@ -91,9 +94,35 @@ DEFAULT_LINT_SELECT = ("E", "F", "W")
 # Seuil de complexité cyclomatique (mccabe / ruff C901) : au-delà = « bloc complexe ».
 DEFAULT_COMPLEXITY_MAX = 10
 
-# Regex de la ligne récapitulative TOTAL de pytest-cov : « TOTAL  120  6  95% ».
-# On exige un espace juste après TOTAL (rejette un fichier nommé « TOTAL.py »).
-_TOTAL_RE = re.compile(r"^\s*TOTAL\s+.*?(\d+(?:\.\d+)?)%", re.MULTILINE)
+# Regex de la ligne récapitulative TOTAL de pytest-cov / coverage.py : « TOTAL  120  6  95% ».
+# Modèle COLONNES (et non « .*? » paresseux) : TOTAL puis des colonnes numériques, puis le %.
+# (1) exige un espace après TOTAL → rejette un fichier nommé « TOTAL.py » ; (2) quantificateurs
+# POSSESSIFS (``\d++`` / ``*+``, Python 3.11+) → AUCUN backtracking : une ligne TOTAL suivie d'un
+# long run de chiffres sans « % » (stdout hostile) ne provoque PAS de ReDoS (#577, revue sécu).
+_TOTAL_RE = re.compile(r"^\s*TOTAL\s++(?:\d++(?:\.\d++)?\s++)*+(\d++(?:\.\d++)?)%", re.MULTILINE)
+
+# #577 : parseurs de couverture multi-écosystèmes, essayés du PLUS SPÉCIFIQUE au plus
+# générique (1er match gagnant). Restaure le terme couverture du composite quand
+# ``GATE_TEST_COMMAND`` émet un rapport NON pytest-cov (go / JS-TS / lcov / cobertura) —
+# sans ça, couverture non mesurée → terme dominant figé. Chaque entrée = (motif, échelle) :
+# 100.0 pour les RATIOS 0-1 (cobertura), 1.0 pour les % directs. Tous les motifs sont
+# ANCRÉS (ligne de statut / libellé / balise) et LINÉAIRES (possessifs, pas de « .*? » non
+# borné) → aucun « % » parasite capté, aucun backtracking catastrophique sur entrée hostile.
+# parse_coverage borne le résultat à [0,100] (un faux-match ne peut pas fausser le composite).
+# Limite go : « go test -cover ./... » émet une ligne PAR paquet (pas d'agrégat) → on lit la
+# 1re ; pour un total fiable, préférer « go tool cover -func » (motif ``total:``).
+_COVERAGE_PATTERNS = (
+    (_TOTAL_RE, 1.0),  # pytest-cov / coverage.py « coverage report » (ligne TOTAL)
+    (re.compile(r"^total:\s+(?:\([^)\n]*\)\s++)?(\d++(?:\.\d++)?)%", re.MULTILINE), 1.0),  # go tool cover -func
+    (
+        re.compile(r"^(?:ok|FAIL)\b[^\n]*\bcoverage:\s*+(\d++(?:\.\d++)?)%\s++of statements", re.MULTILINE),
+        1.0,
+    ),  # go test -cover (ancré sur la ligne de statut ok/FAIL)
+    (re.compile(r"^\s*Statements\s*:\s*(\d++(?:\.\d++)?)\s*%", re.MULTILINE), 1.0),  # istanbul/jest text-summary
+    (re.compile(r"^\s*All files\s*\|\s*(\d++(?:\.\d++)?)\s*\|", re.MULTILINE), 1.0),  # istanbul/vitest tableau
+    (re.compile(r"^\s*lines\.*:\s*(\d++(?:\.\d++)?)%", re.IGNORECASE | re.MULTILINE), 1.0),  # lcov --summary
+    (re.compile(r'<coverage[^>]*\bline-rate="(\d*+\.\d++|\d++)"'), 100.0),  # cobertura xml (ratio → %)
+)
 
 
 @dataclass(frozen=True)
@@ -146,15 +175,23 @@ class ProjectQualityMetrics:
 
 
 def parse_coverage(output: str) -> Optional[float]:
-    """Extrait le pourcentage de couverture de la ligne ``TOTAL`` de pytest-cov.
+    """Extrait le % de couverture TOTAL de la sortie d'une commande de test.
 
-    Retourne ``None`` si aucune ligne ``TOTAL … NN%`` n'est présente (sortie
-    tronquée, pas de couverture mesurée…). Gère les pourcentages décimaux.
+    Essaie plusieurs formats (#577) du plus spécifique au plus générique — pytest-cov /
+    coverage.py, go (``-func`` / ``-cover``), JS-TS istanbul/jest/vitest, lcov, cobertura
+    XML — et renvoie le 1er match (les ratios cobertura 0-1 sont convertis en %, décimaux
+    gérés). Retourne ``None`` si aucun format reconnu (sortie tronquée, pas de couverture…).
     """
     if not output:
         return None
-    match = _TOTAL_RE.search(output)
-    return float(match.group(1)) if match else None
+    for pattern, scale in _COVERAGE_PATTERNS:
+        match = pattern.search(output)
+        if match:
+            # Borne [0,100] (revue #577) : un faux-match ne peut pas injecter une valeur
+            # aberrante qui dominerait le composite (poids couverture = 1.0) ou casserait
+            # l'invariant ProjectQualityMetrics.coverage_pct « 0-100 ».
+            return max(0.0, min(100.0, float(match.group(1)) * scale))
+    return None
 
 
 def composite_score(
@@ -429,7 +466,8 @@ async def measure(
     """Mesure couverture + sécu + lint/complexité (déterministes) → composite.
 
     ``sandbox`` est injectable (mocké en CI) ; la couverture vient du parsing de la
-    sortie pytest-cov et ``tests_passed`` = exit 0. Sécu (``security_scan_fn``) et
+    sortie de tests (multi-format, ``parse_coverage`` #577) et ``tests_passed`` = exit 0.
+    Sécu (``security_scan_fn``) et
     lint/complexité (``quality_scan_fn``) viennent de scans **statiques déterministes**
     du **workspace** (injectables en tests). La couverture de docstrings
     (``doc_coverage_fn``) est **informative** (hors composite). Les vulns de dépendances

--- a/tests/test_improve_metrics.py
+++ b/tests/test_improve_metrics.py
@@ -5,6 +5,7 @@ revue LLM = informative (hors composite).
 """
 
 import math
+import time
 
 import pytest
 
@@ -17,6 +18,7 @@ from collegue.improve import (
     parse_coverage,
     persist,
 )
+from collegue.improve.metrics import DEFAULT_COVERAGE_COMMAND
 from collegue.sandbox import SandboxResult
 from collegue.state import ProjectStateManager
 
@@ -81,6 +83,110 @@ def test_parse_coverage_ignores_file_named_total():
     out = "TOTAL.py   10   5   50%\n----\nTOTAL      10   1   90%\n"
     assert parse_coverage(out) == 90.0
     assert parse_coverage("TOTAL.py   10   5   50%\n") is None
+
+
+# --- parse_coverage : formats multi-écosystèmes (#577) --------------------------
+
+
+def test_parse_coverage_go_test_cover():
+    out = "ok  \tmodule/a\t0.012s\tcoverage: 50.0% of statements\n"
+    assert parse_coverage(out) == 50.0
+
+
+def test_parse_coverage_go_func_total():
+    out = "module/a/x.go:10:\tDo\t100.0%\ntotal:\t(statements)\t87.5%\n"
+    assert parse_coverage(out) == 87.5
+
+
+def test_parse_coverage_istanbul_text_summary():
+    out = (
+        "=============================== Coverage summary ===============================\n"
+        "Statements   : 91.22% ( 166/182 )\n"
+        "Branches     : 75% ( 18/24 )\n"
+        "Lines        : 90% ( 161/179 )\n"
+    )
+    assert parse_coverage(out) == 91.22
+
+
+def test_parse_coverage_istanbul_or_vitest_table():
+    out = (
+        "File           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s\n"
+        "---------------|---------|----------|---------|---------|------------------\n"
+        "All files      |   85.71 |    66.66 |     100 |   85.71 |\n"
+    )
+    assert parse_coverage(out) == 85.71
+
+
+def test_parse_coverage_lcov_summary():
+    out = "Summary coverage rate:\n  lines......: 92.3% (1200 of 1300 lines)\n  functions..: 88.0% (44 of 50)\n"
+    assert parse_coverage(out) == 92.3
+
+
+def test_parse_coverage_cobertura_xml_ratio_converted():
+    out = '<?xml version="1.0" ?>\n<coverage line-rate="0.98" branch-rate="0.75" version="6.5">\n'
+    assert parse_coverage(out) == pytest.approx(98.0)
+
+
+def test_parse_coverage_cobertura_zero_and_full():
+    assert parse_coverage('<coverage line-rate="0" branch-rate="0">') == pytest.approx(0.0)
+    assert parse_coverage('<coverage line-rate="1.0">') == pytest.approx(100.0)
+
+
+def test_parse_coverage_ignores_parasitic_percent():
+    # Un % parasite SANS format de couverture reconnu ne doit JAMAIS matcher (#577).
+    assert parse_coverage("discount: 50% off today\n100%|####| 10/10 done\n") is None
+    assert parse_coverage("coverage rose to 80% this week") is None  # pas « of statements »
+
+
+def test_default_coverage_command_uses_python_m_pytest():
+    # #577 : src-layout — `python -m pytest` met le cwd sur sys.path (vs `pytest` nu),
+    # sinon les imports `from app...` cassent à la collecte → garde dure G2 rejette tout.
+    assert DEFAULT_COVERAGE_COMMAND.startswith("python -m pytest")
+    assert "--cov" in DEFAULT_COVERAGE_COMMAND
+
+
+def test_parse_coverage_clamps_to_0_100():
+    # #577 (revue) : un faux-match ne doit JAMAIS injecter une valeur hors [0,100] qui
+    # dominerait le composite (poids couverture = 1.0) et corromprait le delta du gate.
+    assert parse_coverage("All files |   4200 | MB used") == 100.0
+    assert parse_coverage('<coverage line-rate="1.5">') == 100.0
+
+
+def test_parse_coverage_redos_resistant():
+    # #577 (revue) : parse_coverage tourne CÔTÉ HÔTE sur une stdout NON fiable (projet LLM).
+    # Une ligne TOTAL/total: suivie d'un long run de chiffres SANS « % » ne doit pas faire
+    # exploser le temps (backtracking catastrophique) — patterns possessifs/colonnes.
+    hostile_total = "TOTAL " + "1" * 50000
+    hostile_go = "total: " + "1" * 50000
+    start = time.perf_counter()
+    assert parse_coverage(hostile_total) is None
+    assert parse_coverage(hostile_go) is None
+    assert time.perf_counter() - start < 1.0  # corrigé : ~ms ; vulnérable : plusieurs minutes
+
+
+def test_parse_coverage_go_parasitic_not_captured():
+    # #577 (revue) : le motif go ne doit PAS capter un « coverage: NN% of statements » au
+    # milieu d'une phrase / log / commentaire (ancrage sur la ligne de statut ok/FAIL).
+    assert parse_coverage("Note: coverage: 5% of statements is too low, see docs") is None
+    assert parse_coverage("// historical coverage: 99% of statements (2019)") is None
+
+
+def test_parse_coverage_go_multipackage_takes_first_documented():
+    # Limite connue documentée : « go test -cover ./... » émet une ligne PAR paquet (pas
+    # d'agrégat) → on lit le 1er (déterministe). Pour un total fiable : « go tool cover -func ».
+    out = "ok  pkg/a  0.01s  coverage: 40.0% of statements\nok  pkg/b  0.02s  coverage: 90.0% of statements\n"
+    assert parse_coverage(out) == 40.0
+
+
+def test_parse_coverage_lcov_dots_optional_and_case():
+    # #577 (revue) : tolérer 'lines:' (sans points) et 'Lines:' (capitale).
+    assert parse_coverage("  lines: 92.3% (1200 of 1300 lines)") == 92.3
+    assert parse_coverage("Lines: 88.0%") == 88.0
+
+
+def test_parse_coverage_cobertura_leading_dot():
+    # #577 (revue) : line-rate=".97" (sans zéro de tête) → 97.0.
+    assert parse_coverage('<coverage line-rate=".97" branch-rate="0.5">') == pytest.approx(97.0)
 
 
 # --- composite_score ------------------------------------------------------------


### PR DESCRIPTION
## Problème (#577 — suivi de #573)

La boucle d'amélioration **Phase 4** ne mesurait la couverture que depuis la ligne `TOTAL …NN%` de **pytest-cov** ([`metrics.py:parse_coverage`](collegue/improve/metrics.py)). Une `GATE_TEST_COMMAND` à format **non pytest-cov** (go, JS/TS istanbul/jest/vitest, lcov, cobertura XML) → `coverage_measured=False`, `coverage_pct=0` → le terme **dominant** du composite (poids `coverage=1.0`) reste figé → la Phase 4 ne peut pas optimiser son levier principal.

## Correctif

- **`parse_coverage` généralisé** : table ordonnée de **7 motifs** (spécifique→générique), 1er match gagnant — pytest-cov/coverage.py · go (`tool cover -func` + `test -cover`) · istanbul/jest text-summary · istanbul/vitest tableau · lcov · cobertura XML (ratio 0-1 → ×100). pytest-cov reste **en tête → 0 régression**.
- **`DEFAULT_COVERAGE_COMMAND`** : `pytest` → `python -m pytest` (src-layout : `cwd` sur `sys.path`, cohérent avec le gate de build).
- **Pondération adaptative (piste 2) écartée** (décision actée) : le terme couverture est *constant* avant/après quand non mesuré → s'annule dans le delta du gate ; repondérer casserait la symétrie avant/après fondatrice.

## Revue multi-lentilles (verdict initial : fix-first) → tout corrigé

- **ReDoS (HIGH)** : les motifs `TOTAL`/`total:` en `.*?` backtrackaient (parse exécuté **côté hôte** sur une stdout **non fiable**, hors timeout sandbox → gel de la boucle asyncio). Remplacés par des quantificateurs **possessifs / modèle colonnes** (Python 3.11+). Vérifié : **200 000 chiffres hostiles en <4 ms** (vs **1336 ms** pour 8 000 avant).
- **Clamp [0,100] (HIGH)** : `parse_coverage` borne le résultat → un faux-match (`All files | 4200 |`, `line-rate="1.5"`) ne peut plus injecter une valeur aberrante qui dominerait le composite.
- **go test -cover** ancré sur la ligne de statut `ok`/`FAIL` (ne capte plus un `coverage: NN% of statements` au milieu d'un log) ; **go multi-paquets** documenté (préférer `go tool cover -func`) ; **lcov** sans points & **cobertura** `.98` tolérés.

## Tests (TDD, RED→GREEN)

15 cas `parse_coverage` : 7 formats + clamp hors-borne + **garde ReDoS** (50 000 chiffres < 1 s) + parasites → `None` + go multi-paquets + variantes lcov/cobertura. **Suite non-integration verte**, `ruff check` + `ruff format --check` OK.

## Validation réelle

Vrai `coverage.xml` **Cobertura** généré depuis FacNor dans un **DockerSandbox réel** (`python:3.12-slim`) : **ancien parseur (TOTAL seul) → `None`** (couverture non mesurée = le bug) ; **nouveau → 97.66** (line-rate 0.9766 ×100, couverture **mesurée**).

Closes #577

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)