### PR TITLE
fix(nightly): préserver les 404 de refs absentes

### DIFF
--- a/collegue/tools/clients/base.py
+++ b/collegue/tools/clients/base.py
@@ -159,7 +159,11 @@ class APIClient(ABC):  # noqa: B024
             self.logger.debug(error_msg)
         else:
             self.logger.error(error_msg)
-        raise APIError(error_msg)
+        # Conserver le statut HTTP final : les couches métier doivent pouvoir
+        # distinguer une absence 404 attendue d'une panne d'auth/rate-limit/5xx.
+        # Le perdre ici transformait notamment les sondes de refs GitHub absentes
+        # en erreurs génériques ``status_code=0``.
+        raise APIError(error_msg, status_code=last_status)
 
     def handle_response(self, response: Any, endpoint: str) -> APIResponse:
         try:

--- a/collegue/tools/clients/github.py
+++ b/collegue/tools/clients/github.py
@@ -10,7 +10,7 @@ Provides standardized:
 from typing import Any, Dict, Optional
 
 from ..base import ToolExecutionError
-from .base import APIClient
+from .base import APIClient, APIError
 
 try:
     import requests
@@ -101,6 +101,13 @@ class GitHubClient(APIClient):
             return response.json()
         except ToolExecutionError:
             raise
+        except APIError as e:
+            # ``_execute_with_retry`` normalise toute erreur finale en APIError.
+            # Réinjecter son statut dans l'exception publique est indispensable
+            # aux opérations idempotentes, qui ne convertissent que le 404 en
+            # « ressource absente » et restent fail-closed pour tous les autres
+            # statuts.
+            raise ToolExecutionError(f"Erreur API GitHub: {e}", status_code=e.status_code) from e
         except Exception as e:
             raise ToolExecutionError(f"Erreur API GitHub: {e}") from e
 

--- a/tests/test_clients_retry_logging.py
+++ b/tests/test_clients_retry_logging.py
@@ -39,6 +39,7 @@ def test_expected_404_logs_real_attempt_count_at_debug(caplog):
             client._execute_with_retry(_always_raise(_HTTPError(404, "Ressource introuvable")), "GET contents/x")
     # Compteur RÉEL : le 404 n'est jamais retenté → 1 tentative, pas 4.
     assert "failed after 1 attempt(s)" in str(excinfo.value)
+    assert excinfo.value.status_code == 404
     records = [r for r in caplog.records if "failed after" in r.message]
     assert records and all(r.levelname == "DEBUG" for r in records)
 
@@ -50,6 +51,7 @@ def test_exhausted_retries_log_error_with_real_count(caplog):
             client._execute_with_retry(_always_raise(_HTTPError(503, "Service Unavailable")), "GET ref")
     # 503 retenté jusqu'à épuisement : max_retries + 1 tentatives, en ERROR.
     assert "failed after 4 attempt(s)" in str(excinfo.value)
+    assert excinfo.value.status_code == 503
     records = [r for r in caplog.records if "failed after" in r.message]
     assert records and all(r.levelname == "ERROR" for r in records)
 

--- a/tests/test_pilot_nightly_e2e.py
+++ b/tests/test_pilot_nightly_e2e.py
@@ -17,6 +17,7 @@ from collegue.pilot.nightly_e2e import (
     _write_manifest,
 )
 from collegue.tools.base import ToolExecutionError
+from collegue.tools.github_commands import BranchCommands
 
 SEED = "a" * 40
 BASE_SHA = "b" * 40
@@ -385,6 +386,34 @@ def _runner(tmp_path, *, repos=None):
     return NightlyE2ERunner(config, clients=clients), branches, prs, issues, files
 
 
+def _route_missing_refs_through_http_404(monkeypatch, branches):
+    """Reproduit la vraie frontière HTTP GitHub du run #29209532860."""
+    from collegue.tools.clients import github as github_client_module
+
+    calls = []
+
+    class _NotFoundResponse:
+        status_code = 404
+        headers = {}
+        content = b'{"message":"Not Found"}'
+
+    def request(method, url, **kwargs):
+        calls.append((method, url))
+        return _NotFoundResponse()
+
+    monkeypatch.setattr(github_client_module.requests, "request", request)
+    http_branches = BranchCommands(token="test-token", max_retries=0)
+    original = branches.get_branch_sha
+
+    def get_branch_sha(owner, repo, branch):
+        if branch in branches.refs:
+            return original(owner, repo, branch)
+        return http_branches.get_branch_sha(owner, repo, branch)
+
+    branches.get_branch_sha = get_branch_sha
+    return calls
+
+
 def _own_run_label(runner, manifest):
     runner._create_owned_label(manifest)
     assert manifest.label_creation_started is True
