### PR TITLE
Fiabiliser les oracles QA plan-time

### DIFF
--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -367,6 +367,32 @@ def failure_feedback(outcome: "ExecutionOutcome") -> str:
             "aucun test : " + justification + ". Ajoute une assertion sur la VALEUR/le CALCUL attendu "
             "(pas seulement un code HTTP 200)."
         )[:700]
+    if report is not None and getattr(report, "adequacy_error", None):
+        return (
+            "CONTRÔLE D'ADÉQUATION INDISPONIBLE — le gate fail-closed n'a pas pu confirmer que le diff "
+            "réalise l'issue : " + str(report.adequacy_error)
+        )[:700]
+    if report is not None and (
+        getattr(report, "acceptance_passed", None) is False or getattr(report, "acceptance_error", None)
+    ):
+        # §4.7 : les tests ordinaires peuvent être verts alors que l'oracle QA
+        # indépendant est rouge. Sa sortie est distincte de ``test_output`` ;
+        # sans cette branche, le diagnostic persisté relayait le mauvais succès
+        # pytest et masquait totalement la cause (nightly réel #598).
+        error = str(getattr(report, "acceptance_error", "") or "").strip()
+        output = str(getattr(report, "acceptance_output", "") or "")
+        failures = [
+            line.strip() for line in output.splitlines() if line.strip().startswith(("FAILED ", "ERROR "))
+        ]
+        detail = " ; ".join(failures[:6])
+        if not detail:
+            detail = error or log_tail(filter_pip_noise(output), 500).strip()
+        if not detail:
+            detail = "l'oracle QA a renvoyé un exit code non nul sans diagnostic exploitable"
+        return (
+            "ORACLE D'ACCEPTATION REFUSÉ (§4.7) — les tests du projet peuvent être verts, mais la preuve "
+            "indépendante du contrat a échoué : " + detail
+        )[:700]
     removed = tuple(getattr(report, "requirements_removed", ()) or ()) if report is not None else ()
     if removed:
         # #482 : le motif utile est la liste NOMINATIVE des lignes perdues —

--- a/collegue/executor/pipeline.py
+++ b/collegue/executor/pipeline.py
@@ -381,9 +381,7 @@ def failure_feedback(outcome: "ExecutionOutcome") -> str:
         # pytest et masquait totalement la cause (nightly réel #598).
         error = str(getattr(report, "acceptance_error", "") or "").strip()
         output = str(getattr(report, "acceptance_output", "") or "")
-        failures = [
-            line.strip() for line in output.splitlines() if line.strip().startswith(("FAILED ", "ERROR "))
-        ]
+        failures = [line.strip() for line in output.splitlines() if line.strip().startswith(("FAILED ", "ERROR "))]
         detail = " ; ".join(failures[:6])
         if not detail:
             detail = error or log_tail(filter_pip_noise(output), 500).strip()

