### PR TITLE
Prouver l’oracle rouge avant le code

### DIFF
--- a/collegue/executor/quality_gate.py
+++ b/collegue/executor/quality_gate.py
@@ -1552,6 +1552,7 @@ class AcceptanceOutcome:
     """Verdict des tests d'acceptation §4.7 — exécution OBJECTIVE (exit code pytest)."""
 
     passed: Optional[bool] = None  # None = non évalué (pas de critères / checker absent)
+    exit_code: Optional[int] = None  # code brut du runner ; 1 prouve un test rouge attendu
     output: str = ""
     error: Optional[str] = None  # toute erreur bloque quand le checker est activé
     skipped: bool = False
@@ -1664,15 +1665,45 @@ def _run_acceptance_source(
             oracle_sha256=oracle_sha256,
         )
     output = "\n".join(part for part in (res.stdout, res.stderr) if part).strip()
-    # pytest exit 5 = AUCUN test collecté : le contrat n'est pas prouvé.
-    if getattr(res, "exit_code", None) == 5:
+    exit_code = getattr(res, "exit_code", None)
+    if _INSTALL_FAILED_NOTE in output:
         return AcceptanceOutcome(
             passed=False,
+            exit_code=exit_code,
+            error="installation des dépendances échouée avant l'oracle d'acceptation",
+            output=output,
+            oracle_sha256=oracle_sha256,
+        )
+    if exit_code == 0:
+        return AcceptanceOutcome(
+            passed=True,
+            exit_code=0,
+            output=output,
+            oracle_sha256=oracle_sha256,
+        )
+    if exit_code == 1:
+        return AcceptanceOutcome(
+            passed=False,
+            exit_code=1,
+            output=output,
+            oracle_sha256=oracle_sha256,
+        )
+    # pytest exit 5 = AUCUN test collecté : le contrat n'est pas prouvé.
+    if exit_code == 5:
+        return AcceptanceOutcome(
+            passed=False,
+            exit_code=5,
             error="aucun test d'acceptation collecté (oracle inexploitable)",
             output=output,
             oracle_sha256=oracle_sha256,
         )
-    return AcceptanceOutcome(passed=bool(res.ok), output=output, oracle_sha256=oracle_sha256)
+    return AcceptanceOutcome(
+        passed=False,
+        exit_code=exit_code,
+        error=f"runner d'acceptation terminé avec un code d'infrastructure pytest invalide: {exit_code!r}",
+        output=output,
+        oracle_sha256=oracle_sha256,
+    )
 
 
 _STORED_ACCEPTANCE_SCHEMA_VERSION = 1

--- a/collegue/pilot/nightly_e2e.py
+++ b/collegue/pilot/nightly_e2e.py
@@ -14,6 +14,7 @@ dans le manifeste durable du smoke.
 from __future__ import annotations
 
 import argparse
+import asyncio
 import hashlib
 import json
 import math
@@ -1033,6 +1034,69 @@ class NightlyE2ERunner:
             raise NightlyE2EError("HEAD local de la fixture différent du SPEC synchronisé")
         return destination
 
+    def _run_baseline_acceptance(
+        self,
+        workspace: str,
+        *,
+        project_id: int,
+        task_id: int,
+        issue_number: int,
+    ):
+        """Exécute l'oracle approuvé sur la base encore non conforme, sans secret LLM.
+
+        Le même :class:`StoredAcceptanceChecker` et le même sandbox de gate que le
+        RUN produit sont utilisés. Le test ne reçoit ni diff ni contexte de sampling :
+        il recharge l'artefact QA durable, vérifie le plan approuvé et rend uniquement
+        le verdict objectif de pytest.
+        """
+        from collegue.config import Settings
+        from collegue.executor.quality_gate import StoredAcceptanceChecker
+        from collegue.pilot.driver import _issue_from_task
+        from collegue.pilot.runtime import _build_gate_sandbox
+
+        manager = self._manager()
+        task = manager.get_task(task_id)
+        if (
+            task is None
+            or int(getattr(task, "project_id", 0) or 0) != project_id
+            or int(getattr(task, "issue_number", 0) or 0) != issue_number
+        ):
+            raise NightlyE2EError("tâche durable introuvable pour le contrôle négatif de l'oracle")
+        issue = _issue_from_task(task)
+        if int(issue.number) != issue_number or int(getattr(issue, "source_task_id", 0) or 0) != task_id:
+            raise NightlyE2EError("identité d'issue incohérente pour le contrôle négatif de l'oracle")
+        checker = StoredAcceptanceChecker(manager=manager, project_id=project_id)
+        sandbox = _build_gate_sandbox(Settings())
+        return asyncio.run(
+            checker.check(
+                workspace,
+                "",
+                issue,
+                None,
+                sandbox=sandbox,
+            )
+        )
+
+    @staticmethod
+    def _require_baseline_rejection(outcome, *, oracle_sha256: str) -> int:
+        """Exige un vrai test rouge (pytest 1), pas un vert ni une panne du runner."""
+        if getattr(outcome, "oracle_sha256", None) != oracle_sha256:
+            raise NightlyE2EError("le contrôle négatif n'a pas exécuté l'oracle QA approuvé exact")
+        if bool(getattr(outcome, "skipped", False)):
+            raise NightlyE2EError("le contrôle négatif de l'oracle a été ignoré")
+        if getattr(outcome, "error", None):
+            raise NightlyE2EError("le contrôle négatif a rencontré une erreur au lieu d'un test rouge")
+        if getattr(outcome, "passed", None) is not False:
+            raise NightlyE2EError("l'oracle accepte la fixture non conforme avant le codeur")
+        exit_code = getattr(outcome, "exit_code", None)
+        if exit_code != 1:
+            raise NightlyE2EError(
+                "la fixture non conforme doit être rejetée par pytest avec exit 1, sans erreur de collecte/exécution"
+            )
+        if not str(getattr(outcome, "output", "") or "").strip():
+            raise NightlyE2EError("le contrôle négatif ne fournit aucune sortie pytest vérifiable")
+        return exit_code
+
     def run(self) -> dict[str, Any]:
         cfg = self.config
         root_sha = self._guard_fixture(require_seed=True)
