### PR TITLE
feat(phase5): brancher l’auto-merge faible risque et la garde post-merge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -206,6 +206,8 @@ LLM_API_KEY="votre_clé_api_gemini"
 # AUTO_MERGE_MAX_LOC=50
 # AUTO_MERGE_PATH_ALLOWLIST=docs/**,**/*.md,**/*.rst
 # AUTO_MERGE_METHOD=squash            # squash | merge | rebase
+# AUTO_MERGE_CI_TIMEOUT_SECONDS=900    # attente CI maximale par PR Phase 4
+# AUTO_MERGE_CI_POLL_SECONDS=10        # intervalle de polling GitHub
 
 # --- Auto-revert post-merge (filet de l'auto-merge) ---
 # N'a d'effet que si l'auto-merge est actif. Si main devient rouge → revert.

--- a/README.en.md
+++ b/README.en.md
@@ -175,8 +175,10 @@ Stages: `planner` → `pilote` → `executor` → `improve`, on a durable-state
 displayed hash, and only `plan sync --execute` writes to GitHub. The hard budget
 auto-pauses the engine. In a real BUILD, a **merge-bot** auto-merges each task to
 construct the MVP (`BUILD_AUTO_MERGE`, on by default); the **improvement** phase
-leaves its PRs **open for human merge** (§6). Risk-gated auto-merge, auto-revert and
-the pilot MCP tool stay **off by default** and fail-closed. The coder can run via a
+leaves its PRs **open for human merge** (§6) by default. Phase 5 risk-gated
+auto-merge is wired but remains opt-in: complete CI, a stable SHA, base resync and
+post-merge health are mandatory. Auto-revert and the pilot MCP tool stay **off by
+default** and fail-closed. The coder can run via a
 ChatGPT/Codex **subscription** (`$0` API cost).
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Aperçu **par thème** (liste exhaustive et valeurs par défaut dans
 | `MAX_COST_USD` / `MAX_TOKENS_BUDGET` / `COLLEGUE_RUN_DEADLINE_SECONDS` | Budget dur du run (auto-pause) | |
 | `COLLEGUE_HOME` | Racine de persistance (budget, métriques, checkpoints) | |
 | `CODER_SUBSCRIPTION` (+ `CODER_SUBSCRIPTION_MODEL`, `SANDBOX_SUBSCRIPTION_AUTH_DIR`) | Codage par **abonnement** ChatGPT/Codex (coût API `$0`) au lieu d'une clé | |
-| `BUILD_AUTO_MERGE` | **Merge-bot de la phase build** (auto-merge des PR de tâches ; **on** par défaut). L'amélioration reste à merge humain | |
+| `BUILD_AUTO_MERGE` | **Merge-bot de la phase build** (auto-merge des PR de tâches ; **on** par défaut). Distinct de Phase 5 | |
 | `GATE_ACCEPTANCE_TESTS` | Oracles pytest générés au plan-time par le rôle QA, scellés avec le plan puis rejoués sans LLM (**off** par défaut) | |
 | `SANDBOX_NETWORK` / `SANDBOX_MEMORY` / `SANDBOX_CPUS` / `SANDBOX_TIMEOUT` | Réseau et ressources du conteneur coder | |
 | `AUTO_MERGE_ENABLED` / `AUTO_REVERT_ENABLED` / `PILOT_TOOL_ENABLED` | Capacités autonomes risk-gated (opt-in, **off** par défaut) | |
@@ -176,8 +176,10 @@ durable (Postgres/SQLite) et de sandbox Docker.
 le hash affiché, et seul `plan sync --execute` touche GitHub ;
 budget dur auto-pausé. En BUILD réel, un **merge-bot** auto-merge chaque tâche pour
 construire le MVP (`BUILD_AUTO_MERGE`, on par défaut) ; la phase **amélioration**
-laisse ses PR **ouvertes pour merge humain** (§6). L'auto-merge risk-gated,
-l'auto-revert et l'outil MCP du pilote restent **désactivés par défaut** et fail-closed.
+laisse ses PR **ouvertes pour merge humain** (§6) par défaut. L'auto-merge
+risk-gated Phase 5 est réellement câblé mais reste opt-in : CI complète, SHA stable,
+resync et santé de `main` sont obligatoires. L'auto-revert et l'outil MCP du pilote
+restent **désactivés par défaut** et fail-closed.
 Le codeur peut tourner via **abonnement** ChatGPT/Codex (coût API `$0`).
 
 ```bash

--- a/collegue/config.py
+++ b/collegue/config.py
@@ -299,6 +299,9 @@ class Settings(BaseSettings):
     # dure même s'il est ajouté ici (cf. collegue.pilot.automerge.is_sensitive).
     AUTO_MERGE_PATH_ALLOWLIST: str = "docs/**,**/*.md,**/*.rst"
     AUTO_MERGE_METHOD: str = "squash"
+    # Polling CI borné : au-delà, la PR reste ouverte et Phase 4 s'arrête.
+    AUTO_MERGE_CI_TIMEOUT_SECONDS: float = 900.0
+    AUTO_MERGE_CI_POLL_SECONDS: float = 10.0
 
     # ── Auto-revert post-merge (Phase 5, H3) ─────────────────────────────────
     # Filet de sécurité de l'auto-merge : après un auto-merge, si `main` devient

--- a/collegue/improve/loop.py
+++ b/collegue/improve/loop.py
@@ -14,11 +14,13 @@ l'exécuteur sont importées **paresseusement** pour garder ``collegue.improve``
 léger. Le câblage du **mode `improving`** du pilote (enchaîner build → amélioration)
 est laissé à l'appelant/F4 (optionnel) — ce module fournit l'entrée ``run_improvement``.
 
-Module **isolé** : non câblé au runtime.
+Le runtime l'appelle après le handoff BUILD → IMPROVE et peut lui fournir le hook
+Phase 5 d'auto-merge ; sans ce hook, le comportement reste strictement humain.
 """
 
 from __future__ import annotations
 
+import inspect
 import math
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
@@ -39,6 +41,8 @@ STOP_PLATEAU = "plateau"  # rendements décroissants : les gains plafonnent
 STOP_PAUSED_BUDGET = "paused_budget"
 STOP_DEADLINE = "deadline_reached"
 STOP_SAFETY_CAP = "safety_cap"
+STOP_AUTOMERGE_BLOCKED = "auto_merge_blocked"
+STOP_POST_MERGE_GUARD = "post_merge_guard_failed"
 
 
 @dataclass(frozen=True)
@@ -48,6 +52,7 @@ class PromotedImprovement:
     dimension: str
     delta: float
     pr_number: Optional[int]
+    auto_merged: bool = False
 
 
 @dataclass
@@ -162,6 +167,7 @@ async def run_improvement(
     weights: CompositeWeights = DEFAULT_WEIGHTS,
     coverage_command: str = DEFAULT_COVERAGE_COMMAND,
     measure_fn=measure,
+    promotion_hook=None,
 ) -> ImprovementResult:
     """Fait tourner la boucle d'amélioration jusqu'au plateau ou au budget.
 
@@ -174,6 +180,12 @@ async def run_improvement(
     chaque PR a pour base la branche de la promotion précédente (la 1ʳᵉ sur ``base``),
     pour des diffs incrémentaux mergeables dans l'ordre sans conflit (le compounding
     rendrait sinon les PR cumulatives).
+
+    ``promotion_hook`` (Phase 5, opt-in) est appelé immédiatement après chaque PR
+    réelle. Il doit réaliser la séquence CI → merge → resync → garde. La boucle
+    s'arrête au premier refus : continuer créerait une PR enfant sur une branche
+    non intégrée. Absent (défaut) : comportement historique, PR stackées et merge
+    humain. Jamais appelé en dry-run.
     """
     # Imports paresseux : garder l'import de ``collegue.improve`` léger. ``pilot.budget``
     # est aussi lazy car importer le sous-module déclenche ``pilot/__init__`` (→ driver
@@ -325,17 +337,44 @@ async def run_improvement(
                 # Le numéro est un compteur de round, pas une vraie issue → pas de Closes.
                 closes_issue=False,
             )
+            hook_outcome = None
+            hook_error = None
+            if not dry_run and promotion_hook is not None:
+                if pr.skipped:
+                    # Une PR retrouvée peut avoir été modifiée hors du snapshot de
+                    # ce round : pas d'auto-merge sans preuve d'identité complète.
+                    hook_error = "PR préexistante : auto-merge refusé sans nouvelle preuve de livraison"
+                else:
+                    try:
+                        hook_outcome = promotion_hook(pr)
+                        if inspect.isawaitable(hook_outcome):
+                            hook_outcome = await hook_outcome
+                    except Exception as exc:  # noqa: BLE001 - hook externe fail-closed
+                        hook_error = f"hook Phase 5 en erreur: {exc}"
             if not dry_run:
                 persist(manager, project_id, after)
-                # Stacking (#554) : la PROCHAINE PR se basera sur celle-ci (chaîne de PR
-                # mergeables dans l'ordre). Uniquement en réel (en dry_run aucune branche
-                # n'existe → on garde la base d'origine).
-                last_promoted_branch = pr.head
-            # Compounding (#545) : mémorise le diff promu (corrigé) pour le réappliquer
-            # aux rounds suivants (baseline cumulative) — y compris en dry_run.
-            promoted_diffs.append(final_diff)
-            result.promoted.append(PromotedImprovement(dimension.value, gate.delta, pr.number))
+            auto_merged = bool(getattr(hook_outcome, "merged", False))
+            if auto_merged:
+                # Le hook a resynchronisé repo_source sur main : le diff promu y est
+                # déjà présent. Le réappliquer via compounding le dupliquerait.
+                last_promoted_branch = None
+                promoted_diffs.clear()
+            else:
+                if not dry_run:
+                    # Stacking humain historique (#554).
+                    last_promoted_branch = pr.head
+                promoted_diffs.append(final_diff)
+            result.promoted.append(PromotedImprovement(dimension.value, gate.delta, pr.number, auto_merged))
             plateau = 0
+            if hook_error is not None:
+                result.rejected.append((dimension.value, hook_error))
+                result.stop_reason = STOP_AUTOMERGE_BLOCKED
+                break
+            if hook_outcome is not None and not bool(getattr(hook_outcome, "continue_loop", False)):
+                reason = str(getattr(hook_outcome, "reason", "auto-merge non abouti"))
+                result.rejected.append((dimension.value, reason))
+                result.stop_reason = str(getattr(hook_outcome, "stop_reason", None) or STOP_AUTOMERGE_BLOCKED)
+                break
         else:
             result.rejected.append((dimension.value, gate.reason))
             plateau += 1

--- a/collegue/pilot/__init__.py
+++ b/collegue/pilot/__init__.py
@@ -20,7 +20,9 @@ from collegue.pilot.audit import (
 from collegue.pilot.automerge import (
     AutoMergeDecision,
     AutoMergeOutcome,
+    PromotionAutoMergeOutcome,
     RiskPolicy,
+    auto_merge_promotion,
     evaluate_automerge,
     is_sensitive,
     maybe_auto_merge,
@@ -121,8 +123,10 @@ __all__ = [
     "RiskPolicy",
     "AutoMergeDecision",
     "AutoMergeOutcome",
+    "PromotionAutoMergeOutcome",
     "evaluate_automerge",
     "maybe_auto_merge",
+    "auto_merge_promotion",
     "is_sensitive",
     # H3 (Phase 5) — garde post-merge (auto-revert)
     "RevertPolicy",

--- a/collegue/pilot/automerge.py
+++ b/collegue/pilot/automerge.py
@@ -13,9 +13,12 @@ n'effectue le merge réel (via H1 ``merge_pr``) que sur autorisation explicite.
 
 from __future__ import annotations
 
+import asyncio
 import fnmatch
+import inspect
+import time
 from dataclasses import dataclass
-from typing import List, Optional, Sequence, Tuple
+from typing import Callable, List, Optional, Sequence, Tuple
 
 from collegue.pilot.audit import AUTOMERGE_DECISION
 
@@ -235,6 +238,18 @@ class AutoMergeOutcome:
     merge_result: Optional[object] = None
 
 
+@dataclass(frozen=True)
+class PromotionAutoMergeOutcome:
+    """Verdict complet Phase 5 pour une promotion de la boucle improve."""
+
+    merged: bool
+    continue_loop: bool
+    stop_reason: Optional[str]
+    reason: str
+    automerge: Optional[AutoMergeOutcome] = None
+    guard: Optional[object] = None
+
+
 def maybe_auto_merge(
     pr: object,
     files_changed: Sequence[str],
@@ -288,7 +303,271 @@ def maybe_auto_merge(
         refused = AutoMergeDecision(False, "SHA de tête inconnu — garde anti-course requise pour l'auto-merge")
         _emit(pr_number=pr_number, allowed=False, merged=False, reason=refused.reason)
         return AutoMergeOutcome(decision=refused, merged=False)
-    result = clients.prs.merge_pr(owner, repo, pr.number, method=policy.method, expected_head_sha=expected)
+    result = clients.prs.merge_pr(
+        owner,
+        repo,
+        pr.number,
+        method=policy.method,
+        expected_head_sha=expected,
+        expected_base_branch=getattr(pr, "base_branch", None),
+        expected_base_sha=getattr(pr, "base_sha", None),
+    )
     merged = bool(getattr(result, "merged", False))
     _emit(pr_number=pr_number, allowed=True, merged=merged, reason=decision.reason)
     return AutoMergeOutcome(decision=decision, merged=merged, merge_result=result)
+
+
+_PENDING_CHECK_STATES = frozenset({"pending", "queued", "in_progress", "requested", "waiting"})
+
+
+async def _sleep(value: float, sleep_fn: Callable[[float], object]) -> None:
+    result = sleep_fn(max(0.0, float(value)))
+    if inspect.isawaitable(result):
+        await result
+
+
+async def auto_merge_promotion(
+    pr: object,
+    *,
+    policy: RiskPolicy,
+    revert_policy: object,
+    clients: object,
+    owner: str,
+    repo: str,
+    repo_source: str,
+    base: str,
+    sandbox: object,
+    manager: object = None,
+    project_id: Optional[int] = None,
+    audit: object = None,
+    dry_run: bool = False,
+    ci_timeout_seconds: float = 900.0,
+    ci_poll_seconds: float = 10.0,
+    sleep_fn: Callable[[float], object] = asyncio.sleep,
+    clock: Callable[[], float] = time.monotonic,
+    sync_base_fn: Optional[Callable[[str, str], bool]] = None,
+    guard_fn: Optional[Callable[..., object]] = None,
+    continue_fn: Optional[Callable[[], object]] = None,
+) -> PromotionAutoMergeOutcome:
+    """Tente l'auto-merge d'une PR Phase 4 puis vérifie la santé de ``main``.
+
+    Le chemin est strictement séquentiel : contexte PR exhaustif, tête immobile,
+    CI complètement verte, merge protégé par SHA, resync de la base, puis garde
+    post-merge. Tout refus laisse la PR ouverte et arrête la boucle d'amélioration
+    afin qu'aucune PR enfant ne soit mergée dans une branche non intégrée.
+
+    Politique off ou dry-run : aucun appel GitHub, aucun effet.
+    """
+
+    def blocked(reason: str, *, stop_reason: str = "auto_merge_blocked", merged: bool = False, **kwargs):
+        if audit is not None:
+            try:
+                audit.record(
+                    AUTOMERGE_DECISION,
+                    pr_number=getattr(pr, "number", None),
+                    allowed=False,
+                    merged=merged,
+                    reason=reason,
+                )
+            except Exception:
+                pass
+        return PromotionAutoMergeOutcome(
+            merged=merged,
+            continue_loop=False,
+            stop_reason=stop_reason,
+            reason=reason,
+            **kwargs,
+        )
+
+    if not policy.enabled:
+        return PromotionAutoMergeOutcome(False, True, None, "auto-merge désactivé")
+    if dry_run:
+        return PromotionAutoMergeOutcome(False, True, None, "dry-run : aucun auto-merge")
+    if not bool(getattr(revert_policy, "enabled", False)):
+        return blocked("garde post-merge désactivée — auto-merge refusé (fail-closed)")
+    number = getattr(pr, "number", None)
+    if number is None:
+        return blocked("numéro de PR absent — contexte invérifiable")
+
+    prs = getattr(clients, "prs", None)
+    if prs is None:
+        return blocked("client GitHub PR absent — contexte invérifiable")
+    try:
+        current = prs.get_pr(owner, repo, int(number))
+    except Exception as exc:  # noqa: BLE001 - frontière réseau fail-closed
+        return blocked(f"lecture de la PR impossible: {exc}")
+    head_sha = getattr(current, "head_sha", None)
+    if not head_sha:
+        return blocked("SHA de tête inconnu — garde anti-course impossible")
+    base_sha = getattr(current, "base_sha", None)
+    if not base_sha:
+        return blocked("SHA de base inconnu — diff non stabilisé")
+    if getattr(current, "state", None) != "open" or bool(getattr(current, "draft", False)):
+        return blocked("PR fermée ou encore en draft — auto-merge interdit")
+    if getattr(current, "base_branch", None) != base:
+        return blocked(f"base de PR inattendue ({getattr(current, 'base_branch', None)!r} != {base!r})")
+    raw_stats = (
+        getattr(current, "additions", None),
+        getattr(current, "deletions", None),
+        getattr(current, "changed_files", None),
+    )
+    if any(value is None for value in raw_stats):
+        return blocked("statistiques de PR absentes — diff invérifiable")
+    try:
+        expected_additions, expected_deletions, expected_files = (int(value) for value in raw_stats)
+    except (TypeError, ValueError):
+        return blocked("statistiques de PR malformées — diff invérifiable")
+    if expected_additions < 0 or expected_deletions < 0 or expected_files < 0:
+        return blocked("statistiques de PR négatives — diff invérifiable")
+
+    try:
+        files_snapshot = prs.get_pr_files_snapshot(
+            owner,
+            repo,
+            int(number),
+            expected_count=expected_files,
+        )
+    except Exception as exc:  # noqa: BLE001 - frontière réseau fail-closed
+        return blocked(f"lecture exhaustive du diff impossible: {exc}")
+    files = list(getattr(files_snapshot, "files", ()) or ())
+    filenames = [str(getattr(item, "filename", "")) for item in files]
+    additions = sum(int(getattr(item, "additions", 0) or 0) for item in files)
+    deletions = sum(int(getattr(item, "deletions", 0) or 0) for item in files)
+    files_complete = bool(getattr(files_snapshot, "complete", False))
+    if additions != expected_additions or deletions != expected_deletions:
+        files_complete = False
+
+    # Évalue d'abord le risque intrinsèque avec une CI fictivement verte. Un diff
+    # code/sensible ne justifie pas d'attendre plusieurs minutes les checks.
+    preflight = evaluate_automerge(
+        filenames,
+        additions=additions,
+        deletions=deletions,
+        checks=[_GREEN],
+        policy=policy,
+        files_complete=files_complete,
+    )
+    if not preflight.allowed:
+        return blocked(preflight.reason)
+
+    deadline = clock() + max(0.0, float(ci_timeout_seconds))
+    checks: Sequence[str] = ()
+    while True:
+        if continue_fn is not None:
+            try:
+                continuation = continue_fn()
+            except Exception as exc:  # noqa: BLE001 - contrôleur indisponible
+                return blocked(f"contrôle budget/deadline impossible: {exc}")
+            if not bool(getattr(continuation, "ok", continuation)):
+                reason = str(getattr(continuation, "reason", "budget ou deadline atteint"))
+                return blocked(f"attente CI interrompue: {reason}")
+        try:
+            observed = prs.get_pr(owner, repo, int(number))
+            if getattr(observed, "head_sha", None) != head_sha:
+                return blocked("la tête de la PR a bougé pendant l'attente CI — refus anti-course")
+            if getattr(observed, "base_sha", None) != base_sha:
+                return blocked("la base de la PR a bougé pendant l'attente CI — diff à réévaluer")
+            observed_stats = (
+                getattr(observed, "additions", None),
+                getattr(observed, "deletions", None),
+                getattr(observed, "changed_files", None),
+            )
+            if observed_stats != raw_stats:
+                return blocked("les statistiques de la PR ont changé pendant l'attente CI")
+            if getattr(observed, "state", None) != "open" or bool(getattr(observed, "draft", False)):
+                return blocked("état de la PR modifié pendant l'attente CI")
+            check_snapshot = prs.get_commit_checks(owner, repo, head_sha)
+        except Exception as exc:  # noqa: BLE001 - frontière réseau fail-closed
+            return blocked(f"lecture des vérifications CI impossible: {exc}")
+        if not bool(getattr(check_snapshot, "complete", False)):
+            return blocked("liste des vérifications CI incomplète — fail-closed")
+        checks = tuple(str(state).strip().lower() for state in (getattr(check_snapshot, "states", ()) or ()))
+        if checks and all(state == _GREEN for state in checks):
+            current = observed
+            break
+        terminal = [state for state in checks if state != _GREEN and state not in _PENDING_CHECK_STATES]
+        if terminal:
+            return blocked(f"CI non verte: {', '.join(terminal[:3])}")
+        if clock() >= deadline:
+            return blocked("délai d'attente CI dépassé (checks absents ou pending)")
+        await _sleep(ci_poll_seconds, sleep_fn)
+
+    try:
+        merge_outcome = maybe_auto_merge(
+            current,
+            filenames,
+            additions=additions,
+            deletions=deletions,
+            checks=checks,
+            policy=policy,
+            clients=clients,
+            owner=owner,
+            repo=repo,
+            dry_run=False,
+            files_complete=files_complete,
+            audit=audit,
+        )
+    except Exception as exc:  # noqa: BLE001 - GitHub refuse : PR laissée à l'humain
+        return blocked(f"merge GitHub refusé: {exc}")
+    if not merge_outcome.merged:
+        return blocked(merge_outcome.decision.reason, automerge=merge_outcome)
+    merge_sha = getattr(merge_outcome.merge_result, "sha", None)
+    if not merge_sha:
+        return blocked(
+            "merge confirmé sans SHA — garde post-merge impossible",
+            stop_reason="post_merge_guard_failed",
+            merged=True,
+            automerge=merge_outcome,
+        )
+
+    if sync_base_fn is None:
+        from collegue.executor.workspace import resync_repository_base
+
+        sync_base_fn = resync_repository_base
+    try:
+        synced = bool(sync_base_fn(repo_source, base))
+    except Exception as exc:  # noqa: BLE001 - plomberie git fail-closed
+        return blocked(
+            f"resynchronisation post-merge impossible: {exc}",
+            stop_reason="post_merge_guard_failed",
+            merged=True,
+            automerge=merge_outcome,
+        )
+    if not synced:
+        return blocked(
+            "resynchronisation post-merge échouée",
+            stop_reason="post_merge_guard_failed",
+            merged=True,
+            automerge=merge_outcome,
+        )
+
+    if guard_fn is None:
+        from collegue.pilot.guard import guard_post_merge
+
+        guard_fn = guard_post_merge
+    guard = guard_fn(
+        repo_source,
+        merge_sha,
+        sandbox=sandbox,
+        policy=revert_policy,
+        merge_parent=1 if policy.method == "merge" else None,
+        manager=manager,
+        project_id=project_id,
+        audit=audit,
+    )
+    if not bool(getattr(guard, "checked", False)) or getattr(guard, "healthy", None) is not True:
+        return blocked(
+            getattr(guard, "reason", "santé de main non concluante"),
+            stop_reason="post_merge_guard_failed",
+            merged=True,
+            automerge=merge_outcome,
+            guard=guard,
+        )
+    return PromotionAutoMergeOutcome(
+        merged=True,
+        continue_loop=True,
+        stop_reason=None,
+        reason="PR auto-mergée, base resynchronisée et main verte",
+        automerge=merge_outcome,
+        guard=guard,
+    )

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -522,6 +522,7 @@ async def run_project(
     cost_source: Optional[CostSource] = None,
     improve: bool = False,
     run_improvement_fn=None,
+    improvement_options: Optional[dict] = None,
     max_task_attempts: int = DEFAULT_MAX_TASK_ATTEMPTS,
     retry_backoff_seconds: float = DEFAULT_RETRY_BACKOFF_SECONDS,
     sleep_fn=None,
@@ -550,6 +551,8 @@ async def run_project(
     d'amélioration (Phase 4) **sous le budget restant** et attache l'``ImprovementResult``
     à ``result.improvement``. Défaut faux → comportement inchangé.
     ``run_improvement_fn`` : injection de test ; défaut = ``collegue.improve.run_improvement``.
+    ``improvement_options`` : options produit de Phase 4/5 (notamment le hook
+    d'auto-merge). Dictionnaire copié avant usage pour éviter toute mutation du caller.
 
     ``max_task_attempts`` (#420) : tentatives max par tâche. À 1 (défaut du module),
     tout échec est terminal (comportement historique). Au-delà, un échec re-file la
@@ -1152,11 +1155,11 @@ async def run_project(
         # dur — sinon les tests virent au rouge sur un projet à setup non trivial (make,
         # monorepo, service DB) et la garde dure G2 rejette toute amélioration. Symétrie
         # avec ``execute_issue`` qui reçoit déjà ``gate_options``.
-        improve_extra: dict = {}
+        improve_extra: dict = dict(improvement_options or {})
         if gate_options:
             improve_test_command = gate_options.get("test_command")
             if improve_test_command:
-                improve_extra["coverage_command"] = str(improve_test_command)
+                improve_extra.setdefault("coverage_command", str(improve_test_command))
         improvement = await run_imp(
             project_id,
             repo_source,
@@ -1174,6 +1177,11 @@ async def run_project(
             dry_run=dry_run,
             **improve_extra,
         )
+        improvement_stop = str(getattr(improvement, "stop_reason", "") or "")
+        if improvement_stop in {"auto_merge_blocked", "post_merge_guard_failed"}:
+            # Un BUILD réussi ne doit pas masquer un arrêt critique Phase 5 dans
+            # le verdict global ni dans RUN_STOP / le journal opérateur.
+            stop_reason = improvement_stop
 
     # Le motif peut changer pendant la barrière de handoff (#580) : journaliser
     # seulement le verdict FINAL, pas le faux ``completed`` calculé avant resync.

--- a/collegue/pilot/guard.py
+++ b/collegue/pilot/guard.py
@@ -34,9 +34,10 @@ _SHELL_OPERATORS = (";", "|", "&", "`", "$(", ">", "<", "\n")
 
 @dataclass(frozen=True)
 class RevertPolicy:
-    """Politique d'auto-revert (suit l'auto-merge ; off si l'auto-merge est off)."""
+    """Politique de garde santé et de préparation du revert."""
 
     enabled: bool = False
+    revert_enabled: bool = True
     health_command: str = DEFAULT_HEALTH_COMMAND
 
     @classmethod
@@ -46,7 +47,10 @@ class RevertPolicy:
         auto_merge = bool(getattr(settings, "AUTO_MERGE_ENABLED", False))
         auto_revert = bool(getattr(settings, "AUTO_REVERT_ENABLED", True))
         return cls(
-            enabled=auto_merge and auto_revert,
+            # La santé reste vérifiée dès que l'auto-merge est actif, même si
+            # l'opérateur désactive explicitement la préparation du revert.
+            enabled=auto_merge,
+            revert_enabled=auto_merge and auto_revert,
             health_command=str(
                 getattr(settings, "AUTO_REVERT_HEALTH_COMMAND", DEFAULT_HEALTH_COMMAND) or DEFAULT_HEALTH_COMMAND
             ),
@@ -119,6 +123,12 @@ def check_main_health(
             present = runner.run_command([git_bin, "cat-file", "-e", f"{merge_sha}^{{commit}}"], workspace)
             if not present.ok:
                 return HealthResult(False, "le clone ne contient pas le commit mergé — non concluant")
+            checkout = runner.run_command([git_bin, "checkout", "--detach", merge_sha], workspace)
+            if not checkout.ok:
+                return HealthResult(False, "impossible de positionner la garde sur le commit mergé — non concluant")
+            exact = runner.run_command([git_bin, "rev-parse", "HEAD"], workspace)
+            if not exact.ok or exact.stdout.strip() != merge_sha:
+                return HealthResult(False, "HEAD de la garde différent du commit mergé — non concluant")
         try:
             result = sandbox.run_tests(workspace, command)
         except Exception as exc:  # sandbox indisponible → non concluant → non sain
@@ -170,12 +180,22 @@ def guard_post_merge(
     # ce cas — main rouge ET revert impossible — est le plus critique et doit
     # ESCALADER vers un humain, pas passer pour un succès.
     revert: Optional[RevertResult] = None
-    try:
-        revert = prepare_revert(repo_source, merge_sha, merge_parent=merge_parent, runner=runner, git_bin=git_bin)
-    except RevertError:
-        revert = None
+    command_runner = runner or LocalCommandRunner()
+    source_head = command_runner.run_command([git_bin, "rev-parse", "HEAD"], repo_source)
+    source_is_exact = bool(source_head.ok and source_head.stdout.strip() == merge_sha)
+    if policy.revert_enabled and source_is_exact:
+        try:
+            revert = prepare_revert(
+                repo_source,
+                merge_sha,
+                merge_parent=merge_parent,
+                runner=command_runner,
+                git_bin=git_bin,
+            )
+        except RevertError:
+            revert = None
     reverted = bool(revert and revert.reverted)
-    revert_failed = not reverted
+    revert_failed = bool(policy.revert_enabled and not reverted)
     branch = getattr(revert, "branch", None)
     if revert_failed and revert is not None and getattr(revert, "workspace", None):
         # #466 : un revert en échec (abort, workspace laissé propre) n'a produit
@@ -183,7 +203,13 @@ def guard_post_merge(
         # Un revert RÉUSSI garde le sien : sa branche locale est le livrable
         # (push humain / H3) ; le balayage d'ancienneté le ramassera au-delà.
         cleanup_workspace(revert.workspace)
-    if revert_failed:
+    if not policy.revert_enabled:
+        summary = f"Main rouge après merge {merge_sha[:12]} — revert désactivé, intervention requise ({health.reason})"
+        audit_kind = "auto_revert_disabled"
+    elif not source_is_exact:
+        summary = f"ÉCHEC du revert de {merge_sha[:12]} — source non resynchronisée, intervention requise"
+        audit_kind = "auto_revert_failed"
+    elif revert_failed:
         summary = f"ÉCHEC du revert de {merge_sha[:12]} — intervention humaine requise ({health.reason})"
         audit_kind = "auto_revert_failed"
     else:

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -504,6 +504,39 @@ async def run_project_from_settings(
     # ne doit pas partir d'une base sans le code mergé de sa dépendance (#411).
     require_merged = True if auto_merge else bool(getattr(settings_obj, "DEPS_REQUIRE_MERGED", False))
 
+    # Phase 5-A : uniquement pour les promotions Phase 4. OFF/dry-run n'installe
+    # même pas le hook, donc aucun GET GitHub/check/guard supplémentaire.
+    improvement_options: dict = {}
+    if not dry_run:
+        from collegue.pilot.automerge import RiskPolicy, auto_merge_promotion
+        from collegue.pilot.guard import RevertPolicy
+
+        phase5_policy = RiskPolicy.from_settings(settings_obj)
+        if phase5_policy.enabled:
+            revert_policy = RevertPolicy.from_settings(settings_obj)
+
+            async def _phase5_promotion_hook(pr):
+                return await auto_merge_promotion(
+                    pr,
+                    policy=phase5_policy,
+                    revert_policy=revert_policy,
+                    clients=clients,
+                    owner=owner,
+                    repo=repo,
+                    repo_source=repo_source,
+                    base=base,
+                    sandbox=gate_sandbox,
+                    manager=manager,
+                    project_id=project_id,
+                    audit=audit,
+                    ci_timeout_seconds=float(getattr(settings_obj, "AUTO_MERGE_CI_TIMEOUT_SECONDS", 900) or 0),
+                    ci_poll_seconds=float(getattr(settings_obj, "AUTO_MERGE_CI_POLL_SECONDS", 10) or 0),
+                    sync_base_fn=sync_base_fn,
+                    continue_fn=budget.should_continue,
+                )
+
+            improvement_options["promotion_hook"] = _phase5_promotion_hook
+
     run_kwargs = dict(
         agent=agent,
         owner=owner,
@@ -521,6 +554,7 @@ async def run_project_from_settings(
         # dernier tour, une fois tout mergé. La phase improve n'auto-merge pas ses PR.
         improve=improve,
         run_improvement_fn=run_improvement_fn,
+        improvement_options=improvement_options,
         # Retry au niveau tâche (#420) : le chemin assemblé est résilient par défaut
         # (TASK_MAX_ATTEMPTS=3 en config) ; le module driver isolé reste, lui, à 1.
         max_task_attempts=getattr(settings_obj, "TASK_MAX_ATTEMPTS", 3),

--- a/collegue/tools/github_commands/__init__.py
+++ b/collegue/tools/github_commands/__init__.py
@@ -16,7 +16,16 @@ from .issues import IssueCommands, IssueInfo
 from .labels import LabelCommands, LabelInfo
 from .milestones import MilestoneCommands, MilestoneInfo
 from .projects import ProjectCommands, ProjectInfo
-from .prs import Comment, FileChange, MergeResult, PRCommands, PRInfo, PRNotMergeableError
+from .prs import (
+    Comment,
+    CommitChecks,
+    FileChange,
+    MergeResult,
+    PRCommands,
+    PRFilesSnapshot,
+    PRInfo,
+    PRNotMergeableError,
+)
 from .repos import RepoCommands, RepoInfo
 from .search import SearchCommands, SearchResult
 from .workflows import WorkflowCommands, WorkflowRun
@@ -29,6 +38,8 @@ __all__ = [
     "PRInfo",
     "PRNotMergeableError",
     "FileChange",
+    "PRFilesSnapshot",
+    "CommitChecks",
     "Comment",
     "MergeResult",
     "IssueCommands",

--- a/collegue/tools/github_commands/prs.py
+++ b/collegue/tools/github_commands/prs.py
@@ -45,6 +45,14 @@ class PRInfo(BaseModel):
     # #442 : une PR ``closed`` peut l'être par MERGE ou par simple fermeture —
     # la réconciliation GitHub→état a besoin de distinguer les deux.
     merged: bool = False
+    # Contexte autoritatif requis par l'auto-merge Phase 5. Les endpoints de liste
+    # ne garantissent pas les statistiques, d'où des défauts conservateurs.
+    head_sha: Optional[str] = None
+    base_sha: Optional[str] = None
+    merge_commit_sha: Optional[str] = None
+    additions: Optional[int] = None
+    deletions: Optional[int] = None
+    changed_files: Optional[int] = None
 
 
 class IssueInfo(BaseModel):
@@ -75,6 +83,22 @@ class FileChange(BaseModel):
     deletions: int
     changes: int = 0
     patch: Optional[str] = None
+
+
+class PRFilesSnapshot(BaseModel):
+    """Liste paginée des fichiers d'une PR et preuve de complétude."""
+
+    files: List[FileChange] = []
+    complete: bool = False
+    expected_count: int = 0
+
+
+class CommitChecks(BaseModel):
+    """État agrégé des check-runs et commit statuses d'un SHA."""
+
+    states: List[str] = []
+    names: List[str] = []
+    complete: bool = False
 
 
 class Comment(BaseModel):
@@ -112,6 +136,12 @@ class PRCommands(GitHubClient):
                 updated_at=pr["updated_at"],
                 labels=[l["name"] for l in pr.get("labels", [])],
                 draft=pr.get("draft", False),
+                head_sha=(pr.get("head") or {}).get("sha"),
+                base_sha=(pr.get("base") or {}).get("sha"),
+                merge_commit_sha=pr.get("merge_commit_sha"),
+                additions=pr.get("additions"),
+                deletions=pr.get("deletions"),
+                changed_files=pr.get("changed_files"),
             )
             for pr in data[:limit]
         ]
@@ -147,6 +177,12 @@ class PRCommands(GitHubClient):
             draft=pr.get("draft", False),
             # L'endpoint de liste n'a pas ``merged`` (bool) mais ``merged_at``.
             merged=bool(pr.get("merged") or pr.get("merged_at")),
+            head_sha=(pr.get("head") or {}).get("sha"),
+            base_sha=(pr.get("base") or {}).get("sha"),
+            merge_commit_sha=pr.get("merge_commit_sha"),
+            additions=pr.get("additions"),
+            deletions=pr.get("deletions"),
+            changed_files=pr.get("changed_files"),
         )
 
     def get_pr(self, owner: str, repo: str, pr_number: int) -> PRInfo:
@@ -164,6 +200,12 @@ class PRCommands(GitHubClient):
             labels=[l["name"] for l in data.get("labels", [])],
             draft=data.get("draft", False),
             merged=bool(data.get("merged") or data.get("merged_at")),
+            head_sha=(data.get("head") or {}).get("sha"),
+            base_sha=(data.get("base") or {}).get("sha"),
+            merge_commit_sha=data.get("merge_commit_sha"),
+            additions=data.get("additions"),
+            deletions=data.get("deletions"),
+            changed_files=data.get("changed_files"),
         )
 
     def get_pr_files(self, owner: str, repo: str, pr_number: int, limit: int = 100) -> List[FileChange]:
@@ -181,6 +223,143 @@ class PRCommands(GitHubClient):
             )
             for f in data[:limit]
         ]
+
+    def get_pr_files_snapshot(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        *,
+        expected_count: Optional[int] = None,
+        page_size: int = 100,
+        max_pages: int = 30,
+    ) -> PRFilesSnapshot:
+        """Récupère *tous* les fichiers d'une PR ou marque le résultat incomplet.
+
+        L'endpoint GitHub est paginé et plafonné à 100 éléments. L'auto-merge ne
+        doit jamais juger un diff sur sa seule première page : la complétude est
+        prouvée en comparant le nombre reçu à ``changed_files`` de la PR.
+        """
+        page_size = min(100, max(1, int(page_size)))
+        max_pages = max(1, int(max_pages))
+        if expected_count is None:
+            expected_count = self.get_pr(owner, repo, pr_number).changed_files
+        try:
+            expected = int(expected_count)
+        except (TypeError, ValueError):
+            return PRFilesSnapshot(files=[], complete=False, expected_count=0)
+        if expected < 0:
+            return PRFilesSnapshot(files=[], complete=False, expected_count=expected)
+        if expected == 0:
+            return PRFilesSnapshot(files=[], complete=True, expected_count=0)
+
+        files: List[FileChange] = []
+        for page in range(1, max_pages + 1):
+            data = self._api_get(
+                f"/repos/{owner}/{repo}/pulls/{pr_number}/files",
+                {"per_page": page_size, "page": page},
+            )
+            if not isinstance(data, list):
+                return PRFilesSnapshot(files=files, complete=False, expected_count=expected)
+            files.extend(
+                FileChange(
+                    filename=f["filename"],
+                    status=f["status"],
+                    additions=f.get("additions", 0),
+                    deletions=f.get("deletions", 0),
+                    changes=f.get("changes", 0),
+                    patch=f.get("patch", "")[:2000] if f.get("patch") else None,
+                )
+                for f in data
+            )
+            if len(data) < page_size or len(files) >= expected:
+                break
+        names = [item.filename for item in files]
+        stats_valid = all(item.additions >= 0 and item.deletions >= 0 and item.changes >= 0 for item in files)
+        complete = len(files) == expected and len(set(names)) == len(names) and stats_valid
+        return PRFilesSnapshot(files=files, complete=complete, expected_count=expected)
+
+    def get_commit_checks(
+        self,
+        owner: str,
+        repo: str,
+        head_sha: str,
+        *,
+        page_size: int = 100,
+        max_pages: int = 10,
+    ) -> CommitChecks:
+        """Agrège check-runs et commit statuses, avec pagination fail-closed.
+
+        Un check non terminé devient ``pending``. Une réponse partielle ou
+        malformée rend ``complete=False`` ; l'appelant doit alors refuser le merge.
+        """
+        page_size = min(100, max(1, int(page_size)))
+        max_pages = max(1, int(max_pages))
+        states: List[str] = []
+        names: List[str] = []
+
+        seen_runs = 0
+        total_runs: Optional[int] = None
+        checks_complete = False
+        for page in range(1, max_pages + 1):
+            payload = self._api_get(
+                f"/repos/{owner}/{repo}/commits/{head_sha}/check-runs",
+                {"filter": "latest", "per_page": page_size, "page": page},
+            )
+            if not isinstance(payload, dict) or not isinstance(payload.get("check_runs"), list):
+                break
+            if total_runs is None:
+                try:
+                    total_runs = int(payload.get("total_count", len(payload["check_runs"])))
+                except (TypeError, ValueError):
+                    break
+                if total_runs < 0:
+                    break
+            batch = payload["check_runs"]
+            for check in batch:
+                if not isinstance(check, dict):
+                    return CommitChecks(states=states, names=names, complete=False)
+                names.append(str(check.get("name") or "check-run"))
+                status = str(check.get("status") or "").strip().lower()
+                conclusion = str(check.get("conclusion") or "").strip().lower()
+                states.append(conclusion if status == "completed" and conclusion else "pending")
+            seen_runs += len(batch)
+            if seen_runs >= total_runs:
+                checks_complete = seen_runs == total_runs
+                break
+            if len(batch) < page_size:
+                break
+
+        statuses_complete = False
+        seen_contexts = set()
+        for page in range(1, max_pages + 1):
+            payload = self._api_get(
+                f"/repos/{owner}/{repo}/commits/{head_sha}/statuses",
+                {"per_page": page_size, "page": page},
+            )
+            if not isinstance(payload, list):
+                break
+            batch = payload
+            for status in batch:
+                if not isinstance(status, dict):
+                    return CommitChecks(states=states, names=names, complete=False)
+                context = str(status.get("context") or "commit-status")
+                # L'API renvoie du plus récent au plus ancien : ne conserver que
+                # le verdict le plus récent de chaque contexte legacy.
+                if context in seen_contexts:
+                    continue
+                seen_contexts.add(context)
+                names.append(context)
+                states.append(str(status.get("state") or "pending").strip().lower())
+            if len(batch) < page_size:
+                statuses_complete = True
+                break
+
+        return CommitChecks(
+            states=states,
+            names=names,
+            complete=bool(checks_complete and statuses_complete),
+        )
 
     def get_pr_comments(self, owner: str, repo: str, pr_number: int, limit: int = 100) -> List[Comment]:
         """Get comments on a pull request."""
@@ -223,6 +402,12 @@ class PRCommands(GitHubClient):
             created_at=resp["created_at"],
             updated_at=resp["updated_at"],
             draft=resp.get("draft", False),
+            head_sha=(resp.get("head") or {}).get("sha"),
+            base_sha=(resp.get("base") or {}).get("sha"),
+            merge_commit_sha=resp.get("merge_commit_sha"),
+            additions=resp.get("additions"),
+            deletions=resp.get("deletions"),
+            changed_files=resp.get("changed_files"),
         )
 
     def merge_pr(
@@ -235,6 +420,8 @@ class PRCommands(GitHubClient):
         commit_title: Optional[str] = None,
         commit_message: Optional[str] = None,
         expected_head_sha: Optional[str] = None,
+        expected_base_branch: Optional[str] = None,
+        expected_base_sha: Optional[str] = None,
     ) -> MergeResult:
         """Merge une PR ouverte. **Idempotent** + **garde anti-course**.
 
@@ -259,19 +446,30 @@ class PRCommands(GitHubClient):
             # Réponse vide/partielle : on n'a pas confirmé l'état de la PR → on ne merge
             # pas un état non vu (fail-closed).
             raise ToolExecutionError(f"état de la PR #{pr_number} indisponible — refus de merger (fail-closed)")
-        if current.get("merged"):
-            return MergeResult(
-                merged=True, sha=current.get("merge_commit_sha"), message="PR déjà mergée", already_merged=True
-            )
-        if current.get("state") == "closed":
-            raise ToolExecutionError(f"PR #{pr_number} fermée sans merge — refus de merger")
         head_sha = (current.get("head") or {}).get("sha")
         if expected_head_sha and head_sha != expected_head_sha:
             raise ToolExecutionError(
                 f"la tête de la PR #{pr_number} a bougé (attendu {expected_head_sha}, vu {head_sha}) — "
                 "refus (anti-course)"
             )
-
+        current_base = current.get("base") or {}
+        if expected_base_branch and current_base.get("ref") != expected_base_branch:
+            raise ToolExecutionError(
+                f"la base de la PR #{pr_number} a changé (attendu {expected_base_branch}, "
+                f"vu {current_base.get('ref')}) — refus"
+            )
+        if expected_base_sha and current_base.get("sha") != expected_base_sha:
+            raise ToolExecutionError(
+                f"le SHA de base de la PR #{pr_number} a bougé (attendu {expected_base_sha}, "
+                f"vu {current_base.get('sha')}) — refus"
+            )
+        if current.get("merged"):
+            merge_sha = current.get("merge_commit_sha")
+            if not merge_sha:
+                raise ToolExecutionError(f"PR #{pr_number} déjà mergée sans SHA vérifiable — arrêt fail-closed")
+            return MergeResult(merged=True, sha=merge_sha, message="PR déjà mergée", already_merged=True)
+        if current.get("state") == "closed":
+            raise ToolExecutionError(f"PR #{pr_number} fermée sans merge — refus de merger")
         # #434 : détecter le CONFLIT avant le PUT. GitHub expose ``mergeable``
         # (False = conflit confirmé ; None = calcul en cours → on tente, le PUT
         # tranchera) et ``mergeable_state`` (``dirty`` = conflit). Les autres états
@@ -314,4 +512,8 @@ class PRCommands(GitHubClient):
             raise
         # Un merge réussi renvoie toujours ``{"merged": true, "sha": ...}`` ; l'absence
         # de confirmation = échec (défaut False), jamais un succès supposé (fail-closed).
-        return MergeResult(merged=bool(resp.get("merged", False)), sha=resp.get("sha"), message=resp.get("message", ""))
+        merged = bool(resp.get("merged", False))
+        merge_sha = resp.get("sha")
+        if merged and not merge_sha:
+            raise ToolExecutionError(f"merge de la PR #{pr_number} confirmé sans SHA — arrêt fail-closed")
+        return MergeResult(merged=merged, sha=merge_sha, message=resp.get("message", ""))

--- a/docs/moteur_autonome.md
+++ b/docs/moteur_autonome.md
@@ -65,7 +65,7 @@ ou on refuse) :
 |-----------|--------------|
 | **Merge-bot (phase BUILD)** | Pendant la **construction du MVP**, une tâche réussie est **auto-mergée** (squash) puis le clone local est resynchronisé sur `origin/<base>` avant la tâche suivante (`BUILD_AUTO_MERGE=true` par défaut). Sans lui, avec 1 PR en vol + dépendances strictes, le build se figerait `awaiting_merge` (et des bases périmées créeraient des conflits). C'est le merge humain **simulé** pendant la construction autonome. Mettre `BUILD_AUTO_MERGE=false` ramène tout au merge humain. |
 | **Barrière BUILD → IMPROVE** | Une PR `in_review` ne compte **jamais** comme un MVP intégré. Phase 4 exige toutes les tâches en `merged`/`done`, puis un `git fetch` + `reset --hard origin/<base>` réussi juste avant sa première mesure. Merge final ou resync en échec ⇒ `awaiting_merge` / `repo_sync_failed`, aucune amélioration. |
-| **Merge humain (phase AMÉLIORATION, §6)** | Les PR d'**amélioration** (Phase 4) restent **ouvertes** : elles ne sont **jamais** auto-mergées — relecture/merge par un **humain**. C'est le défaut sûr pour faire évoluer un produit déjà construit. |
+| **Merge humain (phase AMÉLIORATION, §6)** | Par défaut, les PR d'**amélioration** (Phase 4) restent **ouvertes** pour relecture/merge humain. Seul l'opt-in explicite `AUTO_MERGE_ENABLED=true` active la politique Phase 5 ci-dessous. |
 | **`dry_run` par défaut** | Un **run** sans `--execute` va jusqu'aux aperçus de PR sans écriture GitHub/état et sans auto-merge. `plan draft` persiste volontairement son brouillon (SPEC/DAG/oracles/cible) pour permettre validation et reprise ; seul `plan sync --execute` touche GitHub. |
 | **Budget dur** | `MAX_COST_USD` / `MAX_TOKENS_BUDGET` atteints → **auto-pause** (les appels LLM sont stoppés). `COLLEGUE_RUN_DEADLINE_SECONDS` borne la durée mur. |
 | **Gate qualité** | Un diff dont les tests sont rouges, qui retire une exigence, ou qui porte un finding **critical/error** de la revue (sécurité réelle, défaut signalé par le reviewer LLM) **n'ouvre pas / ne merge pas** de PR. Les findings d'heuristiques crues de style/maintenabilité (complexité, duplication, nommage, exception silencieuse) sont **advisory** (informent la PR, ne bloquent pas un code aux tests verts). |
@@ -75,8 +75,8 @@ ou on refuse) :
 | **Validation humaine du plan** | Le produit impose trois processus séparés : `plan draft` affiche le contenu, la cible (dépôt + branche) et son SHA-256 ; `plan approve --expected-plan-hash …` scelle exactement ce snapshot sans LLM/GitHub ; `plan sync` recharge uniquement la cible persistée. SPEC, DAG, oracles, deadline et cible sont hashés. Toute mutation entre les étapes invalide le hash. |
 | **Snapshot d'écriture cohérent** | En sync réelle, cible, SPEC et tâches sont copiés dans une seule transaction verrouillée. Les appels GitHub consomment exclusivement ce snapshot approuvé : une mutation/réapprobation concurrente ne peut pas envoyer le contenu d'une révision vers la cible d'une autre. Après la première issue matérialisée, une révision différente exige une réconciliation explicite des liaisons avant réapprobation. |
 | **SPEC avant issues** | Sur le chemin produit `plan sync --execute`, le DAG est validé intégralement puis GitHub doit confirmer le commit de `SPEC.md` **avant** la première issue. Client absent, erreur API, réponse sans `commit.sha` ou fichier distant divergent = arrêt sans issue. Un SPEC déjà identique est confirmé sans commit vide. |
-| **Auto-merge RISK-GATED (politique, opt-in, distinct)** | Politique séparée du merge-bot ci-dessus : merge **fin** par risque (`AUTO_MERGE_ENABLED=false` par défaut ; activée, n'autoriserait **que** du faible risque : allowlist de chemins **non exécutables**, plafond de LOC, **toutes** les vérifs CI vertes ; garde dure code/exécutable/secret/CI insensible à la casse). ⚠️ **Pas encore câblée dans la boucle du pilote** (le câblage exige une passe CI-aware — suivi). |
-| **Auto-revert (politique)** | Filet prévu de l'auto-merge risk-gated : si `main` devenait rouge après un auto-merge (santé en sandbox), un revert serait préparé (fail-closed : santé non concluante = rouge ; un revert en échec **escalade**). Inactif tant que cette politique n'est pas câblée. |
+| **Auto-merge RISK-GATED (Phase 5, opt-in)** | Politique séparée du merge-bot BUILD, **OFF par défaut**. Après chaque PR Phase 4 : relit SHA/base/stats, pagine tous les fichiers, attend check-runs + statuses sous délai, refuse code/secrets/config/CI ou diff trop grand, puis merge avec `expected_head_sha`. Refus, CI absente/rouge, tête/base mobile ou timeout ⇒ PR laissée ouverte et boucle stoppée, sans PR enfant. |
+| **Garde post-merge / revert préparé** | Après un auto-merge : resync obligatoire de `origin/<base>`, checkout exact du SHA mergé, puis santé en sandbox. Rouge ou non concluant ⇒ boucle stoppée et branche/commit de revert préparé localement si activé. La publication/PR/merge distant de ce revert relève de Phase 5-B ; aucune restauration de GitHub `main` n'est prétendue ici. |
 | **Outil MCP du pilote** | Exposé en MCP **uniquement** si `PILOT_TOOL_ENABLED=true` **et** `OAUTH_ENABLED=true` (sinon **refus de démarrer**). Allowlist d'appelants (sujets OAuth vérifiés, jamais un en-tête client). Jamais auto-découvert. `dry_run` par défaut. |
 
 ---
@@ -272,7 +272,9 @@ sandbox). Le reviewer/juge suit le même chemin quand son modèle n'est pas un
 modèle Gemini (`LLM_MODEL_REVIEWER=gpt-5.4` → échantillonné dans le sandbox).
 Avec `BUILD_AUTO_MERGE=true` (défaut), un seul `--execute` construit **tout le
 MVP** (merge-bot enchaîne les tâches) ; `--improve` ajoute ensuite des PR
-d'amélioration **laissées ouvertes** pour merge humain. Le handoff est fail-closed :
+d'amélioration **laissées ouvertes** pour merge humain par défaut. Avec
+`AUTO_MERGE_ENABLED=true`, seules les promotions Phase 4 faibles risques passent
+le cycle CI → merge SHA-gaté → resync → santé ; tout doute arrête la boucle. Le handoff est fail-closed :
 la Phase 4 ne démarre qu'après le merge de la dernière PR BUILD et une nouvelle
 vérification de l'alignement du clone sur `origin/<base>`.
 
@@ -296,7 +298,7 @@ lit :
 | `TASK_MAX_ATTEMPTS` | Tentatives max par tâche — retry avec backoff sur échec transitoire (`1` = pas de retry). | `3` |
 | `TASK_RETRY_BACKOFF_SECONDS` | Base du backoff linéaire entre tentatives (plafonné à 90 s). | `15` |
 | `DEPS_REQUIRE_MERGED` | Exige le **merge** d'une dépendance avant de débloquer ses dépendants (sinon le démarrage sur PR non mergée est signalé) ; arrêt `awaiting_merge` quand seuls des merges manquent. **Forcé à vrai** quand `BUILD_AUTO_MERGE` est actif. | `false` |
-| `BUILD_AUTO_MERGE` | **Merge-bot de la phase build** : auto-merge (squash) de chaque PR de tâche + resync du clone avant la suivante (+ drain de la dernière PR). `false` → tout au merge humain. La phase amélioration n'est **jamais** auto-mergée. | `true` |
+| `BUILD_AUTO_MERGE` | **Merge-bot de la phase build** : auto-merge (squash) de chaque PR de tâche + resync du clone avant la suivante (+ drain de la dernière PR). `false` → BUILD au merge humain. Distinct de la politique Phase 5. | `true` |
 | `LLM_CALL_TIMEOUT` | Timeout par appel LLM, secondes (`0` = off). | `0` |
 | `CODER_SUBSCRIPTION` | Code via un **abonnement** ChatGPT/Codex (OpenHands `subscription_login`, coût API `$0`) au lieu d'une clé API. Le **reviewer/juge** suit aussi l'abonnement si son modèle n'est pas un modèle Gemini (échantillonné dans le sandbox). | `false` |
 | `CODER_SUBSCRIPTION_MODEL` | Modèle codeur via l'abonnement. | `gpt-5.5` |
@@ -310,7 +312,9 @@ lit :
 | `AUTO_MERGE_MAX_LOC` | Plafond de lignes nettes pour l'auto-merge. | `50` |
 | `AUTO_MERGE_PATH_ALLOWLIST` | Motifs de chemins **faible risque** (CSV ; `**` = sous-dossiers). | `docs/**,**/*.md,**/*.rst` |
 | `AUTO_MERGE_METHOD` | Méthode de merge : `squash` / `merge` / `rebase`. | `squash` |
-| `AUTO_REVERT_ENABLED` | Filet auto-revert (n'a d'effet que si l'auto-merge est actif). | `true` |
+| `AUTO_MERGE_CI_TIMEOUT_SECONDS` | Attente maximale des checks/statuses par PR Phase 4 ; timeout ⇒ PR humaine + arrêt. | `900` |
+| `AUTO_MERGE_CI_POLL_SECONDS` | Intervalle de relecture du SHA et de la CI. | `10` |
+| `AUTO_REVERT_ENABLED` | Prépare localement un revert si la santé post-merge est rouge. Désactivé, la santé reste vérifiée et la boucle s'arrête quand même. | `true` |
 | `AUTO_REVERT_HEALTH_COMMAND` | Commande de santé exécutée en sandbox sur `main`. | `pytest -q` |
 | `PILOT_TOOL_ENABLED` | Expose le pilote en outil MCP (strict : exige `OAUTH_ENABLED`). | `false` |
 | `PILOT_TOOL_ALLOWED_SUBJECTS` | Allowlist de sujets OAuth autorisés (CSV ; vide = personne). | — |

--- a/tests/test_github_merge_delete.py
+++ b/tests/test_github_merge_delete.py
@@ -9,7 +9,14 @@ branches protégées et fail-closed.
 import pytest
 
 from collegue.tools.base import ToolExecutionError
-from collegue.tools.github_commands import BranchCommands, MergeResult, PRCommands, PRNotMergeableError
+from collegue.tools.github_commands import (
+    BranchCommands,
+    CommitChecks,
+    MergeResult,
+    PRCommands,
+    PRFilesSnapshot,
+    PRNotMergeableError,
+)
 
 
 class _Recorder:
@@ -93,6 +100,41 @@ def test_merge_pr_empty_put_response_is_not_merged():
     pr, _ = _pr_with({"merged": False, "state": "open", "head": {"sha": "h1"}})  # put_payload None → {}
     res = pr.merge_pr("o", "r", 7)
     assert res.merged is False
+
+
+def test_merge_pr_success_without_merge_sha_fails_closed():
+    pr, _ = _pr_with(
+        {"merged": False, "state": "open", "head": {"sha": "h1"}},
+        put_payload={"merged": True, "message": "merged without sha"},
+    )
+    with pytest.raises(ToolExecutionError, match="sans SHA"):
+        pr.merge_pr("o", "r", 7, expected_head_sha="h1")
+
+
+def test_merge_pr_already_merged_still_checks_expected_head():
+    pr, _ = _pr_with({"merged": True, "state": "closed", "head": {"sha": "moved"}, "merge_commit_sha": "merge-sha"})
+    with pytest.raises(ToolExecutionError, match="tête"):
+        pr.merge_pr("o", "r", 7, expected_head_sha="evaluated")
+
+
+def test_merge_pr_checks_expected_base_branch_and_sha():
+    pr, _ = _pr_with(
+        {
+            "merged": False,
+            "state": "open",
+            "head": {"sha": "head"},
+            "base": {"ref": "main", "sha": "new-base"},
+        }
+    )
+    with pytest.raises(ToolExecutionError, match="SHA de base"):
+        pr.merge_pr(
+            "o",
+            "r",
+            7,
+            expected_head_sha="head",
+            expected_base_branch="main",
+            expected_base_sha="evaluated-base",
+        )
 
 
 # --- détection de conflit avant merge (#434) --------------------------------------
@@ -191,8 +233,100 @@ def test_find_pr_by_head_maps_merged_from_merged_at():
 
 
 def test_get_pr_maps_merged_bool():
-    pr, _ = _pr_with(_pr_payload(merged=True))
-    assert pr.get_pr("o", "r", 72).merged is True
+    pr, _ = _pr_with(
+        _pr_payload(
+            merged=True,
+            head={"ref": "collegue/issue-11", "sha": "head-sha"},
+            base={"ref": "main", "sha": "base-sha"},
+            additions=7,
+            deletions=2,
+            changed_files=3,
+            merge_commit_sha="merge-sha",
+        )
+    )
+    info = pr.get_pr("o", "r", 72)
+    assert info.merged is True
+    assert (info.head_sha, info.base_sha, info.additions, info.deletions, info.changed_files) == (
+        "head-sha",
+        "base-sha",
+        7,
+        2,
+        3,
+    )
+
+
+# --- contexte Phase 5 : fichiers/checks exhaustifs ------------------------------
+
+
+def _file(number):
+    return {
+        "filename": f"docs/{number}.md",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 0,
+        "changes": 1,
+    }
+
+
+def test_pr_files_snapshot_paginates_and_proves_completeness():
+    pr = PRCommands(token=None)
+    calls = []
+
+    def fake_get(endpoint, params=None):
+        calls.append((endpoint, params))
+        return [_file(1), _file(2)] if params["page"] == 1 else [_file(3)]
+
+    pr._api_get = fake_get
+    snapshot = pr.get_pr_files_snapshot("o", "r", 7, expected_count=3, page_size=2)
+    assert isinstance(snapshot, PRFilesSnapshot)
+    assert snapshot.complete is True and [item.filename for item in snapshot.files] == [
+        "docs/1.md",
+        "docs/2.md",
+        "docs/3.md",
+    ]
+    assert [params["page"] for _, params in calls] == [1, 2]
+
+
+def test_pr_files_snapshot_fails_closed_on_truncation_or_duplicate():
+    pr = PRCommands(token=None)
+    pr._api_get = lambda endpoint, params=None: [_file(1), _file(1)]
+    duplicate = pr.get_pr_files_snapshot("o", "r", 7, expected_count=2, page_size=2, max_pages=1)
+    assert duplicate.complete is False
+
+    pr._api_get = lambda endpoint, params=None: [_file(1)]
+    truncated = pr.get_pr_files_snapshot("o", "r", 7, expected_count=2, page_size=2, max_pages=1)
+    assert truncated.complete is False
+
+
+def test_commit_checks_aggregate_check_runs_and_latest_legacy_statuses():
+    pr = PRCommands(token=None)
+
+    def fake_get(endpoint, params=None):
+        if endpoint.endswith("/check-runs"):
+            return {
+                "total_count": 2,
+                "check_runs": [
+                    {"name": "tests", "status": "completed", "conclusion": "success"},
+                    {"name": "docker", "status": "in_progress", "conclusion": None},
+                ],
+            }
+        assert endpoint.endswith("/statuses")
+        return [
+            {"context": "legacy", "state": "success"},
+            {"context": "legacy", "state": "failure"},  # ancien verdict ignoré
+        ]
+
+    pr._api_get = fake_get
+    checks = pr.get_commit_checks("o", "r", "sha")
+    assert isinstance(checks, CommitChecks) and checks.complete is True
+    assert checks.states == ["success", "pending", "success"]
+    assert checks.names == ["tests", "docker", "legacy"]
+
+
+def test_commit_checks_malformed_endpoint_is_incomplete():
+    pr = PRCommands(token=None)
+    pr._api_get = lambda endpoint, params=None: {} if endpoint.endswith("/check-runs") else []
+    assert pr.get_commit_checks("o", "r", "sha").complete is False
 
 
 # --- delete_branch --------------------------------------------------------------

--- a/tests/test_improve_loop.py
+++ b/tests/test_improve_loop.py
@@ -74,7 +74,7 @@ class _PRs:
         return None
 
     def create_pr(self, owner, repo, title, head, base, body):
-        self.created.append({"head": head, "body": body})
+        self.created.append({"head": head, "base": base, "body": body})
         return SimpleNamespace(number=101, html_url="https://gh/pull/101", head_branch=head)
 
 
@@ -163,6 +163,106 @@ async def test_real_run_promotes_and_persists_metric(git_repo, manager):
     # compteur de round, pas une vraie issue → ne fermerait pas une issue au hasard).
     body = clients.prs.created[0]["body"]
     assert "Closes #" not in body
+
+
+async def test_phase5_hook_runs_immediately_and_auto_merged_round_returns_to_main(git_repo, manager):
+    pid = manager.create_project(name="phase5")
+    clients = _clients()
+    calls = []
+
+    async def hook(pr):
+        calls.append(pr.number)
+        return SimpleNamespace(merged=True, continue_loop=True, stop_reason=None, reason="main verte")
+
+    result = await run_improvement(
+        pid,
+        git_repo,
+        ctx=None,
+        agent=FakeCodeAgent(),
+        owner="o",
+        repo="r",
+        manager=manager,
+        budget=_Budget((CONT, PAUSE)),
+        clients=clients,
+        dry_run=False,
+        measure_fn=_ScriptedMeasure([_metrics(0.5), _metrics(0.7)]),
+        promotion_hook=hook,
+    )
+    assert calls == [101]
+    assert result.promoted[0].auto_merged is True
+    assert result.stop_reason == "paused_budget"
+    assert clients.prs.created[0]["base"] == "main"
+
+
+async def test_phase5_refusal_stops_before_any_child_pr(git_repo, manager):
+    clients = _clients()
+
+    async def hook(pr):
+        return SimpleNamespace(
+            merged=False,
+            continue_loop=False,
+            stop_reason="auto_merge_blocked",
+            reason="CI absente",
+        )
+
+    result = await run_improvement(
+        manager.create_project(name="blocked"),
+        git_repo,
+        ctx=None,
+        agent=FakeCodeAgent(),
+        owner="o",
+        repo="r",
+        manager=manager,
+        budget=_Budget(),
+        clients=clients,
+        dry_run=False,
+        measure_fn=_ScriptedMeasure([_metrics(0.5), _metrics(0.7), _metrics(0.7), _metrics(0.9)]),
+        promotion_hook=hook,
+    )
+    assert result.stop_reason == "auto_merge_blocked"
+    assert len(clients.prs.created) == 1 and len(result.promoted) == 1
+    assert "CI absente" in result.rejected[-1][1]
+
+
+async def test_phase5_guard_failure_reason_propagates(git_repo, manager):
+    async def hook(pr):
+        return SimpleNamespace(
+            merged=True,
+            continue_loop=False,
+            stop_reason="post_merge_guard_failed",
+            reason="main rouge",
+        )
+
+    result = await run_improvement(
+        manager.create_project(name="red"),
+        git_repo,
+        ctx=None,
+        agent=FakeCodeAgent(),
+        owner="o",
+        repo="r",
+        manager=manager,
+        budget=_Budget(),
+        clients=_clients(),
+        dry_run=False,
+        measure_fn=_ScriptedMeasure([_metrics(0.5), _metrics(0.7)]),
+        promotion_hook=hook,
+    )
+    assert result.stop_reason == "post_merge_guard_failed"
+    assert result.promoted[0].auto_merged is True
+
+
+async def test_phase5_hook_is_never_called_in_dry_run(git_repo, manager):
+    def forbidden(_pr):
+        raise AssertionError("hook interdit en dry-run")
+
+    result = await _run(
+        git_repo,
+        manager,
+        measure_seq=[_metrics(0.5), _metrics(0.7), _metrics(0.7), _metrics(0.7)],
+        plateau_rounds=1,
+        promotion_hook=forbidden,
+    )
+    assert result.promoted and result.promoted[0].auto_merged is False
 
 
 async def test_importing_improve_stays_light():

--- a/tests/test_pilot_automerge.py
+++ b/tests/test_pilot_automerge.py
@@ -11,10 +11,12 @@ from collegue.pilot.automerge import (
     DEFAULT_PATH_ALLOWLIST,
     AutoMergeDecision,
     RiskPolicy,
+    auto_merge_promotion,
     evaluate_automerge,
     is_sensitive,
     maybe_auto_merge,
 )
+from collegue.tools.github_commands import CommitChecks, FileChange, PRFilesSnapshot, PRInfo
 
 GREEN = ["success", "success"]
 
@@ -188,9 +190,27 @@ class _PRs:
         self.merged_calls = []
 
     def merge_pr(
-        self, owner, repo, number, *, method="squash", commit_title=None, commit_message=None, expected_head_sha=None
+        self,
+        owner,
+        repo,
+        number,
+        *,
+        method="squash",
+        commit_title=None,
+        commit_message=None,
+        expected_head_sha=None,
+        expected_base_branch=None,
+        expected_base_sha=None,
     ):
-        self.merged_calls.append({"number": number, "method": method, "sha": expected_head_sha})
+        self.merged_calls.append(
+            {
+                "number": number,
+                "method": method,
+                "sha": expected_head_sha,
+                "base": expected_base_branch,
+                "base_sha": expected_base_sha,
+            }
+        )
         return SimpleNamespace(merged=True, sha="merged-sha", already_merged=False)
 
 
@@ -264,7 +284,7 @@ def test_maybe_auto_merge_real_calls_merge_pr():
         dry_run=False,
     )
     assert out.merged is True
-    assert prs.merged_calls == [{"number": 42, "method": "squash", "sha": "abc123"}]
+    assert prs.merged_calls == [{"number": 42, "method": "squash", "sha": "abc123", "base": None, "base_sha": None}]
 
 
 def test_evaluate_returns_decision_type():
@@ -306,3 +326,154 @@ def test_maybe_auto_merge_emits_audit_events():
     )
     ev = audit.events[-1]
     assert ev[0] == "automerge_decision" and ev[1]["allowed"] is True and ev[1]["merged"] is True
+
+
+# --- câblage produit Phase 5-A --------------------------------------------------
+
+
+def _phase5_info(*, head_sha="head", base_sha="base", filename="docs/x.md"):
+    return PRInfo(
+        number=42,
+        title="docs",
+        state="open",
+        html_url="https://gh/pr/42",
+        user="bot",
+        base_branch="main",
+        head_branch="improve/docs",
+        head_sha=head_sha,
+        base_sha=base_sha,
+        additions=1,
+        deletions=0,
+        changed_files=1,
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:00Z",
+    )
+
+
+class _Phase5PRs(_PRs):
+    def __init__(self, *, infos=None, check_states=("success",), filename="docs/x.md"):
+        super().__init__()
+        self.infos = list(infos or [_phase5_info(filename=filename)])
+        self.check_states = list(check_states)
+        self.reads = []
+        self.filename = filename
+
+    def get_pr(self, owner, repo, number):
+        self.reads.append("pr")
+        return self.infos.pop(0) if len(self.infos) > 1 else self.infos[0]
+
+    def get_pr_files_snapshot(self, owner, repo, number, expected_count=None):
+        self.reads.append("files")
+        return PRFilesSnapshot(
+            files=[FileChange(filename=self.filename, status="modified", additions=1, deletions=0, changes=1)],
+            complete=True,
+            expected_count=1,
+        )
+
+    def get_commit_checks(self, owner, repo, sha):
+        self.reads.append(("checks", sha))
+        states = (
+            self.check_states.pop(0)
+            if self.check_states and isinstance(self.check_states[0], (list, tuple))
+            else self.check_states
+        )
+        return CommitChecks(states=list(states), names=["ci"] * len(states), complete=True)
+
+
+async def test_phase5_success_merges_resyncs_then_guards():
+    prs = _Phase5PRs()
+    events = []
+    out = await auto_merge_promotion(
+        SimpleNamespace(number=42),
+        policy=_policy(),
+        revert_policy=SimpleNamespace(enabled=True),
+        clients=_clients(prs),
+        owner="o",
+        repo="r",
+        repo_source="/repo",
+        base="main",
+        sandbox=object(),
+        ci_timeout_seconds=0,
+        sync_base_fn=lambda src, base: events.append(("sync", src, base)) or True,
+        guard_fn=lambda src, sha, **kw: (
+            events.append(("guard", src, sha)) or SimpleNamespace(checked=True, healthy=True, reason="vert")
+        ),
+    )
+    assert out.merged is True and out.continue_loop is True
+    assert prs.merged_calls == [{"number": 42, "method": "squash", "sha": "head", "base": "main", "base_sha": "base"}]
+    assert events == [("sync", "/repo", "main"), ("guard", "/repo", "merged-sha")]
+
+
+async def test_phase5_pending_timeout_leaves_pr_open_and_stops():
+    prs = _Phase5PRs(check_states=("pending",))
+    out = await auto_merge_promotion(
+        SimpleNamespace(number=42),
+        policy=_policy(),
+        revert_policy=SimpleNamespace(enabled=True),
+        clients=_clients(prs),
+        owner="o",
+        repo="r",
+        repo_source="/repo",
+        base="main",
+        sandbox=object(),
+        ci_timeout_seconds=0,
+    )
+    assert out.merged is False and out.continue_loop is False and "délai" in out.reason
+    assert prs.merged_calls == []
+
+
+async def test_phase5_head_move_is_rejected_before_merge():
+    prs = _Phase5PRs(infos=[_phase5_info(), _phase5_info(head_sha="moved")])
+    out = await auto_merge_promotion(
+        SimpleNamespace(number=42),
+        policy=_policy(),
+        revert_policy=SimpleNamespace(enabled=True),
+        clients=_clients(prs),
+        owner="o",
+        repo="r",
+        repo_source="/repo",
+        base="main",
+        sandbox=object(),
+    )
+    assert out.merged is False and "bougé" in out.reason and prs.merged_calls == []
+
+
+async def test_phase5_guard_red_stops_after_merge():
+    prs = _Phase5PRs()
+    out = await auto_merge_promotion(
+        SimpleNamespace(number=42),
+        policy=_policy(),
+        revert_policy=SimpleNamespace(enabled=True),
+        clients=_clients(prs),
+        owner="o",
+        repo="r",
+        repo_source="/repo",
+        base="main",
+        sandbox=object(),
+        sync_base_fn=lambda src, base: True,
+        guard_fn=lambda *a, **kw: SimpleNamespace(checked=True, healthy=False, reverted=True, reason="rouge"),
+    )
+    assert out.merged is True and out.continue_loop is False
+    assert out.stop_reason == "post_merge_guard_failed"
+
+
+async def test_phase5_off_and_dry_run_perform_no_github_reads():
+    class _NoReads:
+        def get_pr(self, *args, **kwargs):
+            raise AssertionError("aucun GET attendu")
+
+    clients = _clients(_NoReads())
+    for policy, dry_run in ((RiskPolicy(), False), (_policy(), True)):
+        out = await auto_merge_promotion(
+            SimpleNamespace(number=42),
+            policy=policy,
+            revert_policy=SimpleNamespace(enabled=True),
+            clients=clients,
+            owner="o",
+            repo="r",
+            repo_source="/repo",
+            base="main",
+            sandbox=object(),
+            dry_run=dry_run,
+        )
+        assert out.continue_loop is True and out.merged is False

--- a/tests/test_pilot_guard.py
+++ b/tests/test_pilot_guard.py
@@ -115,6 +115,23 @@ def test_health_clone_missing_commit_is_failclosed(repo):
     assert res.healthy is False and "ne contient pas" in res.reason
 
 
+def test_health_checks_out_exact_merge_commit_before_tests(repo):
+    src, _ = repo
+    previous = subprocess.run(
+        ["git", "rev-parse", "HEAD^"], cwd=src, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    class _ExactSandbox(_Sandbox):
+        def run_tests(self, workspace, command="pytest -q"):
+            seen = subprocess.run(
+                ["git", "rev-parse", "HEAD"], cwd=workspace, check=True, capture_output=True, text=True
+            ).stdout.strip()
+            assert seen == previous
+            return super().run_tests(workspace, command)
+
+    assert check_main_health(src, sandbox=_ExactSandbox(), merge_sha=previous).healthy is True
+
+
 # --- guard_post_merge -----------------------------------------------------------
 
 
@@ -170,6 +187,25 @@ def test_guard_invalid_sha_escalates_without_raising(repo):
     assert out.revert_failed is True and out.reverted is False
 
 
+def test_guard_red_with_revert_disabled_still_checks_and_escalates(repo):
+    src, sha = repo
+    policy = RevertPolicy(enabled=True, revert_enabled=False, health_command="pytest -q")
+    out = guard_post_merge(src, sha, sandbox=_Sandbox(exit_code=1), policy=policy)
+    assert out.checked is True and out.healthy is False
+    assert out.reverted is False and out.revert_failed is False
+    assert "désactivé" in out.reason
+
+
+def test_guard_refuses_revert_when_source_head_is_not_merged_commit(repo):
+    src, _ = repo
+    previous = subprocess.run(
+        ["git", "rev-parse", "HEAD^"], cwd=src, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    out = guard_post_merge(src, previous, sandbox=_Sandbox(exit_code=1), policy=_policy())
+    assert out.reverted is False and out.revert_failed is True
+    assert "source non resynchronisée" in out.reason
+
+
 # --- RevertPolicy.from_settings -------------------------------------------------
 
 
@@ -185,4 +221,4 @@ def test_policy_on_follows_automerge_by_default():
 
 def test_policy_can_be_disabled_explicitly():
     p = RevertPolicy.from_settings(SimpleNamespace(AUTO_MERGE_ENABLED=True, AUTO_REVERT_ENABLED=False))
-    assert p.enabled is False  # filet désactivé explicitement (risqué)
+    assert p.enabled is True and p.revert_enabled is False  # santé vérifiée, revert désactivé

--- a/tests/test_pilot_resume.py
+++ b/tests/test_pilot_resume.py
@@ -158,6 +158,35 @@ async def test_improving_mode_chains_run_improvement(repo, manager):
     assert seen["dry_run"] is False
 
 
+async def test_phase5_critical_stop_propagates_to_project_result(repo, manager):
+    pid = manager.create_project(name="phase5-stop")
+    tid = manager.add_task(pid, title="T0")
+    manager.update_task_status(tid, "merged")
+
+    async def stopped(*args, **kwargs):
+        return SimpleNamespace(stop_reason="post_merge_guard_failed")
+
+    result = await run_project(
+        pid,
+        repo,
+        ctx=None,
+        agent=FakeCodeAgent(),
+        owner="o",
+        repo="r",
+        manager=manager,
+        budget=_Budget([ContinueDecision(action=ACTION_CONTINUE, reason="ok")]),
+        sandbox=_Sandbox(),
+        reviewer=FakeReviewer(),
+        clients=_clients(),
+        dry_run=False,
+        improve=True,
+        run_improvement_fn=stopped,
+        sync_base_fn=lambda _src, _base: True,
+    )
+    assert result.stop_reason == "post_merge_guard_failed"
+    assert result.improvement.stop_reason == result.stop_reason
+
+
 async def test_improving_forwards_gate_test_command_as_coverage_command(repo, manager):
     # #573 : le test command du gate (gate_options["test_command"]) doit être transmis à
     # run_improvement comme coverage_command, pour que la Phase 4 mesure avec la VRAIE
@@ -337,10 +366,16 @@ async def test_runtime_threads_improve_flag(repo, manager):
 
     async def fake_run_improvement(project_id, repo_source, ctx, **kw):
         seen["called"] = True
+        seen["promotion_hook"] = kw.get("promotion_hook")
         return SimpleNamespace(stop_reason="plateau")
 
     settings_obj = SimpleNamespace(
-        COLLEGUE_RUN_DEADLINE_SECONDS=0, MAX_COST_USD=0, MAX_TOKENS_BUDGET=0, BUDGET_EXHAUSTED_ACTION="pause"
+        COLLEGUE_RUN_DEADLINE_SECONDS=0,
+        MAX_COST_USD=0,
+        MAX_TOKENS_BUDGET=0,
+        BUDGET_EXHAUSTED_ACTION="pause",
+        AUTO_MERGE_ENABLED=True,
+        AUTO_REVERT_ENABLED=True,
     )
     result = await run_project_from_settings(
         pid,
@@ -360,6 +395,7 @@ async def test_runtime_threads_improve_flag(repo, manager):
         sync_base_fn=lambda _src, _base: True,
     )
     assert seen.get("called")
+    assert callable(seen.get("promotion_hook"))
     assert result.improvement.stop_reason == "plateau"
 
 


### PR DESCRIPTION
Closes #592.

## Résumé

Branche la politique Phase 5-A dans la boucle d’amélioration réelle :

- collecte un contexte GitHub autoritatif et exhaustif (SHA stable, fichiers, stats, checks et statuses) ;
- attend la CI sous délai borné et refuse tout état absent, incomplet, mobile ou rouge ;
- n’autorise que les diffs faibles risques conformes à l’allowlist ;
- fusionne avec garde `expected_head_sha`, resynchronise la base puis vérifie la santé de `main` ;
- arrête immédiatement les promotions suivantes si la santé est rouge ou non concluante.

## Sûreté

- `AUTO_MERGE_ENABLED=false` par défaut ;
- aucune écriture en dry-run ;
- tout doute échoue fermé et laisse la PR à un humain ;
- chemins exécutables/sensibles toujours exclus de l’auto-merge.

## Validation

- patch original préservé bit pour bit après rattachement au nouveau `main` ;
- Ruff, compilation Python et `git diff --check` verts ;
- validations ciblées de la chaîne post-#591 : 618 tests réussis, 1 skip attendu.