### PR TITLE
Fiabiliser la convergence GitHub du nightly réel

### DIFF
--- a/collegue/pilot/nightly_e2e.py
+++ b/collegue/pilot/nightly_e2e.py
@@ -23,6 +23,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, Sequence
@@ -48,6 +49,7 @@ _DEFAULT_MARKER_PATH = ".collegue-nightly-fixture"
 _EXEC_MARKER = "<!-- collegue-exec:"
 _TASK_MARKER = "<!-- collegue-task:"
 _NIGHTLY_LABEL_COLOR = "1d76db"
+_GITHUB_CONSISTENCY_BACKOFF_SECONDS = (0.25, 0.5, 1.0, 2.0, 4.0, 8.0)
 
 # Contrat volontairement minuscule : un seul changement observable et un seul
 # test. Les chemins font partie du problème car le planner ne voit pas le dépôt.
@@ -681,6 +683,59 @@ class NightlyE2ERunner:
         manifest.label_created = True
         _write_manifest(self.config.manifest_path, manifest)
 
+    def _verify_synced_issue(
+        self,
+        issue_number: int,
+        *,
+        task_id: int,
+        project_id: int,
+        plan_hash: str,
+    ) -> None:
+        """Prouve l'issue du sync par son endpoint individuel autoritatif.
+
+        GitHub peut servir momentanément une vue retardée de
+        ``GET /issues?labels=...`` juste après le ``POST /issues``. Le GET de
+        l'issue connue confirme directement son état, son label et les deux
+        marqueurs durables. La liste filtrée reste une garde contre un doublon,
+        mais son absence transitoire ne transforme plus un succès confirmé en
+        faux échec.
+        """
+        cfg = self.config
+        issue = self.clients.issues.get_issue(cfg.owner, cfg.repo, issue_number)
+        body = str(getattr(issue, "body", "") or "")
+        task_markers = re.findall(r"<!-- collegue-task:([1-9][0-9]*) -->", body)
+        expected_plan_marker = f"<!-- collegue-plan:{plan_hash};project:{int(project_id)};task:{int(task_id)} -->"
+        if (
+            int(getattr(issue, "number", 0) or 0) != int(issue_number)
+            or getattr(issue, "state", None) != "open"
+            or list(getattr(issue, "labels", ()) or ()).count(cfg.issue_label) != 1
+            or task_markers != [str(int(task_id))]
+            or body.count(expected_plan_marker) != 1
+        ):
+            raise NightlyE2EError("issue synchronisée sans identité GitHub exacte du plan/run")
+
+        # Cette vue indexée doit converger elle aussi : elle prouve l'unicité du
+        # label et alimente ensuite le cleanup. Une vue vide est le seul état
+        # transitoire admis ; tout candidat étranger ou toute erreur API bloque
+        # immédiatement.
+        for attempt in range(len(_GITHUB_CONSISTENCY_BACKOFF_SECONDS) + 1):
+            filtered = self.clients.issues.list_issues(
+                cfg.owner,
+                cfg.repo,
+                state="open",
+                limit=100,
+                labels=cfg.issue_label,
+            )
+            numbers = [int(getattr(item, "number", 0) or 0) for item in filtered]
+            foreign_numbers = {number for number in numbers if number != int(issue_number)}
+            if foreign_numbers or (numbers and numbers != [int(issue_number)]):
+                raise NightlyE2EError("corrélation GitHub ambiguë: le label du run désigne plusieurs issues")
+            if numbers == [int(issue_number)]:
+                return
+            if attempt < len(_GITHUB_CONSISTENCY_BACKOFF_SECONDS):
+                time.sleep(_GITHUB_CONSISTENCY_BACKOFF_SECONDS[attempt])
+        raise NightlyE2EError("corrélation GitHub non confirmée avant épuisement du polling borné")
+
     def _inspect_draft(self, project_id: int, plan_hash: str) -> tuple[int, str, str]:
         manager = self._manager()
         project = manager.get_project(project_id)
