### PR TITLE
ci(nightly): prouver le cycle produit plan → PR réelle

### DIFF
--- a/.github/workflows/integration-nightly.yml
+++ b/.github/workflows/integration-nightly.yml
@@ -240,12 +240,6 @@ jobs:
             echo "::error::Configuration E2E absente : ${missing[*]}"
             exit 1
           fi
-          if ! awk -v prompt="$LLM_PRICE_PROMPT_PER_1M" \
-            -v completion="$LLM_PRICE_COMPLETION_PER_1M" \
-            'BEGIN { exit !((prompt + 0) > 0 || (completion + 0) > 0) }'; then
-            echo "::error::Au moins un prix LLM par million de tokens doit être strictement positif."
-            exit 1
-          fi
           if [[ "${LLM_PROVIDER,,}" != "gemini" ]]; then
             echo "::error::Le premier smoke produit impose LLM_PROVIDER=gemini."
             exit 1
@@ -259,11 +253,21 @@ jobs:
           done
           for name in LLM_MODEL LLM_MODEL_CODER LLM_MODEL_QA LLM_MODEL_REVIEWER LLM_MODEL_PLANNER; do
             value="${!name:-$LLM_MODEL}"
-            if [[ ! "${value,,}" =~ ^gemini-[a-z0-9][a-z0-9._-]*$ ]]; then
-              echo "::error::$name effectif doit être un modèle Gemini non préfixé."
+            if [[ ! "${value,,}" =~ ^gemini-[a-z0-9][a-z0-9._-]*$ \
+              && ! "${value,,}" =~ ^gemma-4-(31b-it|26b-a4b-it)$ ]]; then
+              echo "::error::$name effectif doit être un modèle Gemini API non préfixé autorisé."
               exit 1
             fi
           done
+          coder_model="${LLM_MODEL_CODER:-$LLM_MODEL}"
+          if ! awk -v prompt="$LLM_PRICE_PROMPT_PER_1M" \
+            -v completion="$LLM_PRICE_COMPLETION_PER_1M" \
+            'BEGIN { exit !((prompt + 0) > 0 || (completion + 0) > 0) }'; then
+            if [[ ! "${coder_model,,}" =~ ^gemma-4-(31b-it|26b-a4b-it)$ ]]; then
+              echo "::error::Au moins un prix LLM par million de tokens doit être positif, sauf pour un coder Gemma 4 explicitement gratuit."
+              exit 1
+            fi
+          fi
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5

--- a/.github/workflows/integration-nightly.yml
+++ b/.github/workflows/integration-nightly.yml
@@ -7,6 +7,7 @@
 # Et avec secrets (chiffrés, jamais en clair dans le dépôt) :
 #   - les tests LLM réels (INTEGRATION_LLM_API_KEY), sous budget DUR borné
 #   - Sentry/GitHub réels si fournis (sinon les tests se skippent proprement)
+#   - en opt-in, le cycle produit plan→run→PR→cleanup sur un dépôt fixture dédié
 #
 # Les tests `integration` skippent quand un prérequis manque : le rapport liste
 # les skips (-rs) et l'étape « Bilan » échoue si TOUT a été skippé (un nightly
@@ -21,7 +22,6 @@ on:
 
 permissions:
   contents: read
-  issues: write # notification d'échec (issue de suivi)
 
 concurrency:
   group: integration-nightly
@@ -53,13 +53,6 @@ jobs:
       STATE_DATABASE_URL: postgresql+psycopg2://collegue:collegue@localhost:5432/collegue_state
       # Sandbox Docker réel : image légère publique (pullée ci-dessous).
       SANDBOX_TEST_IMAGE: python:3.12-slim
-      # Secrets chiffrés (Settings → Secrets and variables → Actions). Absent = les
-      # tests correspondants se skippent — JAMAIS de clé en clair dans le dépôt.
-      LLM_API_KEY: ${{ secrets.INTEGRATION_LLM_API_KEY }}
-      GEMINI_API_KEY: ${{ secrets.INTEGRATION_LLM_API_KEY }}
-      GITHUB_TOKEN: ${{ secrets.INTEGRATION_GITHUB_TOKEN }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.INTEGRATION_SENTRY_AUTH_TOKEN }}
-      SENTRY_ORG: ${{ secrets.INTEGRATION_SENTRY_ORG }}
       # Budget DUR : borne le coût d'un nightly même si un test LLM s'emballe.
       MAX_COST_USD: "2.0"
       MAX_TOKENS_BUDGET: "2000000"
@@ -69,6 +62,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
@@ -91,6 +86,13 @@ jobs:
         id: pytest
         env:
           PYTHONPATH: .
+          # Secrets limités au processus de test qui les consomme : setup, pip,
+          # Docker et les actions de rapport ne les reçoivent jamais.
+          LLM_API_KEY: ${{ secrets.INTEGRATION_LLM_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.INTEGRATION_LLM_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.INTEGRATION_GITHUB_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.INTEGRATION_SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.INTEGRATION_SENTRY_ORG }}
         # --override-ini neutralise l'addopts `-m 'not integration'` du pyproject ;
         # -rs liste chaque skip avec sa raison (lisible dans le log du run).
         run: |
@@ -121,21 +123,239 @@ jobs:
             integration-report.xml
             pytest-integration.log
 
-      - name: Notifier l'échec (issue de suivi)
-        if: failure()
+  build-sandbox-openhands:
+    name: Build image sandbox OpenHands (#404)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      # Construit l'image #404 depuis les SOURCES COMMITTÉES SEULES (le harnais
+      # gitignoré scripts/facnor_run/ n'est pas présent en CI) — prouve que le
+      # blocage « image non constructible » est levé. Ce job reste build-only ;
+      # le job product-e2e ci-dessous reconstruit l'image sur son propre runner
+      # avant le smoke réel secret-gated.
+      - name: Build OpenHands sandbox image (committed sources only)
+        run: docker build -f docker/sandbox/Dockerfile.openhands -t collegue-sandbox-openhands:ci .
+      - name: Vérifier le runner produit OpenHands SDK
+        run: |
+          docker run --rm collegue-sandbox-openhands:ci \
+            python -c "from pathlib import Path; from openhands.sdk import Conversation, LLM; from openhands.tools.preset.default import get_default_agent; assert Path('/opt/oh_runner.py').is_file(); print('OpenHands SDK runner OK')"
+
+  product-e2e:
+    name: Produit E2E — plan → run → PR → cleanup (#404)
+    if: vars.INTEGRATION_E2E_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    env:
+      # Opt-in et identité immuable du dépôt fixture public.
+      COLLEGUE_NIGHTLY_E2E: "true"
+      INTEGRATION_FIXTURE_REPOSITORY: ${{ vars.INTEGRATION_FIXTURE_REPOSITORY }}
+      INTEGRATION_FIXTURE_REPOSITORY_ID: ${{ vars.INTEGRATION_FIXTURE_REPOSITORY_ID }}
+      INTEGRATION_FIXTURE_ROOT_BRANCH: ${{ vars.INTEGRATION_FIXTURE_ROOT_BRANCH }}
+      INTEGRATION_FIXTURE_SEED_SHA: ${{ vars.INTEGRATION_FIXTURE_SEED_SHA }}
+      COLLEGUE_NIGHTLY_MANIFEST: ${{ runner.temp }}/collegue-nightly/manifest.json
+
+      # Endpoint/modèles configurables sans modifier le workflow. Les overrides
+      # vides retombent sur le provider/modèle global dans la résolution par rôle.
+      LLM_PROVIDER: ${{ vars.INTEGRATION_LLM_PROVIDER }}
+      LLM_MODEL: ${{ vars.INTEGRATION_LLM_MODEL }}
+      LLM_PROVIDER_CODER: ${{ vars.INTEGRATION_LLM_PROVIDER_CODER }}
+      LLM_MODEL_CODER: ${{ vars.INTEGRATION_LLM_MODEL_CODER }}
+      LLM_PROVIDER_QA: ${{ vars.INTEGRATION_LLM_PROVIDER_QA }}
+      LLM_MODEL_QA: ${{ vars.INTEGRATION_LLM_MODEL_QA }}
+      LLM_PROVIDER_REVIEWER: ${{ vars.INTEGRATION_LLM_PROVIDER_REVIEWER }}
+      LLM_MODEL_REVIEWER: ${{ vars.INTEGRATION_LLM_MODEL_REVIEWER }}
+      LLM_PROVIDER_PLANNER: ${{ vars.INTEGRATION_LLM_PROVIDER_PLANNER }}
+      LLM_MODEL_PLANNER: ${{ vars.INTEGRATION_LLM_MODEL_PLANNER }}
+      LLM_PRICE_PROMPT_PER_1M: ${{ vars.INTEGRATION_LLM_PRICE_PROMPT_PER_1M }}
+      LLM_PRICE_COMPLETION_PER_1M: ${{ vars.INTEGRATION_LLM_PRICE_COMPLETION_PER_1M }}
+
+      # État local éphémère, mais chemins absolus et stables pendant tout le job.
+      STATE_DATABASE_URL: sqlite:///${{ runner.temp }}/collegue-nightly/state.sqlite3
+      COLLEGUE_HOME: ${{ runner.temp }}/collegue-nightly/home
+      SANDBOX_PIP_CACHE_DIR: ${{ runner.temp }}/collegue-nightly/pip-cache
+      SANDBOX_IMAGE: collegue-sandbox-openhands:ci
+      SANDBOX_NETWORK: bridge
+      SANDBOX_MEMORY: 6g
+      SANDBOX_CPUS: "2.0"
+      SANDBOX_TIMEOUT: "720"
+
+      # Contrat objectif §4.7 et posture sans merge : la preuve attend une PR
+      # ouverte, puis le module ferme PR/issues et supprime ses branches exactes.
+      GATE_ACCEPTANCE_TESTS: "true"
+      GATE_TEST_COMMAND: python -m pytest -q
+      GATE_FRONTEND: "false"
+      GATE_SMOKE_RUN: "true"
+      GATE_SMOKE_PATHS: /nightly
+      GATE_SMOKE_CORS_ORIGIN: ""
+      BUILD_AUTO_MERGE: "false"
+      AUTO_MERGE_ENABLED: "false"
+      DEPS_REQUIRE_MERGED: "true"
+      STRICT_MAX_INFLIGHT_PRS: "1"
+      TASK_MAX_ATTEMPTS: "1"
+      TASK_RETRY_BACKOFF_SECONDS: "0"
+
+      # Bornes cumulatives et par appel/processus. Les prix de secours sont
+      # obligatoires pour que le plafond USD ne soit jamais aveugle.
+      REQUIRE_COST_PRICING: "true"
+      BUDGET_EXHAUSTED_ACTION: pause
+      MAX_COST_USD: "2.0"
+      MAX_TOKENS_BUDGET: "250000"
+      COLLEGUE_RUN_DEADLINE_SECONDS: "900"
+      LLM_CALL_TIMEOUT: "180"
+      COLLEGUE_NIGHTLY_COMMAND_TIMEOUT_SECONDS: "1200"
+      CODER_LLM_NUM_RETRIES: "3"
+      CODER_LLM_RETRY_MIN_WAIT: "5"
+      CODER_LLM_RETRY_MAX_WAIT: "30"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Préflight — secrets et variables obligatoires
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.INTEGRATION_FIXTURE_GITHUB_TOKEN }}
+          LLM_API_KEY: ${{ secrets.INTEGRATION_LLM_API_KEY }}
+        run: |
+          required=(
+            GITHUB_TOKEN LLM_API_KEY
+            INTEGRATION_FIXTURE_REPOSITORY INTEGRATION_FIXTURE_REPOSITORY_ID
+            INTEGRATION_FIXTURE_ROOT_BRANCH INTEGRATION_FIXTURE_SEED_SHA
+            LLM_PROVIDER LLM_MODEL
+            LLM_PRICE_PROMPT_PER_1M LLM_PRICE_COMPLETION_PER_1M
+          )
+          missing=()
+          for name in "${required[@]}"; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+          if (( ${#missing[@]} )); then
+            echo "::error::Configuration E2E absente : ${missing[*]}"
+            exit 1
+          fi
+          if ! awk -v prompt="$LLM_PRICE_PROMPT_PER_1M" \
+            -v completion="$LLM_PRICE_COMPLETION_PER_1M" \
+            'BEGIN { exit !((prompt + 0) > 0 || (completion + 0) > 0) }'; then
+            echo "::error::Au moins un prix LLM par million de tokens doit être strictement positif."
+            exit 1
+          fi
+          if [[ "${LLM_PROVIDER,,}" != "gemini" ]]; then
+            echo "::error::Le premier smoke produit impose LLM_PROVIDER=gemini."
+            exit 1
+          fi
+          for name in LLM_PROVIDER_CODER LLM_PROVIDER_QA LLM_PROVIDER_REVIEWER LLM_PROVIDER_PLANNER; do
+            value="${!name:-}"
+            if [[ -n "$value" && "${value,,}" != "gemini" ]]; then
+              echo "::error::$name doit être vide ou égal à gemini."
+              exit 1
+            fi
+          done
+          for name in LLM_MODEL LLM_MODEL_CODER LLM_MODEL_QA LLM_MODEL_REVIEWER LLM_MODEL_PLANNER; do
+            value="${!name:-$LLM_MODEL}"
+            if [[ ! "${value,,}" =~ ^gemini-[a-z0-9][a-z0-9._-]*$ ]]; then
+              echo "::error::$name effectif doit être un modèle Gemini non préfixé."
+              exit 1
+            fi
+          done
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Initialiser l'état durable local
+        run: |
+          mkdir -p \
+            "$COLLEGUE_HOME" \
+            "$SANDBOX_PIP_CACHE_DIR" \
+            "$(dirname "$COLLEGUE_NIGHTLY_MANIFEST")"
+          python -m alembic upgrade head
+
+      - name: Build OpenHands sandbox image from committed sources
+        run: docker build -f docker/sandbox/Dockerfile.openhands -t "$SANDBOX_IMAGE" .
+
+      - name: Vérifier le runner OpenHands SDK embarqué
+        run: |
+          docker run --rm "$SANDBOX_IMAGE" \
+            python -c "from pathlib import Path; from openhands.sdk import Conversation, LLM; from openhands.tools.preset.default import get_default_agent; assert Path('/opt/oh_runner.py').is_file(); print('OpenHands SDK runner OK')"
+
+      - name: Exécuter le cycle produit réel
+        env:
+          GITHUB_TOKEN: ${{ secrets.INTEGRATION_FIXTURE_GITHUB_TOKEN }}
+          LLM_API_KEY: ${{ secrets.INTEGRATION_LLM_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.INTEGRATION_LLM_API_KEY }}
+        run: python -m collegue.pilot.nightly_e2e run
+
+      - name: Réconcilier et nettoyer la fixture
+        if: always()
+        # Le finalizer n'a besoin que du PAT fixture : aucune clé LLM n'est
+        # injectée dans ce chemin, y compris après un échec du préflight run.
+        env:
+          GITHUB_TOKEN: ${{ secrets.INTEGRATION_FIXTURE_GITHUB_TOKEN }}
+        run: python -m collegue.pilot.nightly_e2e cleanup
+
+  notify-failure:
+    name: Notifier l'échec nightly (#404)
+    needs: [integration, build-sandbox-openhands, product-e2e]
+    if: >-
+      ${{ always() &&
+          ((needs.integration.result != 'success' && needs.integration.result != 'skipped') ||
+           (needs.build-sandbox-openhands.result != 'success' && needs.build-sandbox-openhands.result != 'skipped') ||
+           (needs.product-e2e.result != 'success' && needs.product-e2e.result != 'skipped')) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    env:
+      INTEGRATION_RESULT: ${{ needs.integration.result }}
+      SANDBOX_BUILD_RESULT: ${{ needs.build-sandbox-openhands.result }}
+      PRODUCT_E2E_RESULT: ${{ needs.product-e2e.result }}
+    steps:
+      - name: Ouvrir ou commenter l'issue de suivi
         uses: actions/github-script@v7
         with:
+          github-token: ${{ github.token }}
           script: |
-            const title = "CI nightly integration en échec";
+            const title = "CI nightly en échec";
+            const results = {
+              integration: process.env.INTEGRATION_RESULT,
+              "build-sandbox-openhands": process.env.SANDBOX_BUILD_RESULT,
+              "product-e2e": process.env.PRODUCT_E2E_RESULT,
+            };
+            const failed = Object.entries(results)
+              .filter(([, result]) => !["success", "skipped"].includes(result))
+              .map(([job, result]) => `${job} (${result})`);
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const body = `Le run nightly integration a échoué : ${runUrl}\n\n_(notification automatique du workflow integration-nightly — #404)_`;
+            const body = [
+              `Le run nightly a échoué : ${runUrl}`,
+              `Jobs en échec : ${failed.join(", ")}`,
+              "",
+              "_(notification automatique du workflow integration-nightly — #404)_",
+            ].join("\n");
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: "open",
               per_page: 100,
             });
-            const existing = issues.find((i) => i.title === title);
+            const existing = issues.find((issue) => !issue.pull_request && issue.title === title);
             if (existing) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
@@ -151,21 +371,3 @@ jobs:
                 body,
               });
             }
-
-  build-sandbox-openhands:
-    name: Build image sandbox OpenHands (#404)
-    runs-on: ubuntu-latest
-    timeout-minutes: 40
-    steps:
-      - uses: actions/checkout@v4
-      # Construit l'image #404 depuis les SOURCES COMMITTÉES SEULES (le harnais
-      # gitignoré scripts/facnor_run/ n'est pas présent en CI) — prouve que le
-      # blocage « image non constructible » est levé. Build-only : aucun run réel
-      # (LLM/GitHub) ici ; le smoke e2e réel (plan→execute→PR sur fixture) reste
-      # un suivi secret-gated.
-      - name: Build OpenHands sandbox image (committed sources only)
-        run: docker build -f docker/sandbox/Dockerfile.openhands -t collegue-sandbox-openhands:ci .
-      - name: Vérifier l'entrypoint produit (openhands.core.main) importable
-        run: |
-          docker run --rm collegue-sandbox-openhands:ci \
-            python -c "import openhands.core.main; print('openhands.core.main OK')"

--- a/collegue/executor/openhands_agent.py
+++ b/collegue/executor/openhands_agent.py
@@ -119,12 +119,12 @@ def estimate_cost_usd(prompt_tokens: int, completion_tokens: int, settings_obj=N
 
 
 def coder_pricing_resolvable(settings_obj=None) -> bool:
-    """Vrai si un prix de secours coder (``LLM_PRICE_*_PER_1M``) est configuré (#502).
+    """Vrai si le coût coder est résolvable (#502).
 
-    Quand litellm ne mappe pas le modèle coder ET qu'aucun prix n'est configuré,
-    le ledger $ reste à 0 et ``MAX_COST_USD`` est inopérant côté coder (3 runs
-    consécutifs aveugles). Ce prédicat permet de l'AVERTIR au démarrage du run
-    plutôt que de le découvrir en post-mortem. Même robustesse que
+    Un prix de secours positif rend le coût calculable quand LiteLLM ne connaît
+    pas le modèle. Un modèle dont la grille autoritaire fixe explicitement le
+    coût à zéro (Gemma 4 Free Tier) est également résolvable sans prix de
+    secours. Un modèle distant inconnu reste fail-closed. Même robustesse que
     :func:`estimate_cost_usd` (prix absent/non numérique/négatif/non fini → 0).
     """
     if settings_obj is None:
@@ -137,7 +137,22 @@ def coder_pricing_resolvable(settings_obj=None) -> bool:
             return 0.0
         return value if math.isfinite(value) and value > 0 else 0.0
 
-    return _price("LLM_PRICE_PROMPT_PER_1M") > 0 or _price("LLM_PRICE_COMPLETION_PER_1M") > 0
+    return (
+        _price("LLM_PRICE_PROMPT_PER_1M") > 0
+        or _price("LLM_PRICE_COMPLETION_PER_1M") > 0
+        or coder_pricing_is_explicitly_free(settings_obj)
+    )
+
+
+def coder_pricing_is_explicitly_free(settings_obj=None) -> bool:
+    """Vrai si le couple provider/modèle effectif du rôle coder vaut 0 USD."""
+    if settings_obj is None:
+        from collegue.config import settings as settings_obj
+
+    from collegue.monitoring.pricing import is_explicitly_free
+
+    provider, model = resolve_role(LLMRole.CODER, settings_obj)
+    return is_explicitly_free(model, provider=provider)
 
 
 # Politique retries/backoff par défaut du canal coder (#422) — alignée sur les

--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -941,6 +941,10 @@ class QualityReport:
     acceptance_passed: Optional[bool] = None
     acceptance_output: str = ""
     acceptance_error: Optional[str] = None
+    # SHA-256 de l'oracle réellement exécuté. Le checker plan-time le renseigne
+    # après avoir rechargé et vérifié l'artefact durable exact ; ``None`` pour
+    # les checkers historiques/dynamiques qui ne peuvent pas fournir cette preuve.
+    acceptance_oracle_sha256: Optional[str] = None
 
     def to_markdown(self) -> str:
         """Rapport Markdown pour le corps de PR (texte de revue fencé, anti-injection)."""
@@ -1027,7 +1031,10 @@ class QualityReport:
                 "> ⚠️ **aucun fichier de test touché** par ce diff (#437) — la feature livrée "
                 "n'est couverte par aucun test nouveau ou modifié.",
             ]
-        if self.acceptance_passed is False:
+        if self.acceptance_passed is True:
+            oracle = f" — oracle `sha256:{self.acceptance_oracle_sha256}`" if self.acceptance_oracle_sha256 else ""
+            lines += ["", f"**Tests d'acceptation (§4.7)** : ✅ réussis{oracle}"]
+        elif self.acceptance_passed is False:
             lines += [
                 "",
                 "> ⛔ **tests d'acceptation dérivés du SPEC en ÉCHEC (§4.7)** — des tests exécutables "
@@ -1548,6 +1555,7 @@ class AcceptanceOutcome:
     output: str = ""
     error: Optional[str] = None  # toute erreur bloque quand le checker est activé
     skipped: bool = False
+    oracle_sha256: Optional[str] = None
 
 
 @runtime_checkable
@@ -1632,7 +1640,13 @@ raise SystemExit(exit_code)
     )
 
 
-def _run_acceptance_source(workspace: str, source: str, *, sandbox) -> AcceptanceOutcome:
+def _run_acceptance_source(
+    workspace: str,
+    source: str,
+    *,
+    sandbox,
+    oracle_sha256: Optional[str] = None,
+) -> AcceptanceOutcome:
     """Lance un source QA déjà déterminé avec l'oracle pytest isolé commun.
 
     Cette fonction ne génère rien et ne lit aucun diff. Elle est partagée par le
@@ -1645,7 +1659,10 @@ def _run_acceptance_source(workspace: str, source: str, *, sandbox) -> Acceptanc
     try:
         res = sandbox.run_tests(workspace, command)
     except Exception as exc:  # noqa: BLE001 - checker activé = erreur bloquante
-        return AcceptanceOutcome(error=f"exécution de l'oracle d'acceptation impossible : {exc}")
+        return AcceptanceOutcome(
+            error=f"exécution de l'oracle d'acceptation impossible : {exc}",
+            oracle_sha256=oracle_sha256,
+        )
     output = "\n".join(part for part in (res.stdout, res.stderr) if part).strip()
     # pytest exit 5 = AUCUN test collecté : le contrat n'est pas prouvé.
     if getattr(res, "exit_code", None) == 5:
@@ -1653,8 +1670,9 @@ def _run_acceptance_source(workspace: str, source: str, *, sandbox) -> Acceptanc
             passed=False,
             error="aucun test d'acceptation collecté (oracle inexploitable)",
             output=output,
+            oracle_sha256=oracle_sha256,
         )
-    return AcceptanceOutcome(passed=bool(res.ok), output=output)
+    return AcceptanceOutcome(passed=bool(res.ok), output=output, oracle_sha256=oracle_sha256)
 
 
 _STORED_ACCEPTANCE_SCHEMA_VERSION = 1
@@ -1820,7 +1838,12 @@ class StoredAcceptanceChecker:
         source, error = self._load_and_verify(issue)
         if error is not None or source is None:
             return AcceptanceOutcome(error=error or "oracle plan-time invalide")
-        return _run_acceptance_source(workspace, source, sandbox=sandbox)
+        return _run_acceptance_source(
+            workspace,
+            source,
+            sandbox=sandbox,
+            oracle_sha256=_text_sha256(source),
+        )
 
 
 class LLMAcceptanceChecker:
@@ -2180,6 +2203,7 @@ async def run_quality_gate(
     acceptance_passed: Optional[bool] = None
     acceptance_output = ""
     acceptance_error: Optional[str] = None
+    acceptance_oracle_sha256: Optional[str] = None
     acceptance_required = acceptance_checker is not None
     if acceptance_required and would_pass:
         if issue is None:
@@ -2192,6 +2216,7 @@ async def run_quality_gate(
                 acceptance_passed = acc.passed
                 acceptance_output = acc.output
                 acceptance_error = acc.error
+                acceptance_oracle_sha256 = acc.oracle_sha256
                 if acc.skipped:
                     acceptance_passed = None
                     acceptance_error = acceptance_error or "contrôle d'acceptation ignoré sans verdict"
@@ -2245,6 +2270,7 @@ async def run_quality_gate(
         acceptance_passed=acceptance_passed,
         acceptance_output=acceptance_output,
         acceptance_error=acceptance_error,
+        acceptance_oracle_sha256=acceptance_oracle_sha256,
     )
 
 

--- a/collegue/monitoring/pricing.py
+++ b/collegue/monitoring/pricing.py
@@ -30,9 +30,19 @@ _PER_1M = 1_000_000.0
 # Providers locaux : exécution sur la machine → coût nul.
 _LOCAL_PROVIDERS = ("lmstudio", "ollama", "unsloth")
 
+# Modèles distants à coût nul, liés à leur provider. Contrairement aux tarifs
+# payants historiques, un zéro ne doit jamais être réutilisé pour un endpoint
+# homonyme d'un autre provider ni pour un suffixe de modèle inconnu.
+_FREE_REMOTE_MODELS = {"gemini": frozenset({"gemma-4-31b-it", "gemma-4-26b-a4b-it"})}
+
 # Grille par modèle, exprimée en USD / 1M tokens pour rester lisible,
 # convertie en USD / token plus bas.
 _MODEL_PRICES_PER_1M: Dict[str, Tuple[float, float]] = {
+    # Gemma 4 via Gemini API — disponible uniquement sur le Free Tier : le coût
+    # API est explicitement nul. Ces zéros sont autoritaires, contrairement au
+    # repli d'un modèle distant inconnu.
+    "gemma-4-31b-it": (0.0, 0.0),
+    "gemma-4-26b-a4b-it": (0.0, 0.0),
     # Gemini 3.x
     "gemini-3.5-flash": (1.50, 9.00),
     "gemini-3-flash-preview": (1.50, 9.00),
@@ -51,9 +61,9 @@ _MODEL_PRICES_PER_1M: Dict[str, Tuple[float, float]] = {
     "claude-haiku-4": (1.00, 5.00),
 }
 
-# Repli quand le modèle configuré n'est pas dans la table : on reprend les
-# anciens défauts du collecteur (Gemma 4 via Gemini API), volontairement bas
-# pour ne pas surévaluer le coût.
+# Repli historique quand le modèle configuré n'est pas dans la table,
+# volontairement bas pour ne pas surévaluer le coût. Ce repli n'est jamais
+# autoritaire : :func:`has_explicit_pricing` reste faux pour un modèle inconnu.
 _DEFAULT_PER_1M: Tuple[float, float] = (0.15, 0.60)
 
 
@@ -63,6 +73,11 @@ def _normalize(model: str) -> str:
     if name.startswith("models/"):
         name = name[len("models/") :]
     return name
+
+
+def _free_remote_model_is_valid(key: str, provider: Optional[str]) -> bool:
+    provider_key = (provider or "gemini").strip().lower()
+    return key in _FREE_REMOTE_MODELS.get(provider_key, ())
 
 
 def cost_per_token(model: str, provider: Optional[str] = None) -> Tuple[float, float]:
@@ -76,6 +91,8 @@ def cost_per_token(model: str, provider: Optional[str] = None) -> Tuple[float, f
         return 0.0, 0.0
     key = _normalize(model)
     prices = _MODEL_PRICES_PER_1M.get(key)
+    if prices == (0.0, 0.0) and not _free_remote_model_is_valid(key, provider):
+        prices = None
     if prices is None:
         # Correspondance par préfixe pour absorber les suffixes de version/date
         # (``gpt-5.4-mini-2026-01`` → ``gpt-5.4-mini``). On teste les clés de la
@@ -83,6 +100,8 @@ def cost_per_token(model: str, provider: Optional[str] = None) -> Tuple[float, f
         # éviter qu'une clé courte (``gpt-5.4``) ne masque une plus spécifique
         # (``gpt-5.4-mini``) et surfacture.
         for known in sorted(_MODEL_PRICES_PER_1M, key=len, reverse=True):
+            if _MODEL_PRICES_PER_1M[known] == (0.0, 0.0):
+                continue
             if key == known or key.startswith(known + "-"):
                 prices = _MODEL_PRICES_PER_1M[known]
                 break
@@ -96,4 +115,21 @@ def has_explicit_pricing(model: str, provider: Optional[str] = None) -> bool:
     if provider and provider.strip().lower() in _LOCAL_PROVIDERS:
         return True
     key = _normalize(model)
-    return any(key == known or key.startswith(known + "-") for known in _MODEL_PRICES_PER_1M)
+    for known, prices in _MODEL_PRICES_PER_1M.items():
+        if prices == (0.0, 0.0):
+            if key == known and _free_remote_model_is_valid(key, provider):
+                return True
+            continue
+        if key == known or key.startswith(known + "-"):
+            return True
+    return False
+
+
+def is_explicitly_free(model: str, provider: Optional[str] = None) -> bool:
+    """Vrai seulement quand la grille autoritaire fixe les deux prix à zéro.
+
+    Le double contrôle est essentiel : :func:`cost_per_token` retourne aussi un
+    tarif de repli pour les modèles distants inconnus, qui ne doivent jamais être
+    interprétés comme gratuits ni contourner les garde-fous de budget.
+    """
+    return has_explicit_pricing(model, provider=provider) and cost_per_token(model, provider=provider) == (0.0, 0.0)

--- a/collegue/pilot/__main__.py
+++ b/collegue/pilot/__main__.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 from typing import List, Optional
 
 from collegue.pilot.runtime import format_run_report, run_project_from_settings
@@ -93,6 +94,12 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Pour `plan sync` uniquement : commit SPEC + création réelle des issues.",
     )
+    plan_p.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Format de sortie machine/lisible (défaut : text).",
+    )
     # --- args du RUN par défaut (required=False : validés dans main si pas de sous-commande) ---
     parser.add_argument("--project-id", type=int, default=None, help="Id du projet (état durable).")
     parser.add_argument("--repo-source", default=None, help="Dépôt git source (repo-agnostique).")
@@ -110,7 +117,63 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Une fois le MVP construit, enchaîne le moteur d'amélioration (Phase 4) sous le budget restant.",
     )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Format de sortie machine/lisible (défaut : text).",
+    )
     return parser
+
+
+def _json_output(payload: dict) -> str:
+    """Sérialise un contrat CLI stable sans échapper les libellés Unicode."""
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True)
+
+
+def _plan_json_payload(result) -> dict:
+    """Projection machine stable commune à draft/approve/sync."""
+    return {
+        "project_id": result.project_id,
+        "plan_hash": result.plan_hash,
+        "task_count": result.task_count,
+        "action": result.action,
+        "issues": list(result.issues or []),
+    }
+
+
+def _run_json_payload(result, *, project_id: int) -> dict:
+    """Projection machine stable du RUN, indépendante du rendu texte."""
+    return {
+        "project_id": project_id,
+        "stop_reason": result.stop_reason,
+        "iterations": result.iterations,
+        "opened_prs": list(result.opened_prs),
+        "pending_reviews": list(result.pending_reviews or []),
+        "project_status": result.project_status,
+        "processed": [
+            {
+                "task_id": task.task_id,
+                "title": task.title,
+                "success": task.success,
+                "stage": task.stage,
+                "pr_number": task.pr_number,
+                "acceptance_passed": task.acceptance_passed,
+                "acceptance_error": task.acceptance_error,
+                "acceptance_oracle_sha256": task.acceptance_oracle_sha256,
+            }
+            for task in result.processed
+        ],
+    }
+
+
+def _print_plan_result(result, *, output_format: str) -> None:
+    if output_format == "json":
+        print(_json_output(_plan_json_payload(result)))
+        return
+    from collegue.pilot.runtime import format_plan_report
+
+    print(format_plan_report(result))
 
 
 async def _run(args: argparse.Namespace) -> int:
@@ -124,14 +187,17 @@ async def _run(args: argparse.Namespace) -> int:
         max_iterations=args.max_iterations,
         improve=args.improve,
     )
-    print(format_run_report(result, project_id=args.project_id))
+    if args.format == "json":
+        print(_json_output(_run_json_payload(result, project_id=args.project_id)))
+    else:
+        print(format_run_report(result, project_id=args.project_id))
     return 0 if result.stop_reason in _OK_STOPS else 1
 
 
 async def _plan_draft(args: argparse.Namespace) -> int:
     from datetime import datetime, timedelta, timezone
 
-    from collegue.pilot.runtime import format_plan_report, plan_project_from_settings
+    from collegue.pilot.runtime import plan_project_from_settings
 
     deadline = None
     if args.deadline_hours:
@@ -149,23 +215,23 @@ async def _plan_draft(args: argparse.Namespace) -> int:
         spec_filename=args.spec_filename or "SPEC.md",
         base_branch=args.base or "main",
     )
