### PR TITLE
fix(ci): initialiser le nightly après allocation du runner

### DIFF
--- a/.github/workflows/integration-nightly.yml
+++ b/.github/workflows/integration-nightly.yml
@@ -157,7 +157,6 @@ jobs:
       INTEGRATION_FIXTURE_REPOSITORY_ID: ${{ vars.INTEGRATION_FIXTURE_REPOSITORY_ID }}
       INTEGRATION_FIXTURE_ROOT_BRANCH: ${{ vars.INTEGRATION_FIXTURE_ROOT_BRANCH }}
       INTEGRATION_FIXTURE_SEED_SHA: ${{ vars.INTEGRATION_FIXTURE_SEED_SHA }}
-      COLLEGUE_NIGHTLY_MANIFEST: ${{ runner.temp }}/collegue-nightly/manifest.json
 
       # Endpoint/modèles configurables sans modifier le workflow. Les overrides
       # vides retombent sur le provider/modèle global dans la résolution par rôle.
@@ -174,10 +173,8 @@ jobs:
       LLM_PRICE_PROMPT_PER_1M: ${{ vars.INTEGRATION_LLM_PRICE_PROMPT_PER_1M }}
       LLM_PRICE_COMPLETION_PER_1M: ${{ vars.INTEGRATION_LLM_PRICE_COMPLETION_PER_1M }}
 
-      # État local éphémère, mais chemins absolus et stables pendant tout le job.
-      STATE_DATABASE_URL: sqlite:///${{ runner.temp }}/collegue-nightly/state.sqlite3
-      COLLEGUE_HOME: ${{ runner.temp }}/collegue-nightly/home
-      SANDBOX_PIP_CACHE_DIR: ${{ runner.temp }}/collegue-nightly/pip-cache
+      # État local éphémère. Les chemins dépendant du runner sont exportés dans
+      # GITHUB_ENV par le premier step, une fois le runner réellement alloué.
       SANDBOX_IMAGE: collegue-sandbox-openhands:ci
       SANDBOX_NETWORK: bridge
       SANDBOX_MEMORY: 6g
@@ -213,6 +210,17 @@ jobs:
       CODER_LLM_RETRY_MAX_WAIT: "30"
 
     steps:
+      - name: Initialiser les chemins éphémères du runner
+        shell: bash
+        run: |
+          root="$RUNNER_TEMP/collegue-nightly"
+          {
+            printf 'COLLEGUE_NIGHTLY_MANIFEST=%s/manifest.json\n' "$root"
+            printf 'STATE_DATABASE_URL=sqlite:///%s/state.sqlite3\n' "$root"
+            printf 'COLLEGUE_HOME=%s/home\n' "$root"
+            printf 'SANDBOX_PIP_CACHE_DIR=%s/pip-cache\n' "$root"
+          } >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v4
         with:
           persist-credentials: false

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -36,15 +36,12 @@ def test_job_env_does_not_use_runner_context(path: Path) -> None:
             continue
         for name, value in env.items():
             assert "${{ runner." not in str(value), (
-                f"{path}: jobs.{job_id}.env.{name} uses the runner context "
-                "before a runner has been allocated"
+                f"{path}: jobs.{job_id}.env.{name} uses the runner context before a runner has been allocated"
             )
 
 
 def test_nightly_paths_are_exported_from_runner_temp_at_runtime() -> None:
-    workflow = (ROOT / ".github" / "workflows" / "integration-nightly.yml").read_text(
-        encoding="utf-8"
-    )
+    workflow = (ROOT / ".github" / "workflows" / "integration-nightly.yml").read_text(encoding="utf-8")
 
     assert 'root="$RUNNER_TEMP/collegue-nightly"' in workflow
     assert '} >> "$GITHUB_ENV"' in workflow

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -1,0 +1,57 @@
+"""Static regression guards for committed GitHub Actions workflows."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = tuple(sorted((ROOT / ".github" / "workflows").glob("*.y*ml")))
+
+
+def _load_workflow(path: Path) -> dict[str, object]:
+    # BaseLoader keeps keys such as ``on`` as strings while still validating the
+    # YAML structure used by GitHub Actions.
+    parsed = yaml.load(path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    assert isinstance(parsed, dict), f"{path} must contain a YAML mapping"
+    return parsed
+
+
+@pytest.mark.parametrize("path", WORKFLOWS, ids=lambda path: path.name)
+def test_workflow_yaml_is_well_formed(path: Path) -> None:
+    _load_workflow(path)
+
+
+@pytest.mark.parametrize("path", WORKFLOWS, ids=lambda path: path.name)
+def test_job_env_does_not_use_runner_context(path: Path) -> None:
+    """The runner context is unavailable while ``jobs.<id>.env`` is evaluated."""
+
+    jobs = _load_workflow(path).get("jobs", {})
+    assert isinstance(jobs, dict), f"{path}: jobs must be a mapping"
+    for job_id, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        env = job.get("env", {})
+        if not isinstance(env, dict):
+            continue
+        for name, value in env.items():
+            assert "${{ runner." not in str(value), (
+                f"{path}: jobs.{job_id}.env.{name} uses the runner context "
+                "before a runner has been allocated"
+            )
+
+
+def test_nightly_paths_are_exported_from_runner_temp_at_runtime() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "integration-nightly.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'root="$RUNNER_TEMP/collegue-nightly"' in workflow
+    assert '} >> "$GITHUB_ENV"' in workflow
+    for name in (
+        "COLLEGUE_NIGHTLY_MANIFEST",
+        "STATE_DATABASE_URL",
+        "COLLEGUE_HOME",
+        "SANDBOX_PIP_CACHE_DIR",
+    ):
+        assert f"printf '{name}=" in workflow


### PR DESCRIPTION
## Cause racine

Le workflow nightly fusionné par #596 était rejeté avant allocation d'un job : `runner.temp` était utilisé dans `jobs.product-e2e.env`, où le contexte `runner` n'est pas disponible. Le run `29163172714` échouait instantanément avec zéro job.

## Correction

- initialise les quatre chemins éphémères depuis `$RUNNER_TEMP` dans le premier step ;
- les exporte via `$GITHUB_ENV` pour tous les steps suivants ;
- ajoute une garde statique sur tous les workflows : YAML lisible et aucun `runner.*` dans un `jobs.<id>.env` ;
- conserve les secrets, budgets et comportements opt-in inchangés.

## Validation locale

- 5 tests de workflow réussis ;
- Ruff réussi ;
- `git diff --check` réussi.

La PR reste sans configuration de secrets/variables : elle corrige uniquement la validité et ajoute l'anti-régression.