@@ -1147,8 +1211,33 @@ class NightlyE2ERunner:
             if stored_spec.get("content") != spec:
                 raise NightlyE2EError("SPEC.md distant différent du contrat approuvé")
 
-            self._authorize_head_creation(manifest, issue_numbers[0])
+            # L'oracle QA est du code non fiable : son clone est distinct de
+            # celui qui sera remis au codeur et détruit immédiatement après le
+            # verdict, même si le test tente de modifier /workspace.
+            baseline_path = self._clone_base(manifest.base_sha)
+            try:
+                baseline_outcome = self._run_baseline_acceptance(
+                    baseline_path,
+                    project_id=project_id,
+                    task_id=task_id,
+                    issue_number=issue_numbers[0],
+                )
+                baseline_exit_code = self._require_baseline_rejection(
+                    baseline_outcome,
+                    oracle_sha256=oracle_sha256,
+                )
+            finally:
+                shutil.rmtree(os.path.dirname(baseline_path), ignore_errors=True)
+            print(
+                f"oracle QA rouge avant code: exit={baseline_exit_code} sha256:{oracle_sha256}",
+                file=sys.stderr,
+            )
+            if self.clients.branches.get_branch_sha(cfg.owner, cfg.repo, cfg.base_branch) != manifest.base_sha:
+                raise NightlyE2EError("la base éphémère a bougé pendant le contrôle négatif de l'oracle")
 
+            # N'autoriser le codeur à créer sa branche qu'après la preuve que le
+            # contrat manque réellement sur la base immuable.
+            self._authorize_head_creation(manifest, issue_numbers[0])
             source_path = self._clone_base(manifest.base_sha)
             if self.clients.branches.get_branch_sha(cfg.owner, cfg.repo, cfg.base_branch) != manifest.base_sha:
                 raise NightlyE2EError("la base éphémère a bougé entre le clone et le RUN")
@@ -1228,6 +1317,8 @@ class NightlyE2ERunner:
                 "pr_number": opened_prs[0],
                 "base_branch": cfg.base_branch,
                 "head_sha": pr.head_sha,
+                "acceptance_negative_control_exit_code": baseline_exit_code,
+                "acceptance_rejected_base": True,
                 "acceptance_passed": True,
                 "acceptance_oracle_sha256": oracle_sha256,
             }

--- a/tests/test_acceptance_gate.py
+++ b/tests/test_acceptance_gate.py
@@ -137,6 +137,7 @@ async def test_uses_isolated_random_temp_file_and_passes_on_green(tmp_path):
     sb = _green()
     out = await LLMAcceptanceChecker(sample_fn=_gen).check(str(tmp_path), DIFF, ISSUE_AC, None, sandbox=sb)
     assert out.passed is True
+    assert out.exit_code == 0
     assert list(tmp_path.iterdir()) == []  # aucun chemin du dépôt n'est créé/écrasé
     command = sb.commands[0]
     assert "python -I -c" in command  # pytest importé avant d'exposer le workspace
