### PR TITLE
Fiabiliser OpenHands avec Gemma 4 dans le nightly

### DIFF
--- a/.github/workflows/integration-nightly.yml
+++ b/.github/workflows/integration-nightly.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Vérifier le runner produit OpenHands SDK
         run: |
           docker run --rm collegue-sandbox-openhands:ci \
-            python -c "from pathlib import Path; from openhands.sdk import Conversation, LLM; from openhands.tools.preset.default import get_default_agent; assert Path('/opt/oh_runner.py').is_file(); print('OpenHands SDK runner OK')"
+            python -c "from pathlib import Path; from openhands.sdk import Conversation, LLM; from openhands.tools.preset.default import get_default_agent; from openhands.tools.terminal.definition import TerminalAction; assert Path('/opt/oh_runner.py').is_file(); assert TerminalAction.model_validate({'commands': 'true'}).command == 'true'; print('OpenHands SDK runner + Gemma 4 terminal alias OK')"
 
   product-e2e:
     name: Produit E2E — plan → run → PR → cleanup (#404)
@@ -305,7 +305,7 @@ jobs:
       - name: Vérifier le runner OpenHands SDK embarqué
         run: |
           docker run --rm "$SANDBOX_IMAGE" \
-            python -c "from pathlib import Path; from openhands.sdk import Conversation, LLM; from openhands.tools.preset.default import get_default_agent; assert Path('/opt/oh_runner.py').is_file(); print('OpenHands SDK runner OK')"
+            python -c "from pathlib import Path; from openhands.sdk import Conversation, LLM; from openhands.tools.preset.default import get_default_agent; from openhands.tools.terminal.definition import TerminalAction; assert Path('/opt/oh_runner.py').is_file(); assert TerminalAction.model_validate({'commands': 'true'}).command == 'true'; print('OpenHands SDK runner + Gemma 4 terminal alias OK')"
 
       - name: Exécuter le cycle produit réel
         env:

--- a/collegue/pilot/nightly_e2e.py
+++ b/collegue/pilot/nightly_e2e.py
@@ -50,6 +50,9 @@ _EXEC_MARKER = "<!-- collegue-exec:"
 _TASK_MARKER = "<!-- collegue-task:"
 _NIGHTLY_LABEL_COLOR = "1d76db"
 _GITHUB_CONSISTENCY_BACKOFF_SECONDS = (0.25, 0.5, 1.0, 2.0, 4.0, 8.0)
+_TASK_DIAGNOSTIC_MAX_CHARS = 1200
+_TASK_DIAGNOSTIC_REDACTION = "[REDACTED]"
+_TASK_DIAGNOSTIC_SECRET_NAMES = ("GITHUB_TOKEN", "LLM_API_KEY", "GEMINI_API_KEY")
 
 # Contrat volontairement minuscule : un seul changement observable et un seul
 # test. Les chemins font partie du problème car le planner ne voit pas le dépôt.
@@ -613,6 +616,72 @@ class NightlyE2ERunner:
         settings_obj = Settings()
         return ProjectStateManager.from_url(settings_obj.STATE_DATABASE_URL)
 
+    def _safe_task_failure_diagnostic(self, *, project_id: int, plan_hash: str, task_id: int) -> Optional[str]:
+        """Lit le seul ``last_error`` autorisé et le rend sûr pour les logs CI.
+
+        Le diagnostic est purement auxiliaire : au moindre doute sur l'identité
+        durable ``projet + hash approuvé + tâche``, ou si la lecture échoue, il
+        reste absent. On ne cherche jamais une autre tâche par statut/titre et on
+        n'affiche aucun log brut de l'agent.
+        """
+        if (
+            not isinstance(project_id, int)
+            or isinstance(project_id, bool)
+            or project_id <= 0
+            or _SHA256_RE.fullmatch(str(plan_hash or "")) is None
+            or not isinstance(task_id, int)
+            or isinstance(task_id, bool)
+            or task_id <= 0
+        ):
+            return None
+        try:
+            manager = self._manager()
+            project = manager.get_project(project_id)
+        except Exception:  # noqa: BLE001 - diagnostic optionnel, erreur primaire conservée
+            return None
+        if project is None or getattr(project, "approved_plan_hash", None) != plan_hash:
+            return None
+        try:
+            matches = [task for task in project.tasks if getattr(task, "id", None) == task_id]
+        except Exception:  # noqa: BLE001 - relation non chargée/corrompue => absence sûre
+            return None
+        if len(matches) != 1 or getattr(matches[0], "project_id", None) != project_id:
+            return None
+        raw = getattr(matches[0], "last_error", None)
+        if not isinstance(raw, str) or not raw:
+            return None
+
+        # Redacter avant toute troncature évite de conserver le préfixe d'un
+        # secret coupé à la frontière. Le token de config couvre aussi le cas où
+        # os.environ a été modifié après le préflight.
+        secrets = [str(os.environ.get(name, "") or "") for name in _TASK_DIAGNOSTIC_SECRET_NAMES]
+        secrets.append(str(self.config.token or ""))
+        safe = raw
+        for secret in sorted({value for value in secrets if value}, key=len, reverse=True):
+            safe = safe.replace(secret, _TASK_DIAGNOSTIC_REDACTION)
+
+        # ``splitlines`` normalise également CR/CRLF. Une ligne de commande
+        # GitHub Actions ne doit jamais commencer par ``::`` dans stderr.
+        safe = "\n".join((" " + line) if line.startswith("::") else line for line in safe.splitlines())
+        if len(safe) > _TASK_DIAGNOSTIC_MAX_CHARS:
+            marker = "…[diagnostic tronqué]"
+            safe = safe[: _TASK_DIAGNOSTIC_MAX_CHARS - len(marker)] + marker
+        return safe or None
+
+    def _raise_failed_run_contract(self, *, project_id: int, plan_hash: str, task_id: int) -> None:
+        """Échoue le smoke avec, si elle est prouvée, la cause durable sûre."""
+        message = "le RUN réel n'a pas abouti à une unique PR ouverte et validée"
+        diagnostic = self._safe_task_failure_diagnostic(
+            project_id=project_id,
+            plan_hash=plan_hash,
+            task_id=task_id,
+        )
+        if diagnostic is None:
+            raise NightlyE2EError(message)
+        rendered = f"diagnostic tâche durable #{task_id}: {diagnostic}"
+        print(rendered, file=sys.stderr)
+        raise NightlyE2EError(f"{message} — {rendered}")
+
     def _label_owner_description(self) -> str:
         """Marqueur distant compact qui lie le label à ce run exact."""
         cfg = self.config
@@ -735,6 +804,74 @@ class NightlyE2ERunner:
             if attempt < len(_GITHUB_CONSISTENCY_BACKOFF_SECONDS):
                 time.sleep(_GITHUB_CONSISTENCY_BACKOFF_SECONDS[attempt])
         raise NightlyE2EError("corrélation GitHub non confirmée avant épuisement du polling borné")
+
+    def _wait_for_final_cleanup_state(
+        self,
+        *,
+        expected_pr_numbers: set[int],
+        expected_issue_numbers: set[int],
+        label_remote_present: bool,
+    ) -> None:
+        """Attend la disparition bornée des anciennes vues indexées GitHub.
+
+        Les fermetures ont déjà été confirmées par leurs endpoints individuels.
+        Seule une ancienne vue ``open`` d'une ressource précédemment validée est
+        donc transitoire. Un doublon, une identité étrangère, un état incohérent
+        ou une erreur API reste immédiatement fail-closed. Cette boucle ne
+        réémet aucune mutation distante.
+        """
+        cfg = self.config
+        expected_prs = {int(number) for number in expected_pr_numbers}
+        expected_issues = {int(number) for number in expected_issue_numbers}
+
+        for attempt in range(len(_GITHUB_CONSISTENCY_BACKOFF_SECONDS) + 1):
+            remaining_prs = self.clients.prs.list_prs(
+                cfg.owner,
+                cfg.repo,
+                state="open",
+                limit=100,
+                base=cfg.base_branch,
+            )
+            pr_numbers = [int(getattr(pr, "number", 0) or 0) for pr in remaining_prs]
+            if (
+                len(pr_numbers) != len(set(pr_numbers))
+                or any(number not in expected_prs for number in pr_numbers)
+                or any(
+                    getattr(pr, "state", None) != "open" or getattr(pr, "base_branch", None) != cfg.base_branch
+                    for pr in remaining_prs
+                )
+            ):
+                raise NightlyE2EError("candidat PR inattendu pendant la convergence du cleanup")
+
+            remaining_issues = (
+                self.clients.issues.list_issues(
+                    cfg.owner,
+                    cfg.repo,
+                    state="open",
+                    limit=100,
+                    labels=cfg.issue_label,
+                )
+                if label_remote_present
+                else []
+            )
+            issue_numbers = [int(getattr(issue, "number", 0) or 0) for issue in remaining_issues]
+            if (
+                len(issue_numbers) != len(set(issue_numbers))
+                or any(number not in expected_issues for number in issue_numbers)
+                or any(
+                    getattr(issue, "state", None) != "open"
+                    or list(getattr(issue, "labels", ()) or ()).count(cfg.issue_label) != 1
+                    for issue in remaining_issues
+                )
+            ):
+                raise NightlyE2EError("candidat issue inattendu pendant la convergence du cleanup")
+
+            if not remaining_prs and not remaining_issues:
+                return
+            if attempt < len(_GITHUB_CONSISTENCY_BACKOFF_SECONDS):
+                time.sleep(_GITHUB_CONSISTENCY_BACKOFF_SECONDS[attempt])
+
+        raise NightlyE2EError("état final GitHub non convergé avant épuisement du polling borné")
 
     def _inspect_draft(self, project_id: int, plan_hash: str) -> tuple[int, str, str]:
         manager = self._manager()
@@ -965,7 +1102,11 @@ class NightlyE2ERunner:
                 or processed[0].get("acceptance_oracle_sha256") != oracle_sha256
                 or list(run_payload.get("pending_reviews") or []) != [task_id]
             ):
