### PR TITLE
fix(nightly): durcir le premier run Gemma

### DIFF
--- a/collegue/executor/oh_runner.py
+++ b/collegue/executor/oh_runner.py
@@ -19,6 +19,50 @@ import sys
 import threading
 
 
+class _UsageDeltaEmitter:
+    """Émet les deltas d'usage d'un unique objet LLM.
+
+    Les métriques OpenHands sont cumulatives *par objet* ``LLM``. Un fallback
+    construit un nouvel objet dont les compteurs repartent de zéro : partager la
+    dernière valeur du modèle précédent ferait donc disparaître le début de
+    l'usage du fallback. Chaque tentative possède son propre emitter et sa propre
+    base de compteurs.
+    """
+
+    def __init__(self, *, subscription: bool) -> None:
+        self._subscription = subscription
+        self._last_emitted = {"prompt": 0, "completion": 0, "cost": 0.0}
+
+    def emit(self, llm) -> None:
+        # Contrat moteur #441/#464 : lignes `[collegue-usage] {json}` en DELTAS
+        # (parse_usage_from_logs SOMME les occurrences — émettre des cumuls
+        # compterait double). Best-effort : télémétrie, jamais une cause d'échec.
+        try:
+            metrics = getattr(llm, "metrics", None)
+            usage = getattr(metrics, "accumulated_token_usage", None)
+            prompt = int(getattr(usage, "prompt_tokens", 0) or 0)
+            completion = int(getattr(usage, "completion_tokens", 0) or 0)
+            # En abonnement (Codex/ChatGPT), il n'y a AUCUNE facturation au token :
+            # litellm estime quand même un prix API (fantôme). On force 0 pour que le
+            # ledger $ du run reflète la réalité (les tokens, eux, restent comptés).
+            cost = 0.0 if self._subscription else float(getattr(metrics, "accumulated_cost", 0.0) or 0.0)
+            payload = {
+                "prompt_tokens": max(0, prompt - self._last_emitted["prompt"]),
+                "completion_tokens": max(0, completion - self._last_emitted["completion"]),
+                "cost_usd": max(0.0, cost - self._last_emitted["cost"]),
+                # #504 : en abonnement, le run n'est PAS facturé → cost_usd=0 est
+                # AUTORITAIRE. Le flag dit au moteur de NE PAS re-tarifer ce 0 au prix
+                # de secours #484 (sinon coût fantôme). Hors abonnement, billable=true
+                # → un cost=0 reste « inconnu » (modèle non mappé) → #484 légitime.
+                "billable": not self._subscription,
+            }
+            if payload["prompt_tokens"] or payload["completion_tokens"] or payload["cost_usd"]:
+                print(f"[collegue-usage] {json.dumps(payload)}", flush=True)
+                self._last_emitted.update(prompt=prompt, completion=completion, cost=cost)
+        except Exception as exc:  # noqa: BLE001
+            print(f"oh_runner: usage indisponible ({exc})", file=sys.stderr)
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(prog="oh_runner")
     ap.add_argument("-t", "--task", required=True, help="Consigne donnée à l'agent.")
@@ -79,54 +123,26 @@ def main() -> int:
         agent = get_default_agent(llm=llm, cli_mode=True)
         conv = Conversation(agent=agent, workspace=args.workspace, max_iteration_per_run=args.max_iterations)
         conv.send_message(args.task)
+        # Les compteurs OpenHands appartiennent à l'objet LLM courant. Un emitter
+        # neuf est indispensable au fallback, dont les compteurs repartent à zéro.
+        usage_emitter = _UsageDeltaEmitter(subscription=subscription)
         # Contrat #464 : émission INCRÉMENTALE (deltas périodiques) — un agrégat
         # final unique dans un finally perd TOUT au docker-kill (timeout sandbox).
         stop = threading.Event()