--- a/collegue/planner/acceptance_tests.py
+++ b/collegue/planner/acceptance_tests.py
@@ -243,8 +243,7 @@ def validate_pytest_source(source: str, *, max_source_bytes: int = MAX_SOURCE_BY
         # négatif même lorsque le livrable est conforme (nightly réel #598).
         if isinstance(node, ast.Name) and node.id == "__file__":
             raise ValueError(
-                "source pytest invalide : __file__ est interdit ; "
-                "utiliser Path.cwd() pour localiser le workspace"
+                "source pytest invalide : __file__ est interdit ; utiliser Path.cwd() pour localiser le workspace"
             )
         if isinstance(node, (ast.Attribute, ast.Name)):
             parts = _dotted_name(node)

--- a/collegue/planner/acceptance_tests.py
+++ b/collegue/planner/acceptance_tests.py
@@ -37,6 +37,11 @@ Contraintes impératives :
 - réponds uniquement avec la source Python du module (un fence ```python est toléré) ;
 - définis au moins une fonction ou méthode collectable nommée test_* ;
 - chaque test contient au moins une instruction assert qui vérifie un résultat observable ;
+- vérifie uniquement le critère d'acceptation de la tâche : n'ajoute aucun test
+  d'intégrité, de dépendances ou de non-régression sans lien direct avec ce critère ;
+- le runner crée le module sous un nom aléatoire dans /tmp puis l'exécute avec
+  /workspace comme répertoire courant : utilise Path.cwd() pour trouver le projet
+  et n'utilise jamais __file__ pour en déduire la racine ;
 - n'utilise jamais skip, skipif, xfail ou importorskip ;
 - n'utilise aucun conftest, plugin pytest ou configuration pytest du projet ;
 - ne remplace pas la vérification par une opinion, un commentaire ou un placeholder.
@@ -233,6 +238,14 @@ def validate_pytest_source(source: str, *, max_source_bytes: int = MAX_SOURCE_BY
         raise ValueError("source pytest invalide : aucune fonction test_* collectable")
 
     for node in ast.walk(tree):
+        # L'oracle est matérialisé sous un chemin aléatoire dans /tmp au runtime.
+        # En déduire la racine du projet via ``__file__`` produit donc un faux
+        # négatif même lorsque le livrable est conforme (nightly réel #598).
+        if isinstance(node, ast.Name) and node.id == "__file__":
+            raise ValueError(
+                "source pytest invalide : __file__ est interdit ; "
+                "utiliser Path.cwd() pour localiser le workspace"
+            )
         if isinstance(node, (ast.Attribute, ast.Name)):
             parts = _dotted_name(node)
             if any(part.lower() in _FORBIDDEN_PYTEST_CONTROLS for part in parts):

--- a/tests/test_executor_pipeline.py
+++ b/tests/test_executor_pipeline.py
@@ -1293,6 +1293,85 @@ def test_failure_feedback_names_uncovered_criterion():
     assert len(feedback) <= 700
 
 
+def test_failure_feedback_reports_independent_acceptance_failure_before_green_tests():
+    """§4.7 : la sortie de l'oracle est la cause, pas le pytest projet vert."""
+    from collegue.executor import AgentResult, QualityReport, Workspace
+    from collegue.executor.pipeline import ExecutionOutcome, failure_feedback
+    from collegue.executor.runner import ExecutionResult
+
+    outcome = ExecutionOutcome(
+        success=False,
+        stage="gate",
+        workspace=Workspace(path="/w", branch="b", base_commit="c"),
+        execution=ExecutionResult(
+            agent_result=AgentResult(success=True, logs="journal"),
+            changed=True,
+            diff="",
+            files_changed=("app/main.py",),
+            success=True,
+        ),
+        quality_report=QualityReport(
+            tests_passed=True,
+            test_exit_code=0,
+            test_output="2 passed in 0.45s",
+            review_summary="",
+            review_findings=(),
+            review_blocking=False,
+            passed=False,
+            adequacy_implemented=True,
+            acceptance_passed=False,
+            acceptance_output=(
+                "1 passed, 1 failed\n"
+                "FAILED /tmp/collegue_acceptance_x.py::test_dependency_files_integrity - assert False\n"
+            ),
+        ),
+        reason="gate_failed",
+    )
+
+    feedback = failure_feedback(outcome)
+
+    assert "ORACLE D'ACCEPTATION REFUSÉ" in feedback
+    assert "test_dependency_files_integrity" in feedback
+    assert "2 passed in 0.45s" not in feedback
+    assert len(feedback) <= 700
+
+
+def test_failure_feedback_reports_acceptance_execution_error():
+    from collegue.executor import AgentResult, QualityReport, Workspace
+    from collegue.executor.pipeline import ExecutionOutcome, failure_feedback
+    from collegue.executor.runner import ExecutionResult
+
+    outcome = ExecutionOutcome(
+        success=False,
+        stage="gate",
+        workspace=Workspace(path="/w", branch="b", base_commit="c"),
+        execution=ExecutionResult(
+            agent_result=AgentResult(success=True, logs="journal"),
+            changed=True,
+            diff="",
+            files_changed=("app/main.py",),
+            success=True,
+        ),
+        quality_report=QualityReport(
+            tests_passed=True,
+            test_exit_code=0,
+            test_output="2 passed in 0.45s",
+            review_summary="",
+            review_findings=(),
+            review_blocking=False,
+            passed=False,
+            adequacy_implemented=True,
+            acceptance_error="oracle plan-time invalide",
+        ),
+        reason="gate_failed",
+    )
+
+    feedback = failure_feedback(outcome)
+
+    assert "oracle plan-time invalide" in feedback
+    assert "2 passed" not in feedback
+
+
 async def test_requirements_regeneration_stops_at_gate(repo):
     """#482 bout en bout : l'agent régénère requirements.txt en perdant une ligne
     de la base → gate rouge, aucune PR."""

--- a/tests/test_planner_acceptance_tests.py
+++ b/tests/test_planner_acceptance_tests.py
@@ -128,6 +128,10 @@ def test_task_contract_is_canonical_across_task_and_dependency_order():
         ("import pytest\n@pytest.mark.skipif(True, reason='x')\ndef test_x():\n    assert True\n", "skipif"),
         ("import pytest\ndef test_x():\n    pytest.xfail('x')\n    assert True\n", "xfail"),
         ("import pytest\npytest.importorskip('x')\ndef test_x():\n    assert True\n", "importorskip"),
+        (
+            "from pathlib import Path\ndef test_x():\n    root = Path(__file__).parent\n    assert root.exists()\n",
+            "__file__",
+        ),
     ],
 )
 def test_static_validation_is_fail_closed(source, message):
@@ -225,6 +229,9 @@ async def test_prompt_contains_only_spec_and_plan_contract_metadata():
     assert "diff livré" not in prompt.lower()
     assert "workspace" not in prompt.lower()
     assert "indépendant du codeur" in system
+    assert "Path.cwd()" in system
+    assert "n'utilise jamais __file__" in system
+    assert "sans lien direct" in system
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Contexte

Le nightly réel [29213765390](https://github.com/VynoDePal/Collegue/actions/runs/29213765390) a produit un livrable dont les tests et le smoke `GET /nightly` étaient verts, mais la gate §4.7 a échoué. L’oracle QA calculait sa racine depuis `__file__` alors que le runner matérialise volontairement l’oracle sous `/tmp`; il ajoutait aussi un test d’intégrité des dépendances sans lien avec le critère de la tâche.

Le diagnostic persistant masquait ensuite cette cause en ne conservant que la sortie verte des tests ordinaires.

## Changements

- précise au rôle QA que `/workspace` est le répertoire courant et que `Path.cwd()` est la racine autoritative ;
- interdit les tests sans lien direct avec le critère d’acceptation ;
- rejette statiquement tout oracle utilisant `__file__`, avant scellement SHA-256 et approbation du plan ;
- fait remonter prioritairement les échecs de l’oracle §4.7 et les erreurs d’adéquation dans le feedback durable ;
- ajoute les régressions couvrant l’oracle fautif observé dans le nightly.

## Impact

Un oracle dépendant de son chemin temporaire est refusé au plan-time au lieu de bloquer un livrable conforme après consommation du budget. Si l’oracle objectif échoue réellement, le pilote conserve désormais son motif exact pour le diagnostic et un éventuel retry.

## Validation

- `pytest -q tests/test_planner_acceptance_tests.py tests/test_executor_pipeline.py`
- `pytest -q tests/test_acceptance_gate.py tests/test_pilot_driver.py tests/test_pilot_nightly_e2e.py`
- `ruff check` sur les quatre fichiers modifiés
- `git diff --check`

Incident suivi : #598.