### PR TITLE
Valider strictement l’alias terminal Gemma 4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,6 +107,21 @@ jobs:
           context: .
           file: docker/collegue/Dockerfile
           push: false
+
+      - name: Build OpenHands sandbox image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/sandbox/Dockerfile.openhands
+          push: false
+          load: true
+          tags: collegue-sandbox-openhands:pr-check
+
+      - name: Verify OpenHands Gemma 4 terminal contract
+        run: |
+          docker run --rm collegue-sandbox-openhands:pr-check \
+            python -c "from openhands.tools.terminal.definition import TerminalAction; assert TerminalAction.model_validate({'commands': 'true'}).command == 'true'; assert TerminalAction.model_validate({'command': 'canonical', 'commands': 'ignored'}).command == 'canonical'"
+          push: false
           load: true
           tags: collegue:ci
           cache-from: type=gha

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,6 +107,10 @@ jobs:
           context: .
           file: docker/collegue/Dockerfile
           push: false
+          load: true
+          tags: collegue:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Build OpenHands sandbox image
         uses: docker/build-push-action@v5
@@ -121,11 +125,6 @@ jobs:
         run: |
           docker run --rm collegue-sandbox-openhands:pr-check \
             python -c "from openhands.tools.terminal.definition import TerminalAction; assert TerminalAction.model_validate({'commands': 'true'}).command == 'true'; assert TerminalAction.model_validate({'command': 'canonical', 'commands': 'ignored'}).command == 'canonical'"
-          push: false
-          load: true
-          tags: collegue:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Smoke test — container starts
         run: |

--- a/scripts/patch_openhands_gemma4_terminal.py
+++ b/scripts/patch_openhands_gemma4_terminal.py
@@ -33,10 +33,12 @@ _VALIDATOR_BLOCK = """    @model_validator(mode="before")
     @classmethod
     def _normalize_gemma_terminal_arguments(cls, data: object) -> object:
         # The schema remains canonical. Only normalize Gemma 4's known plural
-        # argument when no canonical value is already present.
-        if not isinstance(data, dict) or "command" in data or "commands" not in data:
+        # argument. If both keys exist, discard the plural alias so strict
+        # extra-field validation still succeeds and the canonical value wins.
+        if not isinstance(data, dict) or "commands" not in data:
             return data
-        normalized = {**data, "command": data["commands"]}
+        normalized = dict(data)
+        normalized.setdefault("command", normalized["commands"])
         normalized.pop("commands", None)
         return normalized
 

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -52,3 +52,36 @@ def test_nightly_paths_are_exported_from_runner_temp_at_runtime() -> None:
         "SANDBOX_PIP_CACHE_DIR",
     ):
         assert f"printf '{name}=" in workflow
+
+
+def test_docker_build_images_are_loaded_before_smoke_tests() -> None:
+    """Keep build-push options attached to their action, never inside ``run``."""
+
+    workflow = _load_workflow(ROOT / ".github" / "workflows" / "tests.yml")
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    docker_job = jobs["docker-build"]
+    assert isinstance(docker_job, dict)
+    steps = docker_job["steps"]
+    assert isinstance(steps, list)
+
+    expected = {
+        "docker/collegue/Dockerfile": "collegue:ci",
+        "docker/sandbox/Dockerfile.openhands": "collegue-sandbox-openhands:pr-check",
+    }
+    for dockerfile, tag in expected.items():
+        step = next(
+            item
+            for item in steps
+            if isinstance(item, dict) and isinstance(item.get("with"), dict) and item["with"].get("file") == dockerfile
+        )
+        options = step["with"]
+        assert options["load"] == "true"
+        assert options["tags"] == tag
+
+    for step in steps:
+        if isinstance(step, dict) and "run" in step:
+            script = str(step["run"])
+            assert "\nload:" not in script
+            assert "\npush:" not in script
+            assert "\ntags:" not in script

--- a/tests/test_openhands_gemma4_patch.py
+++ b/tests/test_openhands_gemma4_patch.py
@@ -29,8 +29,8 @@ def _patched_action_type():
     ).decode("utf-8")
     namespace: dict[str, object] = {}
     exec(
-        "from pydantic import BaseModel\n"
-        "class Action(BaseModel):\n    pass\n"
+        "from pydantic import BaseModel, ConfigDict\n"
+        "class Action(BaseModel):\n    model_config = ConfigDict(extra='forbid')\n"
         "class Observation(BaseModel):\n    pass\n"
         "class Text(str):\n    pass\n" + patched,
         namespace,


### PR DESCRIPTION
## Contexte

Le run réel `29211683971` a été annulé avant tout appel LLM : le build OpenHands a correctement refusé le postcheck quand `command` et `commands` coexistaient. `TerminalAction` interdit les champs supplémentaires, donc conserver le pluriel faisait échouer la validation.

## Correctif

- retire toujours l’alias `commands` après normalisation ;
- conserve `command` comme valeur prioritaire quand les deux clés existent ;
- rend le double de test Pydantic strict avec `extra="forbid"` pour reproduire la vraie frontière ;
- étend le contrôle Docker de chaque PR pour construire réellement `Dockerfile.openhands`, charger l’image et exécuter les deux contrats alias/priorité.

## Validation

- 4 tests de patch Gemma verts ;
- 5 tests de workflow verts ;
- Ruff check/format ;
- `git diff --check` ;
- fixture confirmée propre (`main` seule, aucune issue/PR ouverte) ;
- vrai E2E désactivé après annulation.