-        pump = threading.Thread(target=_pump_usage, args=(llm, stop), daemon=True)
+        pump = threading.Thread(target=_pump_usage, args=(llm, stop, usage_emitter), daemon=True)
         pump.start()
         try:
             conv.run()
         finally:
             stop.set()
             pump.join(timeout=10)
-            _emit_usage_delta(llm)  # flush final (delta restant)
+            usage_emitter.emit(llm)  # flush final (delta restant)
 
-    _last_emitted = {"prompt": 0, "completion": 0, "cost": 0.0}
-
-    def _emit_usage_delta(llm) -> None:
-        # Contrat moteur #441/#464 : lignes `[collegue-usage] {json}` en DELTAS
-        # (parse_usage_from_logs SOMME les occurrences — émettre des cumuls
-        # compterait double). Best-effort : télémétrie, jamais une cause d'échec.
-        try:
-            metrics = getattr(llm, "metrics", None)
-            usage = getattr(metrics, "accumulated_token_usage", None)
-            prompt = int(getattr(usage, "prompt_tokens", 0) or 0)
-            completion = int(getattr(usage, "completion_tokens", 0) or 0)
-            # En abonnement (Codex/ChatGPT), il n'y a AUCUNE facturation au token :
-            # litellm estime quand même un prix API (fantôme). On force 0 pour que le
-            # ledger $ du run reflète la réalité (les tokens, eux, restent comptés).
-            cost = 0.0 if subscription else float(getattr(metrics, "accumulated_cost", 0.0) or 0.0)
-            payload = {
-                "prompt_tokens": max(0, prompt - _last_emitted["prompt"]),
-                "completion_tokens": max(0, completion - _last_emitted["completion"]),
-                "cost_usd": max(0.0, cost - _last_emitted["cost"]),
-                # #504 : en abonnement, le run n'est PAS facturé → cost_usd=0 est
-                # AUTORITAIRE. Le flag dit au moteur de NE PAS re-tarifer ce 0 au prix
-                # de secours #484 (sinon coût fantôme). Hors abonnement, billable=true
-                # → un cost=0 reste « inconnu » (modèle non mappé) → #484 légitime.
-                "billable": not subscription,
-            }
-            if payload["prompt_tokens"] or payload["completion_tokens"] or payload["cost_usd"]:
-                print(f"[collegue-usage] {json.dumps(payload)}", flush=True)
-                _last_emitted.update(prompt=prompt, completion=completion, cost=cost)
-        except Exception as exc:  # noqa: BLE001
-            print(f"oh_runner: usage indisponible ({exc})", file=sys.stderr)
-
-    def _pump_usage(llm, stop: "threading.Event") -> None:
+    def _pump_usage(llm, stop: "threading.Event", emitter: _UsageDeltaEmitter) -> None:
         # Un delta toutes les 30 s : au pire, un docker-kill ne perd que la
         # dernière fenêtre (vs la tentative ENTIÈRE avant #464).
         while not stop.wait(30.0):
-            _emit_usage_delta(llm)
+            emitter.emit(llm)
 
     chain = [primary, *[m for m in fallbacks if m != primary]]
     last_exc = None

--- a/collegue/pilot/__main__.py
+++ b/collegue/pilot/__main__.py
@@ -90,6 +90,12 @@ def build_parser() -> argparse.ArgumentParser:
     plan_p.add_argument("--spec-filename", default=None, help="Chemin du SPEC dans le dépôt cible.")
     plan_p.add_argument("--base", default=None, help="Branche de base scellée (défaut draft : main).")
     plan_p.add_argument(
+        "--nightly-exact-task-count",
+        type=int,
+        default=None,
+        help=argparse.SUPPRESS,
+    )
+    plan_p.add_argument(
         "--execute",
         action="store_true",
         help="Pour `plan sync` uniquement : commit SPEC + création réelle des issues.",
@@ -214,6 +220,7 @@ async def _plan_draft(args: argparse.Namespace) -> int:
         board_title=args.board,
         spec_filename=args.spec_filename or "SPEC.md",
         base_branch=args.base or "main",
+        decompose_exact_task_count=args.nightly_exact_task_count,
     )
     _print_plan_result(result, output_format=args.format)
     return 0
