### PR TITLE
Accepter la convergence fermée du cleanup nightly

### DIFF
--- a/collegue/pilot/nightly_e2e.py
+++ b/collegue/pilot/nightly_e2e.py
@@ -805,6 +805,29 @@ class NightlyE2ERunner:
                 time.sleep(_GITHUB_CONSISTENCY_BACKOFF_SECONDS[attempt])
         raise NightlyE2EError("corrélation GitHub non confirmée avant épuisement du polling borné")
 
+    def _assert_canonical_issues_closed(
+        self,
+        *,
+        issue_numbers: set[int],
+        task_by_issue: Mapping[int, int],
+        label_remote_present: bool,
+    ) -> None:
+        """Confirme l'état individuel des issues avant une suppression destructive."""
+
+        cfg = self.config
+        for number in sorted(issue_numbers):
+            task_id = task_by_issue[number]
+            current = self.clients.issues.get_issue(cfg.owner, cfg.repo, number)
+            label_count = list(current.labels or []).count(cfg.issue_label)
+            if (
+                current.number != number
+                or current.state != "closed"
+                or (label_remote_present and label_count != 1)
+                or (not label_remote_present and label_count != 0)
+                or f"<!-- collegue-task:{task_id} -->" not in str(current.body or "")
+            ):
+                raise NightlyE2EError(f"issue #{number} non fermée ou déplacée ; refs conservées")
+
     def _wait_for_final_cleanup_state(
         self,
         *,
@@ -846,7 +869,20 @@ class NightlyE2ERunner:
                 )
             ):
                 raise NightlyE2EError("candidat PR inattendu pendant la convergence du cleanup")
-            pending_prs = [pr for pr in remaining_prs if getattr(pr, "state", None) == "open"]
+            pending_prs = []
+            for pr in remaining_prs:
+                candidate = pr
+                if getattr(pr, "state", None) == "closed":
+                    candidate = self.clients.prs.get_pr(cfg.owner, cfg.repo, int(pr.number))
+                    if (
+                        candidate.number != pr.number
+                        or candidate.state not in {"open", "closed"}
+                        or candidate.merged
+                        or candidate.base_branch != cfg.base_branch
+                    ):
+                        raise NightlyE2EError("candidat PR inattendu pendant la convergence du cleanup")
+                if getattr(candidate, "state", None) == "open":
+                    pending_prs.append(candidate)
 
             remaining_issues = (
                 self.clients.issues.list_issues(
@@ -870,7 +906,19 @@ class NightlyE2ERunner:
                 )
             ):
                 raise NightlyE2EError("candidat issue inattendu pendant la convergence du cleanup")
-            pending_issues = [issue for issue in remaining_issues if getattr(issue, "state", None) == "open"]
+            pending_issues = []
+            for issue in remaining_issues:
+                candidate = issue
+                if getattr(issue, "state", None) == "closed":
+                    candidate = self.clients.issues.get_issue(cfg.owner, cfg.repo, int(issue.number))
+                    if (
+                        candidate.number != issue.number
+                        or candidate.state not in {"open", "closed"}
+                        or list(candidate.labels or []).count(cfg.issue_label) != 1
+                    ):
+                        raise NightlyE2EError("candidat issue inattendu pendant la convergence du cleanup")
+                if getattr(candidate, "state", None) == "open":
+                    pending_issues.append(candidate)
 
             if not pending_prs and not pending_issues:
                 return
@@ -1454,18 +1502,11 @@ class NightlyE2ERunner:
         # Même relecture autoritative pour les issues avant la convergence
         # indexée et avant toute suppression de ref/label. Elle empêche une vue
         # ``closed`` retardée de masquer une réouverture concurrente.
-        for number in sorted(issue_numbers):
-            task_id = task_by_issue[number]
-            current = self.clients.issues.get_issue(cfg.owner, cfg.repo, number)
-            label_count = list(current.labels or []).count(cfg.issue_label)
-            if (
-                current.number != number
-                or current.state != "closed"
-                or (label_remote_present and label_count != 1)
-                or (not label_remote_present and label_count != 0)
-                or f"<!-- collegue-task:{task_id} -->" not in str(current.body or "")
-            ):
-                raise NightlyE2EError(f"issue #{number} non fermée ou déplacée ; refs conservées")
+        self._assert_canonical_issues_closed(
+            issue_numbers=issue_numbers,
+            task_by_issue=task_by_issue,
+            label_remote_present=label_remote_present,
+        )
 
         # La convergence des index doit elle aussi être acquise avant les
         # suppressions destructives. Cela détecte notamment une PR étrangère
@@ -1474,6 +1515,11 @@ class NightlyE2ERunner:
         self._wait_for_final_cleanup_state(
             expected_pr_numbers=pr_numbers,
             expected_issue_numbers=issue_numbers,
+            label_remote_present=label_remote_present,
+        )
+        self._assert_canonical_issues_closed(
+            issue_numbers=issue_numbers,
+            task_by_issue=task_by_issue,
             label_remote_present=label_remote_present,
         )
 