-    print(format_plan_report(result))
+    _print_plan_result(result, output_format=args.format)
     return 0
 
 
 def _approve_plan(args: argparse.Namespace) -> int:
-    from collegue.pilot.runtime import approve_project_plan_from_settings, format_plan_report
+    from collegue.pilot.runtime import approve_project_plan_from_settings
 
     result = approve_project_plan_from_settings(args.project_id, args.expected_plan_hash)
-    print(format_plan_report(result))
+    _print_plan_result(result, output_format=args.format)
     return 0
 
 
 def _sync_plan(args: argparse.Namespace) -> int:
-    from collegue.pilot.runtime import format_plan_report, sync_project_plan_from_settings
+    from collegue.pilot.runtime import sync_project_plan_from_settings
 
     result = sync_project_plan_from_settings(args.project_id, execute=args.execute)
-    print(format_plan_report(result))
+    _print_plan_result(result, output_format=args.format)
     return 0
 
 

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -33,7 +33,11 @@ from dataclasses import dataclass, field
 from typing import Callable, List, Optional, Tuple
 
 from collegue.executor.agent import IssueSpec
-from collegue.executor.openhands_agent import coder_pricing_resolvable, estimate_cost_usd
+from collegue.executor.openhands_agent import (
+    coder_pricing_is_explicitly_free,
+    coder_pricing_resolvable,
+    estimate_cost_usd,
+)
 from collegue.executor.pipeline import (
     agent_crash_signature,
     execute_issue,
@@ -850,7 +854,8 @@ async def run_project(
         # inconnu — ne pas le re-tarifer au prix de secours (#484), sinon le ledger
         # porte un coût FANTÔME sur un run pourtant gratuit (run v6 : ~$2 fantômes).
         coder_authoritative = bool(getattr(agent_result, "cost_authoritative", False))
-        if coder_tokens and coder_usd <= 0 and not coder_authoritative:
+        coder_explicitly_free = coder_pricing_is_explicitly_free()
+        if coder_tokens and coder_usd <= 0 and not coder_authoritative and not coder_explicitly_free:
             # #484 : modèle non mappé litellm → cost_usd=0 malgré des tokens.
             # Prix de secours configurés (LLM_PRICE_*_PER_1M) : coût estimé ;
             # sinon coût INCONNU — signalé une fois par run/segment au lieu

--- a/collegue/pilot/driver.py
+++ b/collegue/pilot/driver.py
@@ -174,6 +174,11 @@ class TaskOutcome:
     success: bool
     stage: str
     pr_number: Optional[int] = None
+    # Preuve machine §4.7 issue du rapport du gate. ``None`` signifie que le
+    # checker n'a pas rendu de verdict / n'était pas câblé.
+    acceptance_passed: Optional[bool] = None
+    acceptance_error: Optional[str] = None
+    acceptance_oracle_sha256: Optional[str] = None
 
 
 @dataclass
@@ -896,6 +901,13 @@ async def run_project(
                 success=outcome.success,
                 stage=outcome.stage,
                 pr_number=pr_number,
+                acceptance_passed=getattr(outcome.quality_report, "acceptance_passed", None),
+                acceptance_error=getattr(outcome.quality_report, "acceptance_error", None),
+                acceptance_oracle_sha256=getattr(
+                    outcome.quality_report,
+                    "acceptance_oracle_sha256",
+                    None,
+                ),
             )
         )
 

--- a/collegue/pilot/nightly_e2e.py
+++ b/collegue/pilot/nightly_e2e.py
@@ -41,6 +41,7 @@ _SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 _REPOSITORY_RE = re.compile(r"^([A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?)/([A-Za-z0-9._-]{1,100})$")
 _RUN_COMPONENT_RE = re.compile(r"^[1-9][0-9]*$")
+_GEMINI_API_MODEL_RE = re.compile(r"^(?:gemini-[a-z0-9][a-z0-9._-]*|gemma-4-(?:31b-it|26b-a4b-it))$")
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
 _FIXTURE_SENTINEL = "COLLEGUE_NIGHTLY_FIXTURE_V1\n"
 _DEFAULT_MARKER_PATH = ".collegue-nightly-fixture"
@@ -127,8 +128,9 @@ def _validate_run_environment(values: Mapping[str, str]) -> None:
     if provider != "gemini":
         raise NightlyE2EError("le premier smoke nightly exige le provider global gemini")
     global_model = _required(values, "LLM_MODEL").lower()
-    from collegue.monitoring.pricing import has_explicit_pricing
+    from collegue.monitoring.pricing import has_explicit_pricing, is_explicitly_free
 
+    effective_models: dict[Optional[str], str] = {}
     for role in (None, "CODER", "QA", "REVIEWER", "PLANNER"):
         suffix = f"_{role}" if role else ""
         label = f"LLM_MODEL{suffix}"
@@ -136,10 +138,11 @@ def _validate_run_environment(values: Mapping[str, str]) -> None:
         # Les noms préfixés ``openai/...``/``models/...`` sont refusés : le coder
         # OpenHands route LiteLLM à partir de ce préfixe et pourrait envoyer la
         # clé Gemini au mauvais provider.
-        if re.fullmatch(r"gemini-[a-z0-9][a-z0-9._-]*", model) is None:
-            raise NightlyE2EError(f"{label} effectif doit être un modèle Gemini non préfixé")
+        if _GEMINI_API_MODEL_RE.fullmatch(model) is None:
+            raise NightlyE2EError(f"{label} effectif doit être un modèle Gemini API non préfixé autorisé")
         if not has_explicit_pricing(model, provider=provider):
             raise NightlyE2EError(f"{label} effectif n'a pas de tarif explicite dans la grille")
+        effective_models[role] = model
         if role:
             role_provider = str(values.get(f"LLM_PROVIDER_{role}", "") or "").strip().lower()
             if role_provider and role_provider != provider:
@@ -154,8 +157,10 @@ def _validate_run_environment(values: Mapping[str, str]) -> None:
         if not math.isfinite(price) or price < 0:
             raise NightlyE2EError(f"{name} doit être un nombre fini positif ou nul")
         prices.append(price)
-    if not any(price > 0 for price in prices):
-        raise NightlyE2EError("au moins un prix LLM doit être strictement positif")
+    if not any(price > 0 for price in prices) and not is_explicitly_free(effective_models["CODER"], provider=provider):
+        raise NightlyE2EError(
+            "au moins un prix LLM doit être strictement positif, sauf pour un modèle coder explicitement gratuit"
+        )
     _required(values, "LLM_API_KEY")
     if not os.path.isabs(os.path.expanduser(_required(values, "COLLEGUE_HOME"))):
         raise NightlyE2EError("COLLEGUE_HOME doit être absolu pour rendre le budget durable")

--- a/collegue/pilot/nightly_e2e.py
+++ b/collegue/pilot/nightly_e2e.py
@@ -1,0 +1,1337 @@
+"""Smoke nightly réel du cycle produit sur un dépôt fixture GitHub dédié.
+
+Ce module orchestre les *vraies* commandes publiques du produit dans des
+processus séparés : ``plan draft`` → ``plan approve`` → ``plan sync --execute``
+→ RUN ``--execute``. Toutes les écritures visent une branche de base éphémère ;
+la branche par défaut du dépôt fixture est épinglée et ne doit jamais bouger.
+
+Le cleanup est une commande autonome et idempotente afin que le workflow puisse
+la relancer avec ``if: always()`` après une erreur du processus principal. Les
+secrets restent dans l'environnement : ils ne sont écrits ni dans les argv, ni
+dans le manifeste durable du smoke.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional, Sequence
+
+from collegue.tools.base import ToolExecutionError
+from collegue.tools.github_commands import (
+    BranchCommands,
+    FileCommands,
+    IssueCommands,
+    LabelCommands,
+    PRCommands,
+    RepoCommands,
+)
+
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_REPOSITORY_RE = re.compile(r"^([A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?)/([A-Za-z0-9._-]{1,100})$")
+_RUN_COMPONENT_RE = re.compile(r"^[1-9][0-9]*$")
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_FIXTURE_SENTINEL = "COLLEGUE_NIGHTLY_FIXTURE_V1\n"
+_DEFAULT_MARKER_PATH = ".collegue-nightly-fixture"
+_EXEC_MARKER = "<!-- collegue-exec:"
+_TASK_MARKER = "<!-- collegue-task:"
+_NIGHTLY_LABEL_COLOR = "1d76db"
+
+# Contrat volontairement minuscule : un seul changement observable et un seul
+# test. Les chemins font partie du problème car le planner ne voit pas le dépôt.
+FIXTURE_PROBLEM = (
+    "Sur le dépôt fixture Python existant, réalise exactement UNE tâche atomique. "
+    "Ajoute dans `app/main.py` une route GET `/nightly` qui renvoie exactement "
+    'le JSON {"status": "ok", "source": "collegue"}, puis ajoute ou '
+    "mets à jour `tests/test_app.py` pour vérifier le code HTTP 200 et ce JSON exact. "
+    "Ne modifie aucun autre comportement et n'ajoute aucune dépendance."
+)
+
+
+class NightlyE2EError(RuntimeError):
+    """Le smoke ne peut pas prouver son contrat sans risque ou sans ambiguïté."""
+
+
+def _required(env: Mapping[str, str], name: str) -> str:
+    value = str(env.get(name, "") or "").strip()
+    if not value:
+        raise NightlyE2EError(f"variable requise absente: {name}")
+    return value
+
+
+def _is_true(value: Any) -> bool:
+    return str(value or "").strip().lower() in _TRUTHY
+
+
+def _is_explicit_false(value: Any) -> bool:
+    return str(value or "").strip().lower() in {"0", "false", "no", "off"}
+
+
+def _validate_run_environment(values: Mapping[str, str]) -> None:
+    """Valide les seules protections nécessaires au chemin coûteux ``run``.
+
+    ``cleanup`` ne doit jamais dépendre d'une clé LLM ou d'un modèle valide : il
+    doit pouvoir finaliser les ressources même si le préflight du run a échoué.
+    """
+    required_truthy = ("GATE_ACCEPTANCE_TESTS", "GATE_SMOKE_RUN", "REQUIRE_COST_PRICING")
+    for name in required_truthy:
+        if not _is_true(values.get(name)):
+            raise NightlyE2EError(f"{name} doit être activé pour le smoke")
+    for name in ("BUILD_AUTO_MERGE", "AUTO_MERGE_ENABLED"):
+        if not _is_explicit_false(values.get(name)):
+            raise NightlyE2EError(f"{name} doit être explicitement false pour le smoke")
+    if str(values.get("BUDGET_EXHAUSTED_ACTION", "pause")).strip().lower() != "pause":
+        raise NightlyE2EError("BUDGET_EXHAUSTED_ACTION doit valoir pause")
+    if _required(values, "GATE_SMOKE_PATHS") != "/nightly":
+        raise NightlyE2EError("GATE_SMOKE_PATHS doit cibler exactement /nightly")
+
+    numeric_bounds = {
+        "MAX_COST_USD": 10.0,
+        "LLM_CALL_TIMEOUT": 600.0,
+        "COLLEGUE_RUN_DEADLINE_SECONDS": 3600.0,
+        "COLLEGUE_NIGHTLY_COMMAND_TIMEOUT_SECONDS": 3600.0,
+        "SANDBOX_TIMEOUT": 1800.0,
+    }
+    for name, maximum in numeric_bounds.items():
+        try:
+            value = float(_required(values, name))
+        except ValueError as exc:
+            raise NightlyE2EError(f"{name} doit être numérique, fini et positif") from exc
+        if not math.isfinite(value) or value <= 0 or value > maximum:
+            raise NightlyE2EError(f"{name} doit être fini dans ]0, {maximum:g}]")
+    try:
+        token_budget = int(_required(values, "MAX_TOKENS_BUDGET"))
+    except ValueError as exc:
+        raise NightlyE2EError("MAX_TOKENS_BUDGET doit être un entier positif") from exc
+    if token_budget <= 0 or token_budget > 2_000_000:
+        raise NightlyE2EError("MAX_TOKENS_BUDGET doit être dans [1, 2000000]")
+    try:
+        attempts = int(_required(values, "TASK_MAX_ATTEMPTS"))
+    except ValueError as exc:
+        raise NightlyE2EError("TASK_MAX_ATTEMPTS doit être un entier") from exc
+    if attempts != 1:
+        raise NightlyE2EError("TASK_MAX_ATTEMPTS doit valoir 1")
+
+    provider = _required(values, "LLM_PROVIDER").lower()
+    if provider != "gemini":
+        raise NightlyE2EError("le premier smoke nightly exige le provider global gemini")
+    global_model = _required(values, "LLM_MODEL").lower()
+    from collegue.monitoring.pricing import has_explicit_pricing
+
+    for role in (None, "CODER", "QA", "REVIEWER", "PLANNER"):
+        suffix = f"_{role}" if role else ""
+        label = f"LLM_MODEL{suffix}"
+        model = str(values.get(label, "") or "").strip().lower() or global_model
+        # Les noms préfixés ``openai/...``/``models/...`` sont refusés : le coder
+        # OpenHands route LiteLLM à partir de ce préfixe et pourrait envoyer la
+        # clé Gemini au mauvais provider.
+        if re.fullmatch(r"gemini-[a-z0-9][a-z0-9._-]*", model) is None:
+            raise NightlyE2EError(f"{label} effectif doit être un modèle Gemini non préfixé")
+        if not has_explicit_pricing(model, provider=provider):
+            raise NightlyE2EError(f"{label} effectif n'a pas de tarif explicite dans la grille")
+        if role:
+            role_provider = str(values.get(f"LLM_PROVIDER_{role}", "") or "").strip().lower()
+            if role_provider and role_provider != provider:
+                raise NightlyE2EError(f"LLM_PROVIDER_{role} doit être vide ou égal au provider global")
+
+    prices: list[float] = []
+    for name in ("LLM_PRICE_PROMPT_PER_1M", "LLM_PRICE_COMPLETION_PER_1M"):
+        try:
+            price = float(_required(values, name))
+        except ValueError as exc:
+            raise NightlyE2EError(f"{name} doit être un nombre fini positif ou nul") from exc
+        if not math.isfinite(price) or price < 0:
+            raise NightlyE2EError(f"{name} doit être un nombre fini positif ou nul")
+        prices.append(price)
+    if not any(price > 0 for price in prices):
+        raise NightlyE2EError("au moins un prix LLM doit être strictement positif")
+    _required(values, "LLM_API_KEY")
+    if not os.path.isabs(os.path.expanduser(_required(values, "COLLEGUE_HOME"))):
+        raise NightlyE2EError("COLLEGUE_HOME doit être absolu pour rendre le budget durable")
+    if _required(values, "SANDBOX_IMAGE") != "collegue-sandbox-openhands:ci":
+        raise NightlyE2EError("SANDBOX_IMAGE doit viser l'image OpenHands construite par le job")
+
+
+@dataclass(frozen=True)
+class NightlyConfig:
+    """Configuration fermée du smoke, dérivée uniquement de l'environnement CI."""
+
+    token: str = field(repr=False)
+    repository: str
+    repository_id: int
+    root_branch: str
+    seed_sha: str
+    run_id: str
+    run_attempt: str
+    manifest_path: str
+    marker_path: str = _DEFAULT_MARKER_PATH
+
+    @classmethod
+    def from_env(
+        cls,
+        env: Optional[Mapping[str, str]] = None,
+        *,
+        action: str = "run",
+    ) -> "NightlyConfig":
+        values = os.environ if env is None else env
+        if action not in {"run", "cleanup"}:
+            raise NightlyE2EError(f"action nightly inconnue: {action!r}")
+        if not _is_true(values.get("COLLEGUE_NIGHTLY_E2E")):
+            raise NightlyE2EError("COLLEGUE_NIGHTLY_E2E doit valoir true/1 (opt-in explicite)")
+
+        repository = _required(values, "INTEGRATION_FIXTURE_REPOSITORY")
+        match = _REPOSITORY_RE.fullmatch(repository)
+        if match is None:
+            raise NightlyE2EError("INTEGRATION_FIXTURE_REPOSITORY doit être owner/repo")
+        source_repository = str(values.get("GITHUB_REPOSITORY", "") or "").strip().lower()
+        if source_repository and repository.lower() == source_repository:
+            raise NightlyE2EError("le dépôt fixture doit être distinct du dépôt Collègue")
+
+        try:
+            repository_id = int(_required(values, "INTEGRATION_FIXTURE_REPOSITORY_ID"))
+        except ValueError as exc:
+            raise NightlyE2EError("INTEGRATION_FIXTURE_REPOSITORY_ID doit être un entier") from exc
+        if repository_id <= 0:
+            raise NightlyE2EError("INTEGRATION_FIXTURE_REPOSITORY_ID doit être positif")
+
+        root_branch = _required(values, "INTEGRATION_FIXTURE_ROOT_BRANCH")
+        seed_sha = _required(values, "INTEGRATION_FIXTURE_SEED_SHA").lower()
+        if _SHA_RE.fullmatch(seed_sha) is None:
+            raise NightlyE2EError("INTEGRATION_FIXTURE_SEED_SHA doit être un SHA Git complet")
+
+        run_id = _required(values, "GITHUB_RUN_ID")
+        run_attempt = _required(values, "GITHUB_RUN_ATTEMPT")
+        if _RUN_COMPONENT_RE.fullmatch(run_id) is None or _RUN_COMPONENT_RE.fullmatch(run_attempt) is None:
+            raise NightlyE2EError("GITHUB_RUN_ID/GITHUB_RUN_ATTEMPT doivent être des entiers positifs")
+
+        manifest_path = _required(values, "COLLEGUE_NIGHTLY_MANIFEST")
+        if not os.path.isabs(os.path.expanduser(manifest_path)):
+            raise NightlyE2EError("COLLEGUE_NIGHTLY_MANIFEST doit être un chemin absolu")
+        marker_path = str(values.get("INTEGRATION_FIXTURE_MARKER_PATH", _DEFAULT_MARKER_PATH) or "").strip()
+        if (
+            not marker_path
+            or marker_path.startswith(("/", ".//"))
+            or "\\" in marker_path
+            or ".." in marker_path.split("/")
+            or any(part in {"", "."} for part in marker_path.split("/"))
+        ):
+            raise NightlyE2EError("INTEGRATION_FIXTURE_MARKER_PATH doit être un chemin relatif sûr")
+
+        _required(values, "GITHUB_TOKEN")
+        state_url = _required(values, "STATE_DATABASE_URL")
+        if not state_url.startswith("sqlite:////"):
+            raise NightlyE2EError("STATE_DATABASE_URL du smoke doit viser une SQLite absolue et éphémère")
+        if action == "run":
+            _validate_run_environment(values)
+
+        return cls(
+            token=_required(values, "GITHUB_TOKEN"),
+            repository=repository,
+            repository_id=repository_id,
+            root_branch=root_branch,
+            seed_sha=seed_sha,
+            run_id=run_id,
+            run_attempt=run_attempt,
+            manifest_path=os.path.expanduser(manifest_path),
+            marker_path=marker_path,
+        )
+
+    @property
+    def owner(self) -> str:
+        return self.repository.split("/", 1)[0]
+
+    @property
+    def repo(self) -> str:
+        return self.repository.split("/", 1)[1]
+
+    @property
+    def tag(self) -> str:
+        return f"{self.run_id}-{self.run_attempt}"
+
+    @property
+    def base_branch(self) -> str:
+        return f"collegue-nightly/{self.tag}"
+
+    @property
+    def issue_label(self) -> str:
+        return f"collegue-nightly-{self.tag}"
+
+
+@dataclass
+class NightlyManifest:
+    version: int
+    repository: str
+    repository_id: int
+    root_branch: str
+    root_sha: str
+    base_branch: str
+    issue_label: str
+    base_creation_started: bool = False
+    base_created: bool = False
+    label_creation_started: bool = False
+    label_created: bool = False
+    label_deleted: bool = False
+    base_sha: Optional[str] = None
+    project_id: Optional[int] = None
+    plan_hash: Optional[str] = None
+    issue_numbers: list[int] = field(default_factory=list)
+    pr_numbers: list[int] = field(default_factory=list)
+    head_shas: dict[str, str] = field(default_factory=dict)
+    head_creation_started: bool = False
+    expected_head_branch: Optional[str] = None
+
+    @classmethod
+    def for_config(cls, config: NightlyConfig) -> "NightlyManifest":
+        return cls(
+            version=1,
+            repository=config.repository,
+            repository_id=config.repository_id,
+            root_branch=config.root_branch,
+            root_sha=config.seed_sha,
+            base_branch=config.base_branch,
+            issue_label=config.issue_label,
+        )
+
+
+@dataclass(frozen=True)
+class NightlyClients:
+    repos: Any
+    files: Any
+    branches: Any
+    prs: Any
+    issues: Any
+    labels: Any
+
+    @classmethod
+    def real(cls, token: str) -> "NightlyClients":
+        return cls(
+            repos=RepoCommands(token=token),
+            files=FileCommands(token=token),
+            branches=BranchCommands(token=token),
+            prs=PRCommands(token=token),
+            issues=IssueCommands(token=token),
+            labels=LabelCommands(token=token),
+        )
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str = ""
+
+
+def _subprocess_runner(argv: Sequence[str], *, cwd: Optional[str] = None) -> CommandResult:
+    try:
+        timeout = float(os.environ.get("COLLEGUE_NIGHTLY_COMMAND_TIMEOUT_SECONDS", "2700"))
+    except ValueError:
+        timeout = 2700.0
+    completed = subprocess.run(
+        list(argv),
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if completed.stderr:
+        print(completed.stderr, file=sys.stderr, end="" if completed.stderr.endswith("\n") else "\n")
+    return CommandResult(completed.returncode, completed.stdout, completed.stderr)
+
+
+def _json_result(result: CommandResult, *, accepted_codes: tuple[int, ...] = (0,)) -> dict[str, Any]:
+    if result.returncode not in accepted_codes:
+        raise NightlyE2EError(
+            f"commande produit échouée (code {result.returncode}): {(result.stderr or result.stdout)[-1000:]}"
+        )
+    try:
+        payload = json.loads(result.stdout)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise NightlyE2EError(f"sortie JSON produit invalide: {result.stdout[-1000:]}") from exc
+    if not isinstance(payload, dict):
+        raise NightlyE2EError("la sortie JSON produit doit être un objet")
+    return payload
+
+
+def _write_manifest(path: str, manifest: NightlyManifest) -> None:
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=destination.name + ".", dir=str(destination.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(asdict(manifest), handle, ensure_ascii=False, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, destination)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def _load_manifest(path: str) -> Optional[NightlyManifest]:
+    try:
+        raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError) as exc:
+        raise NightlyE2EError(f"manifeste nightly illisible: {exc}") from exc
+    try:
+        return NightlyManifest(**raw)
+    except (TypeError, ValueError) as exc:
+        raise NightlyE2EError("manifeste nightly malformé") from exc
+
+
+def _validate_manifest(manifest: NightlyManifest, config: NightlyConfig) -> None:
+    if manifest.version != 1:
+        raise NightlyE2EError(f"version de manifeste nightly inconnue: {manifest.version!r}")
+    if (
+        manifest.repository != config.repository
+        or manifest.repository_id != config.repository_id
+        or manifest.root_branch != config.root_branch
+        or manifest.root_sha != config.seed_sha
+        or manifest.base_branch != config.base_branch
+        or manifest.issue_label != config.issue_label
+    ):
+        raise NightlyE2EError("le manifeste ne correspond pas à ce run/repository/seed")
+    if not isinstance(manifest.base_creation_started, bool):
+        raise NightlyE2EError("base_creation_started invalide dans le manifeste")
+    if not isinstance(manifest.base_created, bool):
+        raise NightlyE2EError("base_created invalide dans le manifeste")
+    if not isinstance(manifest.label_creation_started, bool):
+        raise NightlyE2EError("label_creation_started invalide dans le manifeste")
+    if not isinstance(manifest.label_created, bool):
+        raise NightlyE2EError("label_created invalide dans le manifeste")
+    if not isinstance(manifest.label_deleted, bool):
+        raise NightlyE2EError("label_deleted invalide dans le manifeste")
+    if (manifest.label_created or manifest.label_deleted) and not manifest.label_creation_started:
+        raise NightlyE2EError("état de propriété du label incohérent dans le manifeste")
+    if manifest.base_sha is not None and _SHA_RE.fullmatch(str(manifest.base_sha)) is None:
+        raise NightlyE2EError("base_sha invalide dans le manifeste")
+    if manifest.project_id is not None and (
+        not isinstance(manifest.project_id, int) or isinstance(manifest.project_id, bool) or manifest.project_id <= 0
+    ):
+        raise NightlyE2EError("project_id invalide dans le manifeste")
+    if manifest.plan_hash is not None and _SHA256_RE.fullmatch(str(manifest.plan_hash)) is None:
+        raise NightlyE2EError("plan_hash invalide dans le manifeste")
+    for label, numbers in (("issues", manifest.issue_numbers), ("PR", manifest.pr_numbers)):
+        if (
+            not isinstance(numbers, list)
+            or len(numbers) != len(set(numbers))
+            or any(not isinstance(number, int) or isinstance(number, bool) or number <= 0 for number in numbers)
+        ):
+            raise NightlyE2EError(f"numéros {label} invalides dans le manifeste")
+    if not isinstance(manifest.head_shas, dict):
+        raise NightlyE2EError("head_shas invalide dans le manifeste")
+    for branch, sha in manifest.head_shas.items():
+        if not re.fullmatch(r"collegue/issue-[1-9][0-9]*", str(branch)) or _SHA_RE.fullmatch(str(sha)) is None:
+            raise NightlyE2EError("preuve de branche head invalide dans le manifeste")
+    if not isinstance(manifest.head_creation_started, bool):
+        raise NightlyE2EError("head_creation_started invalide dans le manifeste")
+    if (
+        manifest.expected_head_branch is not None
+        and re.fullmatch(r"collegue/issue-[1-9][0-9]*", str(manifest.expected_head_branch)) is None
+    ):
+        raise NightlyE2EError("branche head attendue invalide dans le manifeste")
+    if manifest.head_creation_started and manifest.expected_head_branch is None:
+        raise NightlyE2EError("intent de création head sans branche attendue")
+    if manifest.head_creation_started:
+        expected_issue = int(str(manifest.expected_head_branch).rsplit("-", 1)[1])
+        if expected_issue not in manifest.issue_numbers:
+            raise NightlyE2EError("intent de création head absent des issues du manifeste")
+
+
+class NightlyE2ERunner:
+    """Orchestrateur injectable : réseau réel en nightly, doubles en tests."""
+
+    def __init__(
+        self,
+        config: NightlyConfig,
+        *,
+        clients: Optional[NightlyClients] = None,
+        command_runner: Callable[..., CommandResult] = _subprocess_runner,
+    ):
+        self.config = config
+        self.clients = clients or NightlyClients.real(config.token)
+        self.command_runner = command_runner
+
+    def _guard_fixture(self, *, require_seed: bool) -> str:
+        cfg = self.config
+        repo = self.clients.repos.get_repo(cfg.owner, cfg.repo)
+        if int(getattr(repo, "id", 0) or 0) != cfg.repository_id:
+            raise NightlyE2EError("identité immuable du dépôt fixture incorrecte")
+        if str(getattr(repo, "full_name", "")).lower() != cfg.repository.lower():
+            raise NightlyE2EError("coordonnée du dépôt fixture incorrecte")
+        if bool(getattr(repo, "is_private", True)):
+            raise NightlyE2EError("le dépôt fixture doit être public (clone sans secret)")
+        if getattr(repo, "default_branch", None) != cfg.root_branch:
+            raise NightlyE2EError("branche par défaut du dépôt fixture inattendue")
+        marker = self.clients.files.get_file_content(cfg.owner, cfg.repo, cfg.marker_path, branch=cfg.root_branch)
+        if marker.get("content") != _FIXTURE_SENTINEL:
+            raise NightlyE2EError("sentinelle du dépôt fixture absente ou invalide")
+        root_sha = self.clients.branches.get_branch_sha(cfg.owner, cfg.repo, cfg.root_branch)
+        if _SHA_RE.fullmatch(str(root_sha or "").lower()) is None:
+            raise NightlyE2EError("SHA racine du dépôt fixture invérifiable")
+        if require_seed and root_sha.lower() != cfg.seed_sha:
+            raise NightlyE2EError("le commit seed de la fixture a bougé — zéro écriture")
+        return root_sha.lower()
+
+    def _branch_sha_or_none(self, branch: str) -> Optional[str]:
+        """Retourne ``None`` uniquement pour une absence GitHub 404 confirmée."""
+        try:
+            return self.clients.branches.get_branch_sha(self.config.owner, self.config.repo, branch)
+        except ToolExecutionError as exc:
+            if getattr(exc, "status_code", 0) == 404:
+                return None
+            raise
+
+    def _base_owner_message(self) -> str:
+        cfg = self.config
+        return f"collegue-nightly: base owner run={cfg.tag} repo_id={cfg.repository_id} seed={cfg.seed_sha}"
+
+    def _is_owned_base_commit(self, sha: str) -> bool:
+        """Prouve que ``sha`` est le commit marqueur créé pour ce run exact."""
+        try:
+            root = self.clients.branches.get_git_commit(
+                self.config.owner,
+                self.config.repo,
+                self.config.seed_sha,
+            )
+            candidate = self.clients.branches.get_git_commit(
+                self.config.owner,
+                self.config.repo,
+                sha,
+            )
+        except Exception:  # noqa: BLE001 - preuve distante absente => refus
+            return False
+        return (
+            list(candidate.parents) == [self.config.seed_sha]
+            and candidate.tree_sha == root.tree_sha
+            and getattr(candidate, "message", None) == self._base_owner_message()
+        )
+
+    def _create_owned_base(self, manifest: NightlyManifest) -> str:
+        """Crée/reprend la base via un commit propriétaire parent+tree+message."""
+        cfg = self.config
+        current = self._branch_sha_or_none(cfg.base_branch)
+        if current is not None:
+            raise NightlyE2EError("la branche de base nightly existe avant son intent de création")
+        root = self.clients.branches.get_git_commit(cfg.owner, cfg.repo, cfg.seed_sha)
+        manifest.base_creation_started = True
+        _write_manifest(cfg.manifest_path, manifest)
+        try:
+            created = self.clients.branches.ensure_commit_branch(
+                cfg.owner,
+                cfg.repo,
+                cfg.base_branch,
+                parent_sha=cfg.seed_sha,
+                tree_sha=root.tree_sha,
+                message=self._base_owner_message(),
+            )
+            owned_sha = str(getattr(created, "commit_sha", "") or "").lower()
+        except Exception:  # noqa: BLE001 - réconcilier une réponse POST perdue
+            owned_sha = str(self._branch_sha_or_none(cfg.base_branch) or "").lower()
+            if not owned_sha or not self._is_owned_base_commit(owned_sha):
+                raise
+        if _SHA_RE.fullmatch(owned_sha) is None or not self._is_owned_base_commit(owned_sha):
+            raise NightlyE2EError("commit propriétaire de la base nightly non confirmé")
+        manifest.base_created = True
+        manifest.base_sha = owned_sha
+        _write_manifest(cfg.manifest_path, manifest)
+        return owned_sha
+
+    def _authorize_head_creation(self, manifest: NightlyManifest, issue_number: int) -> str:
+        """Checkpoint l'absence de la branche code avant de lancer l'exécuteur."""
+        branch = f"collegue/issue-{int(issue_number)}"
+        if self._branch_sha_or_none(branch) is not None:
+            raise NightlyE2EError("branche head nightly présente avant son intent de création")
+        manifest.head_creation_started = True
+        manifest.expected_head_branch = branch
+        _write_manifest(self.config.manifest_path, manifest)
+        return branch
+
+    def _head_chain_is_owned(self, issue_number: int, head_sha: str, base_sha: str) -> bool:
+        """Prouve une branche head sans PR par sa chaîne bornée jusqu'à la base."""
+        current = str(head_sha or "").lower()
+        base = str(base_sha or "").lower()
+        if _SHA_RE.fullmatch(current) is None or _SHA_RE.fullmatch(base) is None:
+            return False
+        prefix = f"collegue: issue #{int(issue_number)} — "
+        for _ in range(32):
+            if current == base:
+                return True
+            try:
+                commit = self.clients.branches.get_git_commit(
+                    self.config.owner,
+                    self.config.repo,
+                    current,
+                )
+            except Exception:  # noqa: BLE001 - preuve incomplète => conservation
+                return False
+            message = str(getattr(commit, "message", "") or "")
+            path = message[len(prefix) :] if message.startswith(prefix) else ""
+            parts = path.split("/")
+            if (
+                list(getattr(commit, "parents", ()) or ()) == []
+                or len(commit.parents) != 1
+                or not path
+                or "\n" in path
+                or "\\" in path
+                or path.startswith("/")
+                or any(part in {"", ".", ".."} for part in parts)
+            ):
+                return False
+            current = str(commit.parents[0]).lower()
+        return False
+
+    def _run_product(self, *args: str, accepted_codes: tuple[int, ...] = (0,), cwd: Optional[str] = None) -> dict:
+        result = self.command_runner([sys.executable, "-m", "collegue.pilot", *args], cwd=cwd)
+        return _json_result(result, accepted_codes=accepted_codes)
+
+    def _manager(self):
+        from collegue.config import Settings
+        from collegue.state import ProjectStateManager
+
+        settings_obj = Settings()
+        return ProjectStateManager.from_url(settings_obj.STATE_DATABASE_URL)
+
+    def _label_owner_description(self) -> str:
+        """Marqueur distant compact qui lie le label à ce run exact."""
+        cfg = self.config
+        material = f"{cfg.repository_id}:{cfg.repository.lower()}:{cfg.tag}:{cfg.seed_sha}"
+        digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:32]
+        return f"collegue-nightly-owner:{digest}"
+
+    def _labels_named_for_run(self) -> list[Any]:
+        target = self.config.issue_label.lower()
+        return [
+            label
+            for label in self.clients.labels.list_labels(self.config.owner, self.config.repo)
+            if str(getattr(label, "name", "")).lower() == target
+        ]
+
+    def _owned_label_or_none(self) -> Optional[Any]:
+        """Retourne uniquement le label portant la preuve exacte de ce run."""
+        matches = self._labels_named_for_run()
+        if not matches:
+            return None
+        if len(matches) != 1:
+            raise NightlyE2EError("plusieurs labels correspondent au nom unique du run")
+        label = matches[0]
+        if (
+            getattr(label, "name", None) != self.config.issue_label
+            or str(getattr(label, "color", "")).lower() != _NIGHTLY_LABEL_COLOR
+            or getattr(label, "description", None) != self._label_owner_description()
+        ):
+            raise NightlyE2EError("label du run présent sans preuve de propriété exacte")
+        return label
+
+    def _create_owned_label(self, manifest: NightlyManifest) -> None:
+        """Crée le label après un constat d'absence, avec intent durable avant POST."""
+        if manifest.label_creation_started:
+            raise NightlyE2EError("création du label nightly déjà engagée")
+        if self._labels_named_for_run():
+            raise NightlyE2EError("le label unique du run existe déjà ; refus de l'adopter")
+
+        # Le checkpoint précède impérativement la mutation distante. Si le POST
+        # réussit mais que sa réponse se perd, cleanup peut reconnaître exactement
+        # le label créé et le supprimer sans adopter un label antérieur au run.
+        manifest.label_creation_started = True
+        _write_manifest(self.config.manifest_path, manifest)
+        description = self._label_owner_description()
+        try:
+            created = self.clients.labels.ensure_label(
+                self.config.owner,
+                self.config.repo,
+                self.config.issue_label,
+                color=_NIGHTLY_LABEL_COLOR,
+                description=description,
+            )
+            if (
+                getattr(created, "name", None) != self.config.issue_label
+                or str(getattr(created, "color", "")).lower() != _NIGHTLY_LABEL_COLOR
+                or getattr(created, "description", None) != description
+            ):
+                raise NightlyE2EError("réponse de création du label sans preuve de propriété exacte")
+        except Exception:  # noqa: BLE001 - réconcilier une réponse POST perdue
+            recovered = self._owned_label_or_none()
+            if recovered is None:
+                raise
+
+        # Confirmation distante y compris lorsque ensure_label a retourné sans
+        # erreur : aucun état "owned" n'est écrit sur la seule foi de la réponse.
+        if self._owned_label_or_none() is None:
+            raise NightlyE2EError("création du label nightly non confirmée")
+        manifest.label_created = True
+        _write_manifest(self.config.manifest_path, manifest)
+
+    def _inspect_draft(self, project_id: int, plan_hash: str) -> tuple[int, str, str]:
+        manager = self._manager()
+        project = manager.get_project(project_id)
+        tasks = manager.get_tasks(project_id)
+        if project is None or len(tasks) != 1:
+            raise NightlyE2EError(f"le draft nightly doit contenir exactement une tâche (vu {len(tasks)})")
+        target = dict(project.plan_sync_config or {})
+        expected = {
+            "owner": self.config.owner,
+            "repo": self.config.repo,
+            "labels": [self.config.issue_label],
+            "milestone_title": None,
+            "board_title": None,
+            "spec_filename": "SPEC.md",
+            "base_branch": self.config.base_branch,
+        }
+        if target != expected:
+            raise NightlyE2EError("la cible durable du draft ne correspond pas à la fixture éphémère")
+        task = tasks[0]
+        source = str(getattr(task, "acceptance_test_source", "") or "")
+        provenance = getattr(task, "acceptance_test_provenance", None) or {}
+        digest = str(getattr(task, "acceptance_test_sha256", "") or "")
+        if (
+            not source
+            or _SHA256_RE.fullmatch(digest) is None
+            or hashlib.sha256(source.encode("utf-8")).hexdigest() != digest
+            or provenance.get("role") != "qa"
+        ):
+            raise NightlyE2EError("oracle QA plan-time absent, non hashé ou de provenance incorrecte")
+        if not _SHA256_RE.fullmatch(plan_hash):
+            raise NightlyE2EError("hash du plan invalide")
+        print("<<<COLLEGUE_NIGHTLY_ORACLE_BEGIN>>>", file=sys.stderr)
+        for line in source.rstrip().splitlines():
+            # Neutralise la syntaxe de commande des logs GitHub Actions sans
+            # altérer l'artefact réellement persisté/exécuté.
+            safe_line = " " + line if line.startswith("::") else line
+            print(safe_line, file=sys.stderr)
+        print("<<<COLLEGUE_NIGHTLY_ORACLE_END>>>", file=sys.stderr)
+        return int(task.id), str(project.spec or ""), digest
+
+    def _clone_base(self, base_sha: str) -> str:
+        parent = tempfile.mkdtemp(prefix="collegue-nightly-source-")
+        destination = os.path.join(parent, "fixture")
+        url = f"https://github.com/{self.config.repository}.git"
+        result = self.command_runner(
+            [
+                "git",
+                "clone",
+                "--quiet",
+                "--branch",
+                self.config.base_branch,
+                "--single-branch",
+                "--depth",
+                "1",
+                url,
+                destination,
+            ],
+            cwd=parent,
+        )
+        if result.returncode != 0:
+            shutil.rmtree(parent, ignore_errors=True)
+            raise NightlyE2EError(f"clone public de la fixture échoué: {(result.stderr or result.stdout)[-1000:]}")
+        remote = self.command_runner(["git", "remote", "get-url", "origin"], cwd=destination)
+        head = self.command_runner(["git", "rev-parse", "HEAD"], cwd=destination)
+        if remote.returncode != 0 or remote.stdout.strip() != url:
+            shutil.rmtree(parent, ignore_errors=True)
+            raise NightlyE2EError("origin du clone fixture inattendu")
+        if head.returncode != 0 or head.stdout.strip().lower() != base_sha.lower():
+            shutil.rmtree(parent, ignore_errors=True)
+            raise NightlyE2EError("HEAD local de la fixture différent du SPEC synchronisé")
+        return destination
+
+    def run(self) -> dict[str, Any]:
+        cfg = self.config
+        root_sha = self._guard_fixture(require_seed=True)
+        try:
+            self._manager().list_projects()
+        except Exception as exc:  # noqa: BLE001 - préflight avant toute écriture distante
+            raise NightlyE2EError(f"schéma STATE_DATABASE_URL non migré ou inaccessible: {exc}") from exc
+        if _load_manifest(cfg.manifest_path) is not None:
+            raise NightlyE2EError("un manifeste existe déjà pour ce run ; lancer cleanup avant toute reprise")
+        manifest = NightlyManifest.for_config(cfg)
+        manifest.root_sha = root_sha
+        _write_manifest(cfg.manifest_path, manifest)
+        source_path: Optional[str] = None
+        run_error: Optional[BaseException] = None
+        try:
+            owned_base_sha = self._create_owned_base(manifest)
+
+            draft = self._run_product(
+                "plan",
+                "draft",
+                "--name",
+                f"Nightly {cfg.tag}",
+                "--problem",
+                FIXTURE_PROBLEM,
+                "--owner",
+                cfg.owner,
+                "--repo",
+                cfg.repo,
+                "--base",
+                cfg.base_branch,
+                "--labels",
+                cfg.issue_label,
+                "--milestone",
+                "",
+                "--spec-filename",
+                "SPEC.md",
+                "--deadline-hours",
+                "0.5",
+                "--format",
+                "json",
+            )
+            project_id = int(draft.get("project_id") or 0)
+            plan_hash = str(draft.get("plan_hash") or "")
+            if draft.get("action") != "draft" or int(draft.get("task_count") or 0) != 1 or project_id <= 0:
+                raise NightlyE2EError("contrat JSON du draft inattendu")
+            task_id, spec, oracle_sha256 = self._inspect_draft(project_id, plan_hash)
+            manifest.project_id = project_id
+            manifest.plan_hash = plan_hash
+            _write_manifest(cfg.manifest_path, manifest)
+
+            approved = self._run_product(
+                "plan",
+                "approve",
+                "--project-id",
+                str(project_id),
+                "--expected-plan-hash",
+                plan_hash,
+                "--format",
+                "json",
+            )
+            if (
+                approved.get("action") != "approve"
+                or int(approved.get("project_id") or 0) != project_id
+                or int(approved.get("task_count") or 0) != 1
+                or approved.get("plan_hash") != plan_hash
+            ):
+                raise NightlyE2EError("l'approbation n'a pas scellé le hash attendu")
+
+            if self.clients.branches.get_branch_sha(cfg.owner, cfg.repo, cfg.base_branch) != owned_base_sha:
+                raise NightlyE2EError("la base éphémère a bougé avant plan sync")
+
+            # Le planner réutilise un label existant. Le driver crée donc lui-même
+            # ce label, après preuve d'absence et checkpoint d'intent durable, afin
+            # de ne jamais adopter/supprimer un label antérieur au run.
+            self._create_owned_label(manifest)
+
+            synced = self._run_product(
+                "plan",
+                "sync",
+                "--project-id",
+                str(project_id),
+                "--execute",
+                "--format",
+                "json",
+            )
+            issues = list(synced.get("issues") or [])
+            issue_numbers = sorted({int(item.get("issue_number") or 0) for item in issues if item.get("issue_number")})
+            if (
+                synced.get("action") != "sync"
+                or int(synced.get("project_id") or 0) != project_id
+                or int(synced.get("task_count") or 0) != 1
+                or synced.get("plan_hash") != plan_hash
+                or len(issue_numbers) != 1
+                or int(issues[0].get("task_id") or 0) != task_id
+            ):
+                raise NightlyE2EError("la synchronisation doit créer exactement une issue")
+            remote_issues = self.clients.issues.list_issues(
+                cfg.owner,
+                cfg.repo,
+                state="open",
+                limit=100,
+                labels=cfg.issue_label,
+            )
+            if [int(issue.number) for issue in remote_issues] != issue_numbers:
+                raise NightlyE2EError("corrélation GitHub ambiguë: le label du run ne désigne pas une issue unique")
+            manifest.issue_numbers = issue_numbers
+            manifest.base_sha = self.clients.branches.get_branch_sha(cfg.owner, cfg.repo, cfg.base_branch)
+            if _SHA_RE.fullmatch(str(manifest.base_sha or "")) is None:
+                raise NightlyE2EError("SHA de base après sync invalide")
+            _write_manifest(cfg.manifest_path, manifest)
+
+            stored_spec = self.clients.files.get_file_content(cfg.owner, cfg.repo, "SPEC.md", branch=cfg.base_branch)
+            if stored_spec.get("content") != spec:
+                raise NightlyE2EError("SPEC.md distant différent du contrat approuvé")
+
+            self._authorize_head_creation(manifest, issue_numbers[0])
+
+            source_path = self._clone_base(manifest.base_sha)
+            if self.clients.branches.get_branch_sha(cfg.owner, cfg.repo, cfg.base_branch) != manifest.base_sha:
+                raise NightlyE2EError("la base éphémère a bougé entre le clone et le RUN")
+            run_result = self.command_runner(
+                [
+                    sys.executable,
+                    "-m",
+                    "collegue.pilot",
+                    "--project-id",
+                    str(project_id),
+                    "--repo-source",
+                    source_path,
+                    "--owner",
+                    cfg.owner,
+                    "--repo",
+                    cfg.repo,
+                    "--base",
+                    cfg.base_branch,
+                    "--execute",
+                    "--format",
+                    "json",
+                ]
+            )
+            run_payload = _json_result(run_result, accepted_codes=(1,))
+            opened_prs = [int(number) for number in list(run_payload.get("opened_prs") or [])]
+            processed = list(run_payload.get("processed") or [])
+            if (
+                run_payload.get("stop_reason") != "awaiting_merge"
+                or int(run_payload.get("project_id") or 0) != project_id
+                or int(run_payload.get("iterations") or 0) != 1
+                or len(opened_prs) != 1
+                or len(processed) != 1
+                or int(processed[0].get("task_id") or 0) != task_id
+                or processed[0].get("success") is not True
+                or processed[0].get("stage") != "pr"
+                or int(processed[0].get("pr_number") or 0) != opened_prs[0]
+                or processed[0].get("acceptance_passed") is not True
+                or processed[0].get("acceptance_error") not in {None, ""}
+                or processed[0].get("acceptance_oracle_sha256") != oracle_sha256
+                or list(run_payload.get("pending_reviews") or []) != [task_id]
+            ):
+                raise NightlyE2EError("le RUN réel n'a pas abouti à une unique PR ouverte et validée")
+
+            issue_number = issue_numbers[0]
+            pr = self.clients.prs.get_pr(cfg.owner, cfg.repo, opened_prs[0])
+            if (
+                pr.state != "open"
+                or pr.merged
+                or pr.base_branch != cfg.base_branch
+                or pr.base_sha != manifest.base_sha
+                or pr.head_branch != f"collegue/issue-{issue_number}"
+                or not pr.head_sha
+                or f"<!-- collegue-exec:{issue_number} -->" not in str(pr.body or "")
+                or "<!-- collegue-diff-sha256:" not in str(pr.body or "")
+                or f"sha256:{oracle_sha256}" not in str(pr.body or "")
+                or int(pr.changed_files or 0) < 1
+            ):
+                raise NightlyE2EError("la PR distante ne prouve pas le livrable attendu")
+            remote_head = self.clients.branches.get_branch_sha(cfg.owner, cfg.repo, pr.head_branch)
+            if remote_head != pr.head_sha:
+                raise NightlyE2EError("la branche distante ne correspond pas au head SHA de la PR")
+            if self.clients.branches.get_branch_sha(cfg.owner, cfg.repo, cfg.base_branch) != manifest.base_sha:
+                raise NightlyE2EError("la base éphémère a bougé pendant la création de PR")
+
+            manifest.pr_numbers = opened_prs
+            manifest.head_shas[pr.head_branch] = pr.head_sha
+            _write_manifest(cfg.manifest_path, manifest)
+            return {
+                "status": "passed",
+                "project_id": project_id,
+                "plan_hash": plan_hash,
+                "issue_number": issue_number,
+                "pr_number": opened_prs[0],
+                "base_branch": cfg.base_branch,
+                "head_sha": pr.head_sha,
+                "acceptance_passed": True,
+                "acceptance_oracle_sha256": oracle_sha256,
+            }
+        except BaseException as exc:  # cleanup garanti, y compris KeyboardInterrupt
+            run_error = exc
+            raise
+        finally:
+            if source_path:
+                shutil.rmtree(os.path.dirname(source_path), ignore_errors=True)
+            try:
+                self.cleanup()
+            except Exception as cleanup_exc:
+                if run_error is None:
+                    raise
+                print(f"cleanup nightly également échoué: {cleanup_exc}", file=sys.stderr)
+
+    def _task_correlations(self, manifest: NightlyManifest) -> dict[int, int]:
+        """Retourne ``issue GitHub → task id`` depuis le plan durable exact."""
+        if manifest.project_id is None or manifest.plan_hash is None:
+            return {}
+        manager = self._manager()
+        project = manager.get_project(manifest.project_id)
+        if project is None or project.approved_plan_hash != manifest.plan_hash:
+            raise NightlyE2EError("plan durable du manifeste absent ou d'empreinte différente")
+        return {
+            int(task.issue_number): int(task.id)
+            for task in manager.get_tasks(manifest.project_id)
+            if task.issue_number is not None
+        }
+
+    def _approved_task_ids(self, manifest: NightlyManifest) -> set[int]:
+        """Ensemble autoritatif des tâches du plan approuvé, issues ou non."""
+        if manifest.project_id is None or manifest.plan_hash is None:
+            return set()
+        manager = self._manager()
+        project = manager.get_project(manifest.project_id)
+        if project is None or project.approved_plan_hash != manifest.plan_hash:
+            raise NightlyE2EError("plan durable du manifeste absent ou d'empreinte différente")
+        return {int(task.id) for task in manager.get_tasks(manifest.project_id)}
+
+    def _recover_spec_commit(self, manifest: NightlyManifest, current_sha: str) -> bool:
+        """Réconcilie le seul mouvement légitime oublié : le commit de SPEC.md."""
+        if (
+            not manifest.base_created
+            or manifest.base_sha is None
+            or manifest.project_id is None
+            or manifest.plan_hash is None
+        ):
+            return False
+        try:
+            commit = self.clients.branches.get_git_commit(self.config.owner, self.config.repo, current_sha)
+            if list(commit.parents) != [manifest.base_sha]:
+                return False
+            manager = self._manager()
+            project = manager.get_project(manifest.project_id)
+            if project is None or project.approved_plan_hash != manifest.plan_hash:
+                return False
+            target = dict(project.plan_sync_config or {})
+            if (
+                target.get("owner") != self.config.owner
+                or target.get("repo") != self.config.repo
+                or target.get("base_branch") != self.config.base_branch
+                or target.get("spec_filename") != "SPEC.md"
+            ):
+                return False
+            remote = self.clients.files.get_file_content(
+                self.config.owner,
+                self.config.repo,
+                "SPEC.md",
+                branch=self.config.base_branch,
+            )
+            return remote.get("content") == project.spec
+        except Exception:  # noqa: BLE001 - preuve absente => aucune suppression
+            return False
+
+    def cleanup(self) -> dict[str, Any]:
+        """Cleanup en phases : inventaire → validation → fermeture → refs."""
+        cfg = self.config
+        # Dépôt fixture statique : si le seed a bougé, aucune mutation de cleanup
+        # n'est assez certaine. On laisse les ancres pour inspection.
+        current_root = self._guard_fixture(require_seed=True)
+        loaded_manifest = _load_manifest(cfg.manifest_path)
+        manifest = loaded_manifest or NightlyManifest.for_config(cfg)
+        _validate_manifest(manifest, cfg)
+
+        closed_prs: list[int] = []
+        closed_issues: list[int] = []
+        owns_label = manifest.label_creation_started
+        task_by_issue = self._task_correlations(manifest) if owns_label else {}
+        approved_task_ids = self._approved_task_ids(manifest) | set(task_by_issue.values()) if owns_label else set()
+
+        # Phase 1 — inventaire complet. Une panne ici interdit toute mutation.
+        try:
+            discovered_prs = self.clients.prs.list_prs(
+                cfg.owner, cfg.repo, state="open", limit=100, base=cfg.base_branch
+            )
+            if not owns_label:
+                owned_label = None
+                discovered_issues = []
+            elif manifest.label_deleted:
+                if self._labels_named_for_run():
+                    raise NightlyE2EError("le label nightly a réapparu après son checkpoint de suppression")
+                owned_label = None
+                discovered_issues = []
+            else:
+                owned_label = self._owned_label_or_none()
+                discovered_issues = (
+                    self.clients.issues.list_issues(
+                        cfg.owner,
+                        cfg.repo,
+                        state="open",
+                        limit=100,
+                        labels=cfg.issue_label,
+                    )
+                    if owned_label is not None
+                    else []
+                )
+        except Exception as exc:  # noqa: BLE001 - frontière distante fail-closed
+            raise NightlyE2EError(f"inventaire GitHub incomplet, aucune suppression: {exc}") from exc
+
+        label_remote_present = owned_label is not None
+        if label_remote_present and not manifest.label_created:
+            # Récupération d'un crash/perte de réponse entre le POST et le
+            # checkpoint final. L'intent durable et le marqueur distant concordent.
+            manifest.label_created = True
+            _write_manifest(cfg.manifest_path, manifest)
+
+        issue_numbers = (
+            set(manifest.issue_numbers) | set(task_by_issue) | {int(issue.number) for issue in discovered_issues}
+            if owns_label
+            else set()
+        )
+        pr_numbers = set(manifest.pr_numbers) | {int(pr.number) for pr in discovered_prs}
+
+        # Lire la base avant de valider les PR. Une base absente est normale lors
+        # d'un second finalizer ; une base présente sans preuve ne sera pas supprimée.
+        base_current = self._branch_sha_or_none(cfg.base_branch)
+        if base_current is not None and not manifest.base_created:
+            if not manifest.base_creation_started or not self._is_owned_base_commit(base_current):
+                raise NightlyE2EError("branche de base présente sans preuve propriétaire du run")
+            manifest.base_created = True
+            manifest.base_sha = base_current
+            _write_manifest(cfg.manifest_path, manifest)
+        if base_current is not None and manifest.base_sha != base_current:
+            if not self._recover_spec_commit(manifest, base_current):
+                raise NightlyE2EError("branche de base nightly déplacée sans preuve du commit SPEC")
+            manifest.base_sha = base_current
+            _write_manifest(cfg.manifest_path, manifest)
+
+        # Phase 2 — validation de corrélation, toujours sans mutation.
+        validated_issues: dict[int, Any] = {}
+        issue_numbers_by_task: dict[int, list[int]] = {}
+        for number in sorted(issue_numbers):
+            issue = self.clients.issues.get_issue(cfg.owner, cfg.repo, number)
+            markers = [
+                int(value) for value in re.findall(r"<!-- collegue-task:([1-9][0-9]*) -->", str(issue.body or ""))
+            ]
+            persisted_task_id = task_by_issue.get(number)
+            task_id = markers[0] if len(markers) == 1 else None
+            plan_marker = (
+                f"<!-- collegue-plan:{manifest.plan_hash};project:{manifest.project_id};task:{task_id} -->"
+                if manifest.plan_hash is not None and manifest.project_id is not None and task_id is not None
+                else None
+            )
+            issue_labels = list(issue.labels or [])
+            has_exact_label = cfg.issue_label in issue_labels
+            if (
+                issue.state not in {"open", "closed"}
+                or (not has_exact_label and (label_remote_present or issue.state == "open"))
+                or (has_exact_label and not label_remote_present)
+                or task_id is None
+                or task_id not in approved_task_ids
+                or (persisted_task_id is not None and persisted_task_id != task_id)
+                or (plan_marker is not None and plan_marker not in str(issue.body or ""))
+            ):
+                raise NightlyE2EError(f"issue #{number} non corrélée exactement au plan/run")
+            validated_issues[number] = issue
+            task_by_issue[number] = task_id
+            issue_numbers_by_task.setdefault(task_id, []).append(number)
+
+        # Perte de réponse POST : le label+marqueur atomiques permettent de
+        # récupérer le numéro. Ne persister que si la correspondance est unique ;
+        # des doublons sont tous nettoyables mais ne doivent pas devenir arbitraires.
+        if manifest.project_id is not None:
+            recoveries = [
+                (task_id, numbers[0])
+                for task_id, numbers in issue_numbers_by_task.items()
+                if len(numbers) == 1 and numbers[0] not in set(manifest.issue_numbers)
+            ]
+            if recoveries:
+                manager = self._manager()
+                for task_id, issue_number in recoveries:
+                    if not manager.update_task(task_id, issue_number=issue_number):
+                        raise NightlyE2EError(f"réconciliation locale impossible pour la tâche {task_id}")
+        correlated_issue_numbers = sorted(validated_issues)
+        if correlated_issue_numbers != sorted(manifest.issue_numbers):
+            manifest.issue_numbers = correlated_issue_numbers
+            _write_manifest(cfg.manifest_path, manifest)
+
+        validated_prs: dict[int, Any] = {}
+        branch_heads: dict[str, str] = {}
+        for number in sorted(pr_numbers):
+            pr = self.clients.prs.get_pr(cfg.owner, cfg.repo, number)
+            head_match = re.fullmatch(r"collegue/issue-([1-9][0-9]*)", str(pr.head_branch or ""))
+            issue_number = int(head_match.group(1)) if head_match else None
+            expected_marker = f"<!-- collegue-exec:{issue_number} -->" if issue_number is not None else None
+            if (
+                pr.merged
+                or pr.base_branch != cfg.base_branch
+                or not pr.head_sha
+                or issue_number not in validated_issues
+                or expected_marker not in str(pr.body or "")
+                or (base_current is not None and pr.base_sha != base_current)
+            ):
+                raise NightlyE2EError(f"PR #{number} non corrélée exactement au plan/run/base")
+            recorded = manifest.head_shas.get(pr.head_branch)
+            if recorded is not None and recorded != pr.head_sha:
+                raise NightlyE2EError(f"head SHA de la PR #{number} différent du manifeste")
+            validated_prs[number] = pr
+            branch_heads[pr.head_branch] = pr.head_sha
+
+        # Une branche peut avoir été créée/poussée puis le POST de PR échouer.
+        # L'intent a été checkpointé avant le RUN ; on n'adopte son SHA que si
+        # toute sa chaîne de commits rejoint la base exacte avec les messages de
+        # publication déterministes de l'exécuteur.
+        head_proof_changed = False
+        for issue_number in sorted(validated_issues):
+            branch = f"collegue/issue-{issue_number}"
+            current = self._branch_sha_or_none(branch)
+            if current is None:
+                continue
+            recorded = branch_heads.get(branch) or manifest.head_shas.get(branch)
+            if recorded is not None:
+                if current != recorded:
+                    raise NightlyE2EError(f"branche {branch} déplacée depuis la preuve")
+                continue
+            if (
+                not manifest.head_creation_started
+                or manifest.expected_head_branch != branch
+                or manifest.base_sha is None
+                or not self._head_chain_is_owned(issue_number, current, manifest.base_sha)
+            ):
+                raise NightlyE2EError(f"branche {branch}: SHA non prouvé (aucune PR/manifeste)")
+            manifest.head_shas[branch] = current
+            branch_heads[branch] = current
+            head_proof_changed = True
+        if head_proof_changed:
+            _write_manifest(cfg.manifest_path, manifest)
+
+        # Phase 3 — fermetures. Si l'une échoue, garder toutes les refs comme
+        # ancres ; aucune suppression de branche/base n'est tentée ensuite.
+        close_errors: list[str] = []
+        for number in pr_numbers:
+            try:
+                pr = validated_prs[number]
+                was_open = pr.state == "open"
+                issue_number = int(pr.head_branch.rsplit("-", 1)[1])
+                self.clients.prs.close_pr(
+                    cfg.owner,
+                    cfg.repo,
+                    number,
+                    expected_head_sha=pr.head_sha,
+                    expected_head_branch=pr.head_branch,
+                    expected_base_branch=cfg.base_branch,
+                    body_marker=f"<!-- collegue-exec:{issue_number} -->",
+                )
+                if was_open:
+                    closed_prs.append(number)
+            except Exception as exc:  # noqa: BLE001 - garder toutes les refs
+                close_errors.append(f"PR #{number}: {exc}")
+        for number in sorted(issue_numbers):
+            try:
+                task_id = task_by_issue[number]
+                issue = validated_issues[number]
+                was_open = issue.state == "open"
+                if was_open:
+                    self.clients.issues.close_issue(
+                        cfg.owner,
+                        cfg.repo,
+                        number,
+                        expected_labels=[cfg.issue_label],
+                        body_marker=f"<!-- collegue-task:{task_id} -->",
+                    )
+                    closed_issues.append(number)
+            except Exception as exc:  # noqa: BLE001 - garder toutes les refs
+                close_errors.append(f"issue #{number}: {exc}")
+        if close_errors:
+            raise NightlyE2EError("fermetures incomplètes, refs conservées: " + " | ".join(close_errors))
+
+        remaining_prs = self.clients.prs.list_prs(cfg.owner, cfg.repo, state="open", limit=100, base=cfg.base_branch)
+        if remaining_prs:
+            raise NightlyE2EError("PR encore ouverte après fermeture ; refs conservées")
+
+        # Phase 4 — refs prouvées seulement. Une issue corrélée ne prouve PAS le
+        # SHA de sa branche déterministe : si le crash a précédé create_pr, on
+        # conserve cette ref au lieu d'adopter son SHA courant comme attendu.
+        branch_errors: list[str] = []
+        candidate_branches = set(branch_heads) | set(manifest.head_shas)
+        unproven_branches = {f"collegue/issue-{number}" for number in validated_issues} - candidate_branches
+        for branch in sorted(unproven_branches):
+            current = self._branch_sha_or_none(branch)
+            if current is None:
+                continue
+            branch_errors.append(f"branche {branch}: SHA non prouvé (aucune PR/manifeste)")
+        for branch in sorted(candidate_branches):
+            try:
+                current = self._branch_sha_or_none(branch)
+                if current is None:
+                    continue
+                recorded = branch_heads.get(branch) or manifest.head_shas.get(branch)
+                if recorded is not None and current != recorded:
+                    raise NightlyE2EError(f"branche {branch} déplacée depuis la preuve")
+                self.clients.branches.delete_branch(
+                    cfg.owner,
+                    cfg.repo,
+                    branch,
+                    default_branch=cfg.root_branch,
+                    expected_sha=current,
+                )
+            except Exception as exc:  # noqa: BLE001 - conserver la base comme ancre
+                branch_errors.append(f"branche {branch}: {exc}")
+        if branch_errors:
+            raise NightlyE2EError("suppression des heads incomplète, base conservée: " + " | ".join(branch_errors))
+
+        if base_current is not None:
+            if not manifest.base_created or manifest.base_sha != base_current:
+                raise NightlyE2EError("branche base présente sans preuve de création/SHA ; conservation")
+            self.clients.branches.delete_branch(
+                cfg.owner,
+                cfg.repo,
+                cfg.base_branch,
+                default_branch=cfg.root_branch,
+                expected_sha=base_current,
+            )
+
+        final_root = self.clients.branches.get_branch_sha(cfg.owner, cfg.repo, cfg.root_branch)
+        if final_root != manifest.root_sha or current_root != manifest.root_sha:
+            raise NightlyE2EError("la branche par défaut de la fixture a bougé pendant le smoke")
+        remaining_prs = self.clients.prs.list_prs(cfg.owner, cfg.repo, state="open", limit=100, base=cfg.base_branch)
+        remaining_issues = (
+            self.clients.issues.list_issues(
+                cfg.owner,
+                cfg.repo,
+                state="open",
+                limit=100,
+                labels=cfg.issue_label,
+            )
+            if label_remote_present
+            else []
+        )
+        if remaining_prs or remaining_issues:
+            raise NightlyE2EError("des PR/issues du run sont encore ouvertes après cleanup")
+        if owns_label and not manifest.label_deleted:
+            # Relecture juste avant DELETE : un nom identique avec un autre
+            # marqueur n'est jamais adopté. Une absence signifie soit que le POST
+            # n'a jamais abouti, soit qu'un premier finalizer a déjà supprimé le
+            # label avant de pouvoir checkpoint son succès.
+            if self._owned_label_or_none() is not None:
+                self.clients.labels.delete_label(
+                    cfg.owner,
+                    cfg.repo,
+                    cfg.issue_label,
+                    expected_name=cfg.issue_label,
+                    expected_color=_NIGHTLY_LABEL_COLOR,
+                    expected_description=self._label_owner_description(),
+                )
+            manifest.label_deleted = True
+            _write_manifest(cfg.manifest_path, manifest)
+        try:
+            Path(cfg.manifest_path).unlink()
+        except FileNotFoundError:
+            pass
+        return {"status": "clean", "closed_prs": closed_prs, "closed_issues": closed_issues}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m collegue.pilot.nightly_e2e")
+    parser.add_argument("action", choices=("run", "cleanup"))
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        runner = NightlyE2ERunner(NightlyConfig.from_env(action=args.action))
+        payload = runner.run() if args.action == "run" else runner.cleanup()
+    except Exception as exc:  # noqa: BLE001 - frontière CLI : erreur lisible + code 1
+        print(f"nightly e2e refusé/échoué: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercé par le workflow réel
+    raise SystemExit(main())

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -122,18 +122,27 @@ def _coder_sandbox_env(settings_obj) -> dict:
     modèle d'**abonnement** nu (gpt-5.5 + ``LLM_SUBSCRIPTION=1`` + fallback gpt-5.4 ;
     le runner appelle ``subscription_login`` avec les creds montées), soit le modèle
     **CODER** au format LiteLLM (``gemini/<modèle>``) avec clé API. ``HOME`` hors /tmp est
-    requis par le montage des creds d'abonnement.
+    requis uniquement par le montage des creds d'abonnement ; en mode clé API,
+    :class:`DockerSandbox` conserve son ``HOME=/tmp`` écrivable quel que soit l'UID hôte.
     """
     from collegue.executor.openhands_sdk_agent import OHSdkAgent
 
     env = {
-        "HOME": "/home/sandbox",
         "OPENHANDS_SUPPRESS_BANNER": "1",
         "OH_NUM_RETRIES": str(getattr(settings_obj, "CODER_LLM_NUM_RETRIES", 8)),
         "OH_RETRY_MIN": str(getattr(settings_obj, "CODER_LLM_RETRY_MIN_WAIT", 8)),
         "OH_RETRY_MAX": str(getattr(settings_obj, "CODER_LLM_RETRY_MAX_WAIT", 90)),
     }
+    try:
+        call_timeout = float(getattr(settings_obj, "LLM_CALL_TIMEOUT", 0) or 0)
+    except (TypeError, ValueError):
+        call_timeout = 0.0
+    if call_timeout > 0 and call_timeout < float("inf"):
+        # Le runner OpenHands a son propre nom d'env. Propager le plafond produit
+        # évite qu'un appel coder dépasse silencieusement la limite planner/QA.
+        env["OH_LLM_TIMEOUT"] = str(max(1, int(call_timeout)))
     if bool(getattr(settings_obj, "CODER_SUBSCRIPTION", False)):
+        env["HOME"] = "/home/sandbox"
         env["LLM_MODEL"] = str(getattr(settings_obj, "CODER_SUBSCRIPTION_MODEL", "gpt-5.5") or "gpt-5.5")
         env["LLM_SUBSCRIPTION"] = "1"
         env["OH_FALLBACK_MODELS"] = str(getattr(settings_obj, "CODER_SUBSCRIPTION_FALLBACK", "gpt-5.4") or "gpt-5.4")

--- a/collegue/planner/github_sync.py
+++ b/collegue/planner/github_sync.py
@@ -195,13 +195,23 @@ def _commit_spec(
         return None, None, False
 
 
-def _issue_body(task: Any, dep_numbers: List[int]) -> str:
+def _issue_body(
+    task: Any,
+    dep_numbers: List[int],
+    *,
+    project_id: Optional[int] = None,
+    plan_hash: Optional[str] = None,
+) -> str:
     parts: List[str] = []
     if task.acceptance:
         parts.append(f"## Critère d'acceptation\n{task.acceptance}")
     if dep_numbers:
         parts.append("Dépend de : " + ", ".join(f"#{n}" for n in dep_numbers))
     parts.append(f"<!-- collegue-task:{task.id} -->")  # marqueur de traçabilité
+    if project_id is not None and plan_hash:
+        # Corrélation distante durable : permet de réconcilier/nettoyer une issue
+        # même si le POST a réussi mais que sa réponse n'a jamais atteint la DB.
+        parts.append(f"<!-- collegue-plan:{plan_hash};project:{int(project_id)};task:{int(task.id)} -->")
     return "\n\n".join(parts)
 
 
@@ -337,13 +347,34 @@ def sync_plan(
             continue
         # Ordre topo + validation → toutes les dépendances ont déjà un numéro (pas de drop silencieux).
         dep_numbers = [task_to_issue[d] for d in dict.fromkeys(task.depends_on or [])]
-        issue = clients.issues.create_issue(owner, repo, title=task.title, body=_issue_body(task, dep_numbers))
+        issue_body = _issue_body(
+            task,
+            dep_numbers,
+            project_id=project_id,
+            plan_hash=getattr(snapshot, "plan_hash", None),
+        )
+        create_with_metadata = getattr(clients.issues, "create_issue_with_metadata", None)
+        if callable(create_with_metadata):
+            issue = create_with_metadata(
+                owner,
+                repo,
+                title=task.title,
+                body=issue_body,
+                labels=labels,
+                milestone_number=getattr(milestone, "number", None),
+            )
+            metadata_created_atomically = True
+        else:
+            # Compatibilité des clients injectés historiques. Le client GitHub
+            # produit expose toujours ``create_issue_with_metadata``.
+            issue = clients.issues.create_issue(owner, repo, title=task.title, body=issue_body)
+            metadata_created_atomically = False
         number = issue.number
         task_to_issue[task.id] = number
         manager.update_task(task.id, issue_number=number)
-        if labels:
+        if labels and not metadata_created_atomically:
             clients.labels.add_labels_to_issue(owner, repo, number, labels)
-        if milestone is not None:
+        if milestone is not None and not metadata_created_atomically:
             clients.milestones.assign_milestone(owner, repo, number, milestone.number)
         if board is not None:
             node_id = clients.projects.issue_node_id(owner, repo, number)

--- a/collegue/tools/github_commands/branches.py
+++ b/collegue/tools/github_commands/branches.py
@@ -38,6 +38,7 @@ class GitCommitInfo(BaseModel):
     sha: str
     tree_sha: str
     parents: List[str]
+    message: str
 
 
 class BranchCommands(GitHubClient):
@@ -70,7 +71,12 @@ class BranchCommands(GitHubClient):
             resp = self._api_get(f"/repos/{owner}/{repo}/git/ref/heads/{branch}")
             return resp["object"]["sha"]
         except ToolExecutionError as e:
-            raise ToolExecutionError(f"Source branch '{branch}' not found") from e
+            # Une absence est la seule erreur que les appelants idempotents
+            # peuvent convertir en ``None``. Préserver explicitement le 404 ;
+            # auth, rate-limit, 5xx et pannes réseau doivent rester bloquants.
+            if getattr(e, "status_code", 0) == 404:
+                raise ToolExecutionError(f"Source branch '{branch}' not found", status_code=404) from e
+            raise
 
     def get_branch_sha(self, owner: str, repo: str, branch: str) -> str:
         """SHA courant d'une branche (API publique, fail-closed)."""
@@ -101,7 +107,7 @@ class BranchCommands(GitHubClient):
         return str(sha)
 
     def get_git_commit(self, owner: str, repo: str, sha: str) -> GitCommitInfo:
-        """Lit un objet commit Git et valide strictement son tree et ses parents."""
+        """Lit un objet commit Git et valide strictement tree, parents et message."""
         validate_ref(owner, "owner")
         validate_ref(repo, "repo")
         sha = self._validate_full_sha(sha, "SHA du commit")
@@ -117,7 +123,10 @@ class BranchCommands(GitHubClient):
             self._validate_full_sha(parent.get("sha") if isinstance(parent, dict) else None, "SHA parent")
             for parent in raw_parents
         ]