@@ -154,6 +155,39 @@ async def test_fails_on_red(tmp_path):
 
     out = await LLMAcceptanceChecker(sample_fn=_gen).check(str(tmp_path), DIFF, ISSUE_AC, None, sandbox=_red())
     assert out.passed is False  # verdict OBJECTIF = exit code pytest
+    assert out.exit_code == 1
+    assert out.error is None
+
+
+@pytest.mark.parametrize("exit_code", [2, 3, 4, 124, 125, 126, 127])
+async def test_non_test_failure_exit_codes_are_infrastructure_errors(tmp_path, exit_code):
+    async def _gen(prompt, system):
+        return "def test_contract():\n    assert observed_contract()\n"
+
+    sandbox = _Sandbox(SandboxResult(exit_code=exit_code, stdout="runner failed", stderr=""))
+    out = await LLMAcceptanceChecker(sample_fn=_gen).check(str(tmp_path), DIFF, ISSUE_AC, None, sandbox=sandbox)
+
+    assert out.passed is False
+    assert out.exit_code == exit_code
+    assert "infrastructure" in (out.error or "")
+
+
+async def test_dependency_install_failure_is_not_a_valid_red_oracle(tmp_path):
+    async def _gen(prompt, system):
+        return "def test_contract():\n    assert observed_contract()\n"
+
+    sandbox = _Sandbox(
+        SandboxResult(
+            exit_code=1,
+            stdout="[gate] installation des dépendances en échec — tests lancés quand même (#414)\n1 failed",
+            stderr="",
+        )
+    )
+    out = await LLMAcceptanceChecker(sample_fn=_gen).check(str(tmp_path), DIFF, ISSUE_AC, None, sandbox=sandbox)
+
+    assert out.passed is False
+    assert out.exit_code == 1
+    assert "installation" in (out.error or "")
 
 
 async def test_exit5_no_tests_collected_is_failure(tmp_path):
@@ -164,6 +198,7 @@ async def test_exit5_no_tests_collected_is_failure(tmp_path):
     sb = _Sandbox(SandboxResult(exit_code=5, stdout="no tests ran", stderr=""))
     out = await LLMAcceptanceChecker(sample_fn=_gen).check(str(tmp_path), DIFF, ISSUE_AC, None, sandbox=sb)
     assert out.passed is False
+    assert out.exit_code == 5
     assert out.error and "collecté" in out.error
 
 
@@ -231,6 +266,7 @@ async def test_stored_checker_runs_exact_approved_source_without_llm(tmp_path):
     out = await checker.check(str(tmp_path), "diff hostile ignoré", issue, _NoSampling(), sandbox=sandbox)
 
     assert out.passed is True and out.error is None
+    assert out.exit_code == 0
     assert out.oracle_sha256 == _task.acceptance_test_sha256
     assert approvals and approvals[0][1] == 3
     assert len(sandbox.commands) == 1

--- a/tests/test_pilot_nightly_e2e.py
+++ b/tests/test_pilot_nightly_e2e.py
@@ -394,6 +394,79 @@ def _runner(tmp_path, *, repos=None):
     return NightlyE2ERunner(config, clients=clients), branches, prs, issues, files
 
 