@@ -1522,6 +1568,18 @@ class NightlyE2ERunner:
         final_root = self.clients.branches.get_branch_sha(cfg.owner, cfg.repo, cfg.root_branch)
         if final_root != manifest.root_sha or current_root != manifest.root_sha:
             raise NightlyE2EError("la branche par défaut de la fixture a bougé pendant le smoke")
+        # Seconde frontière : une ressource étrangère créée pendant la phase de
+        # suppression des refs doit empêcher la suppression du label/manifeste.
+        self._wait_for_final_cleanup_state(
+            expected_pr_numbers=pr_numbers,
+            expected_issue_numbers=issue_numbers,
+            label_remote_present=label_remote_present,
+        )
+        self._assert_canonical_issues_closed(
+            issue_numbers=issue_numbers,
+            task_by_issue=task_by_issue,
+            label_remote_present=label_remote_present,
+        )
         if owns_label and not manifest.label_deleted:
             # Relecture juste avant DELETE : un nom identique avec un autre
             # marqueur n'est jamais adopté. Une absence signifie soit que le POST

--- a/collegue/pilot/nightly_e2e.py
+++ b/collegue/pilot/nightly_e2e.py
@@ -50,7 +50,6 @@ _EXEC_MARKER = "<!-- collegue-exec:"
 _TASK_MARKER = "<!-- collegue-task:"
 _NIGHTLY_LABEL_COLOR = "1d76db"
 _GITHUB_CONSISTENCY_BACKOFF_SECONDS = (0.25, 0.5, 1.0, 2.0, 4.0, 8.0)
-_GITHUB_CLEAR_STABILITY_POLLS = 3
 _TASK_DIAGNOSTIC_MAX_CHARS = 1200
 _TASK_DIAGNOSTIC_REDACTION = "[REDACTED]"
 _TASK_DIAGNOSTIC_SECRET_NAMES = ("GITHUB_TOKEN", "LLM_API_KEY", "GEMINI_API_KEY")
@@ -871,9 +870,8 @@ class NightlyE2ERunner:
         cfg = self.config
         expected_prs = {int(number) for number in expected_pr_numbers}
         expected_issues = {int(number) for number in expected_issue_numbers}
-        clear_views = 0
 