-        return GitCommitInfo(sha=response_sha, tree_sha=tree_sha, parents=parents)
+        message = data.get("message")
+        if not isinstance(message, str) or not message.strip():
+            raise ToolExecutionError("message du commit Git absent ou malformé")
+        return GitCommitInfo(sha=response_sha, tree_sha=tree_sha, parents=parents, message=message)
 
     def _branch_matches_commit_tree(
         self,
@@ -127,12 +136,13 @@ class BranchCommands(GitHubClient):
         *,
         parent_sha: str,
         tree_sha: str,
+        message: str,
     ) -> bool:
         try:
             commit = self.get_git_commit(owner, repo, branch_sha)
         except ToolExecutionError:
             return False
-        return commit.tree_sha == tree_sha and commit.parents == [parent_sha]
+        return commit.tree_sha == tree_sha and commit.parents == [parent_sha] and commit.message == message
 
     def ensure_commit_branch(
         self,
@@ -148,14 +158,15 @@ class BranchCommands(GitHubClient):
 
         Aucun fichier local n'est téléversé : le tree doit déjà appartenir au dépôt.
         Idempotent après crash, sans force-push : une branche existante n'est admise
-        que si son commit possède exactement ``parent_sha`` et ``tree_sha``.
+        que si son commit possède exactement ``parent_sha``, ``tree_sha`` et
+        ``message``.
         """
         validate_ref(owner, "owner")
         validate_ref(repo, "repo")
         self._validate_branch_name(branch)
         parent_sha = self._validate_full_sha(parent_sha, "SHA parent")
         tree_sha = self._validate_full_sha(tree_sha, "SHA tree")
-        if not str(message).strip():
+        if not isinstance(message, str) or not message.strip():
             raise ToolExecutionError("message du commit vide — refus fail-closed")
 
         existing = self._branch_sha_or_none(owner, repo, branch)
@@ -166,14 +177,15 @@ class BranchCommands(GitHubClient):
                 existing,
                 parent_sha=parent_sha,
                 tree_sha=tree_sha,
+                message=message,
             ):
                 return BranchInfo(name=branch, commit_sha=existing, protected=False)
-            raise ToolExecutionError(f"branche {branch!r} déjà présente avec un autre parent/tree — refus")
+            raise ToolExecutionError(f"branche {branch!r} déjà présente avec un autre parent/tree/message — refus")
 
         commit = (
             self._api_post(
                 f"/repos/{owner}/{repo}/git/commits",
-                {"message": str(message), "tree": tree_sha, "parents": [parent_sha]},
+                {"message": message, "tree": tree_sha, "parents": [parent_sha]},
             )
             or {}
         )
@@ -184,8 +196,9 @@ class BranchCommands(GitHubClient):
             commit_sha,
             parent_sha=parent_sha,
             tree_sha=tree_sha,
+            message=message,
         ):
-            raise ToolExecutionError("le commit de branche créé ne correspond pas au parent/tree demandés")
+            raise ToolExecutionError("le commit de branche créé ne correspond pas au parent/tree/message demandés")
         try:
             self._api_post(
                 f"/repos/{owner}/{repo}/git/refs",
@@ -200,6 +213,7 @@ class BranchCommands(GitHubClient):
                 raced,
                 parent_sha=parent_sha,
                 tree_sha=tree_sha,
+                message=message,
             ):
                 raise
             commit_sha = raced
@@ -210,6 +224,7 @@ class BranchCommands(GitHubClient):
             commit_sha,
             parent_sha=parent_sha,
             tree_sha=tree_sha,
+            message=message,
         ):
             raise ToolExecutionError(f"branche {branch!r} mobile ou commit distant non conforme")
         return BranchInfo(name=branch, commit_sha=commit_sha, protected=False)
@@ -226,11 +241,13 @@ class BranchCommands(GitHubClient):
         return BranchInfo(name=branch, commit_sha=resp["object"]["sha"], protected=False)
 
     def _branch_sha_or_none(self, owner: str, repo: str, branch: str) -> Optional[str]:
-        """SHA de la branche, ou None si elle n'existe pas (variante non-levante)."""
+        """SHA de la branche, ou ``None`` uniquement sur un 404 confirmé."""
         try:
             return self._get_branch_sha(owner, repo, branch)
-        except ToolExecutionError:
-            return None
+        except ToolExecutionError as exc:
+            if getattr(exc, "status_code", 0) == 404:
+                return None
+            raise
 
     def ensure_branch(self, owner: str, repo: str, branch: str, from_branch: Optional[str] = None) -> BranchInfo:
         """Retourne la branche existante ou la crée depuis ``from_branch``. Idempotent.
@@ -257,6 +274,7 @@ class BranchCommands(GitHubClient):
         *,
         protect: Iterable[str] = PROTECTED_BRANCHES,
         default_branch: Optional[str] = None,
+        expected_sha: Optional[str] = None,
     ) -> bool:
         """Supprime une branche. **Idempotent** + **refuse les branches protégées**.
 
@@ -271,6 +289,8 @@ class BranchCommands(GitHubClient):
         - Idempotent : si la branche n'existe pas (déjà supprimée), renvoie ``True``
           sans erreur. Gère aussi la **course** (suppression concurrente pendant
           l'appel) en re-vérifiant l'absence avant de propager.
+        - Si ``expected_sha`` est fourni, refuse de supprimer une branche existante
+          dont la tête a bougé depuis son inventaire par le caller.
         """
         validate_ref(owner, "owner")
         validate_ref(repo, "repo")
@@ -298,8 +318,13 @@ class BranchCommands(GitHubClient):
         if default_branch and norm == _norm(default_branch):
             raise ToolExecutionError(f"refus de supprimer la branche par défaut: {branch!r}")
 
-        if self._branch_sha_or_none(owner, repo, branch) is None:
+        current_sha = self._branch_sha_or_none(owner, repo, branch)
+        if current_sha is None:
             return True  # déjà absente → succès idempotent
+        if expected_sha is not None and current_sha != expected_sha:
+            raise ToolExecutionError(
+                f"refus de supprimer la branche {branch!r}: SHA attendu {expected_sha}, vu {current_sha}"
+            )
         try:
             self._request_json("DELETE", f"/repos/{owner}/{repo}/git/refs/heads/{branch}")
         except ToolExecutionError:
@@ -307,4 +332,12 @@ class BranchCommands(GitHubClient):
             if self._branch_sha_or_none(owner, repo, branch) is None:
                 return True
             raise
+        # Un DELETE 2xx ne suffit pas comme preuve pour une opération destructive :
+        # confirmer l'absence distante. Toute lecture autre qu'un 404 reste
+        # bloquante via ``_branch_sha_or_none``.
+        remaining_sha = self._branch_sha_or_none(owner, repo, branch)
+        if remaining_sha is not None:
+            raise ToolExecutionError(
+                f"suppression de la branche {branch!r} non confirmée: tête distante {remaining_sha}"
+            )
         return True

--- a/collegue/tools/github_commands/issues.py
+++ b/collegue/tools/github_commands/issues.py
@@ -4,11 +4,13 @@ Issue Commands for GitHub Operations.
 Handles issue listing, details, and creation.
 """
 
-from typing import List, Optional
+from typing import Iterable, List, Optional
 
 from pydantic import BaseModel
 
+from ..base import ToolExecutionError
 from ..clients import GitHubClient
+from ._helpers import validate_ref
 
 
 class IssueInfo(BaseModel):
@@ -26,10 +28,31 @@ class IssueInfo(BaseModel):
 
 
 class IssueCommands(GitHubClient):
-    def list_issues(self, owner: str, repo: str, state: str = "open", limit: int = 30) -> List[IssueInfo]:
-        data = self._api_get(
-            f"/repos/{owner}/{repo}/issues", {"state": state, "per_page": limit, "sort": "updated", "direction": "desc"}
-        )
+    def list_issues(
+        self,
+        owner: str,
+        repo: str,
+        state: str = "open",
+        limit: int = 30,
+        *,
+        labels: Optional[str | Iterable[str]] = None,
+    ) -> List[IssueInfo]:
+        params = {"state": state, "per_page": limit, "sort": "updated", "direction": "desc"}
+        if isinstance(labels, str):
+            labels_filter = labels.strip()
+        elif labels is None:
+            labels_filter = ""
+        else:
+            try:
+                values = tuple(labels)
+            except TypeError as exc:
+                raise ToolExecutionError("filtre labels invalide") from exc
+            if any(not isinstance(label, str) or not label.strip() for label in values):
+                raise ToolExecutionError("filtre labels invalide")
+            labels_filter = ",".join(label.strip() for label in values)
+        if labels_filter:
+            params["labels"] = labels_filter
+        data = self._api_get(f"/repos/{owner}/{repo}/issues", params)
 
         issues = [i for i in data if "pull_request" not in i]
 
@@ -59,7 +82,10 @@ class IssueCommands(GitHubClient):
             labels=[l["name"] for l in data.get("labels", [])],
             created_at=data["created_at"],
             updated_at=data["updated_at"],
-            body=data.get("body", "")[:2000] if data.get("body") else None,
+            # Le getter individuel sert aux gardes de cleanup/reprise : le
+            # marqueur de corrélation est en fin de corps et ne doit jamais être
+            # tronqué (GitHub borne déjà la taille d'un body d'issue).
+            body=data.get("body") or None,
         )
 
     def create_issue(self, owner: str, repo: str, title: str, body: Optional[str] = None) -> IssueInfo:
@@ -76,3 +102,123 @@ class IssueCommands(GitHubClient):
             updated_at=resp["updated_at"],
             body=resp.get("body"),
         )