+def _baseline_outcome(**overrides):
+    values = {
+        "passed": False,
+        "exit_code": 1,
+        "output": "1 failed",
+        "error": None,
+        "skipped": False,
+        "oracle_sha256": ORACLE_SHA,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_baseline_probe_uses_stored_checker_and_gate_sandbox(tmp_path, monkeypatch):
+    from collegue.executor import quality_gate
+    from collegue.pilot import driver, runtime
+
+    runner, _branches, _prs, _issues, _files = _runner(tmp_path)
+    task = SimpleNamespace(id=3, project_id=9, issue_number=77)
+    manager = SimpleNamespace(get_task=lambda task_id: task if task_id == 3 else None)
+    runner._manager = lambda: manager
+    issue = SimpleNamespace(number=77, source_task_id=3)
+    sandbox = object()
+    monkeypatch.setattr(driver, "_issue_from_task", lambda candidate: issue if candidate is task else None)
+    monkeypatch.setattr(runtime, "_build_gate_sandbox", lambda _settings: sandbox)
+    calls = []
+
+    class _Checker:
+        def __init__(self, *, manager, project_id):
+            calls.append(("init", manager, project_id))
+
+        async def check(self, workspace, diff, checked_issue, ctx, *, sandbox):
+            calls.append(("check", workspace, diff, checked_issue, ctx, sandbox))
+            return _baseline_outcome()
+
+    monkeypatch.setattr(quality_gate, "StoredAcceptanceChecker", _Checker)
+
+    outcome = runner._run_baseline_acceptance(str(tmp_path), project_id=9, task_id=3, issue_number=77)
+
+    assert outcome.exit_code == 1
+    assert calls == [
+        ("init", manager, 9),
+        ("check", str(tmp_path), "", issue, None, sandbox),
+    ]
+
+
+def test_baseline_rejection_requires_exact_red_pytest_exit():
+    assert (
+        NightlyE2ERunner._require_baseline_rejection(
+            _baseline_outcome(),
+            oracle_sha256=ORACLE_SHA,
+        )
+        == 1
+    )
+
+
+@pytest.mark.parametrize(
+    ("outcome", "message"),
+    [
+        (_baseline_outcome(passed=True, exit_code=0), "accepte la fixture"),
+        (_baseline_outcome(error="docker indisponible", exit_code=None), "erreur"),
+        (_baseline_outcome(exit_code=5), "exit 1"),
+        (_baseline_outcome(exit_code=2), "exit 1"),
+        (_baseline_outcome(skipped=True), "ignoré"),
+        (_baseline_outcome(output=""), "aucune sortie"),
+        (_baseline_outcome(oracle_sha256="f" * 64), "oracle QA approuvé exact"),
+    ],
+)
+def test_baseline_rejection_fails_closed(outcome, message):
+    with pytest.raises(NightlyE2EError, match=message):
+        NightlyE2ERunner._require_baseline_rejection(outcome, oracle_sha256=ORACLE_SHA)
+
+
 def _route_missing_refs_through_http_404(monkeypatch, branches):
     """Reproduit la vraie frontière HTTP GitHub du run #29209532860."""
     from collegue.tools.clients import github as github_client_module
@@ -1356,13 +1429,19 @@ def test_full_driver_uses_four_product_processes_and_cleans(tmp_path):
     runner._inspect_draft = lambda project_id, plan_hash: (3, "# SPEC fixture", ORACLE_SHA)
     runner._task_correlations = lambda _manifest: {77: 3}
     runner._approved_task_ids = lambda _manifest: {3}
+    baseline = tmp_path / "baseline-parent" / "fixture"
     source = tmp_path / "clone-parent" / "fixture"
+    baseline.mkdir(parents=True)
     source.mkdir(parents=True)
-    runner._clone_base = lambda base_sha: str(source)
+    clone_paths = iter((baseline, source))
+    runner._clone_base = lambda base_sha: str(next(clone_paths))
+    runner._run_baseline_acceptance = lambda workspace, project_id, task_id, issue_number: _baseline_outcome()
 
     result = runner.run()
     assert result["status"] == "passed"
     assert result["acceptance_passed"] is True
+    assert result["acceptance_negative_control_exit_code"] == 1
+    assert result["acceptance_rejected_base"] is True
     assert result["acceptance_oracle_sha256"] == ORACLE_SHA
     product_calls = [argv for argv, _ in calls if argv[1:3] == ["-m", "collegue.pilot"]]
     assert len(product_calls) == 4
@@ -1374,6 +1453,8 @@ def test_full_driver_uses_four_product_processes_and_cleans(tmp_path):
     assert any("--repo-source" in argv for argv in product_calls)
     assert branches.refs == {"main": SEED}
     assert prs.items[88].state == "closed" and issues.items[77].state == "closed"
+    assert not baseline.parent.exists()
+    assert not source.parent.exists()
 
 
 def test_run_failure_still_invokes_cleanup(tmp_path):


### PR DESCRIPTION
Closes #606

## Pourquoi

Le nightly prouvait seulement que l’oracle QA passait après le code. Un oracle tautologique pouvait donc rester vert sans détecter l’absence du contrat sur la fixture initiale.

## Changements

- conserve le code de sortie brut dans `AcceptanceOutcome` et distingue une assertion rouge (`1`) des erreurs pytest/Docker ;
- refuse comme preuve les erreurs d’installation, collecte, timeout et codes d’infrastructure ;
- exécute le même `StoredAcceptanceChecker` sur la base non conforme avant d’autoriser la branche du codeur ;
- utilise un sandbox sans secrets LLM et un clone jetable distinct du workspace du codeur ;
- lie la preuve rouge et la preuve verte au même SHA-256 d’oracle ;
- expose `acceptance_negative_control_exit_code=1` et `acceptance_rejected_base=true` dans le résultat nightly.

## Validation

- 122 tests ciblés : `tests/test_acceptance_gate.py` + `tests/test_pilot_nightly_e2e.py` ;
- 365 tests de régression : quality gate, pipeline executor, driver et runtime pilote ;
- Ruff check + format ;
- `git diff --check`.

La preuve nightly payante/réelle sera lancée après validation de cette PR, avec l’opt-in remis à `false` immédiatement après.