@@ -851,15 +906,12 @@ class NightlyE2ERunner:
                 or int(issues[0].get("task_id") or 0) != task_id
             ):
                 raise NightlyE2EError("la synchronisation doit créer exactement une issue")
-            remote_issues = self.clients.issues.list_issues(
-                cfg.owner,
-                cfg.repo,
-                state="open",
-                limit=100,
-                labels=cfg.issue_label,
+            self._verify_synced_issue(
+                issue_numbers[0],
+                task_id=task_id,
+                project_id=project_id,
+                plan_hash=plan_hash,
             )
-            if [int(issue.number) for issue in remote_issues] != issue_numbers:
-                raise NightlyE2EError("corrélation GitHub ambiguë: le label du run ne désigne pas une issue unique")
             manifest.issue_numbers = issue_numbers
             manifest.base_sha = self.clients.branches.get_branch_sha(cfg.owner, cfg.repo, cfg.base_branch)
             if _SHA_RE.fullmatch(str(manifest.base_sha or "")) is None:

--- a/collegue/tools/github_commands/branches.py
+++ b/collegue/tools/github_commands/branches.py
@@ -5,6 +5,7 @@ Handles branch listing, creation, and commit operations.
 """
 
 import re
+import time
 from typing import Iterable, List, Optional
 
 from pydantic import BaseModel
@@ -16,6 +17,7 @@ from ._helpers import validate_ref
 # Branches refusées par défaut à la suppression (garde-fou contre la perte de la base).
 PROTECTED_BRANCHES = ("main", "master")
 _SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+_DELETE_CONFIRM_BACKOFF_SECONDS = (0.25, 0.5, 1.0, 2.0, 4.0, 8.0)
 
 
 class BranchInfo(BaseModel):
@@ -325,19 +327,29 @@ class BranchCommands(GitHubClient):
             raise ToolExecutionError(
                 f"refus de supprimer la branche {branch!r}: SHA attendu {expected_sha}, vu {current_sha}"
             )
+        delete_error: Optional[ToolExecutionError] = None
         try:
             self._request_json("DELETE", f"/repos/{owner}/{repo}/git/refs/heads/{branch}")
-        except ToolExecutionError:
-            # Course : supprimée entre-temps ? Si oui, succès idempotent ; sinon propage.
-            if self._branch_sha_or_none(owner, repo, branch) is None:
+        except ToolExecutionError as exc:
+            # Une réponse DELETE peut être perdue après application côté GitHub.
+            # Ne jamais réémettre la mutation : la même confirmation bornée
+            # tranche sur l'état autoritatif de la ref.
+            delete_error = exc
+
+        # Un DELETE 2xx ne suffit pas comme preuve pour une opération destructive.
+        # GitHub peut toutefois servir brièvement l'ancien SHA après suppression :
+        # lui seul est retryable. Un autre SHA prouve une course et bloque aussitôt.
+        for attempt in range(len(_DELETE_CONFIRM_BACKOFF_SECONDS) + 1):
+            remaining_sha = self._branch_sha_or_none(owner, repo, branch)
+            if remaining_sha is None:
                 return True
-            raise
-        # Un DELETE 2xx ne suffit pas comme preuve pour une opération destructive :
-        # confirmer l'absence distante. Toute lecture autre qu'un 404 reste
-        # bloquante via ``_branch_sha_or_none``.
-        remaining_sha = self._branch_sha_or_none(owner, repo, branch)
-        if remaining_sha is not None:
-            raise ToolExecutionError(
-                f"suppression de la branche {branch!r} non confirmée: tête distante {remaining_sha}"
-            )
-        return True
+            if remaining_sha != current_sha:
+                raise ToolExecutionError(
+                    f"suppression de la branche {branch!r} ambiguë: tête déplacée de {current_sha} vers {remaining_sha}"
+                )
+            if attempt < len(_DELETE_CONFIRM_BACKOFF_SECONDS):
+                time.sleep(_DELETE_CONFIRM_BACKOFF_SECONDS[attempt])
+
+        if delete_error is not None:
+            raise delete_error
+        raise ToolExecutionError(f"suppression de la branche {branch!r} non confirmée: tête distante {current_sha}")

--- a/tests/test_github_merge_delete.py
+++ b/tests/test_github_merge_delete.py
@@ -17,6 +17,7 @@ from collegue.tools.github_commands import (
     PRFilesSnapshot,
     PRNotMergeableError,
 )
+from collegue.tools.github_commands import branches as branches_module
 
 
 class _Recorder:
@@ -416,20 +417,41 @@ def test_delete_branch_propagates_transient_initial_ref_read():
     assert not any(c[0] == "DELETE" for c in rec.calls)
 
 
-def test_delete_branch_confirms_absence_after_successful_delete():
-    br, rec = _branches(["before", None])
+def test_delete_branch_polls_stale_sha_then_confirms_absence(monkeypatch):
+    br, rec = _branches(["before", "before", "before", None])
+    sleeps = []
+    monkeypatch.setattr(branches_module.time, "sleep", sleeps.append)
 
     assert br.delete_branch("o", "r", "feat/x") is True
-    assert any(c[0] == "DELETE" for c in rec.calls)
+    assert [call[0] for call in rec.calls].count("DELETE") == 1
+    assert sleeps == [
+        branches_module._DELETE_CONFIRM_BACKOFF_SECONDS[0],
+        branches_module._DELETE_CONFIRM_BACKOFF_SECONDS[1],
+    ]
 
 
-def test_delete_branch_refuses_unconfirmed_successful_delete():
-    br, rec = _branches(["before", "still-present"])
+def test_delete_branch_refuses_unconfirmed_successful_delete(monkeypatch):
+    br, rec = _branches(["before"] + ["before"] * (len(branches_module._DELETE_CONFIRM_BACKOFF_SECONDS) + 1))
+    sleeps = []
+    monkeypatch.setattr(branches_module.time, "sleep", sleeps.append)
 
     with pytest.raises(ToolExecutionError, match="non confirmée"):
         br.delete_branch("o", "r", "feat/x")
 
-    assert any(c[0] == "DELETE" for c in rec.calls)
+    assert [call[0] for call in rec.calls].count("DELETE") == 1
+    assert sleeps == list(branches_module._DELETE_CONFIRM_BACKOFF_SECONDS)
+
+
+def test_delete_branch_refuses_moved_sha_without_retry(monkeypatch):
+    br, rec = _branches(["before", "moved"])
+    sleeps = []
+    monkeypatch.setattr(branches_module.time, "sleep", sleeps.append)
+
+    with pytest.raises(ToolExecutionError, match="tête déplacée"):
+        br.delete_branch("o", "r", "feat/x")
+
+    assert [call[0] for call in rec.calls].count("DELETE") == 1
+    assert sleeps == []
 
 
 def test_delete_branch_propagates_transient_confirmation_read():
@@ -443,24 +465,63 @@ def test_delete_branch_propagates_transient_confirmation_read():
     assert any(c[0] == "DELETE" for c in rec.calls)
 
 
-def test_delete_branch_propagates_delete_error_when_ref_still_exists():
+def test_delete_branch_error_then_stale_sha_times_out_without_second_delete(monkeypatch):
     error = ToolExecutionError("suppression refusée", status_code=403)
-    br, _ = _branches(["before", "before"])
-    br._request_json = lambda *args, **kwargs: (_ for _ in ()).throw(error)
+    br, rec = _branches(["before"] + ["before"] * (len(branches_module._DELETE_CONFIRM_BACKOFF_SECONDS) + 1))
+    delete_calls = []
+
+    def fail_delete(*args, **kwargs):
+        delete_calls.append((args, kwargs))
+        raise error
+
+    br._request_json = fail_delete
+    sleeps = []
+    monkeypatch.setattr(branches_module.time, "sleep", sleeps.append)
 
     with pytest.raises(ToolExecutionError) as caught:
         br.delete_branch("o", "r", "feat/x")
 
     assert caught.value is error
+    assert len(delete_calls) == 1
+    assert not any(call[0] == "DELETE" for call in rec.calls)
+    assert sleeps == list(branches_module._DELETE_CONFIRM_BACKOFF_SECONDS)
 
 
-def test_delete_branch_accepts_delete_error_only_after_confirmed_absence():
-    br, _ = _branches(["before", None])
-    br._request_json = lambda *args, **kwargs: (_ for _ in ()).throw(
-        ToolExecutionError("réponse DELETE perdue", status_code=500)
-    )
+def test_delete_branch_accepts_lost_delete_response_after_stale_then_404(monkeypatch):
+    br, _ = _branches(["before", "before", None])
+    delete_calls = []
+
+    def lose_response(*args, **kwargs):
+        delete_calls.append((args, kwargs))
+        raise ToolExecutionError("réponse DELETE perdue", status_code=500)
+
+    br._request_json = lose_response
+    sleeps = []
+    monkeypatch.setattr(branches_module.time, "sleep", sleeps.append)
 
     assert br.delete_branch("o", "r", "feat/x") is True
+    assert len(delete_calls) == 1
+    assert sleeps == [branches_module._DELETE_CONFIRM_BACKOFF_SECONDS[0]]
+
+
+def test_delete_branch_error_then_moved_sha_fails_immediately_without_second_delete(monkeypatch):
+    br, _ = _branches(["before", "moved"])
+    error = ToolExecutionError("réponse DELETE perdue", status_code=500)
+    delete_calls = []
+
+    def lose_response(*args, **kwargs):
+        delete_calls.append((args, kwargs))
+        raise error
+
+    br._request_json = lose_response
+    sleeps = []
+    monkeypatch.setattr(branches_module.time, "sleep", sleeps.append)
+
+    with pytest.raises(ToolExecutionError, match="tête déplacée"):
+        br.delete_branch("o", "r", "feat/x")
+
+    assert len(delete_calls) == 1
+    assert sleeps == []
 
 
 def test_delete_branch_expected_sha_allows_exact_head():

--- a/tests/test_pilot_nightly_e2e.py
+++ b/tests/test_pilot_nightly_e2e.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from collegue.pilot import nightly_e2e as nightly_e2e_module
 from collegue.pilot.nightly_e2e import (
     CommandResult,
     NightlyClients,
@@ -418,6 +419,106 @@ def _own_run_label(runner, manifest):
     runner._create_owned_label(manifest)
     assert manifest.label_creation_started is True
     assert manifest.label_created is True
+
+
+def test_synced_issue_polls_when_label_filter_index_lags(tmp_path, monkeypatch):
+    """Reproduit la frontière REST observée sur le run réel #29209984188."""
+    runner, _branches, _prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    issue = _issue(
+        cfg,
+        number=77,
+        task_id=9,
+        project_id=4,
+        plan_hash="f" * 64,
+    )
+    issues.items[77] = issue
+    indexed_views = iter(([], [], [issue]))
+    issues.list_issues = lambda *args, **kwargs: next(indexed_views)
+    sleeps = []
+    monkeypatch.setattr(nightly_e2e_module.time, "sleep", sleeps.append)
+
+    runner._verify_synced_issue(
+        77,
+        task_id=9,
+        project_id=4,
+        plan_hash="f" * 64,
+    )
+    assert sleeps == [
+        nightly_e2e_module._GITHUB_CONSISTENCY_BACKOFF_SECONDS[0],
+        nightly_e2e_module._GITHUB_CONSISTENCY_BACKOFF_SECONDS[1],
+    ]
+
+
+def test_synced_issue_fails_closed_when_label_index_never_converges(tmp_path, monkeypatch):
+    runner, _branches, _prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    issues.items[77] = _issue(cfg, number=77, task_id=9, project_id=4, plan_hash="f" * 64)
+    issues.list_issues = lambda *args, **kwargs: []
+    sleeps = []
+    monkeypatch.setattr(nightly_e2e_module.time, "sleep", sleeps.append)
+
+    with pytest.raises(NightlyE2EError, match="polling borné"):
+        runner._verify_synced_issue(77, task_id=9, project_id=4, plan_hash="f" * 64)
+
+    assert sleeps == list(nightly_e2e_module._GITHUB_CONSISTENCY_BACKOFF_SECONDS)
+
+
+def test_synced_issue_propagates_label_index_api_error_without_retry(tmp_path, monkeypatch):
+    runner, _branches, _prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    issues.items[77] = _issue(cfg, number=77, task_id=9, project_id=4, plan_hash="f" * 64)
+    error = ToolExecutionError("GitHub indisponible", status_code=500)
+    issues.list_issues = lambda *args, **kwargs: (_ for _ in ()).throw(error)
+    sleeps = []
+    monkeypatch.setattr(nightly_e2e_module.time, "sleep", sleeps.append)
+
+    with pytest.raises(ToolExecutionError) as caught:
+        runner._verify_synced_issue(77, task_id=9, project_id=4, plan_hash="f" * 64)
+
+    assert caught.value is error
+    assert sleeps == []
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda issue, _cfg: setattr(issue, "labels", []),
+        lambda issue, _cfg: setattr(issue, "body", "<!-- collegue-task:9 -->"),
+        lambda issue, _cfg: setattr(issue, "state", "closed"),
+    ],
+)
+def test_synced_issue_direct_get_fails_closed_without_exact_identity(tmp_path, mutation):
+    runner, _branches, _prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    issue = _issue(cfg, number=77, task_id=9, project_id=4, plan_hash="f" * 64)
+    mutation(issue, cfg)
+    issues.items[77] = issue
+    issues.list_issues = lambda *args, **kwargs: []
+
+    with pytest.raises(NightlyE2EError, match="identité GitHub exacte"):
+        runner._verify_synced_issue(
+            77,
+            task_id=9,
+            project_id=4,
+            plan_hash="f" * 64,
+        )
+
+
+def test_synced_issue_refuses_a_second_issue_exposed_by_run_label(tmp_path):
+    runner, _branches, _prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    primary = _issue(cfg, number=77, task_id=9, project_id=4, plan_hash="f" * 64)
+    duplicate = _issue(cfg, number=78, task_id=9, project_id=4, plan_hash="f" * 64)
+    issues.items.update({77: primary, 78: duplicate})
+
+    with pytest.raises(NightlyE2EError, match="plusieurs issues"):
+        runner._verify_synced_issue(
+            77,
+            task_id=9,
+            project_id=4,
+            plan_hash="f" * 64,
+        )
 
 
 def test_preexisting_run_label_is_never_adopted_or_deleted(tmp_path):


### PR DESCRIPTION
## Contexte

Le run réel Actions `29209984188` a créé et labellisé l’issue fixture, puis a échoué sur une lecture immédiatement incohérente de l’index `GET /issues?labels=...`. Le cleanup a aussi reçu l’ancien SHA juste après un `DELETE` de branche pourtant appliqué.

## Changements

- prouve d’abord l’issue synchronisée par son endpoint individuel : numéro, état, label et marqueurs exacts du plan ;
- attend ensuite de façon bornée la convergence de la liste filtrée afin de prouver l’unicité ;
- confirme une suppression de branche avec un backoff borné, sans jamais réémettre le `DELETE` ;
- bloque immédiatement si un numéro étranger, un SHA déplacé ou une erreur de lecture apparaît ;
- conserve la réconciliation idempotente d’une réponse `DELETE` perdue.

## Impact

Le nightly reste fail-closed tout en tolérant jusqu’à 15,75 s de cohérence éventuelle GitHub. Aucune politique de sécurité ou d’auto-merge n’est assouplie.

## Validation

- 132 tests ciblés (`nightly_e2e`, branches GitHub, sync GitHub) ;
- Ruff check ;
- Ruff format check ;
- `git diff --check`.