+
+    def create_issue_with_metadata(
+        self,
+        owner: str,
+        repo: str,
+        title: str,
+        *,
+        body: Optional[str] = None,
+        labels: Iterable[str] = (),
+        milestone_number: Optional[int] = None,
+    ) -> IssueInfo:
+        """Crée l'issue et ses métadonnées de corrélation dans le même POST.
+
+        Cela supprime la fenêtre ``create_issue`` puis ``add_labels`` pendant
+        laquelle une perte de réponse laisserait une issue distante difficile à
+        retrouver lors du cleanup/retry.
+        """
+        validate_ref(owner, "owner")
+        validate_ref(repo, "repo")
+        try:
+            normalized_labels = [label.strip() for label in labels]
+        except (TypeError, AttributeError) as exc:
+            raise ToolExecutionError("labels de création d'issue invalides") from exc
+        if any(not label for label in normalized_labels):
+            raise ToolExecutionError("labels de création d'issue invalides")
+        if milestone_number is not None and (
+            not isinstance(milestone_number, int) or isinstance(milestone_number, bool) or milestone_number <= 0
+        ):
+            raise ToolExecutionError(f"numéro de milestone invalide: {milestone_number!r}")
+        data: dict = {"title": title, "body": body or "", "labels": normalized_labels}
+        if milestone_number is not None:
+            data["milestone"] = milestone_number
+        resp = self._api_post(f"/repos/{owner}/{repo}/issues", data)
+        return IssueInfo(
+            number=resp["number"],
+            title=resp["title"],
+            state=resp["state"],
+            html_url=resp["html_url"],
+            user=resp["user"]["login"],
+            labels=[label["name"] for label in resp.get("labels", [])],
+            created_at=resp["created_at"],
+            updated_at=resp["updated_at"],
+            body=resp.get("body"),
+        )
+
+    def close_issue(
+        self,
+        owner: str,
+        repo: str,
+        issue_number: int,
+        *,
+        expected_labels: Iterable[str],
+        body_marker: str,
+    ) -> IssueInfo:
+        """Ferme une issue non-PR après validation de ses labels et marqueur.
+
+        ``expected_labels`` est un sous-ensemble obligatoire (comparaison
+        insensible à la casse) : des labels humains supplémentaires ne rendent pas
+        le cleanup inopérant. Une issue conforme déjà fermée est un succès
+        idempotent. Le endpoint ``issues`` expose aussi les PR ; elles sont donc
+        explicitement refusées avant toute mutation.
+        """
+        validate_ref(owner, "owner")
+        validate_ref(repo, "repo")
+        if not isinstance(issue_number, int) or isinstance(issue_number, bool) or issue_number <= 0:
+            raise ToolExecutionError(f"numéro d'issue invalide: {issue_number!r}")
+        try:
+            labels_guard = (expected_labels,) if isinstance(expected_labels, str) else tuple(expected_labels)
+        except TypeError as exc:
+            raise ToolExecutionError("expected_labels invalide") from exc
+        if not labels_guard:
+            raise ToolExecutionError("expected_labels doit contenir au moins un label de cleanup")
+        if any(not isinstance(label, str) or not label.strip() for label in labels_guard):
+            raise ToolExecutionError("expected_labels contient un label invalide")
+        if not isinstance(body_marker, str) or not body_marker:
+            raise ToolExecutionError("garde de fermeture issue absente: body_marker")
+        endpoint = f"/repos/{owner}/{repo}/issues/{issue_number}"
+
+        def read_and_verify() -> tuple[dict, IssueInfo]:
+            payload = self._api_get(endpoint)
+            if not isinstance(payload, dict) or payload.get("number") != issue_number:
+                raise ToolExecutionError(f"identité de l'issue #{issue_number} non confirmée par GitHub")
+            if "pull_request" in payload:
+                raise ToolExecutionError(f"#{issue_number} est une pull request — refus de close_issue")
+            state = payload.get("state")
+            if state not in {"open", "closed"}:
+                raise ToolExecutionError(f"état inattendu pour l'issue #{issue_number}: {state!r}")
+            actual_labels = {
+                str(label.get("name") or "").strip().casefold()
+                for label in payload.get("labels", [])
+                if isinstance(label, dict)
+            }
+            required_labels = {label.strip().casefold() for label in labels_guard}
+            missing = required_labels - actual_labels
+            if missing:
+                raise ToolExecutionError(
+                    f"labels de cleanup absents de l'issue #{issue_number}: {', '.join(sorted(missing))}"
+                )
+            if body_marker not in (payload.get("body") or ""):
+                raise ToolExecutionError(f"marqueur de cleanup absent du corps de l'issue #{issue_number}")
+            return payload, IssueInfo(
+                number=payload["number"],
+                title=payload["title"],
+                state=state,
+                html_url=payload["html_url"],
+                user=payload["user"]["login"],
+                labels=[label["name"] for label in payload.get("labels", [])],
+                created_at=payload["created_at"],
+                updated_at=payload["updated_at"],
+                body=payload.get("body"),
+            )
+
+        _, current = read_and_verify()
+        if current.state == "closed":
+            return current
+        self._request_json("PATCH", endpoint, json_data={"state": "closed"})
+        _, confirmed = read_and_verify()
+        if confirmed.state != "closed":
+            raise ToolExecutionError(f"fermeture de l'issue #{issue_number} non confirmée par GitHub")
+        return confirmed