@@ -247,6 +254,8 @@ def _validate_plan_args(parser: argparse.ArgumentParser, args: argparse.Namespac
             )
         if args.project_id is not None or args.expected_plan_hash is not None or args.execute:
             parser.error("plan draft : --project-id, --expected-plan-hash et --execute ne sont pas acceptés")
+        if args.nightly_exact_task_count is not None and args.nightly_exact_task_count != 1:
+            parser.error("plan draft : --nightly-exact-task-count doit valoir 1")
         return
     if action == "approve":
         missing = []
@@ -277,6 +286,7 @@ def _validate_plan_args(parser: argparse.ArgumentParser, args: argparse.Namespac
         "deadline_hours",
         "spec_filename",
         "base",
+        "nightly_exact_task_count",
     )
     supplied = ["--" + name.replace("_", "-") for name in sealed_args if getattr(args, name) is not None]
     if supplied:

--- a/collegue/pilot/nightly_e2e.py
+++ b/collegue/pilot/nightly_e2e.py
@@ -791,6 +791,8 @@ class NightlyE2ERunner:
                 "SPEC.md",
                 "--deadline-hours",
                 "0.5",
+                "--nightly-exact-task-count",
+                "1",
                 "--format",
                 "json",
             )

--- a/collegue/pilot/runtime.py
+++ b/collegue/pilot/runtime.py
@@ -793,6 +793,7 @@ async def plan_project_from_settings(
     decompose_max_tokens: int = 16384,
     decompose_attempts: int = 3,
     retry_sleep_seconds: float = 3.0,
+    decompose_exact_task_count: Optional[int] = None,
 ) -> PlanResult:
     """Crée un **draft** durable : problème → SPEC → DAG → aperçu hashé.
 
@@ -840,7 +841,7 @@ async def plan_project_from_settings(
 
     try:
         from collegue.planner.acceptance_tests import generate_acceptance_tests
-        from collegue.planner.decomposer import decompose
+        from collegue.planner.decomposer import DecompositionCardinalityError, decompose
         from collegue.planner.plan_review import build_plan_preview
         from collegue.planner.spec_generator import generate_spec, persist_spec
 
@@ -865,8 +866,14 @@ async def plan_project_from_settings(
                     project_id=project_id,
                     settings_obj=settings_obj,
                     max_tokens=decompose_max_tokens,
+                    exact_task_count=decompose_exact_task_count,
                 )
                 break
+            except DecompositionCardinalityError:
+                # Contrainte ferme (nightly) : un retry consommerait du budget
+                # sans rendre le résultat moins ambigu. Le decomposer garantit
+                # qu'aucune tâche/décision n'a encore été persistée.
+                raise
             except ValueError as exc:  # décomposition vide → aléa du modèle, on retente
                 last_err = exc
                 logger.warning("decompose tentative %d/%d : %s", attempt, attempts, exc)

--- a/collegue/planner/_parsing.py
+++ b/collegue/planner/_parsing.py
@@ -8,6 +8,7 @@ prose ou de blocs ```json). Évite la duplication entre ``spec_generator`` et
 from __future__ import annotations
 
 import json
+import re
 from typing import Optional
 
 # ``inline`` vit dans un module léger et sans dépendance (importable hors planner,
@@ -18,8 +19,52 @@ from collegue.textnorm import inline
 __all__ = ["inline", "json_from_text"]
 
 
+_LEADING_THOUGHT_RE = re.compile(r"\A<thought>.*?</thought>", re.DOTALL | re.IGNORECASE)
+_THOUGHT_TAG_RE = re.compile(r"</?thought>", re.IGNORECASE)
+_THOUGHT_MARKER_RE = re.compile(r"<\s*/?\s*thought\b", re.IGNORECASE)
+
+
+def _without_leading_thought(text: str) -> Optional[str]:
+    """Retire l'unique enveloppe de raisonnement Gemma, sinon échoue fermé.
+
+    On n'active ce traitement que si le premier tag ``thought`` précède le
+    premier objet JSON potentiel. Cela conserve notamment les chaînes JSON qui
+    contiennent littéralement ``<thought>``. Dès qu'une enveloppe est détectée,
+    elle doit en revanche être complète, unique et strictement en tête : aucun
+    JSON de raisonnement ne doit pouvoir être pris pour la réponse finale.
+    """
+
+    markers = list(_THOUGHT_MARKER_RE.finditer(text))
+    if not markers:
+        return text
+
+    first_brace = text.find("{")
+    if first_brace >= 0 and first_brace < markers[0].start():
+        return text
+
+    tags = list(_THOUGHT_TAG_RE.finditer(text))
+    thought = _LEADING_THOUGHT_RE.match(text)
+    if (
+        thought is None
+        or len(markers) != 2
+        or len(tags) != 2
+        or tags[0].start() != 0
+        or tags[0].group(0).lower() != "<thought>"
+        or tags[1].group(0).lower() != "</thought>"
+        or tags[1].end() != thought.end()
+    ):
+        return None
+
+    final = text[thought.end() :].strip()
+    return final or None
+
+
 def json_from_text(text: str) -> Optional[dict]:
     """Extrait le premier objet JSON exploitable d'un texte (fallback structured-output).