-                raise NightlyE2EError("le RUN réel n'a pas abouti à une unique PR ouverte et validée")
+                self._raise_failed_run_contract(
+                    project_id=project_id,
+                    plan_hash=plan_hash,
+                    task_id=task_id,
+                )
 
             issue_number = issue_numbers[0]
             pr = self.clients.prs.get_pr(cfg.owner, cfg.repo, opened_prs[0])
@@ -1337,20 +1478,11 @@ class NightlyE2ERunner:
         final_root = self.clients.branches.get_branch_sha(cfg.owner, cfg.repo, cfg.root_branch)
         if final_root != manifest.root_sha or current_root != manifest.root_sha:
             raise NightlyE2EError("la branche par défaut de la fixture a bougé pendant le smoke")
-        remaining_prs = self.clients.prs.list_prs(cfg.owner, cfg.repo, state="open", limit=100, base=cfg.base_branch)
-        remaining_issues = (
-            self.clients.issues.list_issues(
-                cfg.owner,
-                cfg.repo,
-                state="open",
-                limit=100,
-                labels=cfg.issue_label,
-            )
-            if label_remote_present
-            else []
+        self._wait_for_final_cleanup_state(
+            expected_pr_numbers=pr_numbers,
+            expected_issue_numbers=issue_numbers,
+            label_remote_present=label_remote_present,
         )
-        if remaining_prs or remaining_issues:
-            raise NightlyE2EError("des PR/issues du run sont encore ouvertes après cleanup")
         if owns_label and not manifest.label_deleted:
             # Relecture juste avant DELETE : un nom identique avec un autre
             # marqueur n'est jamais adopté. Une absence signifie soit que le POST

--- a/docker/sandbox/Dockerfile.openhands
+++ b/docker/sandbox/Dockerfile.openhands
@@ -31,6 +31,17 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 # attendu par openhands 1.7.0 → TypeError à l'import, agent mort-né.
 RUN uv pip install --system "openhands-ai==1.7.0" "lmnr==0.7.52"
 
+# Compatibilité Gemma 4 / OpenHands SDK 1.7.0 : Gemma peut émettre `commands`
+# alors que TerminalAction exige `command`
+# (OpenHands/software-agent-sdk#3741, encore non mergée).
+# Le patch build-time vérifie openhands-ai 1.7.0, ses SDK/tools 1.19.1 et le
+# SHA-256 exact de la source TerminalAction distribuée,
+# puis importe le modèle et teste alias/canonique/priorité. Toute dérive casse le
+# build : aucune modification silencieuse d'une préimage inconnue.
+COPY scripts/patch_openhands_gemma4_terminal.py /opt/patch_openhands_gemma4_terminal.py
+RUN python /opt/patch_openhands_gemma4_terminal.py \
+    && rm /opt/patch_openhands_gemma4_terminal.py
+
 # Runner de tests du gate qualité (pytest) — couche distincte (cache openhands préservé).
 # PIN pytest<9 : pytest 9.0 a retiré `FixtureDef` du namespace top-level, ce qui
 # casse `from pytest import FixtureDef` de pytest-asyncio<0.24 (que les projets

--- a/scripts/patch_openhands_gemma4_terminal.py
+++ b/scripts/patch_openhands_gemma4_terminal.py
@@ -1,0 +1,171 @@
+"""Patch the terminal schema bundled with OpenHands AI 1.7.0 for Gemma 4.
+
+This is deliberately a build-time, fail-closed compatibility patch.  It may only
+touch the exact ``openhands-tools==1.19.1`` source pulled by ``openhands-ai==1.7.0``.
+When OpenHands changes that source, the image build must fail and this patch must
+be reviewed instead of being applied to an unknown preimage.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import importlib.metadata
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+SUPPORTED_VERSIONS = {
+    "openhands-ai": "1.7.0",
+    "openhands-sdk": "1.19.1",
+    "openhands-tools": "1.19.1",
+}
+EXPECTED_SOURCE_SHA256 = "63db877aa4fe6e8306f845604b7bc8dc05ba06af00fc8196b4054fb7f13223d1"
+TARGET_RELATIVE_PATH = Path("openhands/tools/terminal/definition.py")
+
+_IMPORT_PREIMAGE = "from pydantic import Field\n"
+_IMPORT_POSTIMAGE = "from pydantic import Field, model_validator\n"
+_ACTION_START = "class TerminalAction(Action):\n"
+_ACTION_END = "\n\nclass TerminalObservation(Observation):\n"
+_VALIDATOR_ANCHOR = "    @property\n    def visualize(self) -> Text:\n"
+_VALIDATOR_BLOCK = """    @model_validator(mode="before")
+    @classmethod
+    def _normalize_gemma_terminal_arguments(cls, data: object) -> object:
+        # The schema remains canonical. Only normalize Gemma 4's known plural
+        # argument when no canonical value is already present.
+        if not isinstance(data, dict) or "command" in data or "commands" not in data:
+            return data
+        normalized = {**data, "command": data["commands"]}
+        normalized.pop("commands", None)
+        return normalized
+
+"""
+
+
+class PatchError(RuntimeError):
+    """Raised when a compatibility patch invariant is not satisfied."""
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def patch_source(source: bytes, *, expected_sha256: str = EXPECTED_SOURCE_SHA256) -> bytes:
+    """Return the patched source, refusing every unreviewed preimage."""
+
+    actual_sha256 = _sha256(source)
+    if actual_sha256 != expected_sha256:
+        raise PatchError(
+            "unsupported OpenHands terminal definition preimage: "
+            f"expected sha256={expected_sha256}, got sha256={actual_sha256}"
+        )
+
+    try:
+        text = source.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise PatchError("OpenHands terminal definition is not UTF-8") from exc
+
+    if text.count(_IMPORT_PREIMAGE) != 1:
+        raise PatchError("expected exactly one Pydantic Field import")
+    if _IMPORT_POSTIMAGE in text or _VALIDATOR_BLOCK in text:
+        raise PatchError("Gemma 4 terminal compatibility patch is already present")
+    if text.count(_ACTION_START) != 1 or text.count(_ACTION_END) != 1:
+        raise PatchError("TerminalAction class boundaries are ambiguous")
+
+    before_action, action_and_after = text.split(_ACTION_START, 1)
+    action_body, after_action = action_and_after.split(_ACTION_END, 1)
+    if action_body.count(_VALIDATOR_ANCHOR) != 1:
+        raise PatchError("TerminalAction validator insertion point is ambiguous")
+
+    action_body = action_body.replace(
+        _VALIDATOR_ANCHOR,
+        _VALIDATOR_BLOCK + _VALIDATOR_ANCHOR,
+        1,
+    )
+    patched = (
+        before_action.replace(_IMPORT_PREIMAGE, _IMPORT_POSTIMAGE, 1)
+        + _ACTION_START
+        + action_body
+        + _ACTION_END
+        + after_action
+    ).encode("utf-8")
+
+    if _sha256(patched) == actual_sha256:
+        raise PatchError("compatibility patch produced no source change")
+    return patched
+
+
+def _distribution(name: str) -> importlib.metadata.Distribution:
+    try:
+        distribution = importlib.metadata.distribution(name)
+    except importlib.metadata.PackageNotFoundError as exc:
+        raise PatchError(f"required distribution is missing: {name}") from exc
+    expected_version = SUPPORTED_VERSIONS[name]
+    if distribution.version != expected_version:
+        raise PatchError(f"unsupported {name} version: expected {expected_version}, got {distribution.version}")
+    return distribution
+
+
+def locate_target() -> Path:
+    """Resolve the file owned by the exact pinned OpenHands distributions."""
+
+    _distribution("openhands-ai")
+    _distribution("openhands-sdk")
+    tools_distribution = _distribution("openhands-tools")
+    target = Path(tools_distribution.locate_file(TARGET_RELATIVE_PATH)).resolve()
+    if not target.is_file():
+        raise PatchError(f"OpenHands terminal definition is missing: {target}")
+    return target
+
+
+def _atomic_write(path: Path, content: bytes) -> None:
+    mode = path.stat().st_mode
+    with tempfile.NamedTemporaryFile(dir=path.parent, delete=False) as handle:
+        temporary = Path(handle.name)
+        handle.write(content)
+        handle.flush()
+        os.fsync(handle.fileno())
+    try:
+        temporary.chmod(mode)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def verify_runtime_contract() -> None:
+    """Import the patched class and prove all three compatibility semantics."""
+
+    importlib.invalidate_caches()
+    module = importlib.import_module("openhands.tools.terminal.definition")
+    action_type = module.TerminalAction
+
+    alias = action_type.model_validate({"commands": "git status"})
+    canonical = action_type.model_validate({"command": "echo canonical"})
+    priority = action_type.model_validate({"command": "echo canonical", "commands": "echo ignored"})
+    if alias.command != "git status":
+        raise PatchError("postcheck failed: plural commands alias was not remapped")
+    if canonical.command != "echo canonical":
+        raise PatchError("postcheck failed: canonical command changed")
+    if priority.command != "echo canonical":
+        raise PatchError("postcheck failed: canonical command lost precedence")
+
+
+def main() -> int:
+    try:
+        target = locate_target()
+        patched = patch_source(target.read_bytes())
+        _atomic_write(target, patched)
+        if target.read_bytes() != patched:
+            raise PatchError("post-write verification failed")
+        verify_runtime_contract()
+    except PatchError as exc:
+        print(f"OpenHands Gemma 4 compatibility patch refused: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"OpenHands Gemma 4 terminal compatibility patch applied and verified ({target})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_openhands_gemma4_patch.py
+++ b/tests/test_openhands_gemma4_patch.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from scripts.patch_openhands_gemma4_terminal import PatchError, patch_source
+
+_SOURCE = b"""from pydantic import Field
+
+class TerminalAction(Action):
+    command: str = Field(description="command")
+    reset: bool = Field(default=False)
+
+    @property
+    def visualize(self) -> Text:
+        return Text(self.command)
+
+
+class TerminalObservation(Observation):
+    pass
+"""
+
+
+def _patched_action_type():
+    patched = patch_source(
+        _SOURCE,
+        expected_sha256=hashlib.sha256(_SOURCE).hexdigest(),
+    ).decode("utf-8")
+    namespace: dict[str, object] = {}
+    exec(
+        "from pydantic import BaseModel\n"
+        "class Action(BaseModel):\n    pass\n"
+        "class Observation(BaseModel):\n    pass\n"
+        "class Text(str):\n    pass\n" + patched,
+        namespace,
+    )
+    return namespace["TerminalAction"]
+
+
+def test_plural_commands_alias_is_accepted():
+    action_type = _patched_action_type()
+    assert action_type.model_validate({"commands": "git status"}).command == "git status"
+
+
+def test_canonical_command_is_unchanged():
+    action_type = _patched_action_type()
+    assert action_type.model_validate({"command": "echo hi"}).command == "echo hi"
+
+
+def test_canonical_command_takes_precedence_over_plural_alias():
+    action_type = _patched_action_type()
+    action = action_type.model_validate({"command": "echo canonical", "commands": "echo ignored"})
+    assert action.command == "echo canonical"
+
+
+def test_unknown_preimage_is_rejected():
+    expected = hashlib.sha256(_SOURCE).hexdigest()
+    with pytest.raises(PatchError, match="unsupported .* preimage"):
+        patch_source(_SOURCE + b"# upstream changed\n", expected_sha256=expected)

--- a/tests/test_pilot_nightly_e2e.py
+++ b/tests/test_pilot_nightly_e2e.py
@@ -614,6 +614,108 @@ def test_cleanup_is_exact_verified_and_idempotent(tmp_path):
     assert runner.cleanup() == {"status": "clean", "closed_prs": [], "closed_issues": []}
 
 
+def test_cleanup_polls_an_exact_stale_issue_view_without_reclosing(tmp_path, monkeypatch):
+    """Reproduit la vue retardée observée sur le run réel #29210665392."""
+    runner, _branches, _prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    issue = _issue(cfg)
+    stale_issue = _issue(cfg)
+    issues.items[77] = issue
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.issue_numbers = [77]
+    _own_run_label(runner, manifest)
+    runner._task_correlations = lambda _manifest: {77: 77}
+    indexed_views = iter(([issue], [stale_issue], [stale_issue], []))
+    issues.list_issues = lambda *args, **kwargs: next(indexed_views)
+    sleeps = []
+    monkeypatch.setattr(nightly_e2e_module.time, "sleep", sleeps.append)
+
+    assert runner.cleanup() == {"status": "clean", "closed_prs": [], "closed_issues": [77]}
+    assert issues.closed == [77]
+    assert runner.clients.labels.deleted == [cfg.issue_label]
+    assert sleeps == list(nightly_e2e_module._GITHUB_CONSISTENCY_BACKOFF_SECONDS[:2])
+
+
+def test_cleanup_fails_closed_when_exact_stale_view_never_converges(tmp_path, monkeypatch):
+    runner, _branches, _prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    issue = _issue(cfg)
+    stale_issue = _issue(cfg)
+    issues.items[77] = issue
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.issue_numbers = [77]
+    _own_run_label(runner, manifest)
+    runner._task_correlations = lambda _manifest: {77: 77}
+    indexed_views = iter(
+        ([issue], *([[stale_issue]] * (len(nightly_e2e_module._GITHUB_CONSISTENCY_BACKOFF_SECONDS) + 1)))
+    )
+    issues.list_issues = lambda *args, **kwargs: next(indexed_views)
+    sleeps = []
+    monkeypatch.setattr(nightly_e2e_module.time, "sleep", sleeps.append)
+
+    with pytest.raises(NightlyE2EError, match="état final GitHub non convergé.*polling borné"):
+        runner.cleanup()
+
+    assert issues.closed == [77]
+    assert runner.clients.labels.deleted == []
+    assert sleeps == list(nightly_e2e_module._GITHUB_CONSISTENCY_BACKOFF_SECONDS)
+
+
+def test_cleanup_rejects_an_unexpected_final_candidate_without_retry(tmp_path, monkeypatch):
+    runner, _branches, _prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    issue = _issue(cfg)
+    foreign_issue = _issue(cfg, number=78)
+    issues.items[77] = issue
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.issue_numbers = [77]
+    _own_run_label(runner, manifest)
+    runner._task_correlations = lambda _manifest: {77: 77}
+    indexed_views = iter(([issue], [foreign_issue]))
+    issues.list_issues = lambda *args, **kwargs: next(indexed_views)
+    sleeps = []
+    monkeypatch.setattr(nightly_e2e_module.time, "sleep", sleeps.append)
+
+    with pytest.raises(NightlyE2EError, match="candidat issue inattendu"):
+        runner.cleanup()
+
+    assert issues.closed == [77]
+    assert runner.clients.labels.deleted == []
+    assert sleeps == []
+
+
+def test_cleanup_propagates_final_index_api_error_without_retry(tmp_path, monkeypatch):
+    runner, _branches, _prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    issue = _issue(cfg)
+    issues.items[77] = issue
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.issue_numbers = [77]
+    _own_run_label(runner, manifest)
+    runner._task_correlations = lambda _manifest: {77: 77}
+    error = ToolExecutionError("GitHub indisponible", status_code=500)
+    calls = 0
+
+    def list_issues(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return [issue]
+        raise error
+
+    issues.list_issues = list_issues
+    sleeps = []
+    monkeypatch.setattr(nightly_e2e_module.time, "sleep", sleeps.append)
+
+    with pytest.raises(ToolExecutionError) as caught:
+        runner.cleanup()
+
+    assert caught.value is error
+    assert issues.closed == [77]
+    assert runner.clients.labels.deleted == []
+    assert sleeps == []
+
+
 def test_cleanup_is_idempotent_when_real_http_boundary_returns_404(tmp_path, monkeypatch):
     runner, branches, _prs, _issues, _files = _runner(tmp_path)
     cfg = runner.config
@@ -1059,6 +1161,86 @@ def test_run_failure_still_invokes_cleanup(tmp_path):
         runner.run()
     assert cfg.base_branch not in branches.refs
     assert branches.refs["main"] == SEED
+
+
+def test_failed_run_contract_reports_only_redacted_durable_agent_error(tmp_path, monkeypatch, capsys):
+    runner, _branches, _prs, _issues, _files = _runner(tmp_path)
+    plan_hash = "f" * 64
+    task = SimpleNamespace(
+        id=3,
+        project_id=9,
+        last_error=(
+            "[agent/agent_error] échec coder: secret-github / secret-llm / secret-gemini\r\n"
+            "::error title=agent::détail sûr"
+        ),
+    )
+    project = SimpleNamespace(approved_plan_hash=plan_hash, tasks=[task])
+    runner._manager = lambda: SimpleNamespace(
+        get_project=lambda project_id: project if project_id == 9 else None,
+    )
+    monkeypatch.setenv("GITHUB_TOKEN", "secret-github")
+    monkeypatch.setenv("LLM_API_KEY", "secret-llm")
+    monkeypatch.setenv("GEMINI_API_KEY", "secret-gemini")
+
+    with pytest.raises(NightlyE2EError) as caught:
+        runner._raise_failed_run_contract(project_id=9, plan_hash=plan_hash, task_id=3)
+
+    stderr = capsys.readouterr().err
+    rendered = stderr + str(caught.value)
+    assert "agent_error" in rendered
+    assert rendered.count("[REDACTED]") == 6
+    assert "secret-github" not in rendered
+    assert "secret-llm" not in rendered
+    assert "secret-gemini" not in rendered
+    assert "\n::error" not in rendered
+    assert "\n ::error title=agent::détail sûr" in rendered
+
+
+def test_durable_task_diagnostic_is_strictly_bounded(tmp_path):
+    runner, _branches, _prs, _issues, _files = _runner(tmp_path)
+    plan_hash = "f" * 64
+    task = SimpleNamespace(id=3, project_id=9, last_error="[agent/agent_error] " + "x" * 5000)
+    project = SimpleNamespace(approved_plan_hash=plan_hash, tasks=[task])
+    runner._manager = lambda: SimpleNamespace(
+        get_project=lambda _project_id: project,
+    )
+
+    diagnostic = runner._safe_task_failure_diagnostic(project_id=9, plan_hash=plan_hash, task_id=3)
+
+    assert diagnostic is not None
+    assert len(diagnostic) == nightly_e2e_module._TASK_DIAGNOSTIC_MAX_CHARS
+    assert diagnostic.endswith("…[diagnostic tronqué]")
+    assert "agent_error" in diagnostic
+
+
+@pytest.mark.parametrize(
+    ("project_hash", "task_project_id", "task_result"),
+    [
+        ("e" * 64, 9, "task"),
+        ("f" * 64, 10, "task"),
+        ("f" * 64, 9, None),
+    ],
+)
+def test_failed_run_contract_omits_diagnostic_without_exact_durable_identity(
+    tmp_path,
+    capsys,
+    project_hash,
+    task_project_id,
+    task_result,
+):
+    runner, _branches, _prs, _issues, _files = _runner(tmp_path)
+    expected_hash = "f" * 64
+    task = SimpleNamespace(id=3, project_id=task_project_id, last_error="foreign-agent-error")
+    project = SimpleNamespace(approved_plan_hash=project_hash, tasks=[task] if task_result == "task" else [])
+    runner._manager = lambda: SimpleNamespace(
+        get_project=lambda _project_id: project,
+    )
+
+    with pytest.raises(NightlyE2EError) as caught:
+        runner._raise_failed_run_contract(project_id=9, plan_hash=expected_hash, task_id=3)
+
+    assert str(caught.value) == "le RUN réel n'a pas abouti à une unique PR ouverte et validée"
+    assert "foreign-agent-error" not in capsys.readouterr().err
 
 
 def test_run_accepts_real_http_404_for_absent_base_before_first_mutation(tmp_path, monkeypatch):


### PR DESCRIPTION
## Contexte

Le run réel `29210665392` a validé `SPEC.md`, l’oracle QA et l’issue labellisée, puis OpenHands a échoué avant tout diff avec `reason=agent_error`. La cause la plus probable est confirmée par la PR upstream OpenHands `software-agent-sdk#3741` : Gemma 4 émet `commands` alors que `TerminalAction` attend `command`.

Le même run a aussi montré une vue GitHub retardée juste après la fermeture de l’issue, et le diagnostic durable de l’agent n’était pas relayé au nightly.

## Changements

- applique au build un patch de compatibilité `commands` → `command` ;
- vérifie fail-closed les versions exactes `openhands-ai==1.7.0`, `openhands-sdk==1.19.1`, `openhands-tools==1.19.1` et le SHA-256 de la préimage ;
- exécute un postcheck alias/canonique/priorité et renforce les deux smokes Docker ;
- expose le `last_error` de la tâche exacte dans le nightly, borné à 1 200 caractères, secrets caviardés et commandes Actions neutralisées ;
- attend de façon bornée la convergence finale des listes GitHub après cleanup, sans réémettre de mutation.

## Sûreté

- toute version/préimage OpenHands inconnue casse le build ;
- `command` canonique reste prioritaire ;
- aucun secret ni log brut non borné n’est imprimé ;
- candidats GitHub étrangers, SHA/identités inattendus et erreurs API restent bloquants ;
- autonomie et auto-merge restent inchangés et désactivés par défaut.

## Validation locale

- 125 tests ciblés : nightly, OpenHands runner/agent, GitHub branches et patch Gemma ;
- 74 tests workflow/nightly/patch ;
- Ruff check + format check ;
- `git diff --check`.

Le build Docker local n’est pas disponible dans l’environnement ; le job CI Docker constitue la validation autoritative de la préimage réelle.