--- a/collegue/tools/github_commands/labels.py
+++ b/collegue/tools/github_commands/labels.py
@@ -7,6 +7,7 @@ non câblé au runtime tant que la synchronisation du plan (P4) ne l'appelle pas
 """
 
 from typing import List, Optional
+from urllib.parse import quote
 
 from pydantic import BaseModel
 
@@ -69,3 +70,32 @@ class LabelCommands(GitHubClient):
             {"labels": list(labels)},
         )
         return [label["name"] for label in (resp or [])]
+
+    def delete_label(
+        self,
+        owner: str,
+        repo: str,
+        name: str,
+        *,
+        expected_name: str,
+        expected_color: Optional[str] = None,
+        expected_description: Optional[str] = None,
+    ) -> bool:
+        """Supprime un label exact, de façon idempotente et gardée."""
+        validate_ref(owner, "owner")
+        validate_ref(repo, "repo")
+        if not isinstance(name, str) or not name or name != expected_name:
+            raise ToolExecutionError("nom de label de cleanup invalide ou inattendu")
+        existing = self._find_label(owner, repo, name)
+        if existing is None:
+            return True
+        if existing.name != expected_name:
+            raise ToolExecutionError(f"label de cleanup inattendu: attendu {expected_name!r}, vu {existing.name!r}")
+        if expected_color is not None and existing.color.lower() != expected_color.lower():
+            raise ToolExecutionError(f"couleur inattendue pour le label de cleanup {name!r}")
+        if expected_description is not None and existing.description != expected_description:
+            raise ToolExecutionError(f"description inattendue pour le label de cleanup {name!r}")
+        self._request_json("DELETE", f"/repos/{owner}/{repo}/labels/{quote(existing.name, safe='')}")
+        if self._find_label(owner, repo, name) is not None:
+            raise ToolExecutionError(f"suppression du label {name!r} non confirmée")
+        return True

--- a/collegue/tools/github_commands/prs.py
+++ b/collegue/tools/github_commands/prs.py
@@ -119,10 +119,19 @@ class MergeResult(BaseModel):
 
 
 class PRCommands(GitHubClient):
-    def list_prs(self, owner: str, repo: str, state: str = "open", limit: int = 30) -> List[PRInfo]:
-        data = self._api_get(
-            f"/repos/{owner}/{repo}/pulls", {"state": state, "per_page": limit, "sort": "updated", "direction": "desc"}
-        )
+    def list_prs(
+        self,
+        owner: str,
+        repo: str,
+        state: str = "open",
+        limit: int = 30,
+        *,
+        base: Optional[str] = None,
+    ) -> List[PRInfo]:
+        params = {"state": state, "per_page": limit, "sort": "updated", "direction": "desc"}
+        if base:
+            params["base"] = base
+        data = self._api_get(f"/repos/{owner}/{repo}/pulls", params)
 
         return [
             PRInfo(
@@ -211,6 +220,80 @@ class PRCommands(GitHubClient):
             changed_files=data.get("changed_files"),
             body=data.get("body"),
         )
+
+    def close_pr(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        *,
+        expected_head_sha: str,
+        expected_head_branch: str,
+        expected_base_branch: str,
+        body_marker: str,
+    ) -> PRInfo:
+        """Ferme une PR non mergée après validation stricte de son identité.
+
+        Les quatre gardes sont obligatoires : le cleanup ne doit jamais fermer une
+        PR retrouvée seulement par son numéro. Une PR déjà fermée et conforme est
+        un succès idempotent ; une PR mergée est toujours refusée. Après le PATCH,
+        une nouvelle lecture confirme l'état et rejoue toutes les gardes.
+        """
+        validate_ref(owner, "owner")
+        validate_ref(repo, "repo")
+        if not isinstance(pr_number, int) or isinstance(pr_number, bool) or pr_number <= 0:
+            raise ToolExecutionError(f"numéro de PR invalide: {pr_number!r}")
+        guards = {
+            "expected_head_sha": expected_head_sha,
+            "expected_head_branch": expected_head_branch,
+            "expected_base_branch": expected_base_branch,
+            "body_marker": body_marker,
+        }
+        for name, value in guards.items():
+            if not isinstance(value, str) or not value:
+                raise ToolExecutionError(f"garde de fermeture PR absente: {name}")
+
+        def verify(info: PRInfo) -> None:
+            if info.number != pr_number:
+                raise ToolExecutionError(
+                    f"GitHub a retourné la PR #{info.number} au lieu de la PR #{pr_number} — refus"
+                )
+            if info.merged:
+                raise ToolExecutionError(f"PR #{pr_number} déjà mergée — refus de la fermer par cleanup")
+            if info.head_sha != expected_head_sha:
+                raise ToolExecutionError(
+                    f"SHA head inattendu pour la PR #{pr_number}: attendu {expected_head_sha}, vu {info.head_sha}"
+                )
+            if info.head_branch != expected_head_branch:
+                raise ToolExecutionError(
+                    f"branche head inattendue pour la PR #{pr_number}: "
+                    f"attendu {expected_head_branch}, vu {info.head_branch}"
+                )
+            if info.base_branch != expected_base_branch:
+                raise ToolExecutionError(
+                    f"branche base inattendue pour la PR #{pr_number}: "
+                    f"attendu {expected_base_branch}, vu {info.base_branch}"
+                )
+            if body_marker not in (info.body or ""):
+                raise ToolExecutionError(f"marqueur de cleanup absent du corps de la PR #{pr_number}")
+            if info.state not in {"open", "closed"}:
+                raise ToolExecutionError(f"état inattendu pour la PR #{pr_number}: {info.state!r}")
+
+        current = self.get_pr(owner, repo, pr_number)
+        verify(current)
+        if current.state == "closed":
+            return current
+
+        self._request_json(
+            "PATCH",
+            f"/repos/{owner}/{repo}/pulls/{pr_number}",
+            json_data={"state": "closed"},
+        )
+        confirmed = self.get_pr(owner, repo, pr_number)
+        verify(confirmed)
+        if confirmed.state != "closed":
+            raise ToolExecutionError(f"fermeture de la PR #{pr_number} non confirmée par GitHub")
+        return confirmed
 
     def get_pr_files(self, owner: str, repo: str, pr_number: int, limit: int = 100) -> List[FileChange]:
         """Get files changed in a pull request."""

--- a/collegue/tools/github_commands/repos.py
+++ b/collegue/tools/github_commands/repos.py
@@ -12,6 +12,10 @@ from ..clients import GitHubClient
 
 
 class RepoInfo(BaseModel):
+    # Identité GitHub immuable du dépôt. Optionnelle pour conserver la
+    # compatibilité avec les anciens appelants qui construisent ce modèle à la
+    # main, mais toujours renseignée par les lectures API ci-dessous.
+    id: Optional[int] = None
     name: str
     full_name: str
     description: Optional[str] = None
@@ -36,6 +40,7 @@ class RepoCommands(GitHubClient):
 
         return [
             RepoInfo(
+                id=r["id"],
                 name=r["name"],
                 full_name=r["full_name"],
                 description=r.get("description"),
@@ -54,6 +59,7 @@ class RepoCommands(GitHubClient):
     def get_repo(self, owner: str, repo: str) -> RepoInfo:
         data = self._api_get(f"/repos/{owner}/{repo}")
         return RepoInfo(
+            id=data["id"],
             name=data["name"],
             full_name=data["full_name"],
             description=data.get("description"),

--- a/docs/moteur_autonome.md
+++ b/docs/moteur_autonome.md
@@ -434,20 +434,21 @@ Variables GitHub Actions requises :
 | `INTEGRATION_FIXTURE_ROOT_BRANCH` | Branche racine immuable, par exemple `main`. |
 | `INTEGRATION_FIXTURE_SEED_SHA` | SHA Git complet (40 caractères) du commit seed. |
 | `INTEGRATION_LLM_PROVIDER` / `INTEGRATION_LLM_MODEL` | Endpoint et modèle globaux du nightly. |
-| `INTEGRATION_LLM_PRICE_PROMPT_PER_1M` | Prix USD de secours par million de tokens d'entrée. |
-| `INTEGRATION_LLM_PRICE_COMPLETION_PER_1M` | Prix USD de secours par million de tokens de sortie. |
+| `INTEGRATION_LLM_PRICE_PROMPT_PER_1M` | Prix USD de secours par million de tokens d'entrée (`0` accepté pour un coder Gemma 4 explicitement gratuit). |
+| `INTEGRATION_LLM_PRICE_COMPLETION_PER_1M` | Prix USD de secours par million de tokens de sortie (même règle). |
 
 Les overrides par rôle `INTEGRATION_LLM_{PROVIDER,MODEL}_{CODER,QA,REVIEWER,PLANNER}`
 sont optionnels ; une valeur absente retombe sur le couple global. Le premier
 smoke impose actuellement **Gemini pour tous les rôles** : tout override de
 provider doit être vide ou égal au provider global `gemini`, et chaque modèle
-effectif doit être un nom Gemini non préfixé (`gemini-…`) présent dans la grille
-de prix autoritative de Collègue. Par exemple `gemini-2.5-flash` ou
-`gemini-3-flash-preview`; `openai/...`, `models/...` et un modèle inconnu sont
-refusés avant toute écriture. Cette restriction évite de router la clé vers un
-autre provider et garantit que le plafond USD est calculable. Les prix de secours
-doivent refléter le modèle coder ; au moins l'un des deux doit être strictement
-positif.
+effectif doit être un nom Gemini API non préfixé présent dans la grille de prix
+autoritative de Collègue. Sont notamment acceptés `gemini-2.5-flash`,
+`gemini-3-flash-preview`, `gemma-4-31b-it` et `gemma-4-26b-a4b-it` ; `openai/...`,
+`models/...` et un modèle inconnu sont refusés avant toute écriture. Gemma 4 est
+explicitement tarifé à `0/0` dans la grille (Free Tier Gemini API) : ses deux prix
+de secours peuvent donc rester à zéro. Pour tout autre coder, au moins un prix de
+secours doit être strictement positif. La limite tokens et la deadline restent
+dures même lorsque le plafond USD est, correctement, nul.
 
 Secrets GitHub Actions requis :
 

--- a/docs/moteur_autonome.md
+++ b/docs/moteur_autonome.md
@@ -351,12 +351,128 @@ test dont le pré-requis manque se **skippe** avec sa raison (`-rs`). Garde-fou
 anti-vacuité : si *tous* les tests ont été skippés, le job **échoue** (un nightly
 vert qui n'a rien exercé serait une fausse assurance). Les coûts LLM sont bornés
 par le budget dur (`MAX_COST_USD=2`, `MAX_TOKENS_BUDGET=2M`, deadline 30 min) —
-coût attendu par run : ~0 à 2 $ selon les secrets fournis.
+coût attendu par run : ~0 à 2 $ selon les secrets fournis. Ces secrets sont
+injectés uniquement dans l'étape pytest qui les consomme ; le checkout, l'installation
+des dépendances, Docker et l'upload du rapport ne les reçoivent pas.
 
-En cas d'échec, le workflow ouvre (ou commente) une issue **« CI nightly
-integration en échec »** avec le lien du run — la CI PR normale n'est jamais
-bloquée par le nightly.
+Un job de notification dédié, seul titulaire de `issues: write`, agrège les
+échecs **et annulations** des jobs `integration`, `build-sandbox-openhands` et
+`product-e2e`, puis ouvre (ou commente) une issue **« CI nightly en échec »** avec
+le lien du run, les jobs concernés et leur résultat. Un job volontairement
+`skipped` parce que l'opt-in est OFF n'est pas signalé. La CI PR normale n'est
+jamais bloquée par le nightly.
 
-> Étape suivante (suivi #404) : un smoke **end-to-end** réel (plan → `--execute`
-> sur un dépôt fixture → PR ouverte puis nettoyée). Il exige une image sandbox
-> embarquant OpenHands, que le dépôt ne fournit pas encore.
+#### Smoke produit end-to-end (opt-in)
+
+Le job séparé `product-e2e` exerce le chemin public complet, sans ancien harnais :
+`plan draft` → `plan approve` → `plan sync --execute` → RUN `--execute` avec le
+vrai coder OpenHands → gate d'acceptation objectif → PR ouverte. L'orchestrateur
+committé s'invoque par `python -m collegue.pilot.nightly_e2e run`; une étape
+`if: always()` relance ensuite `python -m collegue.pilot.nightly_e2e cleanup`.
+Le manifeste local corrèle les ressources à leur SHA exact : le cleanup ferme les
+PR/issues du run et supprime uniquement leurs branches, sans toucher à la branche
+par défaut. Le JSON du RUN et le corps de la PR doivent en outre porter le verdict
+`acceptance_passed=true` et le même SHA-256 que l'oracle QA généré au plan-time ;
+un simple succès générique du gate ne suffit pas à rendre ce smoke vert.
+
+Les mutations distantes ont des intents écrits avant leur POST. La base démarre
+sur un commit propriétaire vérifiable par `parent + tree + message` exact. Si le
+head code est poussé mais que la création de PR échoue, le cleanup ne l'adopte
+qu'après avoir prouvé une chaîne bornée de commits `collegue: issue #… — chemin`
+jusqu'au SHA de base scellé. Ces preuves couvrent les réponses GitHub perdues sans
+confondre une branche homonyme préexistante avec une ressource du run.
+
+Ce double finalizer (dans `run`, puis étape `if: always()`) couvre les erreurs et
+timeouts tant que le runner reste disponible. Il ne peut pas garantir le nettoyage
+après une perte brutale du runner ou l'arrêt forcé du job avant le finalizer : le
+manifeste vit dans `${{ runner.temp }}` et des ressources balisées
+`collegue-nightly-<run>-<attempt>` peuvent alors rester sur la fixture. Elles doivent
+être inspectées et nettoyées manuellement avec leurs SHA/marqueurs exacts ; un
+janitor inter-run ou un manifeste distant durable reste nécessaire pour couvrir ce
+cas sans intervention.
+
+Ce job est **désactivé par défaut**. Il n'existe dans un run planifié que si la
+variable de dépôt `INTEGRATION_E2E_ENABLED` vaut exactement `true`. Une
+configuration incomplète échoue avant le build ou la première écriture GitHub ;
+elle n'est jamais transformée en skip vert.
+
+##### Dépôt fixture
+
+Créer un dépôt GitHub **public et dédié**, distinct de Collègue, avec les issues
+activées. Sa branche par défaut (par exemple `main`) sert de racine immuable et
+contient une petite application FastAPI déjà verte : objet `app` dans
+`app/main.py`, un endpoint de santé, `tests/test_app.py`, `requirements.txt` et
+les fichiers `__init__.py` nécessaires. Elle ne doit contenir ni `SPEC.md`, ni
+route `/nightly` : ces éléments sont produits sur la branche éphémère du run.
+
+À la racine, créer `.collegue-nightly-fixture` avec **exactement 28 octets** :
+
+```text
+COLLEGUE_NIGHTLY_FIXTURE_V1
+```
+
+Il s'agit exactement de `COLLEGUE_NIGHTLY_FIXTURE_V1\n` : un unique LF final,
+sans BOM, espace ni seconde ligne. Après le commit seed, relever son SHA Git
+complet de 40 caractères et l'identifiant numérique REST du dépôt. Ne plus
+modifier la branche racine sans mettre volontairement à jour les deux variables
+scellées ; tout écart arrête le smoke avant écriture.
+
+Protéger en plus cette branche racine par un **ruleset GitHub** ciblé : refuser sa
+suppression, les force-push et les mises à jour directes. Le PAT du nightly ne doit
+figurer dans **aucune bypass list** de ce ruleset. Il conserve `Contents: write`
+pour créer les branches éphémères, mais ne peut ainsi pas altérer la racine ; les
+comparaisons de SHA du moteur restent une détection supplémentaire, pas l'unique
+protection.
+
+Variables GitHub Actions requises :
+
+| Variable | Valeur |
+|----------|--------|
+| `INTEGRATION_E2E_ENABLED` | `true` pour activer explicitement le job. |
+| `INTEGRATION_FIXTURE_REPOSITORY` | Coordonnée `owner/repo` du dépôt public dédié. |
+| `INTEGRATION_FIXTURE_REPOSITORY_ID` | Identifiant numérique renvoyé par l'API REST GitHub. |
+| `INTEGRATION_FIXTURE_ROOT_BRANCH` | Branche racine immuable, par exemple `main`. |
+| `INTEGRATION_FIXTURE_SEED_SHA` | SHA Git complet (40 caractères) du commit seed. |
+| `INTEGRATION_LLM_PROVIDER` / `INTEGRATION_LLM_MODEL` | Endpoint et modèle globaux du nightly. |
+| `INTEGRATION_LLM_PRICE_PROMPT_PER_1M` | Prix USD de secours par million de tokens d'entrée. |
+| `INTEGRATION_LLM_PRICE_COMPLETION_PER_1M` | Prix USD de secours par million de tokens de sortie. |
+
+Les overrides par rôle `INTEGRATION_LLM_{PROVIDER,MODEL}_{CODER,QA,REVIEWER,PLANNER}`
+sont optionnels ; une valeur absente retombe sur le couple global. Le premier
+smoke impose actuellement **Gemini pour tous les rôles** : tout override de
+provider doit être vide ou égal au provider global `gemini`, et chaque modèle
+effectif doit être un nom Gemini non préfixé (`gemini-…`) présent dans la grille
+de prix autoritative de Collègue. Par exemple `gemini-2.5-flash` ou
+`gemini-3-flash-preview`; `openai/...`, `models/...` et un modèle inconnu sont
+refusés avant toute écriture. Cette restriction évite de router la clé vers un
+autre provider et garantit que le plafond USD est calculable. Les prix de secours
+doivent refléter le modèle coder ; au moins l'un des deux doit être strictement
+positif.
+
+Secrets GitHub Actions requis :
+
+| Secret | Usage |
+|--------|-------|
+| `INTEGRATION_LLM_API_KEY` | Planner, QA, reviewer et coder OpenHands en mode API. |
+| `INTEGRATION_FIXTURE_GITHUB_TOKEN` | Écritures limitées au seul dépôt fixture. |
+
+Le token fixture doit être un token finement restreint à ce dépôt, avec
+`Metadata: read`, `Contents: read/write`, `Issues: read/write` et
+`Pull requests: read/write`. Le checkout du dépôt source utilise
+`persist-credentials: false`, et le job n'accorde au `GITHUB_TOKEN` automatique
+que `contents: read`. Le dépôt fixture étant public, son clone ne transporte
+aucun secret ; le token dédié n'est utilisé que par les étapes préflight, run et
+cleanup. La clé LLM n'est présente que pendant le préflight et le run, jamais
+pendant `pip install`, le build Docker ou le cleanup. Le finalizer n'exige donc
+que le PAT restreint à la fixture et reste exécutable après un échec de
+configuration du modèle.
+
+Le job construit lui-même `docker/sandbox/Dockerfile.openhands`, initialise une
+base SQLite via Alembic, impose une seule tentative, sonde explicitement
+`GET /nightly` et laisse tous les auto-merges désactivés. Ses plafonds sont
+`MAX_COST_USD=2`, `MAX_TOKENS_BUDGET=250000`, 15 minutes de deadline RUN,
+12 minutes par processus sandbox, 20 minutes par processus produit et 180 secondes
+par appel LLM. Le coût attendu reste inférieur à 2 USD pour cette tâche unique si
+les prix configurés sont fidèles ; il dépend du modèle choisi et doit être suivi
+dans le ledger du run. Le job GitHub lui-même expire après 90 minutes, build de
+l'image inclus, afin de réserver une marge au finalizer.

--- a/tests/test_acceptance_gate.py
+++ b/tests/test_acceptance_gate.py
@@ -231,6 +231,7 @@ async def test_stored_checker_runs_exact_approved_source_without_llm(tmp_path):
     out = await checker.check(str(tmp_path), "diff hostile ignoré", issue, _NoSampling(), sandbox=sandbox)
 
     assert out.passed is True and out.error is None
+    assert out.oracle_sha256 == _task.acceptance_test_sha256
     assert approvals and approvals[0][1] == 3
     assert len(sandbox.commands) == 1
     assert "python -I -c" in sandbox.commands[0]
@@ -311,8 +312,13 @@ async def test_stored_checker_requires_opaque_task_id(tmp_path):
 
 
 class _FakeAcceptance:
-    def __init__(self, *, passed=None, error=None, skipped=False, raises=None):
-        self._outcome = AcceptanceOutcome(passed=passed, error=error, skipped=skipped)
+    def __init__(self, *, passed=None, error=None, skipped=False, oracle_sha256=None, raises=None):
+        self._outcome = AcceptanceOutcome(
+            passed=passed,
+            error=error,
+            skipped=skipped,
+            oracle_sha256=oracle_sha256,
+        )
         self._raises = raises
         self.called = False
 
@@ -334,11 +340,13 @@ async def test_gate_blocks_when_acceptance_fails():
 
 
 async def test_gate_passes_when_acceptance_passes():
-    chk = _FakeAcceptance(passed=True)
+    digest = "a" * 64
+    chk = _FakeAcceptance(passed=True, oracle_sha256=digest)
     report = await run_quality_gate(
         "/ws", DIFF, ctx=None, sandbox=_green(), reviewer=FakeReviewer(), issue=ISSUE_AC, acceptance_checker=chk
     )
     assert report.acceptance_passed is True and report.passed is True
+    assert report.acceptance_oracle_sha256 == digest
 
 
 async def test_gate_generation_error_blocks():
@@ -418,6 +426,25 @@ def test_acceptance_failure_rendered_in_report():
         acceptance_passed=False,
     ).to_markdown()
     assert "tests d'acceptation dérivés du SPEC en ÉCHEC" in md
+
+
+def test_acceptance_success_renders_executed_oracle_sha():
+    from collegue.executor import QualityReport
+
+    digest = "b" * 64
+    md = QualityReport(
+        tests_passed=True,
+        test_exit_code=0,
+        test_output="",
+        review_summary="",
+        review_findings=(),
+        review_blocking=False,
+        passed=True,
+        acceptance_passed=True,
+        acceptance_oracle_sha256=digest,
+    ).to_markdown()
+    assert "Tests d'acceptation (§4.7)" in md
+    assert f"sha256:{digest}" in md
 
 
 def test_acceptance_unavailable_rendered_as_fail_closed():

--- a/tests/test_executor_agent.py
+++ b/tests/test_executor_agent.py
@@ -349,11 +349,20 @@ def test_estimate_cost_usd_survives_poisoned_token_counts():
 
 
 def test_coder_pricing_resolvable():
-    """#502 : vrai si un prix de secours coder est configuré (>0)."""
-    from collegue.executor.openhands_agent import coder_pricing_resolvable
+    """#502 : prix de secours positif ou grille explicitement gratuite."""
+    from collegue.executor.openhands_agent import coder_pricing_is_explicitly_free, coder_pricing_resolvable
 
     assert coder_pricing_resolvable(_settings(LLM_PRICE_PROMPT_PER_1M=1.5)) is True
     assert coder_pricing_resolvable(_settings(LLM_PRICE_COMPLETION_PER_1M=9.0)) is True
     assert coder_pricing_resolvable(_settings()) is False
     for bad in (0.0, -3.0, "n/a", float("nan")):
         assert coder_pricing_resolvable(_settings(LLM_PRICE_PROMPT_PER_1M=bad)) is False