+
+    Une unique enveloppe Gemma ``<thought>...</thought>`` complète et placée
+    strictement en tête est ignorée avant le scan. Les enveloppes ambiguës sont
+    rejetées afin de ne jamais sélectionner un objet JSON issu du raisonnement.
 
     Scan brace-balanced via ``raw_decode`` depuis chaque ``{`` : on retourne le
     PREMIER objet complet qui décode (gère les blocs multiples, les ```json fences
@@ -34,6 +79,9 @@ def json_from_text(text: str) -> Optional[dict]:
             return whole
     except (ValueError, TypeError):
         pass
+    cleaned = _without_leading_thought(cleaned)
+    if cleaned is None:
+        return None
     decoder = json.JSONDecoder()
     for idx, ch in enumerate(cleaned):
         if ch != "{":

--- a/collegue/planner/decomposer.py
+++ b/collegue/planner/decomposer.py
@@ -25,6 +25,16 @@ from collegue.state.models import Decision, Task
 # hallucinée ne doit pas créer des milliers de lignes (et autant d'issues en P4).
 MAX_TASKS = 200
 
+
+class DecompositionCardinalityError(ValueError):
+    """Le LLM n'a pas respecté une cardinalité explicitement scellée.
+
+    Cette erreur est distincte des sorties momentanément vides/malformées : le
+    runtime ne doit pas dépenser plusieurs appels LLM en retentant un plan qui
+    viole une contrainte déterministe du caller.
+    """
+
+
 DECOMPOSE_SYSTEM_PROMPT = """Tu es un planificateur logiciel senior. À partir d'un SPEC de projet, \
 tu le découpes en tâches exécutables et ordonnées.
 
@@ -50,6 +60,16 @@ class _PlannedTask(BaseModel):
 
 class _Decomposition(BaseModel):
     tasks: List[_PlannedTask] = Field(default_factory=list)
+
+
+def _system_prompt(*, exact_task_count: Optional[int] = None) -> str:
+    if exact_task_count is None:
+        return DECOMPOSE_SYSTEM_PROMPT
+    return (
+        DECOMPOSE_SYSTEM_PROMPT
+        + f"\n- Contrainte prioritaire du caller : retourne EXACTEMENT {exact_task_count} tâche(s) ; "
+        "regroupe l'implémentation et ses tests dans la même tâche."
+    )
 
 
 def _coerce(data: dict) -> _Decomposition:
@@ -102,9 +122,19 @@ def _topo_order(tasks: List[_PlannedTask]) -> List[int]:
     return order
 
 
-def _build_prompt(spec: Any) -> str:
+def _build_prompt(spec: Any, *, exact_task_count: Optional[int] = None) -> str:
     spec_text = spec.to_markdown() if hasattr(spec, "to_markdown") else str(spec)
-    return f"SPEC du projet :\n{spec_text}\n\nDécoupe ce SPEC en tâches (JSON décrit par tes instructions système)."
+    constraint = ""
+    if exact_task_count is not None:
+        constraint = (
+            f"\n\nCONTRAINTE FERME : retourne exactement {exact_task_count} tâche(s). "
+            "Une tâche doit couvrir ensemble l'implémentation et ses tests ; "
+            "ne les scinde pas en tâches distinctes."
+        )
+    return (
+        f"SPEC du projet :\n{spec_text}\n\n"
+        f"Découpe ce SPEC en tâches (JSON décrit par tes instructions système).{constraint}"
+    )
 
 
 async def decompose(
@@ -116,6 +146,7 @@ async def decompose(
     settings_obj: Optional[object] = None,
     temperature: float = 0.2,
     max_tokens: int = 4096,
+    exact_task_count: Optional[int] = None,
 ) -> List[Any]:
     """Décompose ``spec`` en tâches persistées pour ``project_id`` ; retourne les tâches créées.
 
@@ -127,14 +158,21 @@ async def decompose(
     Persistance **atomique** : toutes les tâches + la décision sont écrites dans une
     **seule** transaction — un échec en cours de route ne laisse aucun graphe partiel.
     """
+    if exact_task_count is not None and (
+        not isinstance(exact_task_count, int)
+        or isinstance(exact_task_count, bool)
+        or not 1 <= exact_task_count <= MAX_TASKS
+    ):
+        raise ValueError(f"exact_task_count doit être un entier dans [1, {MAX_TASKS}].")
+
     # Idempotence : ne pas ré-décomposer (un retry dupliquerait le graphe → des
     # issues en double en P4). Le caller doit vider les tâches pour re-planifier.
     if manager.get_tasks(project_id):
         raise ValueError("projet déjà décomposé : vider les tâches existantes avant de redécomposer.")
 
     sample_kwargs = {
-        "messages": _build_prompt(spec),
-        "system_prompt": DECOMPOSE_SYSTEM_PROMPT,
+        "messages": _build_prompt(spec, exact_task_count=exact_task_count),
+        "system_prompt": _system_prompt(exact_task_count=exact_task_count),
         "result_type": _Decomposition,
         "temperature": temperature,
         "max_tokens": max_tokens,
@@ -155,6 +193,11 @@ async def decompose(
         raise ValueError("Décomposition vide : aucune tâche produite.")
     if len(planned) > MAX_TASKS:
         raise ValueError(f"Décomposition trop grande ({len(planned)} tâches > MAX_TASKS={MAX_TASKS}).")
+    if exact_task_count is not None and len(planned) != exact_task_count:
+        raise DecompositionCardinalityError(
+            "Décomposition refusée avant persistance : "
+            f"{len(planned)} tâche(s) produite(s), exactement {exact_task_count} attendue(s)."
+        )
 
     order = _topo_order(planned)  # valide le graphe (bornes + acyclique) AVANT toute écriture
 

--- a/tests/test_decomposer.py
+++ b/tests/test_decomposer.py
@@ -124,6 +124,55 @@ async def test_decompose_routes_planner_role(monkeypatch, manager):
     assert ctx.kwargs["model_preferences"] == ["planner-model"]
 
 
+@pytest.mark.asyncio
+async def test_exact_single_task_keeps_route_and_test_in_one_task(manager):
+    pid = _project(manager)
+    ctx = _Ctx(
+        _decomp(
+            [
+                {
+                    "title": "Ajouter la route nightly et son test",
+                    "acceptance": "GET /nightly renvoie 200 et le JSON exact",
+                    "depends_on": [],
+                }
+            ]
+        )
+    )
+
+    tasks = await decompose(
+        "Ajouter GET /nightly et son test",
+        ctx,
+        manager=manager,
+        project_id=pid,
+        exact_task_count=1,
+    )
+
+    assert [task.title for task in tasks] == ["Ajouter la route nightly et son test"]
+    assert "exactement 1 tâche" in ctx.kwargs["messages"]
+    assert "ne les scinde pas" in ctx.kwargs["messages"]
+    assert "EXACTEMENT 1 tâche" in ctx.kwargs["system_prompt"]
+    assert "implémentation et ses tests" in ctx.kwargs["system_prompt"]
+
+
+@pytest.mark.asyncio
+async def test_exact_single_task_rejects_multi_task_before_any_persistence(manager):
+    pid = _project(manager)
+    ctx = _Ctx(
+        _decomp(
+            [
+                {"title": "Ajouter la route", "depends_on": []},
+                {"title": "Ajouter le test", "depends_on": [0]},
+            ]
+        )
+    )
+
+    with pytest.raises(dec.DecompositionCardinalityError, match="exactement 1"):
+        await decompose("spec", ctx, manager=manager, project_id=pid, exact_task_count=1)
+
+    assert manager.get_tasks(pid) == []
+    assert manager.get_decisions(pid) == []
+
+
 # --- validation du graphe (rien persisté si invalide) ---------------------------
 
 

--- a/tests/test_oh_runner.py
+++ b/tests/test_oh_runner.py
@@ -1,0 +1,85 @@
+"""Tests ciblés du runner OpenHands embarqué dans le sandbox."""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from collegue.executor import oh_runner
+
+
+def _llm(*, prompt: int, completion: int, cost: float) -> SimpleNamespace:
+    usage = SimpleNamespace(prompt_tokens=prompt, completion_tokens=completion)
+    metrics = SimpleNamespace(accumulated_token_usage=usage, accumulated_cost=cost)
+    return SimpleNamespace(metrics=metrics)
+
+
+def _usage_payloads(output: str) -> list[dict[str, object]]:
+    prefix = "[collegue-usage] "
+    return [json.loads(line.removeprefix(prefix)) for line in output.splitlines() if line.startswith(prefix)]
+
+
+def test_usage_emitter_emits_complete_cumulative_usage_as_deltas(capsys):
+    llm = _llm(prompt=100, completion=20, cost=0.5)
+    emitter = oh_runner._UsageDeltaEmitter(subscription=False)
+
+    emitter.emit(llm)
+    llm.metrics.accumulated_token_usage.prompt_tokens = 145
+    llm.metrics.accumulated_token_usage.completion_tokens = 32
+    llm.metrics.accumulated_cost = 0.8
+    emitter.emit(llm)
+
+    payloads = _usage_payloads(capsys.readouterr().out)
+    assert [(p["prompt_tokens"], p["completion_tokens"]) for p in payloads] == [(100, 20), (45, 12)]
+    assert sum(int(p["prompt_tokens"]) for p in payloads) == 145
+    assert sum(int(p["completion_tokens"]) for p in payloads) == 32
+    assert sum(float(p["cost_usd"]) for p in payloads) == pytest.approx(0.8)
+
+
+def test_fallback_model_starts_with_fresh_usage_baseline(monkeypatch, capsys):
+    created: list[object] = []
+
+    class FakeLLM:
+        def __init__(self, *, model, **_kwargs):
+            self.model = model
+            self.metrics = _llm(prompt=0, completion=0, cost=0.0).metrics
+            created.append(self)
+
+    class FakeConversation:
+        def __init__(self, *, agent, **_kwargs):
+            self.llm = agent
+
+        def send_message(self, _task):
+            return None
+
+        def run(self):
+            if self.llm.model == "gemini/gemma-4-31b-it":
+                self.llm.metrics = _llm(prompt=100, completion=40, cost=1.25).metrics
+                raise RuntimeError("primary unavailable")
+            self.llm.metrics = _llm(prompt=20, completion=5, cost=0.2).metrics
+
+    sdk = types.ModuleType("openhands.sdk")
+    sdk.LLM = FakeLLM
+    sdk.Conversation = FakeConversation
+    default = types.ModuleType("openhands.tools.preset.default")
+    default.get_default_agent = lambda *, llm, cli_mode: llm
+    monkeypatch.setitem(sys.modules, "openhands.sdk", sdk)
+    monkeypatch.setitem(sys.modules, "openhands.tools.preset.default", default)
+    monkeypatch.setenv("LLM_API_KEY", "test-key")
+    monkeypatch.setenv("LLM_MODEL", "gemini/gemma-4-31b-it")
+    monkeypatch.setenv("OH_FALLBACK_MODELS", "gemini/gemma-4-26b-a4b-it")
+    monkeypatch.delenv("LLM_SUBSCRIPTION", raising=False)
+    monkeypatch.setattr(sys, "argv", ["oh_runner", "--task", "implement the issue"])
+
+    assert oh_runner.main() == 0
+
+    assert [llm.model for llm in created] == ["gemini/gemma-4-31b-it", "gemini/gemma-4-26b-a4b-it"]
+    payloads = _usage_payloads(capsys.readouterr().out)
+    assert [(p["prompt_tokens"], p["completion_tokens"]) for p in payloads] == [(100, 40), (20, 5)]
+    assert sum(int(p["prompt_tokens"]) for p in payloads) == 120
+    assert sum(int(p["completion_tokens"]) for p in payloads) == 45
+    assert sum(float(p["cost_usd"]) for p in payloads) == pytest.approx(1.45)

--- a/tests/test_pilot_nightly_e2e.py
+++ b/tests/test_pilot_nightly_e2e.py
@@ -895,7 +895,9 @@ def test_full_driver_uses_four_product_processes_and_cleans(tmp_path):
     assert result["acceptance_oracle_sha256"] == ORACLE_SHA
     product_calls = [argv for argv, _ in calls if argv[1:3] == ["-m", "collegue.pilot"]]
     assert len(product_calls) == 4
-    assert any("draft" in argv for argv in product_calls)
+    draft_call = next(argv for argv in product_calls if "draft" in argv)
+    exact_count_index = draft_call.index("--nightly-exact-task-count")
+    assert draft_call[exact_count_index + 1] == "1"
     assert any("approve" in argv for argv in product_calls)
     assert any("sync" in argv for argv in product_calls)
     assert any("--repo-source" in argv for argv in product_calls)

--- a/tests/test_pilot_plan.py
+++ b/tests/test_pilot_plan.py
@@ -205,6 +205,42 @@ async def test_decompose_max_tokens_widened(monkeypatch):
     assert calls["decompose"]["max_tokens"] == 16384
 
 
+async def test_exact_task_count_is_forwarded_to_decomposer(monkeypatch):
+    calls = _patch_planner(monkeypatch, tasks=[object()])
+    result, _ = await _plan(monkeypatch, decompose_exact_task_count=1)
+    assert result.task_count == 1
+    assert calls["decompose"]["exact_task_count"] == 1
+
+
+async def test_cardinality_mismatch_is_not_retried_or_sent_to_qa(monkeypatch):
+    from collegue.planner.decomposer import DecompositionCardinalityError
+
+    attempts = {"decompose": 0, "acceptance": 0}
+
+    async def _multi_task(*args, **kwargs):
+        attempts["decompose"] += 1
+        raise DecompositionCardinalityError("2 tâches, exactement 1 attendue")
+
+    async def _acceptance(*args, **kwargs):
+        attempts["acceptance"] += 1
+
+    calls = _patch_planner(
+        monkeypatch,
+        decompose_fn=_multi_task,
+        acceptance_fn=_acceptance,
+    )
+    with pytest.raises(DecompositionCardinalityError, match="exactement 1"):
+        await _plan(
+            monkeypatch,
+            settings_obj=SimpleNamespace(GATE_ACCEPTANCE_TESTS=True),
+            decompose_exact_task_count=1,
+            retry_sleep_seconds=0,
+        )
+
+    assert attempts == {"decompose": 1, "acceptance": 0}
+    assert "preview" not in calls["order"]
+
+
 async def test_decompose_retries_on_empty_then_succeeds(monkeypatch):
     attempts = {"n": 0}
 

--- a/tests/test_planner_parsing.py
+++ b/tests/test_planner_parsing.py
@@ -1,0 +1,44 @@
+"""Tests du fallback JSON partagé par les étapes P1/P2 du planner."""
+
+from __future__ import annotations
+
+import pytest
+
+from collegue.planner._parsing import json_from_text
+
+
+def test_json_from_text_ignores_json_inside_one_leading_thought():
+    raw = (
+        '  <ThOuGhT>Essai interne : {"title": "mauvais"}</tHoUgHt>\nRéponse finale :\n```json\n{"title": "bon"}\n```  '
+    )
+
+    assert json_from_text(raw) == {"title": "bon"}
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '<thought>{"draft": true}\n{"final": true}',
+        'préface <thought>{"draft": true}</thought>\n{"final": true}',
+        '<thought>un</thought><thought>deux</thought>{"final": true}',
+        '<thought>un</thought>{"final": true}<thought>deux</thought>',
+        '</thought>{"final": true}',
+        '< thought>{"draft": true}</thought>{"final": true}',
+        '<thought >{"draft": true}</thought>{"final": true}',
+        '<thought>{"draft": true}</thought >{"final": true}',
+    ],
+)
+def test_json_from_text_rejects_ambiguous_thought_envelopes(raw):
+    assert json_from_text(raw) is None
+
+
+def test_json_from_text_preserves_legacy_first_object_fallback():
+    raw = 'Option A: {"choice": "a"}\nOption B: {"choice": "b"}'
+
+    assert json_from_text(raw) == {"choice": "a"}
+
+
+def test_json_from_text_preserves_thought_literal_inside_json_string():
+    raw = '{"template": "<thought> est un texte, pas une enveloppe"}'
+
+    assert json_from_text(raw) == {"template": "<thought> est un texte, pas une enveloppe"}


### PR DESCRIPTION
## Contexte

Le premier dispatch E2E Gemma a validé la fixture et les deux secrets, puis a été interrompu avant le premier appel produit : un audit a révélé trois ambiguïtés incompatibles avec un budget fail-closed.

## Correction

- isole la télémétrie d'usage par objet/tentative OpenHands afin que le fallback 31B → 26B ne perde aucun token ;
- ignore un unique bloc `<thought>…</thought>` Gemma strictement en tête avant d'extraire le JSON final, et rejette les enveloppes ambiguës ;
- transmet au nightly une cardinalité scellée à exactement une tâche ;
- regroupe explicitement implémentation et tests dans cette tâche ;
- refuse toute sortie multi-tâches avant transaction, sans retry ni génération QA ;
- ne change pas le comportement des plans produit normaux.

## Validation

- validation intégrée ciblée : 191 tests réussis ;
- Ruff check et format verts sur les 11 fichiers ;
- `git diff --check` vert ;
- fixture après arrêt : uniquement `main`, aucune branche, issue ou PR résiduelle.

L'opt-in E2E reste temporairement à `false` jusqu'à la fusion de cette PR.