@@ -482,6 +511,21 @@ def test_cleanup_is_exact_verified_and_idempotent(tmp_path):
 
     # Relance indépendante du finalizer : aucune ressource, toujours un succès.
     assert runner.cleanup() == {"status": "clean", "closed_prs": [], "closed_issues": []}
+
+
+def test_cleanup_is_idempotent_when_real_http_boundary_returns_404(tmp_path, monkeypatch):
+    runner, branches, _prs, _issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    calls = _route_missing_refs_through_http_404(monkeypatch, branches)
+
+    assert runner.cleanup() == {"status": "clean", "closed_prs": [], "closed_issues": []}
+    assert runner.cleanup() == {"status": "clean", "closed_prs": [], "closed_issues": []}
+    assert branches.refs == {"main": SEED}
+    assert branches.deleted == []
+    assert calls == [
+        ("GET", f"https://api.github.com/repos/fixture/app/git/ref/heads/{cfg.base_branch}"),
+        ("GET", f"https://api.github.com/repos/fixture/app/git/ref/heads/{cfg.base_branch}"),
+    ]
 
 
 def test_cleanup_refuses_a_moved_base_instead_of_deleting_it(tmp_path):
@@ -914,3 +958,28 @@ def test_run_failure_still_invokes_cleanup(tmp_path):
         runner.run()
     assert cfg.base_branch not in branches.refs
     assert branches.refs["main"] == SEED
+
+
+def test_run_accepts_real_http_404_for_absent_base_before_first_mutation(tmp_path, monkeypatch):
+    runner, branches, _prs, _issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    calls = _route_missing_refs_through_http_404(monkeypatch, branches)
+    runner._manager = lambda: SimpleNamespace(list_projects=lambda: [])
+    product_calls = []
+
+    def fail_after_base_creation(argv, *, cwd=None):
+        product_calls.append(list(argv))
+        return CommandResult(2, "", "planner cassé après création de la base")
+
+    runner.command_runner = fail_after_base_creation
+
+    with pytest.raises(NightlyE2EError, match="commande produit échouée"):
+        runner.run()
+
+    # Le 404 de la sonde initiale est bien traité comme « branche absente » :
+    # le run atteint la première commande produit, puis son cleanup retire
+    # exactement la base propriétaire créée entre-temps.
+    assert len(product_calls) == 1
+    assert (cfg.base_branch, BASE_OWNER_SHA) in branches.deleted
+    assert branches.refs == {"main": SEED}
+    assert len(calls) == 1  # sonde HTTP pré-mutation ; le DELETE est simulé par le double


### PR DESCRIPTION
## Cause réelle

Le run E2E [29209532860](https://github.com/VynoDePal/Collegue/actions/runs/29209532860) a atteint le produit mais s'est arrêté avant toute mutation : GitHub renvoie normalement 404 quand la branche nightly n'existe pas encore, et la couche de retry perdait ce statut en le transformant en erreur générique.

Le même défaut rendait aussi le cleanup idempotent rouge sur une branche déjà absente.

## Correction

- conserve le statut HTTP final dans `APIError` ;
- le propage dans le `ToolExecutionError` public GitHub ;
- autorise uniquement le 404 confirmé à devenir « branche absente » ;
- conserve le comportement fail-closed sur 401/403/429/5xx et erreurs réseau.

## Validation

- 101 tests ciblés réussis ;
- tests à la vraie frontière HTTP simulée pour run et cleanup répété ;
- 503 vérifié comme toujours bloquant ;
- Ruff check/format et `git diff --check` verts ;
- fixture distante intacte : seulement `main`, aucune issue/PR/branche résiduelle.

L'opt-in E2E reste à `false` jusqu'à fusion.