+    free = _settings(LLM_MODEL_CODER="gemma-4-31b-it")
+    assert coder_pricing_is_explicitly_free(free) is True
+    assert coder_pricing_resolvable(free) is True
+    unknown = _settings(LLM_MODEL_CODER="gemma-4-inconnu")
+    assert coder_pricing_is_explicitly_free(unknown) is False
+    assert coder_pricing_resolvable(unknown) is False
+    wrong_provider = _settings(LLM_PROVIDER_CODER="openai", LLM_MODEL_CODER="gemma-4-31b-it")
+    assert coder_pricing_is_explicitly_free(wrong_provider) is False
+    assert coder_pricing_resolvable(wrong_provider) is False

--- a/tests/test_github_cleanup.py
+++ b/tests/test_github_cleanup.py
@@ -1,0 +1,375 @@
+"""Primitives GitHub de cleanup distant, avec identité gardée et sans réseau."""
+
+from __future__ import annotations
+
+import pytest
+
+from collegue.tools.base import ToolExecutionError
+from collegue.tools.github_commands import IssueCommands, LabelCommands, PRCommands, RepoCommands
+
+
+def _repo_payload(repo_id: int = 123) -> dict:
+    return {
+        "id": repo_id,
+        "name": "fixture",
+        "full_name": "owner/fixture",
+        "description": "nightly fixture",
+        "html_url": "https://github.test/owner/fixture",
+        "default_branch": "main",
+        "language": "Python",
+        "stargazers_count": 0,
+        "forks_count": 0,
+        "open_issues_count": 0,
+        "private": True,
+        "updated_at": "2026-07-10T00:00:00Z",
+    }
+
+
+def _pr_payload(*, state: str = "open", merged: bool = False) -> dict:
+    return {
+        "number": 17,
+        "title": "Nightly",
+        "state": state,
+        "html_url": "https://github.test/owner/fixture/pull/17",
+        "user": {"login": "collegue-bot"},
+        "base": {"ref": "nightly/run-1", "sha": "b" * 40},
+        "head": {"ref": "collegue/issue-42", "sha": "a" * 40},
+        "created_at": "2026-07-10T00:00:00Z",
+        "updated_at": "2026-07-10T00:01:00Z",
+        "labels": [],
+        "draft": False,
+        "merged": merged,
+        "merged_at": "2026-07-10T00:02:00Z" if merged else None,
+        "body": "rapport\n<!-- nightly-run:1 -->",
+    }
+
+
+def _issue_payload(*, state: str = "open", pull_request: bool = False) -> dict:
+    payload = {
+        "number": 42,
+        "title": "Nightly task",
+        "state": state,
+        "html_url": "https://github.test/owner/fixture/issues/42",
+        "user": {"login": "collegue-bot"},
+        "labels": [{"name": "collegue-nightly"}, {"name": "Run-1"}, {"name": "human-extra"}],
+        "created_at": "2026-07-10T00:00:00Z",
+        "updated_at": "2026-07-10T00:01:00Z",
+        "body": "critère\n<!-- nightly-run:1 -->",
+    }
+    if pull_request:
+        payload["pull_request"] = {"url": "https://api.github.test/pulls/42"}
+    return payload
+
+
+def test_repo_commands_expose_immutable_id_for_list_and_get():
+    repos = RepoCommands(token=None)
+    repos._api_get = lambda endpoint, params=None: (
+        [_repo_payload(123)] if endpoint == "/user/repos" else _repo_payload(456)
+    )
+
+    listed = repos.list_repos(None)
+    fetched = repos.get_repo("owner", "fixture")
+
+    assert listed[0].id == 123
+    assert fetched.id == 456
+
+
+def test_list_prs_passes_base_filter_to_github():
+    prs = PRCommands(token=None)
+    calls = []
+
+    def fake_get(endpoint, params=None):
+        calls.append((endpoint, params))
+        return [_pr_payload()]
+
+    prs._api_get = fake_get
+    result = prs.list_prs("owner", "fixture", state="all", limit=7, base="nightly/run-1")
+
+    assert result[0].base_branch == "nightly/run-1"
+    assert calls == [
+        (
+            "/repos/owner/fixture/pulls",
+            {
+                "state": "all",
+                "per_page": 7,
+                "sort": "updated",
+                "direction": "desc",
+                "base": "nightly/run-1",
+            },
+        )
+    ]
+
+
+def _pr_cleanup_client(payloads: list[dict]):
+    prs = PRCommands(token=None)
+    queue = list(payloads)
+    calls = []
+
+    def fake_get(endpoint, params=None):
+        calls.append(("GET", endpoint, params))
+        return queue.pop(0)
+
+    def fake_request(method, endpoint, **kwargs):
+        calls.append((method, endpoint, kwargs))
+        return {"state": "closed"}
+
+    prs._api_get = fake_get
+    prs._request_json = fake_request
+    return prs, calls
+
+
+_PR_GUARDS = {
+    "expected_head_sha": "a" * 40,
+    "expected_head_branch": "collegue/issue-42",
+    "expected_base_branch": "nightly/run-1",
+    "body_marker": "<!-- nightly-run:1 -->",
+}
+
+
+def test_close_pr_validates_then_confirms_remote_close():
+    prs, calls = _pr_cleanup_client([_pr_payload(), _pr_payload(state="closed")])
+
+    closed = prs.close_pr("owner", "fixture", 17, **_PR_GUARDS)
+
+    assert closed.state == "closed" and closed.merged is False
+    assert [call[0] for call in calls] == ["GET", "PATCH", "GET"]
+    assert calls[1][2] == {"json_data": {"state": "closed"}}
+
+
+def test_close_pr_is_idempotent_when_already_closed_and_matching():
+    prs, calls = _pr_cleanup_client([_pr_payload(state="closed")])
+
+    assert prs.close_pr("owner", "fixture", 17, **_PR_GUARDS).state == "closed"
+    assert [call[0] for call in calls] == ["GET"]
+
+
+@pytest.mark.parametrize(
+    ("guard", "value"),
+    [
+        ("expected_head_sha", "f" * 40),
+        ("expected_head_branch", "collegue/issue-999"),
+        ("expected_base_branch", "main"),
+        ("body_marker", "<!-- another-run -->"),
+    ],
+)
+def test_close_pr_refuses_identity_mismatch_before_patch(guard, value):
+    prs, calls = _pr_cleanup_client([_pr_payload()])
+    guards = {**_PR_GUARDS, guard: value}
+
+    with pytest.raises(ToolExecutionError):
+        prs.close_pr("owner", "fixture", 17, **guards)
+
+    assert [call[0] for call in calls] == ["GET"]
+
+
+def test_close_pr_refuses_merged_pr_even_when_other_guards_match():
+    prs, calls = _pr_cleanup_client([_pr_payload(state="closed", merged=True)])
+
+    with pytest.raises(ToolExecutionError, match="mergée"):
+        prs.close_pr("owner", "fixture", 17, **_PR_GUARDS)
+
+    assert [call[0] for call in calls] == ["GET"]
+
+
+def test_close_pr_fails_closed_when_confirmation_stays_open():
+    prs, calls = _pr_cleanup_client([_pr_payload(), _pr_payload()])
+
+    with pytest.raises(ToolExecutionError, match="non confirmée"):
+        prs.close_pr("owner", "fixture", 17, **_PR_GUARDS)
+
+    assert [call[0] for call in calls] == ["GET", "PATCH", "GET"]
+
+
+def test_list_issues_passes_labels_filter_and_excludes_pull_requests():
+    issues = IssueCommands(token=None)
+    calls = []
+
+    def fake_get(endpoint, params=None):
+        calls.append((endpoint, params))
+        return [_issue_payload(), _issue_payload(pull_request=True)]
+
+    issues._api_get = fake_get
+    result = issues.list_issues("owner", "fixture", state="all", limit=9, labels="run-1,collegue-nightly")
+
+    assert [issue.number for issue in result] == [42]
+    assert calls[0][1]["labels"] == "run-1,collegue-nightly"
+
+
+def test_create_issue_with_metadata_is_one_atomic_post():
+    issues = IssueCommands(token=None)
+    calls = []
+
+    def fake_post(endpoint, data):
+        calls.append((endpoint, data))
+        return _issue_payload()
+
+    issues._api_post = fake_post
+    created = issues.create_issue_with_metadata(
+        "owner",
+        "fixture",
+        "Nightly task",
+        body="critère\n<!-- nightly-run:1 -->",
+        labels=["collegue-nightly", "run-1"],
+        milestone_number=7,
+    )
+
+    assert created.number == 42
+    assert calls == [
+        (
+            "/repos/owner/fixture/issues",
+            {
+                "title": "Nightly task",
+                "body": "critère\n<!-- nightly-run:1 -->",
+                "labels": ["collegue-nightly", "run-1"],
+                "milestone": 7,
+            },
+        )
+    ]
+
+
+def _issue_cleanup_client(payloads: list[dict]):
+    issues = IssueCommands(token=None)
+    queue = list(payloads)
+    calls = []
+
+    def fake_get(endpoint, params=None):
+        calls.append(("GET", endpoint, params))
+        return queue.pop(0)
+
+    def fake_request(method, endpoint, **kwargs):
+        calls.append((method, endpoint, kwargs))
+        return {"state": "closed"}
+
+    issues._api_get = fake_get
+    issues._request_json = fake_request
+    return issues, calls
+
+
+_ISSUE_GUARDS = {
+    "expected_labels": ["COLLEGUE-NIGHTLY", "run-1"],
+    "body_marker": "<!-- nightly-run:1 -->",
+}
+
+
+def test_close_issue_validates_then_confirms_remote_close():
+    issues, calls = _issue_cleanup_client([_issue_payload(), _issue_payload(state="closed")])
+
+    closed = issues.close_issue("owner", "fixture", 42, **_ISSUE_GUARDS)
+
+    assert closed.state == "closed"
+    assert [call[0] for call in calls] == ["GET", "PATCH", "GET"]
+    assert calls[1][2] == {"json_data": {"state": "closed"}}
+
+
+def test_close_issue_is_idempotent_when_already_closed_and_matching():
+    issues, calls = _issue_cleanup_client([_issue_payload(state="closed")])
+
+    assert issues.close_issue("owner", "fixture", 42, **_ISSUE_GUARDS).state == "closed"
+    assert [call[0] for call in calls] == ["GET"]
+
+
+def test_close_issue_refuses_pull_request_before_patch():
+    issues, calls = _issue_cleanup_client([_issue_payload(pull_request=True)])
+
+    with pytest.raises(ToolExecutionError, match="pull request"):
+        issues.close_issue("owner", "fixture", 42, **_ISSUE_GUARDS)
+
+    assert [call[0] for call in calls] == ["GET"]
+
+
+@pytest.mark.parametrize(
+    "guards",
+    [
+        {"expected_labels": ["missing"], "body_marker": "<!-- nightly-run:1 -->"},
+        {"expected_labels": ["run-1"], "body_marker": "<!-- another-run -->"},
+    ],
+)
+def test_close_issue_refuses_identity_mismatch_before_patch(guards):
+    issues, calls = _issue_cleanup_client([_issue_payload()])
+
+    with pytest.raises(ToolExecutionError):
+        issues.close_issue("owner", "fixture", 42, **guards)
+
+    assert [call[0] for call in calls] == ["GET"]
+
+
+def test_close_issue_fails_closed_when_confirmation_stays_open():
+    issues, calls = _issue_cleanup_client([_issue_payload(), _issue_payload()])
+
+    with pytest.raises(ToolExecutionError, match="non confirmée"):
+        issues.close_issue("owner", "fixture", 42, **_ISSUE_GUARDS)
+
+    assert [call[0] for call in calls] == ["GET", "PATCH", "GET"]
+
+
+def test_get_issue_preserves_a_marker_after_two_thousand_characters():
+    issues = IssueCommands(token=None)
+    payload = _issue_payload()
+    payload["body"] = "x" * 3000 + "\n<!-- collegue-task:42 -->"
+    issues._api_get = lambda endpoint, params=None: payload
+
+    fetched = issues.get_issue("owner", "fixture", 42)
+
+    assert fetched.body.endswith("<!-- collegue-task:42 -->")
+    assert len(fetched.body) > 3000
+
+
+def test_delete_label_is_exact_idempotent_and_confirmed():
+    labels = LabelCommands(token=None)
+    responses = [
+        [{"name": "collegue-nightly-1", "color": "ededed"}],
+        [],
+        [],
+    ]
+    calls = []
+
+    def fake_get(endpoint, params=None):
+        calls.append(("GET", endpoint))
+        return responses.pop(0)
+
+    def fake_request(method, endpoint, **kwargs):
+        calls.append((method, endpoint))
+        return None
+
+    labels._api_get = fake_get
+    labels._request_json = fake_request
+
+    assert labels.delete_label(
+        "owner",
+        "fixture",
+        "collegue-nightly-1",
+        expected_name="collegue-nightly-1",
+    )
+    assert ("DELETE", "/repos/owner/fixture/labels/collegue-nightly-1") in calls
+    assert labels.delete_label(
+        "owner",
+        "fixture",
+        "collegue-nightly-1",
+        expected_name="collegue-nightly-1",
+    )
+
+
+@pytest.mark.parametrize(
+    ("expected_color", "expected_description", "message"),
+    [("1d76db", "wrong", "description"), ("ffffff", "owner-proof", "couleur")],
+)
+def test_delete_label_refuses_wrong_ownership_metadata(expected_color, expected_description, message):
+    labels = LabelCommands(token=None)
+    labels._api_get = lambda endpoint, params=None: [
+        {
+            "name": "collegue-nightly-1",
+            "color": "1d76db",
+            "description": "owner-proof",
+        }
+    ]
+    labels._request_json = lambda *args, **kwargs: pytest.fail("DELETE ne doit pas partir")
+
+    with pytest.raises(ToolExecutionError, match=message):
+        labels.delete_label(
+            "owner",
+            "fixture",
+            "collegue-nightly-1",
+            expected_name="collegue-nightly-1",
+            expected_color=expected_color,
+            expected_description=expected_description,
+        )

--- a/tests/test_github_commit_branch.py
+++ b/tests/test_github_commit_branch.py
@@ -1,7 +1,8 @@
 """Tests Git Data de ``BranchCommands`` pour la publication du revert distant.
 
 Le client HTTP est integralement simule. Ces tests verrouillent la preuve
-``parent + tree`` utilisee par Phase 5-B, ainsi que l'idempotence sans force-push.
+``parent + tree + message`` utilisee par Phase 5-B, ainsi que l'idempotence sans
+force-push.
 """
 
 from __future__ import annotations
@@ -16,17 +17,19 @@ TREE = "b" * 40
 COMMIT = "c" * 40
 RACED_COMMIT = "d" * 40
 OTHER = "e" * 40
+MESSAGE = "revert exact"
 
 
-def _commit_payload(sha=COMMIT, *, tree=TREE, parents=(PARENT,)):
+def _commit_payload(sha=COMMIT, *, tree=TREE, parents=(PARENT,), message=MESSAGE):
     return {
         "sha": sha,
         "tree": {"sha": tree},
         "parents": [{"sha": parent} for parent in parents],
+        "message": message,
     }
 
 
-def test_get_git_commit_returns_exact_tree_and_parents():
+def test_get_git_commit_returns_exact_tree_parents_and_message():
     commands = BranchCommands(token=None)
     calls = []
 
@@ -37,7 +40,7 @@ def test_get_git_commit_returns_exact_tree_and_parents():
     commands._api_get = fake_get
     result = commands.get_git_commit("owner", "repo", COMMIT)
 
-    assert result == GitCommitInfo(sha=COMMIT, tree_sha=TREE, parents=[PARENT])
+    assert result == GitCommitInfo(sha=COMMIT, tree_sha=TREE, parents=[PARENT], message=MESSAGE)
     assert calls == [(f"/repos/owner/repo/git/commits/{COMMIT}", None)]
 
 
@@ -46,8 +49,10 @@ def test_get_git_commit_returns_exact_tree_and_parents():
     [
         (_commit_payload(sha=OTHER), "commit Git inattendu"),
         (_commit_payload(tree="tree-invalide"), "SHA du tree"),
-        ({"sha": COMMIT, "tree": {"sha": TREE}, "parents": "non-liste"}, "parents"),
+        ({"sha": COMMIT, "tree": {"sha": TREE}, "parents": "non-liste", "message": MESSAGE}, "parents"),
         (_commit_payload(parents=("parent-invalide",)), "SHA parent"),
+        (_commit_payload(message=None), "message"),
+        (_commit_payload(message="   "), "message"),
     ],
 )
 def test_get_git_commit_rejects_malformed_or_mismatched_payload(payload, expected_fragment):
@@ -93,14 +98,14 @@ def test_ensure_commit_branch_creates_exact_commit_then_ref():
         "collegue/revert-test",
         parent_sha=PARENT,
         tree_sha=TREE,
-        message="revert exact",
+        message=MESSAGE,
     )
 
     assert result.name == "collegue/revert-test" and result.commit_sha == COMMIT
     assert calls == [
         (
             "/repos/owner/repo/git/commits",
-            {"message": "revert exact", "tree": TREE, "parents": [PARENT]},
+            {"message": MESSAGE, "tree": TREE, "parents": [PARENT]},
         ),
         (
             "/repos/owner/repo/git/refs",
@@ -121,10 +126,27 @@ def test_ensure_commit_branch_reuses_exact_existing_branch_without_write():
         "collegue/revert-test",
         parent_sha=PARENT,
         tree_sha=TREE,
-        message="revert exact",
+        message=MESSAGE,
     )
 
     assert result.commit_sha == COMMIT
+
+
+def test_ensure_commit_branch_rejects_existing_branch_with_different_message():
+    commands = BranchCommands(token=None)
+    commands._branch_sha_or_none = lambda *args: COMMIT
+    commands._api_get = lambda endpoint, params=None: _commit_payload(message="autre propriétaire")
+    commands._api_post = lambda *args, **kwargs: pytest.fail("aucune ecriture attendue")
+
+    with pytest.raises(ToolExecutionError, match="parent/tree/message"):
+        commands.ensure_commit_branch(
+            "owner",
+            "repo",
+            "collegue/revert-test",
+            parent_sha=PARENT,
+            tree_sha=TREE,
+            message=MESSAGE,
+        )
 
 
 def test_ensure_commit_branch_rejects_existing_multi_parent_commit():
@@ -140,7 +162,7 @@ def test_ensure_commit_branch_rejects_existing_multi_parent_commit():
             "collegue/revert-test",
             parent_sha=PARENT,
             tree_sha=TREE,
-            message="revert exact",
+            message=MESSAGE,
         )
 
 
@@ -164,8 +186,35 @@ def test_ensure_commit_branch_rejects_divergent_homonymous_branch(payload):
             "collegue/revert-test",
             parent_sha=PARENT,
             tree_sha=TREE,
-            message="revert exact",
+            message=MESSAGE,
         )
+
+
+def test_ensure_commit_branch_rejects_new_commit_with_different_message_before_ref():
+    commands = BranchCommands(token=None)
+    commands._branch_sha_or_none = lambda *args: None
+    posts = []
+    commands._api_get = lambda endpoint, params=None: _commit_payload(message="message modifié")
+
+    def fake_post(endpoint, data):
+        posts.append((endpoint, data))
+        if endpoint.endswith("/git/commits"):
+            return {"sha": COMMIT}
+        pytest.fail("la ref ne doit pas être créée sans preuve exacte du message")
+
+    commands._api_post = fake_post
+
+    with pytest.raises(ToolExecutionError, match="parent/tree/message"):
+        commands.ensure_commit_branch(
+            "owner",
+            "repo",
+            "collegue/revert-test",
+            parent_sha=PARENT,
+            tree_sha=TREE,
+            message=MESSAGE,
+        )
+
+    assert [endpoint for endpoint, _ in posts] == ["/repos/owner/repo/git/commits"]
 
 
 def test_ensure_commit_branch_accepts_equivalent_creation_race():
@@ -196,7 +245,7 @@ def test_ensure_commit_branch_accepts_equivalent_creation_race():
         "collegue/revert-test",
         parent_sha=PARENT,
         tree_sha=TREE,
-        message="revert exact",
+        message=MESSAGE,
     )
 
     assert result.commit_sha == RACED_COMMIT
@@ -206,12 +255,44 @@ def test_ensure_commit_branch_accepts_equivalent_creation_race():
     ]
 
 
+def test_ensure_commit_branch_rejects_creation_race_with_different_message():
+    commands = BranchCommands(token=None)
+    branch_reads = iter((None, RACED_COMMIT))
+    commands._branch_sha_or_none = lambda *args: next(branch_reads)
+
+    def fake_get(endpoint, params=None):
+        sha = endpoint.rsplit("/", 1)[-1]
+        if sha == COMMIT:
+            return _commit_payload(sha=COMMIT)
+        assert sha == RACED_COMMIT
+        return _commit_payload(sha=RACED_COMMIT, message="message concurrent")
+
+    def fake_post(endpoint, data):
+        if endpoint.endswith("/git/commits"):
+            return {"sha": COMMIT}
+        raise ToolExecutionError("Reference already exists")
+
+    commands._api_get = fake_get
+    commands._api_post = fake_post
+
+    with pytest.raises(ToolExecutionError, match="Reference already exists"):
+        commands.ensure_commit_branch(
+            "owner",
+            "repo",
+            "collegue/revert-test",
+            parent_sha=PARENT,
+            tree_sha=TREE,
+            message=MESSAGE,
+        )
+
+
 @pytest.mark.parametrize(
     ("parent_sha", "tree_sha", "message"),
     [
         ("parent-court", TREE, "revert"),
         (PARENT, "tree-court", "revert"),
         (PARENT, TREE, "   "),
+        (PARENT, TREE, None),
     ],
 )
 def test_ensure_commit_branch_rejects_malformed_sha_tree_or_message_before_write(parent_sha, tree_sha, message):
@@ -242,5 +323,5 @@ def test_ensure_commit_branch_rejects_malformed_created_commit_sha():
             "collegue/revert-test",
             parent_sha=PARENT,
             tree_sha=TREE,
-            message="revert exact",
+            message=MESSAGE,
         )

--- a/tests/test_github_merge_delete.py
+++ b/tests/test_github_merge_delete.py
@@ -343,7 +343,10 @@ def _branches(sha_seq, *, default_branch="main", repo_get_error=False):
     seq = list(sha_seq)
 
     def fake_sha(owner, repo, branch):
-        return seq.pop(0) if seq else None
+        value = seq.pop(0) if seq else None
+        if isinstance(value, BaseException):
+            raise value
+        return value
 
     def fake_get(endpoint, params=None):
         rec.calls.append(("GET", endpoint))
@@ -367,10 +370,116 @@ def test_delete_branch_deletes_existing():
     assert any(c[0] == "DELETE" for c in rec.calls)
 
 
+@pytest.mark.parametrize("status_code", [0, 401, 403, 500])
+def test_branch_absence_probe_propagates_every_non_404_error(status_code):
+    br = BranchCommands(token=None)
+    error = ToolExecutionError("lecture de ref indisponible", status_code=status_code)
+    br._api_get = lambda *args, **kwargs: (_ for _ in ()).throw(error)
+
+    with pytest.raises(ToolExecutionError) as caught:
+        br._branch_sha_or_none("o", "r", "feat/x")
+
+    assert caught.value is error
+
+
+def test_branch_absence_probe_only_converts_http_404_to_none():
+    br = BranchCommands(token=None)
+    br._api_get = lambda *args, **kwargs: (_ for _ in ()).throw(ToolExecutionError("ref absente", status_code=404))
+
+    assert br._branch_sha_or_none("o", "r", "feat/x") is None
+
+
+def test_get_branch_sha_preserves_http_404_status():
+    br = BranchCommands(token=None)
+    br._api_get = lambda *args, **kwargs: (_ for _ in ()).throw(ToolExecutionError("ref absente", status_code=404))
+
+    with pytest.raises(ToolExecutionError, match="not found") as caught:
+        br.get_branch_sha("o", "r", "feat/x")
+
+    assert caught.value.status_code == 404
+
+
 def test_delete_branch_idempotent_when_absent():
     br, rec = _branches([None])
     assert br.delete_branch("o", "r", "feat/x") is True
     assert not any(c[0] == "DELETE" for c in rec.calls)  # rien à supprimer
