### PR TITLE
fix(pilot): barrière stricte BUILD → IMPROVE après merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,13 @@ python -m collegue.pilot ... --execute            # écritures réelles (PR + é
 python -m collegue.pilot ... --execute --improve  # + cycle d'amélioration
 ```
 
-`--improve` enchaîne, une fois le MVP construit, la **boucle d'amélioration continue**
+`--improve` enchaîne, une fois le MVP **réellement mergé puis resynchronisé sur
+`origin/<base>`**, la **boucle d'amélioration continue**
 (Phase 4) : un **objectif de qualité déterministe** (couverture − sécu − lint −
 complexité, sans avis de LLM) ouvre des PR seulement quand le diff **progresse sans
 régression** (gate fail-closed) ; les PR sont **stackées** et s'arrêtent au plateau.
+Une dernière PR BUILD non mergée ou un resync git en échec bloque Phase 4 au lieu
+de produire un faux succès `completed`.
 
 Architecture, boucle d'amélioration, garde-fous, observabilité/audit, reprise après
 crash et réglages : **[docs/moteur_autonome.md](docs/moteur_autonome.md)**.

--- a/collegue/executor/workspace.py
+++ b/collegue/executor/workspace.py
@@ -47,6 +47,30 @@ def branch_for_issue(number: int) -> str:
     return f"{BRANCH_PREFIX}{int(number)}"
 
 
+def resync_repository_base(
+    repo_source: str,
+    base: str,
+    *,
+    runner=None,
+) -> bool:
+    """Réaligne le clone source sur ``origin/<base>`` avant une nouvelle phase.
+
+    La construction autonome merge des PR sur GitHub alors que ``repo_source``
+    reste un clone local. Une phase suivante lancée sans ``fetch`` + ``reset``
+    mesurerait donc une base potentiellement périmée. Le résultat est explicite :
+    ``False`` dès qu'une des deux commandes échoue, afin que l'appelant puisse
+    rester fail-closed (notamment avant la Phase 4).
+
+    ``runner`` est injectable pour tester l'ordre merge → resync → amélioration.
+    """
+    command_runner = runner or LocalCommandRunner()
+    fetched = command_runner.run_command(["git", "fetch", "origin", base], repo_source)
+    if not getattr(fetched, "ok", False):
+        return False
+    reset = command_runner.run_command(["git", "reset", "--hard", f"origin/{base}"], repo_source)
+    return bool(getattr(reset, "ok", False))
+
+
 def prepare_workspace(
     repo_source: str,
     issue: IssueSpec,

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -30,7 +30,7 @@ import logging
 import math
 import re
 from dataclasses import dataclass, field
-from typing import List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 from collegue.executor.agent import IssueSpec
 from collegue.executor.openhands_agent import coder_pricing_resolvable, estimate_cost_usd
@@ -43,7 +43,12 @@ from collegue.executor.pipeline import (
     is_infra_noise,
     log_tail,
 )
-from collegue.executor.workspace import branch_for_issue, cleanup_workspace, sweep_stale_temp_clones
+from collegue.executor.workspace import (
+    branch_for_issue,
+    cleanup_workspace,
+    resync_repository_base,
+    sweep_stale_temp_clones,
+)
 from collegue.pilot.audit import (
     BUDGET_EVENT,
     CHECKPOINT_SAVED,
@@ -91,6 +96,7 @@ STOP_BLOCKED = "blocked"  # graphe coincé (dépendance échouée)
 STOP_AWAITING_MERGE = "awaiting_merge"  # mode strict (#411) : tout est prêt SAUF des merges humains
 STOP_SAFETY_CAP = "safety_cap"  # garde-fou anti-boucle
 STOP_SANDBOX_BROKEN = "sandbox_broken"  # crash-loop d'import agent : image/runner cassé (#498)
+STOP_REPO_SYNC_FAILED = "repo_sync_failed"  # base locale non vérifiée → Phase 4 interdite (#580)
 
 
 class CostPricingUnresolvedError(RuntimeError):
@@ -518,6 +524,7 @@ async def run_project(
     reconcile_reviews: bool = True,
     cleanup_workspaces: bool = True,
     require_cost_pricing: bool = False,
+    sync_base_fn: Optional[Callable[[str, str], bool]] = None,
 ) -> ProjectRunResult:
     """Pilote un projet : chaîne ``execute_issue`` sur les tâches prêtes sous budget.
 
@@ -576,6 +583,10 @@ async def run_project(
     (merge 405 irrécupérable sans opérateur). Augmenter rétablit N PRs en vol
     (au risque documenté de #434). Ignoré hors mode strict (comportement
     historique inchangé : ``in_review`` débloque déjà les dépendants).
+
+    ``sync_base_fn`` (#580) : barrière injectable ``(repo_source, base) -> bool``
+    exécutée avant la Phase 4. Le défaut fait ``git fetch`` + ``reset --hard`` sur
+    ``origin/<base>``. Un échec interdit l'amélioration (``repo_sync_failed``).
     """
     budget = budget or BudgetTimeController()
     audit = audit or NullAuditLog()
@@ -729,6 +740,11 @@ async def run_project(
             # run après merge reprend naturellement) ; soit un graphe coincé
             # (dépendance échouée) → bloqué ; sinon, tout est construit → MVP.
             if not remaining_tasks(tasks):
+                # Le BUILD a produit toutes ses PR. Elles peuvent encore être
+                # ``in_review`` : ce stop historique reste ``completed`` pour le
+                # driver bas niveau, mais #580 interdit désormais de le confondre
+                # avec un MVP INTÉGRÉ (voir ``mvp_built`` ci-dessous). Le runtime
+                # produit transforme ce cas en awaiting_merge si le drain échoue.
                 stop_reason = STOP_COMPLETED
             elif require_merged_deps and ready_tasks(tasks):
                 stop_reason = STOP_AWAITING_MERGE
@@ -1082,16 +1098,37 @@ async def run_project(
             )
             audit.record(CHECKPOINT_SAVED, iteration=iteration)
 
-    audit.record(RUN_STOP, iteration=iteration, reason=stop_reason, iterations=len(processed))
-
     project_status: Optional[str] = None
-    # MVP atteint : run terminé (``STOP_COMPLETED`` implique qu'aucune tâche n'a échoué
-    # — sinon ``STOP_BLOCKED``) et le projet a des tâches, toutes satisfaites. Vrai aussi
-    # à la REPRISE d'un MVP déjà construit (tâches déjà ``in_review`` en DB → ``processed``
-    # vide) : on se base donc sur ``len(tasks) > 0`` et non sur ``processed`` (sinon une
-    # reprise ne basculerait jamais en amélioration — le cas même que H5 doit couvrir).
-    # ``len(tasks) > 0`` exclut le projet vide (anti-vacuité). Réel uniquement.
-    mvp_built = stop_reason == STOP_COMPLETED and len(tasks) > 0 and not dry_run
+    # #580 : « construit » signifie désormais INTÉGRÉ dans la branche de base.
+    # ``in_review`` n'est pas suffisant : la PR peut encore échouer au merge et son
+    # code n'est pas dans ``repo_source``. Les statuts stricts sont précisément
+    # ``done``/``merged``. ``len(tasks) > 0`` conserve l'anti-vacuité.
+    mvp_built = (
+        stop_reason == STOP_COMPLETED
+        and len(tasks) > 0
+        and all(t.status in SATISFIED_STATUSES_STRICT for t in tasks)
+        and not dry_run
+    )
+
+    # Barrière de handoff BUILD → IMPROVE : même après des merges confirmés dans
+    # l'état durable, on refuse de mesurer une copie locale qui n'a pas été
+    # explicitement réalignée sur origin/<base>. Ce second resync vérifie aussi le
+    # chemin « merges humains entre deux runs », que le merge-bot n'a pas vu.
+    if mvp_built and improve:
+        sync = sync_base_fn or resync_repository_base
+        try:
+            base_current = bool(sync(repo_source, base))
+        except Exception as exc:  # noqa: BLE001 - plomberie git : fail-closed
+            logger.warning("handoff BUILD→IMPROVE : resync de la base en erreur : %s", exc)
+            base_current = False
+        if not base_current:
+            stop_reason = STOP_REPO_SYNC_FAILED
+            mvp_built = False
+            logger.error(
+                "Phase 4 interdite : impossible de vérifier que %s est aligné sur origin/%s (#580).",
+                repo_source,
+                base,
+            )
     if mvp_built:
         manager.update_project(project_id, status=PROJECT_STATUS_IMPROVING)
         project_status = PROJECT_STATUS_IMPROVING
@@ -1130,6 +1167,10 @@ async def run_project(
             dry_run=dry_run,
             **improve_extra,
         )
+
+    # Le motif peut changer pendant la barrière de handoff (#580) : journaliser
+    # seulement le verdict FINAL, pas le faux ``completed`` calculé avant resync.
+    audit.record(RUN_STOP, iteration=iteration, reason=stop_reason, iterations=len(processed))
 
     return ProjectRunResult(
         stop_reason=stop_reason,

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -301,12 +301,9 @@ def _resync_repo_source(repo_source: str, base: str, *, git_runner=None) -> bool
     Après un merge sur GitHub, le ``repo_source`` local est PÉRIMÉ ; la tâche
     suivante (qui le clone) ne contiendrait pas le code mergé → conflits. On
     ``fetch`` + ``reset --hard`` pour que la base reparte du MVP en cours."""
-    from collegue.executor.command import LocalCommandRunner
+    from collegue.executor.workspace import resync_repository_base
 
-    runner = git_runner or LocalCommandRunner()
-    fetched = runner.run_command(["git", "fetch", "origin", base], repo_source)
-    reset = runner.run_command(["git", "reset", "--hard", f"origin/{base}"], repo_source)
-    return bool(getattr(fetched, "ok", False) and getattr(reset, "ok", False))
+    return resync_repository_base(repo_source, base, runner=git_runner)
 
 
 async def _merge_in_review_prs(
@@ -383,6 +380,7 @@ async def run_project_from_settings(
     run_improvement_fn=None,
     audit=None,
     cost_source=None,
+    sync_base_fn=None,
 ) -> ProjectRunResult:
     """Assemble les dépendances (depuis la config) et lance ``run_project``.
 
@@ -471,6 +469,9 @@ async def run_project_from_settings(
         cost_source=cost_source,
         # #502 : refus opt-in de démarrer si le prix coder n'est pas résolvable.
         require_cost_pricing=bool(getattr(settings_obj, "REQUIRE_COST_PRICING", False)),
+        # #580 : vérification stricte juste avant Phase 4. Injectable pour les
+        # tests ; le défaut vit dans le driver (fetch + reset origin/<base>).
+        sync_base_fn=sync_base_fn,
     )
 
     try:
@@ -512,6 +513,8 @@ async def run_project_from_settings(
             # complète dès que sa PR est ouverte (plus aucune tâche prête), SANS repasser par
             # `awaiting_merge` → la boucle ci-dessus ne l'aurait pas mergée. On draine les PR
             # in_review résiduelles (travail validé) pour finir le MVP à 100%. Idempotent.
+            tasks_before_final_drain = manager.get_tasks(project_id)
+            had_pending_final_reviews = any(getattr(t, "status", None) == "in_review" for t in tasks_before_final_drain)
             await _merge_in_review_prs(
                 manager,
                 clients,
@@ -521,10 +524,44 @@ async def run_project_from_settings(
                 repo_source=repo_source,
                 base=base,
             )
+            # #580 : le premier ``completed`` peut signifier « dernière PR BUILD
+            # ouverte », pas encore « MVP intégré ». Après le drain final, si tout
+            # est réellement merged/done, une ultime passe sans tâche réalise le
+            # handoff strict (resync vérifié dans le driver) puis Phase 4. Sans
+            # cette passe, --execute --improve s'arrêterait après le merge sans
+            # jamais améliorer dans la même invocation.
+            integrated = manager.get_tasks(project_id)
+            all_integrated = bool(integrated) and all(
+                getattr(t, "status", None) in {"merged", "done"} for t in integrated
+            )
+            if (
+                improve
+                and had_pending_final_reviews
+                and result.stop_reason == "completed"
+                and result.improvement is None
+                and all_integrated
+            ):
+                result = await run_project(project_id, repo_source, ctx, **run_kwargs)
+                all_processed.extend(result.processed)
+
             # Le reporting reflète TOUTES les tâches traitées sur l'ensemble des passes
             # (sinon `processed`/`iterations` ne refléteraient que la dernière passe).
             result.processed = all_processed
             result.iterations = len(all_processed)
+
+        # #580, défense en profondeur : un adaptateur/fake qui rapporterait
+        # ``completed`` alors que l'état durable porte encore des PR BUILD
+        # ouvertes ne doit jamais produire un faux succès. Le vrai driver renvoie
+        # déjà awaiting_merge ; cette relecture couvre le drain final et les
+        # erreurs de merge tardives.
+        fresh_tasks = manager.get_tasks(project_id)
+        pending_review_ids = [t.id for t in fresh_tasks if getattr(t, "status", None) == "in_review"]
+        result.pending_reviews = pending_review_ids
+        if not dry_run and result.stop_reason == "completed" and pending_review_ids:
+            from collegue.pilot.driver import STOP_AWAITING_MERGE
+
+            result.stop_reason = STOP_AWAITING_MERGE
+            result.project_status = None
 
         # Reporting (journal de décisions) — réel uniquement (dry_run n'écrit rien).
         if not dry_run:

--- a/docs/moteur_autonome.md
+++ b/docs/moteur_autonome.md
@@ -64,6 +64,7 @@ ou on refuse) :
 | Garde-fou | Comportement |
 |-----------|--------------|
 | **Merge-bot (phase BUILD)** | Pendant la **construction du MVP**, une tâche réussie est **auto-mergée** (squash) puis le clone local est resynchronisé sur `origin/<base>` avant la tâche suivante (`BUILD_AUTO_MERGE=true` par défaut). Sans lui, avec 1 PR en vol + dépendances strictes, le build se figerait `awaiting_merge` (et des bases périmées créeraient des conflits). C'est le merge humain **simulé** pendant la construction autonome. Mettre `BUILD_AUTO_MERGE=false` ramène tout au merge humain. |
+| **Barrière BUILD → IMPROVE** | Une PR `in_review` ne compte **jamais** comme un MVP intégré. Phase 4 exige toutes les tâches en `merged`/`done`, puis un `git fetch` + `reset --hard origin/<base>` réussi juste avant sa première mesure. Merge final ou resync en échec ⇒ `awaiting_merge` / `repo_sync_failed`, aucune amélioration. |
 | **Merge humain (phase AMÉLIORATION, §6)** | Les PR d'**amélioration** (Phase 4) restent **ouvertes** : elles ne sont **jamais** auto-mergées — relecture/merge par un **humain**. C'est le défaut sûr pour faire évoluer un produit déjà construit. |
 | **`dry_run` par défaut** | Sans `--execute`, le pipeline va jusqu'aux **aperçus** de PR sans **aucune** écriture (ni GitHub ni état) — et **aucun** auto-merge. |
 | **Budget dur** | `MAX_COST_USD` / `MAX_TOKENS_BUDGET` atteints → **auto-pause** (les appels LLM sont stoppés). `COLLEGUE_RUN_DEADLINE_SECONDS` borne la durée mur. |
@@ -76,7 +77,7 @@ ou on refuse) :
 
 ## Amélioration continue (Phase 4)
 
-Une fois le MVP construit (`--improve`), le moteur ne s'arrête pas : il **fait
+Une fois le MVP **mergé et resynchronisé** (`--improve`), le moteur ne s'arrête pas : il **fait
 progresser la qualité du projet généré** en ouvrant des PR d'amélioration, sous le
 budget restant. Le cœur est une **fonction objectif déterministe** — pas un avis de
 LLM — pour qu'une promotion soit reproductible et **sans faux-rejet** :
@@ -242,7 +243,9 @@ sandbox). Le reviewer/juge suit le même chemin quand son modèle n'est pas un
 modèle Gemini (`LLM_MODEL_REVIEWER=gpt-5.4` → échantillonné dans le sandbox).
 Avec `BUILD_AUTO_MERGE=true` (défaut), un seul `--execute` construit **tout le
 MVP** (merge-bot enchaîne les tâches) ; `--improve` ajoute ensuite des PR
-d'amélioration **laissées ouvertes** pour merge humain.
+d'amélioration **laissées ouvertes** pour merge humain. Le handoff est fail-closed :
+la Phase 4 ne démarre qu'après le merge de la dernière PR BUILD et une nouvelle
+vérification de l'alignement du clone sur `origin/<base>`.
 
 ---
 

--- a/tests/test_executor_workspace.py
+++ b/tests/test_executor_workspace.py
@@ -59,6 +59,42 @@ def test_branch_for_issue():
     assert branch_for_issue(42) == "collegue/issue-42"
 
 
+# --- resync_repository_base -----------------------------------------------------
+
+
+def test_resync_repository_base_fetches_before_reset():
+    from collegue.executor.workspace import resync_repository_base
+    from collegue.sandbox import SandboxResult
+
+    calls = []
+
+    class _Runner:
+        def run_command(self, command, workspace):
+            calls.append((command, workspace))
+            return SandboxResult(exit_code=0, stdout="", stderr="")
+
+    assert resync_repository_base("/repo", "main", runner=_Runner()) is True
+    assert calls == [
+        (["git", "fetch", "origin", "main"], "/repo"),
+        (["git", "reset", "--hard", "origin/main"], "/repo"),
+    ]
+
+
+def test_resync_repository_base_never_resets_after_failed_fetch():
+    from collegue.executor.workspace import resync_repository_base
+    from collegue.sandbox import SandboxResult
+
+    calls = []
+
+    class _Runner:
+        def run_command(self, command, workspace):
+            calls.append(command)
+            return SandboxResult(exit_code=1, stdout="", stderr="fetch failed")
+
+    assert resync_repository_base("/repo", "main", runner=_Runner()) is False
+    assert calls == [["git", "fetch", "origin", "main"]]
+
+
 # --- prepare_workspace ----------------------------------------------------------
 
 

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -162,14 +162,14 @@ async def test_dry_run_builds_whole_chain_without_writes(repo, manager):
     assert all(t.status == "todo" for t in manager.get_tasks(pid))
 
 
-async def test_real_run_advances_states_and_switches_to_improving(repo, manager):
+async def test_real_run_advances_states_but_does_not_promote_unmerged_mvp(repo, manager):
     pid = _linear_project(manager, 2)
     result = await _run(manager, repo, pid, dry_run=False)
     assert result.stop_reason == "completed"
     assert result.iterations == 2
-    assert result.project_status == "improving"
+    assert result.project_status is None  # #580 : PRs ouvertes != MVP intégré
     assert all(t.status == "in_review" for t in manager.get_tasks(pid))
-    assert manager.get_project(pid).status == "improving"
+    assert manager.get_project(pid).status != "improving"
     assert result.opened_prs == [101, 101]
 
 
@@ -210,7 +210,7 @@ async def test_interrupted_in_progress_task_is_retried(repo, manager):
     result = await _run(manager, repo, pid, dry_run=False)
     assert result.stop_reason == "completed"
     assert result.iterations == 1  # re-tentée
-    assert result.project_status == "improving"
+    assert result.project_status is None  # PR encore in_review : pas de Phase 4
     assert manager.get_tasks(pid)[0].status == "in_review"
 
 

--- a/tests/test_pilot_e2e.py
+++ b/tests/test_pilot_e2e.py
@@ -150,7 +150,9 @@ async def test_plan_then_run_handoff_via_product(monkeypatch, manager, git_repo)
         budget=_Budget(),
         ctx=_Ctx(),
     )
-    assert result.stop_reason == "completed"
+    # #580 : sans merge-bot, des PR ouvertes ne constituent pas encore un MVP
+    # intégré. Le runtime produit expose donc explicitement l'attente de merge.
+    assert result.stop_reason == "awaiting_merge"
     assert result.iterations == 2
     # Le handoff fonctionne : le run a repris les tâches planifiées et les a construites.
     assert all(t.status == "in_review" for t in manager.get_tasks(plan.project_id))

--- a/tests/test_pilot_resume.py
+++ b/tests/test_pilot_resume.py
@@ -122,9 +122,10 @@ def repo(tmp_path):
 
 
 async def test_improving_mode_chains_run_improvement(repo, manager):
-    # MVP construit (réel) + improve=True → enchaîne run_improvement sous le MÊME budget.
+    # MVP INTÉGRÉ (merged) + improve=True → run_improvement sous le MÊME budget.
     pid = manager.create_project(name="mvp")
-    manager.add_task(pid, title="T0")
+    tid = manager.add_task(pid, title="T0")
+    manager.update_task_status(tid, "merged")
     seen = {}
 
     async def fake_run_improvement(project_id, repo_source, ctx, **kw):
@@ -148,6 +149,7 @@ async def test_improving_mode_chains_run_improvement(repo, manager):
         dry_run=False,
         improve=True,
         run_improvement_fn=fake_run_improvement,
+        sync_base_fn=lambda _src, _base: True,
     )
     assert result.project_status == "improving"
     assert result.improvement is not None and result.improvement.stop_reason == "plateau"
@@ -161,7 +163,8 @@ async def test_improving_forwards_gate_test_command_as_coverage_command(repo, ma
     # commande de test du projet. Sinon measure() lance pytest --cov en dur → tests rouges
     # sur un projet à setup non trivial → garde G2 rejette toute amélioration (improve mort).
     pid = manager.create_project(name="mvp")
-    manager.add_task(pid, title="T0")
+    tid = manager.add_task(pid, title="T0")
+    manager.update_task_status(tid, "merged")
     seen = {}
 
     async def fake_run_improvement(project_id, repo_source, ctx, **kw):
@@ -184,6 +187,7 @@ async def test_improving_forwards_gate_test_command_as_coverage_command(repo, ma
         improve=True,
         gate_options={"test_command": "make check"},
         run_improvement_fn=fake_run_improvement,
+        sync_base_fn=lambda _src, _base: True,
     )
     assert seen["coverage_command"] == "make check"
 
@@ -191,7 +195,8 @@ async def test_improving_forwards_gate_test_command_as_coverage_command(repo, ma
 async def test_improving_not_chained_when_improve_false(repo, manager):
     # improve=False (défaut) → pas d'enchaînement, comportement inchangé.
     pid = manager.create_project(name="noimp")
-    manager.add_task(pid, title="T0")
+    tid = manager.add_task(pid, title="T0")
+    manager.update_task_status(tid, "merged")
 
     async def fake_run_improvement(*a, **k):  # ne doit pas être appelé
         raise AssertionError("run_improvement ne doit pas être enchaîné si improve=False")
@@ -216,11 +221,11 @@ async def test_improving_not_chained_when_improve_false(repo, manager):
 
 
 async def test_improving_chains_on_resumed_completed_mvp(repo, manager):
-    # Reprise d'un MVP DÉJÀ construit (toutes les tâches in_review en DB → processed vide)
-    # : on doit quand même basculer + enchaîner l'amélioration. C'est le cas que H5 vise.
+    # Reprise d'un MVP DÉJÀ intégré (toutes les tâches merged en DB → processed vide)
+    # : on doit quand même basculer + enchaîner l'amélioration.
     pid = manager.create_project(name="resumed")
     tid = manager.add_task(pid, title="T0")
-    manager.update_task_status(tid, "in_review")  # construite lors d'un run précédent
+    manager.update_task_status(tid, "merged")
     seen = {}
 
     async def fake_run_improvement(project_id, repo_source, ctx, **kw):
@@ -242,17 +247,90 @@ async def test_improving_chains_on_resumed_completed_mvp(repo, manager):
         dry_run=False,
         improve=True,
         run_improvement_fn=fake_run_improvement,
+        sync_base_fn=lambda _src, _base: True,
     )
     assert result.iterations == 0  # rien à reconstruire
     assert result.project_status == "improving"
     assert seen.get("called") and result.improvement.stop_reason == "plateau"
 
 
+async def test_improving_is_blocked_until_every_build_pr_is_merged(repo, manager):
+    """#580 : du code validé mais encore ``in_review`` n'est pas un MVP intégré."""
+    pid = manager.create_project(name="pending-merge")
+    tid = manager.add_task(pid, title="T0")
+    manager.update_task_status(tid, "in_review")
+    called = {"improve": False, "sync": False}
+
+    async def fake_run_improvement(*args, **kwargs):
+        called["improve"] = True
+        raise AssertionError("Phase 4 ne doit jamais voir un MVP non mergé")
+
+    def fake_sync(_src, _base):
+        called["sync"] = True
+        return True
+
+    result = await run_project(
+        pid,
+        repo,
+        ctx=None,
+        agent=FakeCodeAgent(),
+        owner="o",
+        repo="r",
+        manager=manager,
+        budget=_Budget([ContinueDecision(action=ACTION_CONTINUE, reason="ok")]),
+        sandbox=_Sandbox(),
+        reviewer=FakeReviewer(),
+        clients=_clients(),
+        dry_run=False,
+        improve=True,
+        run_improvement_fn=fake_run_improvement,
+        sync_base_fn=fake_sync,
+    )
+    assert result.improvement is None
+    assert result.pending_reviews == [tid]
+    assert result.project_status is None
+    assert called == {"improve": False, "sync": False}
+
+
+async def test_improving_fails_closed_when_base_resync_fails(repo, manager):
+    """#580 : même avec l'état ``merged``, une base locale non vérifiée bloque Phase 4."""
+    pid = manager.create_project(name="stale-base")
+    tid = manager.add_task(pid, title="T0")
+    manager.update_task_status(tid, "merged")
+    called = {"improve": False}
+
+    async def fake_run_improvement(*args, **kwargs):
+        called["improve"] = True
+        raise AssertionError("Phase 4 ne doit pas partir d'un clone périmé")
+
+    result = await run_project(
+        pid,
+        repo,
+        ctx=None,
+        agent=FakeCodeAgent(),
+        owner="o",
+        repo="r",
+        manager=manager,
+        budget=_Budget([ContinueDecision(action=ACTION_CONTINUE, reason="ok")]),
+        sandbox=_Sandbox(),
+        reviewer=FakeReviewer(),
+        clients=_clients(),
+        dry_run=False,
+        improve=True,
+        run_improvement_fn=fake_run_improvement,
+        sync_base_fn=lambda _src, _base: False,
+    )
+    assert result.stop_reason == "repo_sync_failed"
+    assert result.improvement is None and called["improve"] is False
+    assert result.project_status is None
+    assert manager.get_project(pid).status != "improving"
+
+
 async def test_runtime_threads_improve_flag(repo, manager):
     # Le runtime propage `improve`/`run_improvement_fn` jusqu'au driver (sinon mode mort).
     pid = manager.create_project(name="rt2")
     tid = manager.add_task(pid, title="T0")
-    manager.update_task_status(tid, "in_review")  # MVP déjà construit
+    manager.update_task_status(tid, "merged")  # MVP déjà intégré
     seen = {}
 
     async def fake_run_improvement(project_id, repo_source, ctx, **kw):
@@ -277,6 +355,7 @@ async def test_runtime_threads_improve_flag(repo, manager):
         budget=None,
         improve=True,
         run_improvement_fn=fake_run_improvement,
+        sync_base_fn=lambda _src, _base: True,
     )
     assert seen.get("called")
     assert result.improvement.stop_reason == "plateau"

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -118,7 +118,7 @@ async def test_dry_run_builds_chain_without_writes(git_repo, manager):
 async def test_real_run_records_summary_decision(git_repo, manager):
     pid = _linear(manager, 1)
     result = await _run(manager, git_repo, pid, dry_run=False)
-    assert result.stop_reason == "completed"
+    assert result.stop_reason == "awaiting_merge"  # #580 : le fake ne sait pas merger
     assert any("Run pilote" in d.summary for d in manager.get_decisions(pid))
     assert manager.get_tasks(pid)[0].status == "in_review"
 
@@ -153,7 +153,7 @@ async def test_real_run_wires_cost_governance_by_default(git_repo, manager):
         clients=_clients(),
         budget=_Budget(),
     )
-    assert result.stop_reason == "completed"
+    assert result.stop_reason == "awaiting_merge"  # usage compté, mais PR non mergée
     summary = run_cost_summary(manager, pid)
     assert summary["tokens"] == 1200  # canal coder enfin compté
     assert summary["usd"] == pytest.approx(0.003)
@@ -405,6 +405,135 @@ async def test_build_auto_merge_drains_last_pr_on_complete(monkeypatch, manager,
     )
     assert calls["run"] == 1  # pas d'awaiting_merge → 1 passe
     assert calls["merge"] == 1  # drain final exécuté quand même (dernière PR)
+
+
+async def test_build_improve_handoff_orders_merge_resync_then_phase4(monkeypatch, manager, git_repo):
+    """#580 : preuve combinée du vrai runtime, sans LLM/réseau.
+
+    La dernière PR BUILD doit être ouverte, mergée, le clone resynchronisé, puis
+    seulement Phase 4 peut démarrer dans une seconde passe sans tâche.
+    """
+    import collegue.pilot.runtime as runtime
+
+    pid = _linear(manager, 1)
+    events = []
+    pr = SimpleNamespace(number=77, html_url="https://gh/pull/77", head_branch="collegue/issue-1")
+
+    class _TrackingPRs:
+        def __init__(self):
+            self.created = False
+
+        def find_pr_by_head(self, owner, repo, head, base=None, state="open"):
+            return pr if self.created else None
+
+        def create_pr(self, owner, repo, title, head, base, body):
+            self.created = True
+            events.append("pr_opened")
+            return pr
+
+        def merge_pr(self, owner, repo, number, method="squash", expected_head_sha=None):
+            events.append("merged")
+            return SimpleNamespace(merged=True, already_merged=False)
+
+    async def fake_improvement(project_id, repo_source, ctx, **kwargs):
+        events.append("improved")
+        return SimpleNamespace(stop_reason="plateau")
+
+    def strict_handoff_sync(_src, _base):
+        events.append("handoff_resynced")
+        return True
+
+    # Le merge-bot fait déjà un resync après merge ; on le rend déterministe et
+    # visible, puis le driver effectue sa seconde vérification stricte.
+    monkeypatch.setattr(
+        runtime,
+        "_resync_repo_source",
+        lambda _src, _base, **_kw: events.append("merge_resynced") or True,
+    )
+    monkeypatch.setattr("collegue.executor.openhands_agent.coder_pricing_resolvable", lambda s=None: True)
+
+    clients = PrClients(branches=_Branches(), files=_Files(), prs=_TrackingPRs())
+    result = await run_project_from_settings(
+        pid,
+        git_repo,
+        owner="o",
+        repo="r",
+        dry_run=False,
+        settings_obj=SimpleNamespace(BUILD_AUTO_MERGE=True),
+        manager=manager,
+        sandbox=_Sandbox(),
+        agent=FakeCodeAgent(),
+        reviewer=FakeReviewer(),
+        clients=clients,
+        budget=_Budget(),
+        ctx=SimpleNamespace(),
+        improve=True,
+        run_improvement_fn=fake_improvement,
+        sync_base_fn=strict_handoff_sync,
+        audit=SimpleNamespace(
+            record=lambda *a, **k: None,
+            record_cost=lambda *a, **k: None,
+            record_once=lambda *a, **k: None,
+            cost_summary=lambda: {"usd": 0.0, "tokens": 0},
+        ),
+        cost_source=lambda: (0.0, 0),
+    )
+
+    assert result.stop_reason == "completed"
+    assert result.improvement.stop_reason == "plateau"
+    assert manager.get_task(1).status == "merged"
+    assert events == ["pr_opened", "merged", "merge_resynced", "handoff_resynced", "improved"]
+
+
+async def test_failed_final_merge_never_reports_completed_or_runs_phase4(monkeypatch, manager, git_repo):
+    """#580 : un drain final KO reste awaiting_merge, sans faux succès ni Phase 4."""
+    import collegue.pilot.runtime as runtime
+
+    pid = _linear(manager, 1)
+    improved = {"called": False}
+
+    async def never_merge(*args, **kwargs):
+        return False, "CI/merge indisponible"
+
+    async def fake_improvement(*args, **kwargs):
+        improved["called"] = True
+        raise AssertionError("Phase 4 interdite après un merge BUILD échoué")
+
+    class _KnownPRs(_PRs):
+        def find_pr_by_head(self, owner, repo, head, base=None, state="open"):
+            return SimpleNamespace(number=88)
+
+    monkeypatch.setattr(runtime, "_try_merge_pr", never_merge)
+    clients = PrClients(branches=_Branches(), files=_Files(), prs=_KnownPRs())
+    result = await run_project_from_settings(
+        pid,
+        git_repo,
+        owner="o",
+        repo="r",
+        dry_run=False,
+        settings_obj=SimpleNamespace(BUILD_AUTO_MERGE=True),
+        manager=manager,
+        sandbox=_Sandbox(),
+        agent=FakeCodeAgent(),
+        reviewer=FakeReviewer(),
+        clients=clients,
+        budget=_Budget(),
+        ctx=SimpleNamespace(),
+        improve=True,
+        run_improvement_fn=fake_improvement,
+        sync_base_fn=lambda _src, _base: True,
+        audit=SimpleNamespace(
+            record=lambda *a, **k: None,
+            record_cost=lambda *a, **k: None,
+            record_once=lambda *a, **k: None,
+            cost_summary=lambda: {"usd": 0.0, "tokens": 0},
+        ),
+        cost_source=lambda: (0.0, 0),
+    )
+
+    assert result.stop_reason == "awaiting_merge"
+    assert result.pending_reviews == [1]
+    assert result.improvement is None and improved["called"] is False
 
 
 async def test_build_auto_merge_off_single_pass(monkeypatch, manager, git_repo):


### PR DESCRIPTION
## Problème

Le pilote pouvait considérer le BUILD comme `completed` alors que la dernière PR était encore `in_review`. Le runtime tentait ensuite un drain final sans refléter strictement son échec, et la Phase 4 pouvait mesurer un clone local qui n'avait pas été réaligné sur la branche distante.

Cela créait trois risques :

- passage prématuré du projet à `improving` ;
- faux succès après un merge final échoué ;
- mesures Phase 4 sur une base locale périmée.

## Correctif

- exige que toutes les tâches BUILD soient réellement `merged` ou `done` avant Phase 4 ;
- ajoute une barrière fail-closed `git fetch origin <base>` puis `git reset --hard origin/<base>` ;
- introduit le motif d'arrêt `repo_sync_failed` si cette vérification échoue ;
- reprend automatiquement le handoff dans la même invocation après le merge de la dernière PR BUILD ;
- relit l'état durable après le drain final et transforme tout faux `completed` avec PR ouvertes en `awaiting_merge` ;
- évite de relancer deux fois l'amélioration lors d'une reprise déjà intégrée ;
- documente explicitement la barrière BUILD → IMPROVE.

## Impact

Avec `--execute --improve`, la Phase 4 ne démarre plus tant que le MVP n'est pas effectivement intégré dans la branche de base et vérifié localement. Les échecs restent visibles et aucune amélioration n'est lancée sur une base incertaine.

## Validation

Suites ciblées validées :

- pilote, reprise et runtime ;
- handoff produit E2E ;
- audit et workspace Git ;
- ordre `PR ouverte → merge → resync → Phase 4` ;
- échec du merge final et échec du fetch en mode fail-closed ;
- Ruff check, Ruff format et `git diff --check`.

Closes #580