-        for attempt in range(len(_GITHUB_CONSISTENCY_BACKOFF_SECONDS) + 1):
+        def has_pending_resources() -> bool:
             remaining_prs = self.clients.prs.list_prs(
                 cfg.owner,
                 cfg.repo,
@@ -944,16 +942,24 @@ class NightlyE2ERunner:
                 if getattr(candidate, "state", None) == "open":
                     pending_issues.append(candidate)
 
-            if not pending_prs and not pending_issues:
-                clear_views += 1
-                if clear_views >= _GITHUB_CLEAR_STABILITY_POLLS:
-                    return
-            else:
-                clear_views = 0
-            if attempt < len(_GITHUB_CONSISTENCY_BACKOFF_SECONDS):
-                time.sleep(_GITHUB_CONSISTENCY_BACKOFF_SECONDS[attempt])
+            return bool(pending_prs or pending_issues)
 
-        raise NightlyE2EError("état final GitHub non convergé avant épuisement du polling borné")
+        # Phase 1 : laisser une ancienne vue ``open`` converger dans le budget
+        # historique. Une convergence tardive ne consomme pas la phase suivante.
+        for attempt in range(len(_GITHUB_CONSISTENCY_BACKOFF_SECONDS) + 1):
+            if not has_pending_resources():
+                break
+            if attempt == len(_GITHUB_CONSISTENCY_BACKOFF_SECONDS):
+                raise NightlyE2EError("état final GitHub non convergé avant épuisement du polling borné")
+            time.sleep(_GITHUB_CONSISTENCY_BACKOFF_SECONDS[attempt])
+
+        # Phase 2 : une première absence n'est pas une preuve. Rééchantillonner
+        # pendant toute la fenêtre de cohérence (15,75 s) ; toute réapparition
+        # est fail-closed et conserve les ancres pour une reprise ultérieure.
+        for delay in _GITHUB_CONSISTENCY_BACKOFF_SECONDS:
+            time.sleep(delay)
+            if has_pending_resources():
+                raise NightlyE2EError("état final GitHub instable pendant la fenêtre de confirmation")
 
     def _inspect_draft(self, project_id: int, plan_hash: str) -> tuple[int, str, str]:
         manager = self._manager()

--- a/collegue/pilot/nightly_e2e.py
+++ b/collegue/pilot/nightly_e2e.py
@@ -50,6 +50,7 @@ _EXEC_MARKER = "<!-- collegue-exec:"
 _TASK_MARKER = "<!-- collegue-task:"
 _NIGHTLY_LABEL_COLOR = "1d76db"
 _GITHUB_CONSISTENCY_BACKOFF_SECONDS = (0.25, 0.5, 1.0, 2.0, 4.0, 8.0)
+_GITHUB_CLEAR_STABILITY_POLLS = 3
 _TASK_DIAGNOSTIC_MAX_CHARS = 1200
 _TASK_DIAGNOSTIC_REDACTION = "[REDACTED]"
 _TASK_DIAGNOSTIC_SECRET_NAMES = ("GITHUB_TOKEN", "LLM_API_KEY", "GEMINI_API_KEY")
@@ -805,6 +806,28 @@ class NightlyE2ERunner:
                 time.sleep(_GITHUB_CONSISTENCY_BACKOFF_SECONDS[attempt])
         raise NightlyE2EError("corrélation GitHub non confirmée avant épuisement du polling borné")
 
+    def _assert_canonical_prs_closed(
+        self,
+        *,
+        pr_numbers: set[int],
+        validated_prs: Mapping[int, Any],
+    ) -> None:
+        """Confirme l'état individuel des PR avant une suppression destructive."""
+
+        cfg = self.config
+        for number in sorted(pr_numbers):
+            expected = validated_prs[number]
+            current = self.clients.prs.get_pr(cfg.owner, cfg.repo, number)
+            if (
+                current.number != number
+                or current.state != "closed"
+                or current.merged
+                or current.head_sha != expected.head_sha
+                or current.head_branch != expected.head_branch
+                or current.base_branch != expected.base_branch
+            ):
+                raise NightlyE2EError(f"PR #{number} non fermée ou déplacée ; refs conservées")
+
     def _assert_canonical_issues_closed(
         self,
         *,
@@ -848,6 +871,7 @@ class NightlyE2ERunner:
         cfg = self.config
         expected_prs = {int(number) for number in expected_pr_numbers}
         expected_issues = {int(number) for number in expected_issue_numbers}
+        clear_views = 0
 
         for attempt in range(len(_GITHUB_CONSISTENCY_BACKOFF_SECONDS) + 1):
             remaining_prs = self.clients.prs.list_prs(
@@ -921,7 +945,11 @@ class NightlyE2ERunner:
                     pending_issues.append(candidate)
 
             if not pending_prs and not pending_issues:
-                return
+                clear_views += 1
+                if clear_views >= _GITHUB_CLEAR_STABILITY_POLLS:
+                    return
+            else:
+                clear_views = 0
             if attempt < len(_GITHUB_CONSISTENCY_BACKOFF_SECONDS):
                 time.sleep(_GITHUB_CONSISTENCY_BACKOFF_SECONDS[attempt])
 
@@ -1486,18 +1514,10 @@ class NightlyE2ERunner:
         # Relecture canonique juste avant de supprimer les refs. Contrairement à
         # l'index ``state=open`` éventuellement retardé, l'endpoint individuel
         # doit confirmer que personne n'a rouvert ou mergé la PR entre-temps.
-        for number in sorted(pr_numbers):
-            expected = validated_prs[number]
-            current = self.clients.prs.get_pr(cfg.owner, cfg.repo, number)
-            if (
-                current.number != number
-                or current.state != "closed"
-                or current.merged
-                or current.head_sha != expected.head_sha
-                or current.head_branch != expected.head_branch
-                or current.base_branch != expected.base_branch
-            ):
-                raise NightlyE2EError(f"PR #{number} non fermée ou déplacée ; refs conservées")
+        self._assert_canonical_prs_closed(
+            pr_numbers=pr_numbers,
+            validated_prs=validated_prs,
+        )
 
         # Même relecture autoritative pour les issues avant la convergence
         # indexée et avant toute suppression de ref/label. Elle empêche une vue
@@ -1516,6 +1536,10 @@ class NightlyE2ERunner:
             expected_pr_numbers=pr_numbers,
             expected_issue_numbers=issue_numbers,
             label_remote_present=label_remote_present,
+        )
+        self._assert_canonical_prs_closed(
+            pr_numbers=pr_numbers,
+            validated_prs=validated_prs,
         )
         self._assert_canonical_issues_closed(
             issue_numbers=issue_numbers,
@@ -1574,6 +1598,10 @@ class NightlyE2ERunner:
             expected_pr_numbers=pr_numbers,
             expected_issue_numbers=issue_numbers,
             label_remote_present=label_remote_present,
+        )
+        self._assert_canonical_prs_closed(
+            pr_numbers=pr_numbers,
+            validated_prs=validated_prs,
         )
         self._assert_canonical_issues_closed(
             issue_numbers=issue_numbers,

--- a/collegue/pilot/nightly_e2e.py
+++ b/collegue/pilot/nightly_e2e.py
@@ -815,8 +815,10 @@ class NightlyE2ERunner:
         """Attend la disparition bornée des anciennes vues indexées GitHub.
 
         Les fermetures ont déjà été confirmées par leurs endpoints individuels.
-        Seule une ancienne vue ``open`` d'une ressource précédemment validée est
-        donc transitoire. Un doublon, une identité étrangère, un état incohérent
+        Une ancienne vue indexée peut donc encore inclure une ressource validée,
+        soit avec son ancien état ``open``, soit avec son nouvel état ``closed``
+        malgré le filtre ``state=open``. Le second cas est déjà convergé ; le
+        premier est pollé. Un doublon, une identité étrangère, un état incohérent
         ou une erreur API reste immédiatement fail-closed. Cette boucle ne
         réémet aucune mutation distante.
         """
@@ -837,11 +839,14 @@ class NightlyE2ERunner:
                 len(pr_numbers) != len(set(pr_numbers))
                 or any(number not in expected_prs for number in pr_numbers)
                 or any(
-                    getattr(pr, "state", None) != "open" or getattr(pr, "base_branch", None) != cfg.base_branch
+                    getattr(pr, "state", None) not in {"open", "closed"}
+                    or bool(getattr(pr, "merged", False))
+                    or getattr(pr, "base_branch", None) != cfg.base_branch
                     for pr in remaining_prs
                 )
             ):
                 raise NightlyE2EError("candidat PR inattendu pendant la convergence du cleanup")
+            pending_prs = [pr for pr in remaining_prs if getattr(pr, "state", None) == "open"]
 
             remaining_issues = (
                 self.clients.issues.list_issues(
@@ -859,14 +864,15 @@ class NightlyE2ERunner:
                 len(issue_numbers) != len(set(issue_numbers))
                 or any(number not in expected_issues for number in issue_numbers)
                 or any(
-                    getattr(issue, "state", None) != "open"
+                    getattr(issue, "state", None) not in {"open", "closed"}
                     or list(getattr(issue, "labels", ()) or ()).count(cfg.issue_label) != 1
                     for issue in remaining_issues
                 )
             ):
                 raise NightlyE2EError("candidat issue inattendu pendant la convergence du cleanup")
+            pending_issues = [issue for issue in remaining_issues if getattr(issue, "state", None) == "open"]
 
-            if not remaining_prs and not remaining_issues:
+            if not pending_prs and not pending_issues:
                 return
             if attempt < len(_GITHUB_CONSISTENCY_BACKOFF_SECONDS):
                 time.sleep(_GITHUB_CONSISTENCY_BACKOFF_SECONDS[attempt])
@@ -1429,9 +1435,20 @@ class NightlyE2ERunner:
         if close_errors:
             raise NightlyE2EError("fermetures incomplètes, refs conservées: " + " | ".join(close_errors))
 
-        remaining_prs = self.clients.prs.list_prs(cfg.owner, cfg.repo, state="open", limit=100, base=cfg.base_branch)
-        if remaining_prs:
-            raise NightlyE2EError("PR encore ouverte après fermeture ; refs conservées")
+        # Relecture canonique juste avant de supprimer les refs. Contrairement à
+        # l'index ``state=open`` éventuellement retardé, l'endpoint individuel
+        # doit confirmer que personne n'a rouvert ou mergé la PR entre-temps.
+        for number in sorted(pr_numbers):
+            expected = validated_prs[number]
+            current = self.clients.prs.get_pr(cfg.owner, cfg.repo, number)
+            if (
+                current.state != "closed"
+                or current.merged
+                or current.head_sha != expected.head_sha
+                or current.head_branch != expected.head_branch
+                or current.base_branch != expected.base_branch
+            ):
+                raise NightlyE2EError(f"PR #{number} non fermée ou déplacée ; refs conservées")
 
         # Phase 4 — refs prouvées seulement. Une issue corrélée ne prouve PAS le
         # SHA de sa branche déterministe : si le crash a précédé create_pr, on

--- a/collegue/pilot/nightly_e2e.py
+++ b/collegue/pilot/nightly_e2e.py
@@ -1442,13 +1442,40 @@ class NightlyE2ERunner:
             expected = validated_prs[number]
             current = self.clients.prs.get_pr(cfg.owner, cfg.repo, number)
             if (
-                current.state != "closed"
+                current.number != number
+                or current.state != "closed"
                 or current.merged
                 or current.head_sha != expected.head_sha
                 or current.head_branch != expected.head_branch
                 or current.base_branch != expected.base_branch
             ):
                 raise NightlyE2EError(f"PR #{number} non fermée ou déplacée ; refs conservées")
+
+        # Même relecture autoritative pour les issues avant la convergence
+        # indexée et avant toute suppression de ref/label. Elle empêche une vue
+        # ``closed`` retardée de masquer une réouverture concurrente.
+        for number in sorted(issue_numbers):
+            task_id = task_by_issue[number]
+            current = self.clients.issues.get_issue(cfg.owner, cfg.repo, number)
+            label_count = list(current.labels or []).count(cfg.issue_label)
+            if (
+                current.number != number
+                or current.state != "closed"
+                or (label_remote_present and label_count != 1)
+                or (not label_remote_present and label_count != 0)
+                or f"<!-- collegue-task:{task_id} -->" not in str(current.body or "")
+            ):
+                raise NightlyE2EError(f"issue #{number} non fermée ou déplacée ; refs conservées")
+
+        # La convergence des index doit elle aussi être acquise avant les
+        # suppressions destructives. Cela détecte notamment une PR étrangère
+        # ouverte après l'inventaire initial tout en tolérant les objets attendus
+        # déjà hydratés avec leur état canonique ``closed``.
+        self._wait_for_final_cleanup_state(
+            expected_pr_numbers=pr_numbers,
+            expected_issue_numbers=issue_numbers,
+            label_remote_present=label_remote_present,
+        )
 
         # Phase 4 — refs prouvées seulement. Une issue corrélée ne prouve PAS le
         # SHA de sa branche déterministe : si le crash a précédé create_pr, on
@@ -1495,11 +1522,6 @@ class NightlyE2ERunner:
         final_root = self.clients.branches.get_branch_sha(cfg.owner, cfg.repo, cfg.root_branch)
         if final_root != manifest.root_sha or current_root != manifest.root_sha:
             raise NightlyE2EError("la branche par défaut de la fixture a bougé pendant le smoke")
-        self._wait_for_final_cleanup_state(
-            expected_pr_numbers=pr_numbers,
-            expected_issue_numbers=issue_numbers,
-            label_remote_present=label_remote_present,
-        )
         if owns_label and not manifest.label_deleted:
             # Relecture juste avant DELETE : un nom identique avec un autre
             # marqueur n'est jamais adopté. Une absence signifie soit que le POST

--- a/tests/test_pilot_nightly_e2e.py
+++ b/tests/test_pilot_nightly_e2e.py
@@ -625,7 +625,7 @@ def test_cleanup_polls_an_exact_stale_issue_view_without_reclosing(tmp_path, mon
     manifest.issue_numbers = [77]
     _own_run_label(runner, manifest)
     runner._task_correlations = lambda _manifest: {77: 77}
-    indexed_views = iter(([issue], [stale_issue], [stale_issue], []))
+    indexed_views = iter(([issue], [stale_issue], [stale_issue], [], []))
     issues.list_issues = lambda *args, **kwargs: next(indexed_views)
     sleeps = []
     monkeypatch.setattr(nightly_e2e_module.time, "sleep", sleeps.append)
@@ -725,6 +725,75 @@ def test_cleanup_rejects_issue_reopened_before_canonical_recheck(tmp_path):
 
     assert issues.closed == [77]
     assert branches.deleted == []
+    assert runner.clients.labels.deleted == []
+
+
+def test_cleanup_rechecks_closed_index_candidate_before_deleting_refs(tmp_path, monkeypatch):
+    runner, branches, _prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    branches.refs[cfg.base_branch] = BASE_SHA
+    issue = _issue(cfg)
+    stale_closed = _issue(cfg)
+    stale_closed.state = "closed"
+    issues.items[77] = issue
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.base_created = True
+    manifest.base_sha = BASE_SHA
+    manifest.issue_numbers = [77]
+    _own_run_label(runner, manifest)
+    runner._task_correlations = lambda _manifest: {77: 77}
+    calls = 0
+
+    def list_issues(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return [issue]
+        if calls == 2:
+            issue.state = "open"
+            return [stale_closed]
+        return []
+
+    issues.list_issues = list_issues
+    sleeps = []
+    monkeypatch.setattr(nightly_e2e_module.time, "sleep", sleeps.append)
+
+    with pytest.raises(NightlyE2EError, match="issue #77 non fermée ou déplacée"):
+        runner.cleanup()
+
+    assert branches.deleted == []
+    assert runner.clients.labels.deleted == []
+    assert sleeps == [nightly_e2e_module._GITHUB_CONSISTENCY_BACKOFF_SECONDS[0]]
+
+
+def test_cleanup_final_guard_rejects_foreign_issue_created_during_ref_deletion(tmp_path):
+    runner, branches, _prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    branches.refs[cfg.base_branch] = BASE_SHA
+    issue = _issue(cfg)
+    foreign_issue = _issue(cfg, number=78)
+    issues.items[77] = issue
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.base_created = True
+    manifest.base_sha = BASE_SHA
+    manifest.issue_numbers = [77]
+    _own_run_label(runner, manifest)
+    runner._task_correlations = lambda _manifest: {77: 77}
+    indexed_views = iter(([issue], [], [foreign_issue]))
+    issues.list_issues = lambda *args, **kwargs: next(indexed_views)
+    delete_branch = branches.delete_branch
+
+    def delete_then_create_foreign_issue(*args, **kwargs):
+        result = delete_branch(*args, **kwargs)
+        issues.items[78] = foreign_issue
+        return result
+
+    branches.delete_branch = delete_then_create_foreign_issue
+
+    with pytest.raises(NightlyE2EError, match="candidat issue inattendu"):
+        runner.cleanup()
+
+    assert (cfg.base_branch, BASE_SHA) in branches.deleted
     assert runner.clients.labels.deleted == []
 
 

--- a/tests/test_pilot_nightly_e2e.py
+++ b/tests/test_pilot_nightly_e2e.py
@@ -625,7 +625,7 @@ def test_cleanup_polls_an_exact_stale_issue_view_without_reclosing(tmp_path, mon
     manifest.issue_numbers = [77]
     _own_run_label(runner, manifest)
     runner._task_correlations = lambda _manifest: {77: 77}
-    indexed_views = iter(([issue], [stale_issue], [stale_issue], [], []))
+    indexed_views = iter(([issue], [stale_issue], [stale_issue], [], [], [], [], [], []))
     issues.list_issues = lambda *args, **kwargs: next(indexed_views)
     sleeps = []
     monkeypatch.setattr(nightly_e2e_module.time, "sleep", sleeps.append)
@@ -633,7 +633,7 @@ def test_cleanup_polls_an_exact_stale_issue_view_without_reclosing(tmp_path, mon
     assert runner.cleanup() == {"status": "clean", "closed_prs": [], "closed_issues": [77]}
     assert issues.closed == [77]
     assert runner.clients.labels.deleted == [cfg.issue_label]
-    assert sleeps == list(nightly_e2e_module._GITHUB_CONSISTENCY_BACKOFF_SECONDS[:2])
+    assert sleeps == [0.25, 0.5, 1.0, 2.0, 0.25, 0.5]
 
 
 def test_cleanup_accepts_closed_resources_still_returned_by_open_indexes(tmp_path, monkeypatch):
@@ -667,7 +667,7 @@ def test_cleanup_accepts_closed_resources_still_returned_by_open_indexes(tmp_pat
     assert pr.state == "closed" and issue.state == "closed"
     assert prs.closed == [88] and issues.closed == [77]
     assert runner.clients.labels.deleted == [cfg.issue_label]
-    assert sleeps == []
+    assert sleeps == [0.25, 0.5, 0.25, 0.5]
 
 
 def test_cleanup_rejects_foreign_pr_created_after_inventory_before_deleting_refs(tmp_path):
@@ -763,7 +763,47 @@ def test_cleanup_rechecks_closed_index_candidate_before_deleting_refs(tmp_path, 
 
     assert branches.deleted == []
     assert runner.clients.labels.deleted == []
-    assert sleeps == [nightly_e2e_module._GITHUB_CONSISTENCY_BACKOFF_SECONDS[0]]
+    assert sleeps == [0.25, 0.5, 1.0]
+
+
+def test_cleanup_rechecks_pr_reopened_behind_a_closed_index_view(tmp_path):
+    runner, branches, prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    branches.refs[cfg.base_branch] = BASE_SHA
+    branches.refs["collegue/issue-77"] = HEAD_SHA
+    pr = _pr(cfg)
+    stale_closed = _pr(cfg)
+    stale_closed.state = "closed"
+    issue = _issue(cfg)
+    prs.items[88] = pr
+    issues.items[77] = issue
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.base_created = True
+    manifest.base_sha = BASE_SHA
+    manifest.issue_numbers = [77]
+    manifest.pr_numbers = [88]
+    manifest.head_shas = {"collegue/issue-77": HEAD_SHA}
+    _own_run_label(runner, manifest)
+    runner._task_correlations = lambda _manifest: {77: 77}
+    calls = 0
+
+    def list_prs(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return [pr]
+        if calls == 2:
+            pr.state = "open"
+            return [stale_closed]
+        return []
+
+    prs.list_prs = list_prs
+
+    with pytest.raises(NightlyE2EError, match="PR #88 non fermée ou déplacée"):
+        runner.cleanup()
+
+    assert branches.deleted == []
+    assert runner.clients.labels.deleted == []
 
 
 def test_cleanup_final_guard_rejects_foreign_issue_created_during_ref_deletion(tmp_path):
@@ -779,7 +819,7 @@ def test_cleanup_final_guard_rejects_foreign_issue_created_during_ref_deletion(t
     manifest.issue_numbers = [77]
     _own_run_label(runner, manifest)
     runner._task_correlations = lambda _manifest: {77: 77}
-    indexed_views = iter(([issue], [], [foreign_issue]))
+    indexed_views = iter(([issue], [], [], [], [], [], [foreign_issue]))
     issues.list_issues = lambda *args, **kwargs: next(indexed_views)
     delete_branch = branches.delete_branch
 

--- a/tests/test_pilot_nightly_e2e.py
+++ b/tests/test_pilot_nightly_e2e.py
@@ -670,6 +670,64 @@ def test_cleanup_accepts_closed_resources_still_returned_by_open_indexes(tmp_pat
     assert sleeps == []
 
 
+def test_cleanup_rejects_foreign_pr_created_after_inventory_before_deleting_refs(tmp_path):
+    runner, branches, prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    branches.refs[cfg.base_branch] = BASE_SHA
+    branches.refs["collegue/issue-77"] = HEAD_SHA
+    pr = _pr(cfg)
+    foreign_pr = _pr(cfg, number=89, issue_number=78)
+    issue = _issue(cfg)
+    prs.items[88] = pr
+    issues.items[77] = issue
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.base_created = True
+    manifest.base_sha = BASE_SHA
+    manifest.issue_numbers = [77]
+    manifest.pr_numbers = [88]
+    manifest.head_shas = {"collegue/issue-77": HEAD_SHA}
+    _own_run_label(runner, manifest)
+    runner._task_correlations = lambda _manifest: {77: 77}
+    indexed_prs = iter(([pr], [foreign_pr]))
+    prs.list_prs = lambda *args, **kwargs: next(indexed_prs)
+
+    with pytest.raises(NightlyE2EError, match="candidat PR inattendu"):
+        runner.cleanup()
+
+    assert prs.closed == [88] and issues.closed == [77]
+    assert branches.deleted == []
+    assert runner.clients.labels.deleted == []
+
+
+def test_cleanup_rejects_issue_reopened_before_canonical_recheck(tmp_path):
+    runner, branches, _prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    branches.refs[cfg.base_branch] = BASE_SHA
+    issue = _issue(cfg)
+    issues.items[77] = issue
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.base_created = True
+    manifest.base_sha = BASE_SHA
+    manifest.issue_numbers = [77]
+    _own_run_label(runner, manifest)
+    runner._task_correlations = lambda _manifest: {77: 77}
+    close_issue = issues.close_issue
+
+    def close_then_reopen(*args, **kwargs):
+        closed = close_issue(*args, **kwargs)
+        closed.state = "open"
+        return closed
+
+    issues.close_issue = close_then_reopen
+
+    with pytest.raises(NightlyE2EError, match="issue #77 non fermée ou déplacée"):
+        runner.cleanup()
+
+    assert issues.closed == [77]
+    assert branches.deleted == []
+    assert runner.clients.labels.deleted == []
+
+
 def test_cleanup_fails_closed_when_exact_stale_view_never_converges(tmp_path, monkeypatch):
     runner, _branches, _prs, issues, _files = _runner(tmp_path)
     cfg = runner.config

--- a/tests/test_pilot_nightly_e2e.py
+++ b/tests/test_pilot_nightly_e2e.py
@@ -28,6 +28,13 @@ ORACLE_SHA = "e" * 64
 ROOT_TREE_SHA = "1" * 40
 
 
+@pytest.fixture(autouse=True)
+def _disable_real_consistency_waits(monkeypatch):
+    """Les tests pilotent les vues ; ils ne doivent pas attendre le temps mur."""
+
+    monkeypatch.setattr(nightly_e2e_module.time, "sleep", lambda _delay: None)
+
+
 def _env(tmp_path, **overrides):
     values = {
         "COLLEGUE_NIGHTLY_E2E": "true",
@@ -625,15 +632,21 @@ def test_cleanup_polls_an_exact_stale_issue_view_without_reclosing(tmp_path, mon
     manifest.issue_numbers = [77]
     _own_run_label(runner, manifest)
     runner._task_correlations = lambda _manifest: {77: 77}
-    indexed_views = iter(([issue], [stale_issue], [stale_issue], [], [], [], [], [], []))
-    issues.list_issues = lambda *args, **kwargs: next(indexed_views)
+    calls = 0
+
+    def list_issues(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return [stale_issue] if calls in {2, 3} else ([issue] if calls == 1 else [])
+
+    issues.list_issues = list_issues
     sleeps = []
     monkeypatch.setattr(nightly_e2e_module.time, "sleep", sleeps.append)
 
     assert runner.cleanup() == {"status": "clean", "closed_prs": [], "closed_issues": [77]}
     assert issues.closed == [77]
     assert runner.clients.labels.deleted == [cfg.issue_label]
-    assert sleeps == [0.25, 0.5, 1.0, 2.0, 0.25, 0.5]
+    assert sleeps == [0.25, 0.5, *(nightly_e2e_module._GITHUB_CONSISTENCY_BACKOFF_SECONDS * 2)]
 
 
 def test_cleanup_accepts_closed_resources_still_returned_by_open_indexes(tmp_path, monkeypatch):
@@ -667,7 +680,7 @@ def test_cleanup_accepts_closed_resources_still_returned_by_open_indexes(tmp_pat
     assert pr.state == "closed" and issue.state == "closed"
     assert prs.closed == [88] and issues.closed == [77]
     assert runner.clients.labels.deleted == [cfg.issue_label]
-    assert sleeps == [0.25, 0.5, 0.25, 0.5]
+    assert sleeps == list(nightly_e2e_module._GITHUB_CONSISTENCY_BACKOFF_SECONDS * 2)
 
 
 def test_cleanup_rejects_foreign_pr_created_after_inventory_before_deleting_refs(tmp_path):
@@ -763,7 +776,7 @@ def test_cleanup_rechecks_closed_index_candidate_before_deleting_refs(tmp_path, 
 
     assert branches.deleted == []
     assert runner.clients.labels.deleted == []
-    assert sleeps == [0.25, 0.5, 1.0]
+    assert sleeps == [0.25, *nightly_e2e_module._GITHUB_CONSISTENCY_BACKOFF_SECONDS]
 
 
 def test_cleanup_rechecks_pr_reopened_behind_a_closed_index_view(tmp_path):
@@ -819,8 +832,18 @@ def test_cleanup_final_guard_rejects_foreign_issue_created_during_ref_deletion(t
     manifest.issue_numbers = [77]
     _own_run_label(runner, manifest)
     runner._task_correlations = lambda _manifest: {77: 77}
-    indexed_views = iter(([issue], [], [], [], [], [], [foreign_issue]))
-    issues.list_issues = lambda *args, **kwargs: next(indexed_views)
+    calls = 0
+
+    def list_issues(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return [issue]
+        if calls == 12:
+            return [foreign_issue]
+        return []
+
+    issues.list_issues = list_issues
     delete_branch = branches.delete_branch
 
     def delete_then_create_foreign_issue(*args, **kwargs):

--- a/tests/test_pilot_nightly_e2e.py
+++ b/tests/test_pilot_nightly_e2e.py
@@ -636,6 +636,40 @@ def test_cleanup_polls_an_exact_stale_issue_view_without_reclosing(tmp_path, mon
     assert sleeps == list(nightly_e2e_module._GITHUB_CONSISTENCY_BACKOFF_SECONDS[:2])
 
 
+def test_cleanup_accepts_closed_resources_still_returned_by_open_indexes(tmp_path, monkeypatch):
+    """Reproduit le faux négatif observé sur le run réel #29212284046."""
+
+    runner, branches, prs, issues, _files = _runner(tmp_path)
+    cfg = runner.config
+    branches.refs[cfg.base_branch] = BASE_SHA
+    branches.refs["collegue/issue-77"] = HEAD_SHA
+    pr = _pr(cfg)
+    issue = _issue(cfg)
+    prs.items[88] = pr
+    issues.items[77] = issue
+    manifest = NightlyManifest.for_config(cfg)
+    manifest.base_created = True
+    manifest.base_sha = BASE_SHA
+    manifest.issue_numbers = [77]
+    manifest.pr_numbers = [88]
+    manifest.head_shas = {"collegue/issue-77": HEAD_SHA}
+    _own_run_label(runner, manifest)
+    runner._task_correlations = lambda _manifest: {77: 77}
+
+    # Les objets sont mutés vers ``closed`` par les endpoints individuels, mais
+    # l'index filtré ``state=open`` les renvoie encore une fois.
+    prs.list_prs = lambda *args, **kwargs: [pr]
+    issues.list_issues = lambda *args, **kwargs: [issue]
+    sleeps = []
+    monkeypatch.setattr(nightly_e2e_module.time, "sleep", sleeps.append)
+
+    assert runner.cleanup() == {"status": "clean", "closed_prs": [88], "closed_issues": [77]}
+    assert pr.state == "closed" and issue.state == "closed"
+    assert prs.closed == [88] and issues.closed == [77]
+    assert runner.clients.labels.deleted == [cfg.issue_label]
+    assert sleeps == []
+
+
 def test_cleanup_fails_closed_when_exact_stale_view_never_converges(tmp_path, monkeypatch):
     runner, _branches, _prs, issues, _files = _runner(tmp_path)
     cfg = runner.config


### PR DESCRIPTION
## Contexte

Le run réel `29212284046` a exécuté avec succès le cycle produit complet : plan, `SPEC.md`, issue #3, code OpenHands/Gemma 4, tests objectifs, smoke HTTP et PR fixture #4. Le cleanup interne a ensuite produit un faux négatif : l’index GitHub filtré `state=open` a encore renvoyé l’issue attendue, mais déjà hydratée avec `state=closed`.

## Correctif final

- accepte uniquement les ressources déjà corrélées avec un état canonique `open|closed`, tout en refusant doublons, numéros étrangers, labels/bases incohérents, PR mergées et états inconnus ;
- revalide les entrées indexées `closed` via les endpoints individuels ;
- relit canoniquement toutes les PR et issues après chaque frontière de convergence ;
- vérifie les index avant suppression des refs, puis à nouveau avant suppression du label/manifeste ;
- sépare convergence et stabilité : après convergence, exige 15,75 s complètes de vues stables ;
- conserve les ancres si une PR/issue est rouverte, déplacée ou apparaît concurremment.

## Validation

- 93 tests ciblés verts (`test_pilot_nightly_e2e.py`, `test_github_cleanup.py`) ;
- CI GitHub 5/5 verte sur le head `5bf8149` ;
- build et smoke OpenHands/Gemma 4 réels verts ;
- Ruff check/format et `git diff --check` ;
- deux fils P2 traités et résolus ;
- ré-audit sans bloqueur P1/P2 ;
- fixture finale propre (`main` seule, aucune issue/PR ouverte) ;
- `INTEGRATION_E2E_ENABLED=false` après le run.