+
+
+def test_delete_branch_propagates_transient_initial_ref_read():
+    error = ToolExecutionError("rate limit", status_code=403)
+    br, rec = _branches([error])
+
+    with pytest.raises(ToolExecutionError) as caught:
+        br.delete_branch("o", "r", "feat/x")
+
+    assert caught.value is error
+    assert not any(c[0] == "DELETE" for c in rec.calls)
+
+
+def test_delete_branch_confirms_absence_after_successful_delete():
+    br, rec = _branches(["before", None])
+
+    assert br.delete_branch("o", "r", "feat/x") is True
+    assert any(c[0] == "DELETE" for c in rec.calls)
+
+
+def test_delete_branch_refuses_unconfirmed_successful_delete():
+    br, rec = _branches(["before", "still-present"])
+
+    with pytest.raises(ToolExecutionError, match="non confirmée"):
+        br.delete_branch("o", "r", "feat/x")
+
+    assert any(c[0] == "DELETE" for c in rec.calls)
+
+
+def test_delete_branch_propagates_transient_confirmation_read():
+    error = ToolExecutionError("GitHub indisponible", status_code=500)
+    br, rec = _branches(["before", error])
+
+    with pytest.raises(ToolExecutionError) as caught:
+        br.delete_branch("o", "r", "feat/x")
+
+    assert caught.value is error
+    assert any(c[0] == "DELETE" for c in rec.calls)
+
+
+def test_delete_branch_propagates_delete_error_when_ref_still_exists():
+    error = ToolExecutionError("suppression refusée", status_code=403)
+    br, _ = _branches(["before", "before"])
+    br._request_json = lambda *args, **kwargs: (_ for _ in ()).throw(error)
+
+    with pytest.raises(ToolExecutionError) as caught:
+        br.delete_branch("o", "r", "feat/x")
+
+    assert caught.value is error
+
+
+def test_delete_branch_accepts_delete_error_only_after_confirmed_absence():
+    br, _ = _branches(["before", None])
+    br._request_json = lambda *args, **kwargs: (_ for _ in ()).throw(
+        ToolExecutionError("réponse DELETE perdue", status_code=500)
+    )
+
+    assert br.delete_branch("o", "r", "feat/x") is True
+
+
+def test_delete_branch_expected_sha_allows_exact_head():
+    br, rec = _branches(["expected"])
+    assert br.delete_branch("o", "r", "feat/x", expected_sha="expected") is True
+    assert any(c[0] == "DELETE" for c in rec.calls)
+
+
+def test_delete_branch_expected_sha_refuses_moved_head_before_delete():
+    br, rec = _branches(["moved"])
+    with pytest.raises(ToolExecutionError, match="SHA attendu"):
+        br.delete_branch("o", "r", "feat/x", expected_sha="expected")
+    assert not any(c[0] == "DELETE" for c in rec.calls)
+
+
+def test_delete_branch_expected_sha_remains_idempotent_when_absent():
+    br, rec = _branches([None])
+    assert br.delete_branch("o", "r", "feat/x", expected_sha="expected") is True
+    assert not any(c[0] == "DELETE" for c in rec.calls)
 
 
 def test_delete_branch_refuses_protected():

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -168,6 +168,8 @@ def test_real_sync_creates_linked_issues(manager):
     b_body = clients.issues.created[1]["body"]
     assert f"#{a_number}" in b_body
     assert "## Critère d'acceptation" in b_body
+    assert f";project:{pid};task:" in b_body
+    assert "<!-- collegue-plan:" in b_body
     # labels appliqués à chaque issue
     assert len(clients.labels.added) == 2
     # milestone assigné, ajout au board
@@ -176,6 +178,48 @@ def test_real_sync_creates_linked_issues(manager):
     assert result.milestone == "Phase 1" and result.board == "Board"
     # issue_number persisté sur les tâches (mapping task↔issue)
     assert all(t.issue_number for t in manager.get_tasks(pid))
+
+
+def test_product_client_creates_issue_labels_and_milestone_atomically(manager):
+    class _AtomicIssues(_FakeIssues):
+        def __init__(self):
+            super().__init__()
+            self.atomic = []
+
+        def create_issue_with_metadata(
+            self,
+            owner,
+            repo,
+            title,
+            *,
+            body=None,
+            labels=(),
+            milestone_number=None,
+        ):
+            issue = super().create_issue(owner, repo, title, body)
+            self.atomic.append((issue.number, list(labels), milestone_number))
+            return issue
+
+    pid = _planned(manager, approve=True)
+    issues = _AtomicIssues()
+    labels = _FakeLabels()
+    milestones = _FakeMilestones()
+    clients = SyncClients(issues, labels, milestones, _FakeProjects())
+
+    sync_plan(
+        manager,
+        pid,
+        "o",
+        "r",
+        dry_run=False,
+        labels=["nightly-run"],
+        milestone_title="Nightly",
+        clients=clients,
+    )
+
+    assert issues.atomic == [(101, ["nightly-run"], 7), (102, ["nightly-run"], 7)]
+    assert labels.added == []
+    assert milestones.assigned == []
 
 
 def test_real_sync_journals_decision(manager):

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -175,7 +175,7 @@ async def test_persisted_acceptance_reaches_enabled_gate(repo, manager):
 
         async def check(self, workspace, diff, issue, ctx, *, sandbox):
             self.called_with = issue.acceptance_criteria
-            return AcceptanceOutcome(passed=True)
+            return AcceptanceOutcome(passed=True, oracle_sha256="c" * 64)
 
     pid = manager.create_project(name="acceptance-wiring")
     manager.add_task(pid, title="API", acceptance="retourne HTTP 200")
@@ -189,6 +189,9 @@ async def test_persisted_acceptance_reaches_enabled_gate(repo, manager):
     )
     assert result.stop_reason == "completed"
     assert checker.called_with == ("retourne HTTP 200",)
+    assert result.processed[0].acceptance_passed is True
+    assert result.processed[0].acceptance_error is None
+    assert result.processed[0].acceptance_oracle_sha256 == "c" * 64
 
 
 # --- bout en bout ---------------------------------------------------------------

--- a/tests/test_pilot_driver.py
+++ b/tests/test_pilot_driver.py
@@ -1924,6 +1924,34 @@ async def test_cost_unknown_event_when_tokens_without_price(repo, manager, monke
     assert len([e for e in audit.events if e.kind == "cost_observed"]) == 2
 
 
+async def test_explicitly_free_coder_keeps_zero_authoritative(repo, manager, monkeypatch):
+    """Gemma 4 Free Tier : tokens comptés, coût nul connu, aucun faux signal."""
+    from collegue import config
+    from collegue.pilot.audit import RunAuditLog
+
+    monkeypatch.setattr(config.settings, "LLM_PROVIDER_CODER", "gemini", raising=False)
+    monkeypatch.setattr(config.settings, "LLM_MODEL_CODER", "gemma-4-31b-it", raising=False)
+    monkeypatch.setattr(config.settings, "LLM_PRICE_PROMPT_PER_1M", 0.0, raising=False)
+    monkeypatch.setattr(config.settings, "LLM_PRICE_COMPLETION_PER_1M", 0.0, raising=False)
+    pid = _linear_project(manager, 1)
+    audit = RunAuditLog(pid)
+
+    result = await _run(
+        manager,
+        repo,
+        pid,
+        dry_run=False,
+        agent=_UnmappedModelAgent(),
+        audit=audit,
+        require_cost_pricing=True,
+    )
+
+    assert result.stop_reason == "completed"
+    assert audit.cost.usd == 0.0
+    assert audit.cost.tokens == 1_100_000
+    assert not [e for e in audit.events if e.kind in {"cost_unknown", "cost_pricing_unresolved"}]
+
+
 async def test_no_cost_unknown_when_cost_reported(repo, manager):
     """#441 préservé : un coût déclaré par le runner ne déclenche aucun signal."""
     import dataclasses

--- a/tests/test_pilot_nightly_e2e.py
+++ b/tests/test_pilot_nightly_e2e.py
@@ -85,8 +85,9 @@ def test_config_is_opt_in_bounded_and_does_not_repr_token(tmp_path):
         ({"GATE_SMOKE_PATHS": "/"}, "exactement /nightly"),
         ({"LLM_PROVIDER": "openai"}, "provider global gemini"),
         ({"LLM_PROVIDER_QA": "openai"}, "LLM_PROVIDER_QA"),
-        ({"LLM_MODEL": "openai/gpt-5.4"}, "modèle Gemini non préfixé"),
-        ({"LLM_MODEL_QA": "models/gemini-2.5-flash"}, "modèle Gemini non préfixé"),
+        ({"LLM_MODEL": "openai/gpt-5.4"}, "modèle Gemini API non préfixé"),
+        ({"LLM_MODEL_QA": "models/gemini-2.5-flash"}, "modèle Gemini API non préfixé"),
+        ({"LLM_MODEL_QA": "gemma-4-inconnu"}, "modèle Gemini API non préfixé"),
         ({"LLM_MODEL_REVIEWER": "gemini-inconnu"}, "tarif explicite"),
         ({"LLM_PRICE_PROMPT_PER_1M": "0", "LLM_PRICE_COMPLETION_PER_1M": "0"}, "prix LLM"),
         ({"MAX_COST_USD": "0"}, "doit être fini"),
@@ -101,6 +102,34 @@ def test_config_is_opt_in_bounded_and_does_not_repr_token(tmp_path):
 def test_config_refuses_unsafe_or_unbounded_modes(tmp_path, override, message):
     with pytest.raises(NightlyE2EError, match=message):
         NightlyConfig.from_env(_env(tmp_path, **override))
+
+
+@pytest.mark.parametrize("model", ["gemma-4-31b-it", "gemma-4-26b-a4b-it"])
+def test_config_accepts_explicitly_free_gemma_4_without_fallback_prices(tmp_path, model):
+    config = NightlyConfig.from_env(
+        _env(
+            tmp_path,
+            LLM_MODEL=model,
+            LLM_PRICE_PROMPT_PER_1M="0",
+            LLM_PRICE_COMPLETION_PER_1M="0",
+        )
+    )
+
+    assert config.repository == "fixture/app"
+
+
+def test_config_accepts_free_coder_override_with_paid_other_roles(tmp_path):
+    config = NightlyConfig.from_env(
+        _env(
+            tmp_path,
+            LLM_MODEL="gemini-2.5-flash",
+            LLM_MODEL_CODER="gemma-4-26b-a4b-it",
+            LLM_PRICE_PROMPT_PER_1M="0",
+            LLM_PRICE_COMPLETION_PER_1M="0",
+        )
+    )
+
+    assert config.repository == "fixture/app"
 
 
 def test_cleanup_config_does_not_require_llm_or_run_policy(tmp_path):

--- a/tests/test_pilot_nightly_e2e.py
+++ b/tests/test_pilot_nightly_e2e.py
@@ -1,0 +1,885 @@
+"""Tests hors réseau du driver nightly produit (#404)."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from collegue.pilot.nightly_e2e import (
+    CommandResult,
+    NightlyClients,
+    NightlyConfig,
+    NightlyE2EError,
+    NightlyE2ERunner,
+    NightlyManifest,
+    _write_manifest,
+)
+from collegue.tools.base import ToolExecutionError
+
+SEED = "a" * 40
+BASE_SHA = "b" * 40
+HEAD_SHA = "c" * 40
+BASE_OWNER_SHA = "d" * 40
+ORACLE_SHA = "e" * 64
+ROOT_TREE_SHA = "1" * 40
+
+
+def _env(tmp_path, **overrides):
+    values = {
+        "COLLEGUE_NIGHTLY_E2E": "true",
+        "INTEGRATION_FIXTURE_REPOSITORY": "fixture/app",
+        "INTEGRATION_FIXTURE_REPOSITORY_ID": "4242",
+        "INTEGRATION_FIXTURE_ROOT_BRANCH": "main",
+        "INTEGRATION_FIXTURE_SEED_SHA": SEED,
+        "GITHUB_REPOSITORY": "VynoDePal/Collegue",
+        "GITHUB_RUN_ID": "12345",
+        "GITHUB_RUN_ATTEMPT": "2",
+        "COLLEGUE_NIGHTLY_MANIFEST": str(tmp_path / "manifest.json"),
+        "GATE_ACCEPTANCE_TESTS": "true",
+        "GATE_SMOKE_RUN": "true",
+        "GATE_SMOKE_PATHS": "/nightly",
+        "REQUIRE_COST_PRICING": "true",
+        "BUILD_AUTO_MERGE": "false",
+        "AUTO_MERGE_ENABLED": "false",
+        "BUDGET_EXHAUSTED_ACTION": "pause",
+        "MAX_COST_USD": "2",
+        "MAX_TOKENS_BUDGET": "200000",
+        "LLM_CALL_TIMEOUT": "180",
+        "COLLEGUE_RUN_DEADLINE_SECONDS": "900",
+        "COLLEGUE_NIGHTLY_COMMAND_TIMEOUT_SECONDS": "2700",
+        "SANDBOX_TIMEOUT": "720",
+        "TASK_MAX_ATTEMPTS": "1",
+        "LLM_API_KEY": "secret-llm",
+        "LLM_PROVIDER": "gemini",
+        "LLM_MODEL": "gemini-2.5-flash",
+        "LLM_PRICE_PROMPT_PER_1M": "0.1",
+        "LLM_PRICE_COMPLETION_PER_1M": "0.2",
+        "GITHUB_TOKEN": "secret-github",
+        "COLLEGUE_HOME": str(tmp_path / "home"),
+        "STATE_DATABASE_URL": f"sqlite:///{tmp_path / 'state.db'}",
+        "SANDBOX_IMAGE": "collegue-sandbox-openhands:ci",
+    }
+    values.update(overrides)
+    return values
+
+
+def test_config_is_opt_in_bounded_and_does_not_repr_token(tmp_path):
+    config = NightlyConfig.from_env(_env(tmp_path))
+    assert config.repository == "fixture/app"
+    assert config.base_branch == "collegue-nightly/12345-2"
+    assert config.issue_label == "collegue-nightly-12345-2"
+    assert "secret-github" not in repr(config)
+
+
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"COLLEGUE_NIGHTLY_E2E": "false"}, "opt-in"),
+        ({"INTEGRATION_FIXTURE_REPOSITORY": "VynoDePal/Collegue"}, "distinct"),
+        ({"INTEGRATION_FIXTURE_SEED_SHA": "short"}, "SHA Git complet"),
+        ({"BUILD_AUTO_MERGE": "true"}, "explicitement false"),
+        ({"BUILD_AUTO_MERGE": ""}, "explicitement false"),
+        ({"GATE_ACCEPTANCE_TESTS": "false"}, "GATE_ACCEPTANCE_TESTS"),
+        ({"GATE_SMOKE_PATHS": "/"}, "exactement /nightly"),
+        ({"LLM_PROVIDER": "openai"}, "provider global gemini"),
+        ({"LLM_PROVIDER_QA": "openai"}, "LLM_PROVIDER_QA"),
+        ({"LLM_MODEL": "openai/gpt-5.4"}, "modèle Gemini non préfixé"),
+        ({"LLM_MODEL_QA": "models/gemini-2.5-flash"}, "modèle Gemini non préfixé"),
+        ({"LLM_MODEL_REVIEWER": "gemini-inconnu"}, "tarif explicite"),
+        ({"LLM_PRICE_PROMPT_PER_1M": "0", "LLM_PRICE_COMPLETION_PER_1M": "0"}, "prix LLM"),
+        ({"MAX_COST_USD": "0"}, "doit être fini"),
+        ({"MAX_COST_USD": "inf"}, "doit être fini"),
+        ({"LLM_CALL_TIMEOUT": "inf"}, "doit être fini"),
+        ({"COLLEGUE_RUN_DEADLINE_SECONDS": "inf"}, "doit être fini"),
+        ({"SANDBOX_TIMEOUT": "1801"}, "doit être fini"),
+        ({"TASK_MAX_ATTEMPTS": "3"}, "doit valoir 1"),
+        ({"COLLEGUE_NIGHTLY_MANIFEST": "relative.json"}, "chemin absolu"),
+    ],
+)
+def test_config_refuses_unsafe_or_unbounded_modes(tmp_path, override, message):
+    with pytest.raises(NightlyE2EError, match=message):
+        NightlyConfig.from_env(_env(tmp_path, **override))
+
+
+def test_cleanup_config_does_not_require_llm_or_run_policy(tmp_path):
+    env = _env(
+        tmp_path,
+        LLM_API_KEY="",
+        LLM_PROVIDER="",
+        LLM_MODEL="",
+        GATE_ACCEPTANCE_TESTS="false",
+        BUILD_AUTO_MERGE="true",
+    )
+
+    config = NightlyConfig.from_env(env, action="cleanup")
+
+    assert config.token == "secret-github"
+
+
+class _Repos:
+    def __init__(self, *, repo_id=4242, full_name="fixture/app", private=False):
+        self.repo_id = repo_id
+        self.full_name = full_name
+        self.private = private
+
+    def get_repo(self, owner, repo):
+        return SimpleNamespace(
+            id=self.repo_id,
+            full_name=self.full_name,
+            is_private=self.private,
+            default_branch="main",
+        )
+
+
+class _Files:
+    def __init__(self):
+        self.spec = None
+
+    def get_file_content(self, owner, repo, path, branch=None):
+        if path == ".collegue-nightly-fixture":
+            return {"content": "COLLEGUE_NIGHTLY_FIXTURE_V1\n"}
+        if path == "SPEC.md" and self.spec is not None:
+            return {"content": self.spec}
+        raise ToolExecutionError("fichier absent")
+
+
+class _Branches:
+    def __init__(self):
+        self.refs = {"main": SEED}
+        self.deleted = []
+        self.commits = {
+            SEED: SimpleNamespace(
+                sha=SEED,
+                tree_sha=ROOT_TREE_SHA,
+                parents=[],
+                message="fixture seed",
+            )
+        }
+
+    def get_branch_sha(self, owner, repo, branch):
+        if branch not in self.refs:
+            raise ToolExecutionError("branche absente", status_code=404)
+        return self.refs[branch]
+
+    def create_branch(self, owner, repo, branch, from_branch):
+        if branch in self.refs:
+            raise ToolExecutionError("branche déjà présente")
+        self.refs[branch] = self.refs[from_branch]
+        return SimpleNamespace(name=branch, commit_sha=self.refs[branch])
+
+    def ensure_commit_branch(self, owner, repo, branch, *, parent_sha, tree_sha, message):
+        if branch in self.refs:
+            current = self.refs[branch]
+            commit = self.commits.get(current)
+            if (
+                commit is None
+                or commit.parents != [parent_sha]
+                or commit.tree_sha != tree_sha
+                or commit.message != message
+            ):
+                raise ToolExecutionError("branche propriétaire divergente")
+            return SimpleNamespace(name=branch, commit_sha=current)
+        self.commits[BASE_OWNER_SHA] = SimpleNamespace(
+            sha=BASE_OWNER_SHA,
+            tree_sha=tree_sha,
+            parents=[parent_sha],
+            message=message,
+        )
+        self.refs[branch] = BASE_OWNER_SHA
+        return SimpleNamespace(name=branch, commit_sha=BASE_OWNER_SHA)
+
+    def get_git_commit(self, owner, repo, sha):
+        if sha not in self.commits:
+            raise ToolExecutionError("commit absent")
+        return self.commits[sha]
+
+    def delete_branch(self, owner, repo, branch, *, default_branch, expected_sha):
+        if branch == default_branch:
+            raise AssertionError("suppression de la branche par défaut")
+        if self.refs.get(branch) != expected_sha:
+            raise ToolExecutionError("SHA déplacé")
+        self.refs.pop(branch)
+        self.deleted.append((branch, expected_sha))
+        return True
+
+
+class _PRs:
+    def __init__(self):
+        self.items = {}
+        self.closed = []
+
+    def list_prs(self, owner, repo, state="open", limit=30, *, base=None):
+        return [
+            item for item in self.items.values() if item.state == state and (base is None or item.base_branch == base)
+        ]
+
+    def get_pr(self, owner, repo, number):
+        return self.items[number]
+
+    def close_pr(
+        self,
+        owner,
+        repo,
+        number,
+        *,
+        expected_head_sha,
+        expected_head_branch,
+        expected_base_branch,
+        body_marker,
+    ):
+        item = self.items[number]
+        assert item.head_sha == expected_head_sha
+        assert item.head_branch == expected_head_branch
+        assert item.base_branch == expected_base_branch
+        assert body_marker in item.body
+        item.state = "closed"
+        self.closed.append(number)
+        return item
+
+
+class _Issues:
+    def __init__(self):
+        self.items = {}
+        self.closed = []
+
+    def list_issues(self, owner, repo, state="open", limit=30, *, labels=None):
+        return [
+            item for item in self.items.values() if item.state == state and (labels is None or labels in item.labels)
+        ]
+
+    def get_issue(self, owner, repo, number):
+        return self.items[number]
+
+    def close_issue(self, owner, repo, number, *, expected_labels, body_marker):
+        item = self.items[number]
+        assert set(expected_labels).issubset(item.labels)
+        assert body_marker in item.body
+        item.state = "closed"
+        self.closed.append(number)
+        return item
+
+
+class _Labels:
+    def __init__(self):
+        self.items = {}
+        self.deleted = []
+        self.ensure_calls = []
+        self.fail_after_create = False
+        self.on_ensure = None
+
+    def list_labels(self, owner, repo):
+        return list(self.items.values())
+
+    def ensure_label(self, owner, repo, name, color="ededed", description=None):
+        self.ensure_calls.append(name)
+        if self.on_ensure is not None:
+            self.on_ensure()
+        existing = next(
+            (label for label in self.items.values() if label.name.lower() == name.lower()),
+            None,
+        )
+        if existing is None:
+            existing = SimpleNamespace(name=name, color=color, description=description)
+            self.items[name] = existing
+        if self.fail_after_create:
+            raise ToolExecutionError("réponse ensure_label perdue")
+        return existing
+
+    def delete_label(
+        self,
+        owner,
+        repo,
+        name,
+        *,
+        expected_name,
+        expected_color=None,
+        expected_description=None,
+    ):
+        assert name == expected_name
+        existing = self.items.get(name)
+        if existing is not None:
+            assert expected_color is None or existing.color.lower() == expected_color.lower()
+            assert expected_description is None or existing.description == expected_description
+        self.deleted.append(name)
+        self.items.pop(name, None)
+        return True
+
+
+def _pr(config, number=88, issue_number=77):
+    return SimpleNamespace(
+        number=number,
+        state="open",
+        merged=False,
+        base_branch=config.base_branch,
+        head_branch=f"collegue/issue-{issue_number}",
+        head_sha=HEAD_SHA,
+        base_sha=BASE_SHA,
+        body=(
+            f"<!-- collegue-exec:{issue_number} -->\n"
+            f"<!-- collegue-diff-sha256:{'d' * 64} -->\n"
+            f"**Tests d'acceptation (§4.7)** : ✅ réussis — oracle `sha256:{ORACLE_SHA}`"
+        ),
+        changed_files=2,
+    )
+
+
+def _issue(config, number=77, task_id=None, *, project_id=None, plan_hash=None):
+    task_id = number if task_id is None else task_id
+    body = f"critère\n\n<!-- collegue-task:{task_id} -->"
+    if project_id is not None and plan_hash is not None:
+        body += f"\n\n<!-- collegue-plan:{plan_hash};project:{project_id};task:{task_id} -->"
+    return SimpleNamespace(
+        number=number,
+        state="open",
+        labels=[config.issue_label],
+        body=body,
+    )
+
+
+def _runner(tmp_path, *, repos=None):
+    config = NightlyConfig.from_env(_env(tmp_path))
+    branches = _Branches()
+    prs = _PRs()
+    issues = _Issues()
+    labels = _Labels()
+    files = _Files()
+    clients = NightlyClients(
+        repos=repos or _Repos(),
+        files=files,
+        branches=branches,
+        prs=prs,
+        issues=issues,
+        labels=labels,
+    )
+    return NightlyE2ERunner(config, clients=clients), branches, prs, issues, files
+
+
+def _own_run_label(runner, manifest):
+    runner._create_owned_label(manifest)
+    assert manifest.label_creation_started is True
+    assert manifest.label_created is True
+
+
+def test_preexisting_run_label_is_never_adopted_or_deleted(tmp_path):
+    runner, _branches, _prs, _issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    labels = runner.clients.labels
+    labels.items[cfg.issue_label] = SimpleNamespace(
+        name=cfg.issue_label,
+        color="abcdef",
+        description="créé avant le run",
+    )
+    manifest = NightlyManifest.for_config(cfg)
+    _write_manifest(cfg.manifest_path, manifest)
+
+    with pytest.raises(NightlyE2EError, match="refus de l'adopter"):
+        runner._create_owned_label(manifest)
+
+    assert manifest.label_creation_started is False
+    assert labels.ensure_calls == []
+    assert runner.cleanup() == {"status": "clean", "closed_prs": [], "closed_issues": []}
+    assert cfg.issue_label in labels.items
+    assert labels.deleted == []
+
+
+def test_lost_ensure_label_response_is_recovered_from_exact_owned_name(tmp_path):
+    runner, _branches, _prs, _issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    labels = runner.clients.labels
+    checkpoints = []
+    labels.fail_after_create = True
+    labels.on_ensure = lambda: checkpoints.append(json.loads((tmp_path / "manifest.json").read_text(encoding="utf-8")))
+    manifest = NightlyManifest.for_config(cfg)
+    _write_manifest(cfg.manifest_path, manifest)
+
+    runner._create_owned_label(manifest)
+
+    assert checkpoints[0]["label_creation_started"] is True
+    assert checkpoints[0]["label_created"] is False
+    assert manifest.label_created is True
+    assert labels.items[cfg.issue_label].description == runner._label_owner_description()
+    assert runner.cleanup()["status"] == "clean"
+    assert labels.deleted == [cfg.issue_label]
+
+
+def test_cleanup_recovers_owned_label_created_before_checkpoint(tmp_path):
+    runner, _branches, _prs, _issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    labels = runner.clients.labels
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.label_creation_started = True
+    _write_manifest(cfg.manifest_path, manifest)
+    labels.items[cfg.issue_label] = SimpleNamespace(
+        name=cfg.issue_label,
+        color="1d76db",
+        description=runner._label_owner_description(),
+    )
+
+    assert runner.cleanup()["status"] == "clean"
+    assert labels.deleted == [cfg.issue_label]
+
+
+def test_fixture_identity_guard_fails_before_any_mutation(tmp_path):
+    runner, branches, prs, issues, _files = _runner(tmp_path, repos=_Repos(repo_id=999))
+    with pytest.raises(NightlyE2EError, match="identité immuable"):
+        runner.cleanup()
+    assert branches.deleted == [] and prs.closed == [] and issues.closed == []
+
+
+def test_cleanup_is_exact_verified_and_idempotent(tmp_path):
+    runner, branches, prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    branches.refs[cfg.base_branch] = BASE_SHA
+    branches.refs["collegue/issue-77"] = HEAD_SHA
+    prs.items[88] = _pr(cfg)
+    issues.items[77] = _issue(cfg)
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.base_created = True
+    manifest.base_sha = BASE_SHA
+    manifest.issue_numbers = [77]
+    manifest.pr_numbers = [88]
+    manifest.head_shas = {"collegue/issue-77": HEAD_SHA}
+    _own_run_label(runner, manifest)
+    runner._task_correlations = lambda _manifest: {77: 77}
+
+    result = runner.cleanup()
+    assert result == {"status": "clean", "closed_prs": [88], "closed_issues": [77]}
+    assert prs.closed == [88] and issues.closed == [77]
+    assert ("collegue/issue-77", HEAD_SHA) in branches.deleted
+    assert (cfg.base_branch, BASE_SHA) in branches.deleted
+    assert branches.refs == {"main": SEED}
+
+    # Relance indépendante du finalizer : aucune ressource, toujours un succès.
+    assert runner.cleanup() == {"status": "clean", "closed_prs": [], "closed_issues": []}
+
+
+def test_cleanup_refuses_a_moved_base_instead_of_deleting_it(tmp_path):
+    runner, branches, _prs, _issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    branches.refs[cfg.base_branch] = "e" * 40
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.base_created = True
+    manifest.base_sha = BASE_SHA
+    _write_manifest(cfg.manifest_path, manifest)
+
+    with pytest.raises(NightlyE2EError, match="base nightly déplacée"):
+        runner.cleanup()
+    assert branches.refs[cfg.base_branch] == "e" * 40
+
+
+def test_cleanup_propagates_non_404_base_read_failure(tmp_path):
+    runner, branches, _prs, _issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    branches.refs[cfg.base_branch] = BASE_SHA
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.base_created = True
+    manifest.base_sha = BASE_SHA
+    _write_manifest(cfg.manifest_path, manifest)
+    original = branches.get_branch_sha
+
+    def fail_base(owner, repo, branch):
+        if branch == cfg.base_branch:
+            raise ToolExecutionError("GitHub indisponible", status_code=500)
+        return original(owner, repo, branch)
+
+    branches.get_branch_sha = fail_base
+
+    with pytest.raises(ToolExecutionError, match="indisponible"):
+        runner.cleanup()
+
+    assert branches.refs[cfg.base_branch] == BASE_SHA
+    assert branches.deleted == []
+
+
+def test_create_branch_collision_never_deletes_the_preexisting_branch(tmp_path):
+    runner, branches, _prs, _issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    branches.refs[cfg.base_branch] = SEED
+    runner._manager = lambda: SimpleNamespace(list_projects=lambda: [])
+
+    with pytest.raises(NightlyE2EError, match="existe avant"):
+        runner.run()
+
+    assert branches.refs[cfg.base_branch] == SEED
+    assert branches.deleted == []
+
+
+def test_base_creation_recovers_a_lost_ref_response(tmp_path):
+    runner, branches, _prs, _issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    manifest = NightlyManifest.for_config(cfg)
+    _write_manifest(cfg.manifest_path, manifest)
+    original = branches.ensure_commit_branch
+
+    def lose_response(*args, **kwargs):
+        original(*args, **kwargs)
+        raise ToolExecutionError("réponse create ref perdue", status_code=500)
+
+    branches.ensure_commit_branch = lose_response
+
+    recovered_sha = runner._create_owned_base(manifest)
+
+    assert recovered_sha == BASE_OWNER_SHA
+    assert manifest.base_creation_started is True
+    assert manifest.base_created is True
+    assert manifest.base_sha == BASE_OWNER_SHA
+    assert branches.refs[cfg.base_branch] == BASE_OWNER_SHA
+    assert runner.cleanup()["status"] == "clean"
+    assert cfg.base_branch not in branches.refs
+
+
+def test_inventory_failure_keeps_every_remote_anchor(tmp_path):
+    runner, branches, prs, _issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    branches.refs[cfg.base_branch] = BASE_SHA
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.base_created = True
+    manifest.base_sha = BASE_SHA
+    _write_manifest(cfg.manifest_path, manifest)
+    prs.list_prs = lambda *args, **kwargs: (_ for _ in ()).throw(ToolExecutionError("API down"))
+
+    with pytest.raises(NightlyE2EError, match="inventaire GitHub incomplet"):
+        runner.cleanup()
+
+    assert branches.refs[cfg.base_branch] == BASE_SHA
+    assert branches.deleted == []
+
+
+def test_close_failure_keeps_head_and_base_refs(tmp_path):
+    runner, branches, prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    branches.refs[cfg.base_branch] = BASE_SHA
+    branches.refs["collegue/issue-77"] = HEAD_SHA
+    prs.items[88] = _pr(cfg)
+    issues.items[77] = _issue(cfg)
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.base_created = True
+    manifest.base_sha = BASE_SHA
+    manifest.issue_numbers = [77]
+    manifest.pr_numbers = [88]
+    manifest.head_shas = {"collegue/issue-77": HEAD_SHA}
+    _own_run_label(runner, manifest)
+    runner._task_correlations = lambda _manifest: {77: 77}
+    prs.close_pr = lambda *args, **kwargs: (_ for _ in ()).throw(ToolExecutionError("close down"))
+
+    with pytest.raises(NightlyE2EError, match="refs conservées"):
+        runner.cleanup()
+
+    assert branches.refs[cfg.base_branch] == BASE_SHA
+    assert branches.refs["collegue/issue-77"] == HEAD_SHA
+    assert branches.deleted == []
+
+
+def test_issue_alone_never_authorizes_deleting_an_unproved_head(tmp_path):
+    runner, branches, _prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    branches.refs[cfg.base_branch] = BASE_SHA
+    branches.refs["collegue/issue-77"] = HEAD_SHA
+    issues.items[77] = _issue(cfg)
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.base_created = True
+    manifest.base_sha = BASE_SHA
+    manifest.issue_numbers = [77]
+    _own_run_label(runner, manifest)
+    runner._task_correlations = lambda _manifest: {77: 77}
+
+    with pytest.raises(NightlyE2EError, match="SHA non prouvé"):
+        runner.cleanup()
+
+    assert branches.refs["collegue/issue-77"] == HEAD_SHA
+    assert branches.refs[cfg.base_branch] == BASE_SHA
+    assert branches.deleted == []
+
+
+def test_cleanup_recovers_head_pushed_before_pr_creation(tmp_path):
+    runner, branches, _prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    branches.refs[cfg.base_branch] = BASE_SHA
+    branches.refs["collegue/issue-77"] = HEAD_SHA
+    branches.commits[HEAD_SHA] = SimpleNamespace(
+        sha=HEAD_SHA,
+        tree_sha="2" * 40,
+        parents=[BASE_SHA],
+        message="collegue: issue #77 — app/main.py",
+    )
+    issues.items[77] = _issue(cfg, task_id=3, project_id=9, plan_hash="f" * 64)
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.base_created = True
+    manifest.base_sha = BASE_SHA
+    manifest.project_id = 9
+    manifest.plan_hash = "f" * 64
+    manifest.issue_numbers = [77]
+    manifest.head_creation_started = True
+    manifest.expected_head_branch = "collegue/issue-77"
+    _own_run_label(runner, manifest)
+    runner._task_correlations = lambda _manifest: {77: 3}
+    runner._approved_task_ids = lambda _manifest: {3}
+
+    result = runner.cleanup()
+
+    assert result["closed_issues"] == [77]
+    assert ("collegue/issue-77", HEAD_SHA) in branches.deleted
+    assert (cfg.base_branch, BASE_SHA) in branches.deleted
+
+
+def test_cleanup_refuses_unowned_head_before_closing_issue(tmp_path):
+    runner, branches, _prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    branches.refs[cfg.base_branch] = BASE_SHA
+    branches.refs["collegue/issue-77"] = HEAD_SHA
+    branches.commits[HEAD_SHA] = SimpleNamespace(
+        sha=HEAD_SHA,
+        tree_sha="2" * 40,
+        parents=[BASE_SHA],
+        message="commit humain sans marqueur",
+    )
+    issues.items[77] = _issue(cfg, task_id=3, project_id=9, plan_hash="f" * 64)
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.base_created = True
+    manifest.base_sha = BASE_SHA
+    manifest.project_id = 9
+    manifest.plan_hash = "f" * 64
+    manifest.issue_numbers = [77]
+    manifest.head_creation_started = True
+    manifest.expected_head_branch = "collegue/issue-77"
+    _own_run_label(runner, manifest)
+    runner._task_correlations = lambda _manifest: {77: 3}
+    runner._approved_task_ids = lambda _manifest: {3}
+
+    with pytest.raises(NightlyE2EError, match="SHA non prouvé"):
+        runner.cleanup()
+
+    assert issues.items[77].state == "open"
+    assert branches.deleted == []
+
+
+def test_cleanup_recovers_a_lost_spec_commit_checkpoint(tmp_path):
+    runner, branches, _prs, _issues, files = _runner(tmp_path)
+    cfg = runner.config
+    branches.refs[cfg.base_branch] = BASE_SHA
+    branches.commits[BASE_SHA] = SimpleNamespace(parents=[SEED])
+    files.spec = "# SPEC fixture"
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.base_created = True
+    manifest.base_sha = SEED
+    manifest.project_id = 9
+    manifest.plan_hash = "f" * 64
+    _write_manifest(cfg.manifest_path, manifest)
+    project = SimpleNamespace(
+        approved_plan_hash="f" * 64,
+        spec="# SPEC fixture",
+        plan_sync_config={
+            "owner": cfg.owner,
+            "repo": cfg.repo,
+            "base_branch": cfg.base_branch,
+            "spec_filename": "SPEC.md",
+        },
+    )
+    runner._manager = lambda: SimpleNamespace(get_project=lambda project_id: project, get_tasks=lambda project_id: [])
+
+    assert runner.cleanup()["status"] == "clean"
+    assert cfg.base_branch not in branches.refs
+
+
+def test_cleanup_recovers_issue_created_before_db_persistence(tmp_path):
+    runner, branches, _prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    branches.refs[cfg.base_branch] = BASE_SHA
+    issues.items[77] = _issue(cfg, task_id=3, project_id=9, plan_hash="f" * 64)
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.base_created = True
+    manifest.base_sha = BASE_SHA
+    manifest.project_id = 9
+    manifest.plan_hash = "f" * 64
+    _own_run_label(runner, manifest)
+    updates = []
+    project = SimpleNamespace(approved_plan_hash="f" * 64)
+    task = SimpleNamespace(id=3, issue_number=None)
+    manager = SimpleNamespace(
+        get_project=lambda project_id: project,
+        get_tasks=lambda project_id: [task],
+        update_task=lambda task_id, **fields: updates.append((task_id, fields)) or True,
+    )
+    runner._manager = lambda: manager
+
+    result = runner.cleanup()
+
+    assert result["closed_issues"] == [77]
+    assert updates == [(3, {"issue_number": 77})]
+    assert cfg.base_branch not in branches.refs
+
+
+def test_cleanup_retries_after_label_deleted_before_manifest_checkpoint(tmp_path):
+    runner, _branches, _prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.project_id = 9
+    manifest.plan_hash = "f" * 64
+    manifest.issue_numbers = [77]
+    _own_run_label(runner, manifest)
+
+    # Simule le crash juste après DELETE label : GitHub retire aussi le label
+    # des issues, tandis que le manifeste garde label_deleted=false.
+    runner.clients.labels.items.clear()
+    issues.items[77] = _issue(cfg, task_id=3, project_id=9, plan_hash="f" * 64)
+    issues.items[77].state = "closed"
+    issues.items[77].labels = []
+    runner._task_correlations = lambda _manifest: {77: 3}
+    runner._approved_task_ids = lambda _manifest: {3}
+
+    assert runner.cleanup() == {"status": "clean", "closed_prs": [], "closed_issues": []}
+    assert runner.clients.labels.deleted == []
+
+
+def test_cleanup_never_accepts_an_open_issue_after_owned_label_disappears(tmp_path):
+    runner, branches, _prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    branches.refs[cfg.base_branch] = BASE_SHA
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.base_created = True
+    manifest.base_sha = BASE_SHA
+    manifest.project_id = 9
+    manifest.plan_hash = "f" * 64
+    manifest.issue_numbers = [77]
+    _own_run_label(runner, manifest)
+    runner.clients.labels.items.clear()
+    issues.items[77] = _issue(cfg, task_id=3, project_id=9, plan_hash="f" * 64)
+    issues.items[77].labels = []
+    runner._task_correlations = lambda _manifest: {77: 3}
+    runner._approved_task_ids = lambda _manifest: {3}
+
+    with pytest.raises(NightlyE2EError, match="non corrélée exactement"):
+        runner.cleanup()
+
+    assert issues.items[77].state == "open"
+    assert cfg.base_branch in branches.refs
+    assert branches.deleted == []
+
+
+def test_corrupt_manifest_is_rejected_before_remote_mutation(tmp_path):
+    runner, branches, _prs, _issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.root_sha = "0" * 40
+    _write_manifest(cfg.manifest_path, manifest)
+
+    with pytest.raises(NightlyE2EError, match="manifeste ne correspond"):
+        runner.cleanup()
+    assert branches.deleted == []
+
+
+def test_full_driver_uses_four_product_processes_and_cleans(tmp_path):
+    runner, branches, prs, issues, files = _runner(tmp_path)
+    cfg = runner.config
+    calls = []
+
+    def command(argv, *, cwd=None):
+        calls.append((list(argv), cwd))
+        if argv[:3] == ["git", "clone", "--quiet"]:
+            raise AssertionError("_clone_base est remplacé dans ce test")
+        if "plan" in argv and "draft" in argv:
+            return CommandResult(
+                0,
+                json.dumps(
+                    {
+                        "project_id": 9,
+                        "plan_hash": "f" * 64,
+                        "task_count": 1,
+                        "action": "draft",
+                        "issues": [],
+                    }
+                ),
+            )
+        if "plan" in argv and "approve" in argv:
+            return CommandResult(
+                0,
+                json.dumps(
+                    {
+                        "project_id": 9,
+                        "plan_hash": "f" * 64,
+                        "task_count": 1,
+                        "action": "approve",
+                        "issues": [],
+                    }
+                ),
+            )
+        if "plan" in argv and "sync" in argv:
+            branches.refs[cfg.base_branch] = BASE_SHA
+            files.spec = "# SPEC fixture"
+            issues.items[77] = _issue(cfg, task_id=3, project_id=9, plan_hash="f" * 64)
+            return CommandResult(
+                0,
+                json.dumps(
+                    {
+                        "project_id": 9,
+                        "plan_hash": "f" * 64,
+                        "task_count": 1,
+                        "action": "sync",
+                        "issues": [{"task_id": 3, "issue_number": 77}],
+                    }
+                ),
+            )
+        if "--execute" in argv:
+            branches.refs["collegue/issue-77"] = HEAD_SHA
+            prs.items[88] = _pr(cfg)
+            return CommandResult(
+                1,
+                json.dumps(
+                    {
+                        "project_id": 9,
+                        "stop_reason": "awaiting_merge",
+                        "iterations": 1,
+                        "opened_prs": [88],
+                        "pending_reviews": [3],
+                        "project_status": "active",
+                        "processed": [
+                            {
+                                "task_id": 3,
+                                "title": "route nightly",
+                                "success": True,
+                                "stage": "pr",
+                                "pr_number": 88,
+                                "acceptance_passed": True,
+                                "acceptance_error": None,
+                                "acceptance_oracle_sha256": ORACLE_SHA,
+                            }
+                        ],
+                    }
+                ),
+            )
+        raise AssertionError(f"commande inattendue: {argv}")
+
+    runner.command_runner = command
+    runner._manager = lambda: SimpleNamespace(list_projects=lambda: [])
+    runner._inspect_draft = lambda project_id, plan_hash: (3, "# SPEC fixture", ORACLE_SHA)
+    runner._task_correlations = lambda _manifest: {77: 3}
+    runner._approved_task_ids = lambda _manifest: {3}
+    source = tmp_path / "clone-parent" / "fixture"
+    source.mkdir(parents=True)
+    runner._clone_base = lambda base_sha: str(source)
+
+    result = runner.run()
+    assert result["status"] == "passed"
+    assert result["acceptance_passed"] is True
+    assert result["acceptance_oracle_sha256"] == ORACLE_SHA
+    product_calls = [argv for argv, _ in calls if argv[1:3] == ["-m", "collegue.pilot"]]
+    assert len(product_calls) == 4
+    assert any("draft" in argv for argv in product_calls)
+    assert any("approve" in argv for argv in product_calls)
+    assert any("sync" in argv for argv in product_calls)
+    assert any("--repo-source" in argv for argv in product_calls)
+    assert branches.refs == {"main": SEED}
+    assert prs.items[88].state == "closed" and issues.items[77].state == "closed"
+
+
+def test_run_failure_still_invokes_cleanup(tmp_path):
+    runner, branches, _prs, _issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    runner._manager = lambda: SimpleNamespace(list_projects=lambda: [])
+    runner.command_runner = lambda argv, cwd=None: CommandResult(2, "", "planner cassé")
+    with pytest.raises(NightlyE2EError, match="commande produit échouée"):
+        runner.run()
+    assert cfg.base_branch not in branches.refs
+    assert branches.refs["main"] == SEED

--- a/tests/test_pilot_plan.py
+++ b/tests/test_pilot_plan.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -448,6 +449,7 @@ def test_cli_parses_plan_subcommand():
     assert args.plan_action == "draft"
     assert args.problem == "P" and args.owner == "o" and args.repo == "r"
     assert args.execute is False
+    assert args.format == "text"
 
 
 def test_cli_parses_approve_and_sync_actions():
@@ -455,10 +457,11 @@ def test_cli_parses_approve_and_sync_actions():
 
     parser = build_parser()
     approve = parser.parse_args(["plan", "approve", "--project-id", "7", "--expected-plan-hash", "abc"])
-    sync = parser.parse_args(["plan", "sync", "--project-id", "7", "--execute"])
+    sync = parser.parse_args(["plan", "sync", "--project-id", "7", "--execute", "--format", "json"])
     assert approve.plan_action == "approve" and approve.project_id == 7
     assert approve.expected_plan_hash == "abc"
     assert sync.plan_action == "sync" and sync.execute is True
+    assert sync.format == "json"
 
 
 def test_cli_plan_dispatches_and_parses_args(monkeypatch, capsys):
@@ -515,6 +518,121 @@ def test_cli_approve_and_sync_dispatch_without_async_planner(monkeypatch, capsys
     assert cli.main(["plan", "sync", "--project-id", "7", "--execute"]) == 0
     assert calls == [("approve", 7, "abc"), ("sync", 7, True)]
     assert capsys.readouterr().out.count("REPORT") == 2
+
+
+def test_cli_draft_json_has_stable_machine_contract(monkeypatch, capsys):
+    import collegue.pilot.__main__ as cli
+
+    async def _fake_plan(*args, **kwargs):
+        return PlanResult(
+            project_id=17,
+            spec_title="Fixture",
+            objectives=1,
+            acceptance_criteria=2,
+            task_count=2,
+            preview_markdown="# aperçu non exposé en JSON",
+            dry_run=True,
+            action="draft",
+            plan_hash="a" * 64,
+        )
+
+    monkeypatch.setattr("collegue.pilot.runtime.plan_project_from_settings", _fake_plan)
+
+    assert (
+        cli.main(
+            [
+                "plan",
+                "draft",
+                "--problem",
+                "P",
+                "--owner",
+                "o",
+                "--repo",
+                "r",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    assert json.loads(capsys.readouterr().out) == {
+        "project_id": 17,
+        "plan_hash": "a" * 64,
+        "task_count": 2,
+        "action": "draft",
+        "issues": [],
+    }
+
+
+def test_cli_approve_and_sync_json_share_the_same_schema(monkeypatch, capsys):
+    import collegue.pilot.__main__ as cli
+
+    approved = PlanResult(
+        project_id=7,
+        spec_title="Fixture",
+        objectives=0,
+        acceptance_criteria=0,
+        task_count=1,
+        preview_markdown="",
+        dry_run=True,
+        action="approve",
+        plan_hash="b" * 64,
+    )
+    synced = PlanResult(
+        project_id=7,
+        spec_title="Fixture",
+        objectives=0,
+        acceptance_criteria=0,
+        task_count=1,
+        preview_markdown="",
+        dry_run=False,
+        issues=[{"task_id": 11, "title": "T", "issue_number": 101, "skipped": False}],
+        action="sync",
+        plan_hash="b" * 64,
+    )
+    monkeypatch.setattr(
+        "collegue.pilot.runtime.approve_project_plan_from_settings",
+        lambda project_id, expected_hash: approved,
+    )
+    monkeypatch.setattr(
+        "collegue.pilot.runtime.sync_project_plan_from_settings",
+        lambda project_id, *, execute=False: synced,
+    )
+
+    assert (
+        cli.main(
+            [
+                "plan",
+                "approve",
+                "--project-id",
+                "7",
+                "--expected-plan-hash",
+                "a" * 64,
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    approve_payload = json.loads(capsys.readouterr().out)
+    assert approve_payload == {
+        "project_id": 7,
+        "plan_hash": "b" * 64,
+        "task_count": 1,
+        "action": "approve",
+        "issues": [],
+    }
+
+    assert cli.main(["plan", "sync", "--project-id", "7", "--execute", "--format", "json"]) == 0
+    sync_payload = json.loads(capsys.readouterr().out)
+    assert set(sync_payload) == set(approve_payload)
+    assert sync_payload == {
+        "project_id": 7,
+        "plan_hash": "b" * 64,
+        "task_count": 1,
+        "action": "sync",
+        "issues": [{"task_id": 11, "title": "T", "issue_number": 101, "skipped": False}],
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pilot_runtime.py
+++ b/tests/test_pilot_runtime.py
@@ -1,5 +1,6 @@
 """Tests F4 (#377) : câblage runtime opt-in (entrypoint + assemblage) + reporting."""
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -263,12 +264,16 @@ def test_coder_sandbox_env_subscription_mode():
     import collegue.pilot.runtime as runtime
 
     settings = SimpleNamespace(
-        CODER_SUBSCRIPTION=True, CODER_SUBSCRIPTION_MODEL="gpt-5.5", CODER_SUBSCRIPTION_FALLBACK="gpt-5.4"
+        CODER_SUBSCRIPTION=True,
+        CODER_SUBSCRIPTION_MODEL="gpt-5.5",
+        CODER_SUBSCRIPTION_FALLBACK="gpt-5.4",
+        LLM_CALL_TIMEOUT=180,
     )
     env = runtime._coder_sandbox_env(settings)
     assert env["LLM_MODEL"] == "gpt-5.5"  # modèle d'abonnement NU (pas de préfixe gemini/)
     assert env["LLM_SUBSCRIPTION"] == "1"
     assert env["OH_FALLBACK_MODELS"] == "gpt-5.4"
+    assert env["OH_LLM_TIMEOUT"] == "180"
     assert env["HOME"] == "/home/sandbox"  # hors /tmp (requis par le montage des creds)
 
 
@@ -279,6 +284,17 @@ def test_coder_sandbox_env_api_key_mode():
     env = runtime._coder_sandbox_env(settings)
     assert env["LLM_MODEL"] == "gemini/gemma-x"  # format LiteLLM
     assert "LLM_SUBSCRIPTION" not in env
+    assert "HOME" not in env  # DockerSandbox conserve son HOME=/tmp écrivable
+    assert "OH_LLM_TIMEOUT" not in env  # 0/absent conserve le défaut sûr du runner
+
+
+@pytest.mark.parametrize("value", [None, 0, -1, float("nan"), float("inf"), "invalide"])
+def test_coder_sandbox_env_ignores_invalid_call_timeout(value):
+    import collegue.pilot.runtime as runtime
+
+    settings = SimpleNamespace(LLM_PROVIDER="gemini", LLM_MODEL="gemini-2.5-flash", LLM_CALL_TIMEOUT=value)
+
+    assert "OH_LLM_TIMEOUT" not in runtime._coder_sandbox_env(settings)
 
 
 def test_gate_sandbox_keeps_runtime_resources_without_coder_credentials(tmp_path):
@@ -861,6 +877,7 @@ def test_parser_defaults_dry_run():
     assert ns.base == "main"
     assert ns.execute is False  # dry_run par défaut
     assert ns.max_iterations is None
+    assert ns.format == "text"
 
 
 def test_parser_execute_and_overrides():
@@ -879,11 +896,14 @@ def test_parser_execute_and_overrides():
             "dev",
             "--max-iterations",
             "5",
+            "--format",
+            "json",
         ]
     )
     assert ns.execute is True
     assert ns.base == "dev"
     assert ns.max_iterations == 5
+    assert ns.format == "json"
 
 
 def test_parser_requires_mandatory_args():
@@ -1039,6 +1059,72 @@ def test_main_returns_0_on_completed(monkeypatch, capsys):
 def test_main_returns_1_on_blocked(monkeypatch):
     cli = _patch_run(monkeypatch, ProjectRunResult(stop_reason="blocked", iterations=0, processed=[]))
     assert cli.main(_CLI_ARGS) == 1
+
+
+def test_main_run_json_has_stable_machine_contract(monkeypatch, capsys):
+    result = ProjectRunResult(
+        stop_reason="completed",
+        iterations=2,
+        processed=[
+            TaskOutcome(
+                task_id=5,
+                title="Faire X",
+                success=True,
+                stage="pr",
+                pr_number=42,
+                acceptance_passed=True,
+                acceptance_oracle_sha256="a" * 64,
+            ),
+            TaskOutcome(task_id=6, title="Vérifier Y", success=False, stage="gate", pr_number=None),
+        ],
+        project_status="improving",
+        pending_reviews=[5],
+    )
+    cli = _patch_run(monkeypatch, result)
+
+    assert cli.main([*_CLI_ARGS, "--format", "json"]) == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "project_id": 1,
+        "stop_reason": "completed",
+        "iterations": 2,
+        "opened_prs": [42],
+        "pending_reviews": [5],
+        "project_status": "improving",
+        "processed": [
+            {
+                "task_id": 5,
+                "title": "Faire X",
+                "success": True,
+                "stage": "pr",
+                "pr_number": 42,
+                "acceptance_passed": True,
+                "acceptance_error": None,
+                "acceptance_oracle_sha256": "a" * 64,
+            },
+            {
+                "task_id": 6,
+                "title": "Vérifier Y",
+                "success": False,
+                "stage": "gate",
+                "pr_number": None,
+                "acceptance_passed": None,
+                "acceptance_error": None,
+                "acceptance_oracle_sha256": None,
+            },
+        ],
+    }
+
+
+def test_main_run_json_preserves_nonzero_exit_code(monkeypatch, capsys):
+    cli = _patch_run(
+        monkeypatch,
+        ProjectRunResult(stop_reason="awaiting_merge", iterations=1, processed=[], pending_reviews=[7]),
+    )
+
+    assert cli.main([*_CLI_ARGS, "--format", "json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["stop_reason"] == "awaiting_merge"
+    assert payload["pending_reviews"] == [7]
 
 
 def test_gate_options_built_from_settings():

--- a/tests/test_pricing_capture.py
+++ b/tests/test_pricing_capture.py
@@ -1,6 +1,6 @@
 """Tests C3 (#337) : tarifs multi-provider + capture du modèle utilisé."""
 
-from collegue.monitoring.pricing import cost_per_token, has_explicit_pricing
+from collegue.monitoring.pricing import cost_per_token, has_explicit_pricing, is_explicitly_free
 from collegue.monitoring.sampling_usage import record_usage, take_usage
 
 _PER_1M = 1_000_000.0
@@ -50,6 +50,26 @@ def test_prefix_requires_separator_boundary():
 def test_gemini_still_priced():
     cin, cout = cost_per_token("gemini-3.5-flash")
     assert abs(cin - 1.50 / _PER_1M) < 1e-12
+
+
+def test_gemma_4_gemini_api_models_are_explicitly_free():
+    for model in ("gemma-4-31b-it", "gemma-4-26b-a4b-it"):
+        assert cost_per_token(model, provider="gemini") == (0.0, 0.0)
+        assert has_explicit_pricing(model, provider="gemini") is True
+        assert is_explicitly_free(model, provider="gemini") is True
+
+
+def test_unknown_remote_model_is_never_explicitly_free():
+    for model in ("gemma-4-inconnu", "gemma-4-31b-it-inconnu"):
+        assert has_explicit_pricing(model, provider="gemini") is False
+        assert is_explicitly_free(model, provider="gemini") is False
+        assert cost_per_token(model, provider="gemini") != (0.0, 0.0)
+
+
+def test_gemma_4_free_price_is_scoped_to_gemini_provider():
+    assert has_explicit_pricing("gemma-4-31b-it", provider="openai") is False
+    assert is_explicitly_free("gemma-4-31b-it", provider="openai") is False
+    assert cost_per_token("gemma-4-31b-it", provider="openai") != (0.0, 0.0)
 
 
 def test_local_provider_is_free():


### PR DESCRIPTION
Closes #404.

> Les lots Phase 5-A/B requis (#592/#593) sont désormais fusionnés dans `main`.

## Résumé

Livre la preuve nightly par le produit, sans harnais gitignoré :

- workflow planifié et déclenchable manuellement ;
- préflight fermé des secrets, modèles, budgets, fixture et commandes ;
- cycle `plan draft → approve → sync → run --execute → PR` sur dépôt fixture ;
- vérification des oracles QA plan-time et des sorties d’audit ;
- nettoyage idempotent des PR/branches/issues créés ;
- rapports/artifacts même en cas d’échec.

Le second commit reconnaît aussi les modèles Gemini API gratuits `gemma-4-31b-it` et `gemma-4-26b-a4b-it` à leur coût officiel nul, sans rendre gratuits les modèles inconnus ou les mauvais providers.

## Sûreté

- nightly produit explicitement opt-in ;
- coût, tokens, deadline et tentatives bornés ;
- aucune clé dans le dépôt ou les logs ;
- dry-run et autonomie restent OFF par défaut.

## Validation

- suite complète avant rattachement : 2 276 tests réussis, 41 skips attendus, 9 désélectionnés ;
- prise en charge Gemma : 193 tests ciblés réussis ;
- après rattachement au nouveau `main` : patch-ids inchangés, Ruff/compilation/diff-check verts et 618 tests ciblés réussis.